### PR TITLE
Saving tournament report [Closes #249]

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -138,6 +138,15 @@ def parse_args():
         "--contender",
         help="Race timestamp of the contender (see %s list races)" % PROGRAM_NAME,
         default="")
+    compare_parser.add_argument(
+            "--report-format",
+            help="define the output format for the command line report (default: markdown).",
+            choices=["markdown", "csv"],
+            default="markdown")
+    compare_parser.add_argument(
+        "--report-file",
+        help="write the command line report also to the provided file",
+        default="")
 
     config_parser = subparsers.add_parser("configure", help="Write the configuration file or reconfigure Rally")
     for p in [parser, config_parser]:

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -139,10 +139,10 @@ def parse_args():
         help="Race timestamp of the contender (see %s list races)" % PROGRAM_NAME,
         default="")
     compare_parser.add_argument(
-            "--report-format",
-            help="define the output format for the command line report (default: markdown).",
-            choices=["markdown", "csv"],
-            default="markdown")
+        "--report-format",
+        help="define the output format for the command line report (default: markdown).",
+        choices=["markdown", "csv"],
+        default="markdown")
     compare_parser.add_argument(
         "--report-file",
         help="write the command line report also to the provided file",

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -419,6 +419,7 @@ class ComparisonReporter:
         print_internal("")
 
         print_internal(self.format_as_table(self.metrics_table(baseline_stats, contender_stats)))
+        self.write_report(metrics_table())
 
     def format_as_table(self, table):
         return tabulate.tabulate(table,
@@ -444,6 +445,50 @@ class ComparisonReporter:
                 metrics_table += self.report_service_time(baseline_stats, contender_stats, op)
                 metrics_table += self.report_error_rate(baseline_stats, contender_stats, op)
         return metrics_table
+
+    def write_report(self, metrics_table, meta_info_table):
+        report_file = self._config.opts("reporting", "output.path")
+
+        self.write_single_report(report_file, headers=["Metric", "Operation", "Baseline", "Contender", "Diff", "Unit"], data=metrics_table)
+
+
+    def write_single_report(self, report_file, headers, data, show_also_in_console=True):
+        report_format = self._config.opts("reporting", "format")
+        if report_format == "markdown":
+            formatter = self.format_as_markdown
+        elif report_format == "csv":
+            formatter = self.format_as_csv
+        else:
+            raise exceptions.SystemSetupError("Unknown report format '%s'" % report_format)
+
+        if show_also_in_console:
+            print_internal(formatter(headers, data))
+        if len(report_file) > 0:
+            cwd = self._config.opts("node", "rally.cwd")
+            normalized_report_file = rio.normalize_path(report_file, cwd)
+            logger.info("Writing report to [%s] (user specified: [%s]) in format [%s]" %
+                        (normalized_report_file, report_file, report_format))
+            # ensure that the parent folder already exists when we try to write the file...
+            rio.ensure_dir(rio.dirname(normalized_report_file))
+            with open(normalized_report_file, mode="a+", encoding="UTF-8") as f:
+                f.writelines(formatter(headers, data, write_header))
+
+    def format_as_markdown(self, headers, data, write_header=True):
+        rendered = tabulate.tabulate(data, headers=headers, tablefmt="pipe", numalign="right", stralign="right")
+        if write_header:
+            return rendered + "\n"
+        else:
+            # remove all header data (it's not possible to do so entirely with tabulate directly...)
+            return "\n".join(rendered.splitlines()[2:]) + "\n"
+
+    def format_as_csv(self, headers, data, write_header=True):
+        with io.StringIO() as out:
+            writer = csv.writer(out)
+            if write_header:
+                writer.writerow(headers)
+            for metric_record in data:
+                writer.writerow(metric_record)
+            return out.getvalue()
 
     def report_throughput(self, baseline_stats, contender_stats, operation):
         b_min, b_median, b_max, b_unit = baseline_stats.op_metrics[operation]["throughput"]

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -34,19 +34,18 @@ def print_internal(message):
 def print_header(message):
     print_internal(console.format.bold(message))
 
-def write_single_report(self, report_file, headers, data, write_header=True, show_also_in_console=True):
-    report_format = self._config.opts("reporting", "format")
+def write_single_report(report_file, report_format, cwd, headers, data, write_header=True, show_also_in_console=True):
+    
     if report_format == "markdown":
-        formatter = self.format_as_markdown
+        formatter = format_as_markdown
     elif report_format == "csv":
-        formatter = self.format_as_csv
+        formatter = format_as_csv
     else:
         raise exceptions.SystemSetupError("Unknown report format '%s'" % report_format)
 
     if show_also_in_console:
         print_internal(formatter(headers, data))
     if len(report_file) > 0:
-        cwd = self._config.opts("node", "rally.cwd")
         normalized_report_file = rio.normalize_path(report_file, cwd)
         logger.info("Writing report to [%s] (user specified: [%s]) in format [%s]" %
                     (normalized_report_file, report_file, report_format))
@@ -54,6 +53,23 @@ def write_single_report(self, report_file, headers, data, write_header=True, sho
         rio.ensure_dir(rio.dirname(normalized_report_file))
         with open(normalized_report_file, mode="a+", encoding="UTF-8") as f:
             f.writelines(formatter(headers, data, write_header))
+
+def format_as_markdown(headers, data, write_header=True):
+    rendered = tabulate.tabulate(data, headers=headers, tablefmt="pipe", numalign="right", stralign="right")
+    if write_header:
+        return rendered + "\n"
+    else:
+        # remove all header data (it's not possible to do so entirely with tabulate directly...)
+        return "\n".join(rendered.splitlines()[2:]) + "\n"
+
+def format_as_csv(headers, data, write_header=True):
+    with io.StringIO() as out:
+        writer = csv.writer(out)
+        if write_header:
+            writer.writerow(headers)
+        for metric_record in data:
+            writer.writerow(metric_record)
+        return out.getvalue()
 
 class Stats:
     def __init__(self, store, challenge, lap=None):
@@ -252,30 +268,12 @@ class SummaryReporter:
 
     def write_report(self, metrics_table, meta_info_table):
         report_file = self._config.opts("reporting", "output.path")
-
-        write_single_report(report_file, headers=["Lap", "Metric", "Operation", "Value", "Unit"], data=metrics_table,
+        report_format = self._config.opts("reporting", "format")
+        cwd = self._config.opts("node", "rally.cwd")
+        write_single_report(report_file, report_format, cwd, headers=["Lap", "Metric", "Operation", "Value", "Unit"], data=metrics_table,
                                  write_header=self.needs_header())
-
         if self.is_final_report() and len(report_file) > 0:
             write_single_report("%s.meta" % report_file, headers=["Name", "Value"], data=meta_info_table, show_also_in_console=False)
-
-
-    def format_as_markdown(self, headers, data, write_header=True):
-        rendered = tabulate.tabulate(data, headers=headers, tablefmt="pipe", numalign="right", stralign="right")
-        if write_header:
-            return rendered + "\n"
-        else:
-            # remove all header data (it's not possible to do so entirely with tabulate directly...)
-            return "\n".join(rendered.splitlines()[2:]) + "\n"
-
-    def format_as_csv(self, headers, data, write_header=True):
-        with io.StringIO() as out:
-            writer = csv.writer(out)
-            if write_header:
-                writer.writerow(headers)
-            for metric_record in data:
-                writer.writerow(metric_record)
-            return out.getvalue()
 
     def report_throughput(self, stats, operation):
         min, median, max, unit = stats.op_metrics[operation.name]["throughput"]
@@ -382,8 +380,8 @@ class SummaryReporter:
 
 class ComparisonReporter:
     def __init__(self, config):
-        self._config = config    
-        
+        self._config = config
+    
     def report(self, r1, r2):
         logger.info("Generating comparison report for baseline (invocation=[%s], track=[%s], challenge=[%s], car=[%s]) and "
                     "contender (invocation=[%s], track=[%s], challenge=[%s], car=[%s])" %
@@ -418,14 +416,15 @@ class ComparisonReporter:
         print_header("------------------------------------------------------")
         print_internal("")
 
-        print_internal(self.format_as_table(self.metrics_table(baseline_stats, contender_stats)))
+        metric_table = self.metrics_table(baseline_stats, contender_stats)
+        self.write_report(metric_table)
+
+    def metrics_table(self, baseline_stats, contender_stats):
         metrics_table = []
         metrics_table += self.report_total_times(baseline_stats, contender_stats)
         metrics_table += self.report_merge_part_times(baseline_stats, contender_stats)
-
         # metrics_table += self.report_cpu_usage(baseline_stats, contender_stats)
         metrics_table += self.report_gc_times(baseline_stats, contender_stats)
-
         metrics_table += self.report_disk_usage(baseline_stats, contender_stats)
         metrics_table += self.report_segment_memory(baseline_stats, contender_stats)
         metrics_table += self.report_segment_counts(baseline_stats, contender_stats)
@@ -435,8 +434,8 @@ class ComparisonReporter:
                 metrics_table += self.report_throughput(baseline_stats, contender_stats, op)
                 metrics_table += self.report_latency(baseline_stats, contender_stats, op)
                 metrics_table += self.report_service_time(baseline_stats, contender_stats, op)
-                metrics_table += self.report_error_rate(baseline_stats, contender_stats, op)        
-        self.write_report(metrics_table)
+                metrics_table += self.report_error_rate(baseline_stats, contender_stats, op)
+        return metrics_table
 
     def format_as_table(self, table):
         return tabulate.tabulate(table,
@@ -445,25 +444,10 @@ class ComparisonReporter:
 
     def write_report(self, metrics_table):
         report_file = self._config.opts("reporting", "output.path")
-
-        write_single_report(report_file, headers=["Metric", "Operation", "Baseline", "Contender", "Diff", "Unit"], data=metrics_table,write_header=self.needs_header())
-
-    def format_as_markdown(self, headers, data, write_header=True):
-        rendered = tabulate.tabulate(data, headers=headers, tablefmt="pipe", numalign="right", stralign="right")
-        if write_header:
-            return rendered + "\n"
-        else:
-            # remove all header data (it's not possible to do so entirely with tabulate directly...)
-            return "\n".join(rendered.splitlines()[2:]) + "\n"
-
-    def format_as_csv(self, headers, data, write_header=True):
-        with io.StringIO() as out:
-            writer = csv.writer(out)
-            if write_header:
-                writer.writerow(headers)
-            for metric_record in data:
-                writer.writerow(metric_record)
-            return out.getvalue()
+        report_format = self._config.opts("reporting", "format")
+        cwd = self._config.opts("node", "rally.cwd")
+        write_single_report(report_file, report_format, cwd, headers=["Metric", "Operation", "Baseline", "Contender", "Diff", "Unit"], 
+            data= metrics_table, write_header=True)
 
     def report_throughput(self, baseline_stats, contender_stats, operation):
         b_min, b_median, b_max, b_unit = baseline_stats.op_metrics[operation]["throughput"]
@@ -629,9 +613,9 @@ class ComparisonReporter:
             color_smaller = console.format.green
 
         if diff > 0:
-            return color_greater("+%.5f" % diff)
+            return ("+%.5f" % diff)
         elif diff < 0:
-            return color_smaller("%.5f" % diff)
+            return ("%.5f" % diff)
         else:
             # tabulate needs this to align all values correctly
-            return console.format.neutral("%.5f" % diff)
+            return ("%.5f" % diff)

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -273,7 +273,7 @@ class SummaryReporter:
         write_single_report(report_file, report_format, cwd, headers=["Lap", "Metric", "Operation", "Value", "Unit"], data_plain=metrics_table,
                                  data_rich = metrics_table, write_header=self.needs_header())
         if self.is_final_report() and len(report_file) > 0:
-            write_single_report("%s.meta" % report_file, headers=["Name", "Value"], data=meta_info_table, data_rich = meta_info_table, show_also_in_console=False)
+            write_single_report("%s.meta" % report_file, report_format, cwd, headers=["Name", "Value"], data_plain = meta_info_table, data_rich = meta_info_table, show_also_in_console=False)
 
     def report_throughput(self, stats, operation):
         min, median, max, unit = stats.op_metrics[operation.name]["throughput"]

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -34,6 +34,26 @@ def print_internal(message):
 def print_header(message):
     print_internal(console.format.bold(message))
 
+def write_single_report(self, report_file, headers, data, write_header=True, show_also_in_console=True):
+    report_format = self._config.opts("reporting", "format")
+    if report_format == "markdown":
+        formatter = self.format_as_markdown
+    elif report_format == "csv":
+        formatter = self.format_as_csv
+    else:
+        raise exceptions.SystemSetupError("Unknown report format '%s'" % report_format)
+
+    if show_also_in_console:
+        print_internal(formatter(headers, data))
+    if len(report_file) > 0:
+        cwd = self._config.opts("node", "rally.cwd")
+        normalized_report_file = rio.normalize_path(report_file, cwd)
+        logger.info("Writing report to [%s] (user specified: [%s]) in format [%s]" %
+                    (normalized_report_file, report_file, report_format))
+        # ensure that the parent folder already exists when we try to write the file...
+        rio.ensure_dir(rio.dirname(normalized_report_file))
+        with open(normalized_report_file, mode="a+", encoding="UTF-8") as f:
+            f.writelines(formatter(headers, data, write_header))
 
 class Stats:
     def __init__(self, store, challenge, lap=None):
@@ -233,32 +253,12 @@ class SummaryReporter:
     def write_report(self, metrics_table, meta_info_table):
         report_file = self._config.opts("reporting", "output.path")
 
-        self.write_single_report(report_file, headers=["Lap", "Metric", "Operation", "Value", "Unit"], data=metrics_table,
+        write_single_report(report_file, headers=["Lap", "Metric", "Operation", "Value", "Unit"], data=metrics_table,
                                  write_header=self.needs_header())
 
         if self.is_final_report() and len(report_file) > 0:
-            self.write_single_report("%s.meta" % report_file, headers=["Name", "Value"], data=meta_info_table, show_also_in_console=False)
+            write_single_report("%s.meta" % report_file, headers=["Name", "Value"], data=meta_info_table, show_also_in_console=False)
 
-    def write_single_report(self, report_file, headers, data, write_header=True, show_also_in_console=True):
-        report_format = self._config.opts("reporting", "format")
-        if report_format == "markdown":
-            formatter = self.format_as_markdown
-        elif report_format == "csv":
-            formatter = self.format_as_csv
-        else:
-            raise exceptions.SystemSetupError("Unknown report format '%s'" % report_format)
-
-        if show_also_in_console:
-            print_internal(formatter(headers, data))
-        if len(report_file) > 0:
-            cwd = self._config.opts("node", "rally.cwd")
-            normalized_report_file = rio.normalize_path(report_file, cwd)
-            logger.info("Writing report to [%s] (user specified: [%s]) in format [%s]" %
-                        (normalized_report_file, report_file, report_format))
-            # ensure that the parent folder already exists when we try to write the file...
-            rio.ensure_dir(rio.dirname(normalized_report_file))
-            with open(normalized_report_file, mode="a+", encoding="UTF-8") as f:
-                f.writelines(formatter(headers, data, write_header))
 
     def format_as_markdown(self, headers, data, write_header=True):
         rendered = tabulate.tabulate(data, headers=headers, tablefmt="pipe", numalign="right", stralign="right")
@@ -382,8 +382,8 @@ class SummaryReporter:
 
 class ComparisonReporter:
     def __init__(self, config):
-        self._config = config
-
+        self._config = config    
+        
     def report(self, r1, r2):
         logger.info("Generating comparison report for baseline (invocation=[%s], track=[%s], challenge=[%s], car=[%s]) and "
                     "contender (invocation=[%s], track=[%s], challenge=[%s], car=[%s])" %
@@ -419,14 +419,6 @@ class ComparisonReporter:
         print_internal("")
 
         print_internal(self.format_as_table(self.metrics_table(baseline_stats, contender_stats)))
-        self.write_report(metrics_table())
-
-    def format_as_table(self, table):
-        return tabulate.tabulate(table,
-                                 headers=["Metric", "Operation", "Baseline", "Contender", "Diff", "Unit"],
-                                 tablefmt="pipe", numalign="right", stralign="right")
-
-    def metrics_table(self, baseline_stats, contender_stats):
         metrics_table = []
         metrics_table += self.report_total_times(baseline_stats, contender_stats)
         metrics_table += self.report_merge_part_times(baseline_stats, contender_stats)
@@ -443,35 +435,18 @@ class ComparisonReporter:
                 metrics_table += self.report_throughput(baseline_stats, contender_stats, op)
                 metrics_table += self.report_latency(baseline_stats, contender_stats, op)
                 metrics_table += self.report_service_time(baseline_stats, contender_stats, op)
-                metrics_table += self.report_error_rate(baseline_stats, contender_stats, op)
-        return metrics_table
+                metrics_table += self.report_error_rate(baseline_stats, contender_stats, op)        
+        self.write_report(metrics_table)
 
-    def write_report(self, metrics_table, meta_info_table):
+    def format_as_table(self, table):
+        return tabulate.tabulate(table,
+                                 headers=["Metric", "Operation", "Baseline", "Contender", "Diff", "Unit"],
+                                 tablefmt="pipe", numalign="right", stralign="right")
+
+    def write_report(self, metrics_table):
         report_file = self._config.opts("reporting", "output.path")
 
-        self.write_single_report(report_file, headers=["Metric", "Operation", "Baseline", "Contender", "Diff", "Unit"], data=metrics_table)
-
-
-    def write_single_report(self, report_file, headers, data, show_also_in_console=True):
-        report_format = self._config.opts("reporting", "format")
-        if report_format == "markdown":
-            formatter = self.format_as_markdown
-        elif report_format == "csv":
-            formatter = self.format_as_csv
-        else:
-            raise exceptions.SystemSetupError("Unknown report format '%s'" % report_format)
-
-        if show_also_in_console:
-            print_internal(formatter(headers, data))
-        if len(report_file) > 0:
-            cwd = self._config.opts("node", "rally.cwd")
-            normalized_report_file = rio.normalize_path(report_file, cwd)
-            logger.info("Writing report to [%s] (user specified: [%s]) in format [%s]" %
-                        (normalized_report_file, report_file, report_format))
-            # ensure that the parent folder already exists when we try to write the file...
-            rio.ensure_dir(rio.dirname(normalized_report_file))
-            with open(normalized_report_file, mode="a+", encoding="UTF-8") as f:
-                f.writelines(formatter(headers, data, write_header))
+        write_single_report(report_file, headers=["Metric", "Operation", "Baseline", "Contender", "Diff", "Unit"], data=metrics_table,write_header=self.needs_header())
 
     def format_as_markdown(self, headers, data, write_header=True):
         rendered = tabulate.tabulate(data, headers=headers, tablefmt="pipe", numalign="right", stralign="right")


### PR DESCRIPTION
Added parameters in compare parsers to enable saving tournament report in csv or md format.

```
compare_parser.add_argument(
        "--report-format",
        help="define the output format for the command line report (default: markdown).",
        choices=["markdown", "csv"],
        default="markdown")
compare_parser.add_argument(
        "--report-file",
        help="write the command line report also to the provided file",
        default="")

```
