### PR TITLE
Search across all types

### DIFF
--- a/esrally/track.py
+++ b/esrally/track.py
@@ -583,8 +583,8 @@ class TrackReader:
             "body": query_body
         }
 
-        if not index_name or not type_name:
-            raise TrackSyntaxError("Query '%s' requires an index and a type." % ops_spec_name)
+        if not index_name:
+            raise TrackSyntaxError("Query '%s' requires an index." % ops_spec_name)
 
         if pages:
             params["pages"] = pages

--- a/tests/track_test.py
+++ b/tests/track_test.py
@@ -85,6 +85,11 @@ class TrackReaderTests(TestCase):
                     "name": "index-append",
                     "operation-type": "index",
                     "bulk-size": 5000,
+                },
+                {
+                    "name": "search",
+                    "operation-type": "search",
+                    "index": "index-historical"
                 }
             ],
             "challenges": [
@@ -96,6 +101,10 @@ class TrackReaderTests(TestCase):
                             "index-settings": {},
                             "clients": 8,
                             "operation": "index-append"
+                        },
+                        {
+                            "clients": 1,
+                            "operation": "search"
                         }
                     ]
                 }


### PR DESCRIPTION
Removed the check for a type to be specified by the user. This will enable the search operation to be done on all doc_types by default.

Ref: #161 

