### PR TITLE
Leave the host parsing on elasticsearch-py

### DIFF
--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -143,8 +143,12 @@ class MechanicActor(actor.RallyActor):
                     if len(hosts) == 0:
                         raise exceptions.LaunchError("No target hosts are configured.")
                     for host in hosts:
-                        host_or_ip = host["host"]
-                        port = int(host["port"])
+                        host = host.copy()
+                        host_or_ip = host.pop("host")
+                        port = host.pop("port", 9200)
+                        if host:
+                            raise exceptions.SystemSetupError("When specifying nodes to be managed by rally you can only supply hostname:port "
+                                                              "pairs (e.g. 'localhost:9200'), any additional options cannot be supported.")
                         # user may specify "localhost" on the command line but the problem is that we auto-register the actor system
                         # with "ip": "127.0.0.1" so we convert this special case automatically. In all other cases the user needs to
                         # start the actor system on the other host and is aware that the parameter for the actor system and the

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -499,19 +499,6 @@ def kv_to_map(kvs):
     return result
 
 
-def convert_hosts(configured_host_list):
-    hosts = []
-    try:
-        for authority in configured_host_list:
-            host, port = authority.split(":")
-            hosts.append({"host": host, "port": port})
-        return hosts
-    except ValueError:
-        msg = "Could not convert hosts [%s] (expected a list of host:port pairs e.g. host1:9200,host2:9200)." % configured_host_list
-        logger.exception(msg)
-        raise exceptions.SystemSetupError(msg)
-
-
 def main():
     start = time.time()
     # Early init of console output so we start to show everything consistently.
@@ -581,7 +568,7 @@ def main():
     cfg.add(config.Scope.applicationOverride, "driver", "profiling", args.enable_driver_profiling)
     if sub_command != "list":
         # Also needed by mechanic (-> telemetry) - duplicate by module?
-        cfg.add(config.Scope.applicationOverride, "client", "hosts", convert_hosts(csv_to_list(args.target_hosts)))
+        cfg.add(config.Scope.applicationOverride, "client", "hosts", csv_to_list(args.target_hosts))
         client_options = kv_to_map(csv_to_list(args.client_options))
         cfg.add(config.Scope.applicationOverride, "client", "options", client_options)
         if "timeout" not in client_options:

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -14,6 +14,8 @@ from esrally import PROGRAM_NAME, DOC_LINK, BANNER, SKULL
 from esrally.mechanic import car, telemetry
 from esrally.utils import io, convert, process, console, net
 
+from elasticsearch.client import _normalize_hosts
+
 logger = logging.getLogger("rally.main")
 
 DEFAULT_CLIENT_OPTIONS = "timeout:60000,request_timeout:60000"
@@ -568,7 +570,7 @@ def main():
     cfg.add(config.Scope.applicationOverride, "driver", "profiling", args.enable_driver_profiling)
     if sub_command != "list":
         # Also needed by mechanic (-> telemetry) - duplicate by module?
-        cfg.add(config.Scope.applicationOverride, "client", "hosts", csv_to_list(args.target_hosts))
+        cfg.add(config.Scope.applicationOverride, "client", "hosts", _normalize_hosts(csv_to_list(args.target_hosts)))
         client_options = kv_to_map(csv_to_list(args.client_options))
         cfg.add(config.Scope.applicationOverride, "client", "options", client_options)
         if "timeout" not in client_options:

--- a/tests/rally_test.py
+++ b/tests/rally_test.py
@@ -4,17 +4,6 @@ from esrally import exceptions, rally
 
 
 class RallyTests(TestCase):
-    def test_can_convert_valid_list(self):
-        hosts = rally.convert_hosts(["search.host-a.internal:9200", "search.host-b.internal:9200"])
-        self.assertEqual([{"host": "search.host-a.internal", "port": "9200"}, {"host": "search.host-b.internal", "port": "9200"}], hosts)
-
-    def test_raise_system_setup_exception_on_invalid_list(self):
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            rally.convert_hosts(["search.host-a.internal", "search.host-b.internal:9200"])
-            self.assertTrue("Could not convert hosts. Invalid format for [search.host-a.internal, "
-                            "search.host-b.internal:9200]. Expected a comma-separated list of host:port pairs, "
-                            "e.g. host1:9200,host2:9200." in ctx.exception)
-
     def test_csv_to_list(self):
         self.assertEqual([], rally.csv_to_list(""))
         self.assertEqual(["a", "b", "c", "d"], rally.csv_to_list("    a,b,c   , d"))


### PR DESCRIPTION
That way you can specify 'https://user:secret@localhost:9200' if needed

There is already a comprehensive parsing logic in `elasticsearch-py` (0), no need to reimplement.

0 - https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/client/__init__.py#L19-L59