### PR TITLE
Handle $TERM being set to 'dumb' in progress reporting

### DIFF
--- a/esrally/utils/progress.py
+++ b/esrally/utils/progress.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 
 class CmdLineProgressReporter:
@@ -6,9 +7,12 @@ class CmdLineProgressReporter:
     CmdLineProgressReporter supports displaying an updating progress indication together with an information message.
     """
 
-    def __init__(self, width=80):
+    def __init__(self, width=80, plain_output=False):
         self._width = width
         self._first_print = True
+        self._plain_output = plain_output
+        if (os.environ.get('TERM') == 'dumb'):
+            self._plain_output = True
 
     def print(self, message, progress):
         """
@@ -26,7 +30,11 @@ class CmdLineProgressReporter:
             self._first_print = False
 
         formatted_progress = progress.rjust(w - len(message))
-        print("\033[{0}D{1}{2}".format(w, message, formatted_progress), end="")
+        if (self._plain_output):
+            print("\n{0}{1}".format(message, formatted_progress), end="")
+        else:
+            print("\033[{0}D{1}{2}".format(w, message, formatted_progress), end="")
+
         sys.stdout.flush()
 
     def finish(self):


### PR DESCRIPTION
Some shells set their `TERM` environment variable to 'dumb' when they do
not support all shell escape codes. This changes the progress reporting
to check if the `$TERM` is 'dumb', and if so, report progress like:

```
  Benchmarking indexing at 0.0 docs/s                                [  0% done]
  Benchmarking indexing at 1425.2 docs/s                             [100% done]

  Benchmarking stats (warmup iteration 0/100)                        [  0% done]
  Benchmarking stats (warmup iteration 5/100)                        [  5% done]
  Benchmarking stats (warmup iteration 10/100)                       [ 10% done]
  Benchmarking stats (warmup iteration 15/100)                       [ 15% done]
  Benchmarking stats (warmup iteration 20/100)                       [ 20% done]
  Benchmarking stats (warmup iteration 25/100)                       [ 25% done]
... etc ...
```

instead of using escape codes to overwrite the previous progress line.

Additionally, this adds the `plain_output` parameter to
`CmdLineProgressReporter` (defaulting to `False`) in hope of hooking
this up as a `--plain_output=true` CLI parameter as future work.