### PR TITLE
Update setup.py for MarkupSafe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     "tabulate==0.8.1",
     "jsonschema==2.5.1",
     "Jinja2==2.9.5",
+    "MarkupSafe==1.0",
     # remote messaging
     "thespian==3.8.0",
     # recommended library for thespian to identify actors more easily with `ps`


### PR DESCRIPTION
Tested on Ubuntu 14.04 LTS.
After:
`pip3 install esrally`
and running command: **esrally**:
`Traceback (most recent call last):
  File "/usr/local/bin/esrally", line 7, in <module>
    from esrally.rally import main
  File "/usr/local/lib/python3.4/dist-packages/esrally/__init__.py", line 5, in <module>
    __version__ = pkg_resources.require("esrally")[0].version
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 725, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 628, in resolve
    raise DistributionNotFound(req)
pkg_resources.DistributionNotFound: MarkupSafe>=0.23`
