### PR TITLE
Mappings should be created on a single call when the index is created

### DIFF
--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -173,12 +173,21 @@ class IndexManagementTests(TestCase):
         index_settings = {
             "index.number_of_replicas": 0
         }
+        expected_body = {
+            "settings": {
+                "index.number_of_replicas": 0
+            },
+            "mappings": {
+                "test-type": {
+                    "mapping": "empty-for-test"
+                }
+            }
+        }
         driver.setup_index(es, index, index_settings, source=io.StringAsFileSource)
 
         es.indices.exists.assert_called_with(index="test-index")
         es.indices.delete.assert_not_called()
-        es.indices.create.assert_called_with(index="test-index", body=index_settings)
-        es.indices.put_mapping.assert_called_with(index="test-index", doc_type="test-type", body={"mapping": "empty-for-test"})
+        es.indices.create.assert_called_with(index="test-index", body=expected_body)
 
     @mock.patch("elasticsearch.Elasticsearch")
     def test_recreate_existing_managed_index(self, es):
@@ -190,12 +199,21 @@ class IndexManagementTests(TestCase):
         index_settings = {
             "index.number_of_replicas": 0
         }
+        expected_body = {
+            "settings": {
+                "index.number_of_replicas": 0
+            },
+            "mappings": {
+                "test-type": {
+                    "mapping": "empty-for-test"
+                }
+            }
+        }
         driver.setup_index(es, index, index_settings, source=io.StringAsFileSource)
 
         es.indices.exists.assert_called_with(index="test-index")
         es.indices.delete.assert_called_with(index="test-index")
-        es.indices.create.assert_called_with(index="test-index", body=index_settings)
-        es.indices.put_mapping.assert_called_with(index="test-index", doc_type="test-type", body={"mapping": "empty-for-test"})
+        es.indices.create.assert_called_with(index="test-index", body=expected_body)
 
     @mock.patch("elasticsearch.Elasticsearch")
     def test_do_not_change_manually_managed_index(self, es):


### PR DESCRIPTION
Mappings for a race are always known beforehand so it is possible to create the index with the final mapping rather than calling `put_mapping` right after the creation of the index.
This change creates the full mapping and adds it to the call to create_index when the index for a race is created for the first time.
This is required if we want to benchmark index sorting which requires to create the mapping when the index is created in order to apply the correct sort specification extracted from the index settings.