### PR TITLE
Increase `maxage` of the `jfr` telemetry.

### DIFF
--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -203,7 +203,7 @@ class FlightRecorder(TelemetryDevice):
         #
         # in that case change to: -XX:StartFlightRecording=defaultrecording=true,settings=es-memory-profiling
         return {"ES_JAVA_OPTS": "-XX:+UnlockDiagnosticVMOptions -XX:+UnlockCommercialFeatures -XX:+DebugNonSafepoints -XX:+FlightRecorder "
-                                "-XX:FlightRecorderOptions=disk=true,dumponexit=true,dumponexitpath=%s "
+                                "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath=%s "
                                 "-XX:StartFlightRecording=defaultrecording=true" % log_file}
 
 


### PR DESCRIPTION
By default, the `jfr` telemetry only keeps information about the last 15
minutes. This commit increases it to one day so that we keep information about
the whole benchmark in most cases.