### PR TITLE
Additional metrics for bulk requests

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -283,7 +283,7 @@ class BulkIndex(Runner):
 
             line_size = len(data.encode('utf-8'))
             if params["action_metadata_present"]:
-                if i % 2 == 1:
+                if line_number % 2 == 1:
                     total_document_size_bytes += line_size
             else:
                 total_document_size_bytes += line_size

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -130,7 +130,8 @@ class BulkIndex(Runner):
         * ``shards_histogram``: An array of hashes where each hash has two keys: ``item-count`` contains the number of items to which a shard
           distribution applies and ``shards`` contains another hash with the actual distribution of ``total``, ``successful`` and ``failed``
           shards (see examples below).
-
+        * ``bulk-request-size-bytes``: Total size of the bulk request body in bytes.
+        * ``total-document-size-bytes``: Total size of all documents within the bulk request body in bytes.
 
         Here are a few examples:
 
@@ -141,8 +142,6 @@ class BulkIndex(Runner):
                 "weight": 5000,
                 "unit": "docs",
                 "bulk-size": 5000,
-                "bulk-request-size-bytes": 2250000,
-                "total-document-size-bytes": 2000000,
                 "success": True,
                 "success-count": 5000,
                 "error-count": 0
@@ -155,8 +154,6 @@ class BulkIndex(Runner):
                 "weight": 5000,
                 "unit": "docs",
                 "bulk-size": 5000,
-                "bulk-request-size-bytes": 2250000,
-                "total-document-size-bytes": 2000000,
                 "success": False,
                 "success-count": 4000,
                 "error-count": 1000

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -457,6 +457,8 @@ class BulkIndexRunnerTests(TestCase):
                     }
                 }
             ], result["shards_histogram"])
+        self.assertEqual(158, result["bulk-request-size-bytes"])
+        self.assertEqual(62, result["total-document-size-bytes"])
 
         es.bulk.assert_called_with(body=bulk_params["body"], params={})
 


### PR DESCRIPTION
When comparing bulk indexing throughput for different types of data, pure EPS can be very misleading if events have different sizes. I have found the total volume of JSON records indexed per time period to sometimes be a more useful measure, as this takes event size into consideration.

This pull request adds the total size of the bulk request as well as the total size of the documents indexed to the metrics reported, allowing the amount of JSON indexed per timeframe and total volume sent over the wire to be calculated.