### PR TITLE
Add support for max_num_segments in forcemerge action

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -162,7 +162,8 @@ Example::
 force-merge
 ~~~~~~~~~~~
 
-With the operation type ``force-merge`` you can call the `force merge API <http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html>`_. On older versions of Elasticsearch (prior to 2.1), Rally will use the ``optimize API`` instead. It does not support any parameters.
+With the operation type ``force-merge`` you can call the `force merge API <http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html>`_. On older versions of Elasticsearch (prior to 2.1), Rally will use the ``optimize API`` instead. It support the following parameter:
+* ``max_num_segments`` (optional)  The number of segments the index should be merged into. Defaults to simply checking if a merge needs to execute, and if so, executes it.
 
 index-stats
 ~~~~~~~~~~~


### PR DESCRIPTION
This change adds support to provide the maximum number of segments an index should be merged to when using the forcemerge action.
It can be useful to force merge an index to 1 segment in a challenge in order to be able to compare index size between
previous runs. Merging down to 1 segment would ensure that different runs would always have the same number of segments.