### PR TITLE
Improve internal message handling

### DIFF
--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -128,7 +128,7 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
 
 # Defined on top-level to allow pickling
 def configure_utc_formatter(*args, **kwargs):
-    formatter = logging.Formatter(fmt=kwargs["fmt"], datefmt=kwargs["datefmt"])
+    formatter = logging.Formatter(fmt=kwargs["format"], datefmt=kwargs["datefmt"])
     formatter.converter = time.gmtime
     return formatter
 
@@ -137,16 +137,16 @@ def configure_actor_logging():
     log_dir = "%s/.rally/logs" % os.path.expanduser("~")
     io.ensure_dir(log_dir)
 
-    # actor_log_handler = {"class": "logging.handlers.SysLogHandler", "address": "/var/run/syslog"}
-    # actor_messages_handler = {"class": "logging.handlers.SysLogHandler", "address": "/var/run/syslog"}
-
     return {
         "version": 1,
         "formatters": {
             "normal": {
                 "format": "%(asctime)s,%(msecs)d %(actorAddress)s/PID:%(process)d %(name)s %(levelname)s %(message)s",
                 "datefmt": "%Y-%m-%d %H:%M:%S",
-                #"()": 'esrally.actor.configure_utc_formatter'
+                # paraphrasing from 70a4bc8: If we use thespian directory functionality, we need to remove the callable formatter.
+                # A potential other solution would then be to enforce UTC timezones by setting the TZ env variable before we start
+                # the actor system.
+                "()": "esrally.actor.configure_utc_formatter"
             },
         },
         "filters": {
@@ -157,7 +157,7 @@ def configure_actor_logging():
         "handlers": {
             "rally_log_handler": {
                 "class": "logging.handlers.TimedRotatingFileHandler",
-                "filename": "%s/rally-actors.log" % log_dir,
+                "filename": "%s/rally-actor-messages.log" % log_dir,
                 "when": "midnight",
                 "backupCount": 14,
                 "encoding": "UTF-8",

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -127,18 +127,6 @@ class RallyActor(thespian.actors.Actor):
 
 
 # Defined on top-level to allow pickling
-class ActorLogFilter(logging.Filter):
-    def filter(self, log_record):
-        return "actorAddress" in log_record.__dict__
-
-
-# Defined on top-level to allow pickling
-class NotActorLogFilter(logging.Filter):
-    def filter(self, log_record):
-        return "actorAddress" not in log_record.__dict__
-
-
-# Defined on top-level to allow pickling
 def configure_utc_formatter(*args, **kwargs):
     formatter = logging.Formatter(fmt=kwargs["fmt"], datefmt=kwargs["datefmt"])
     formatter.converter = time.gmtime
@@ -160,19 +148,11 @@ def configure_actor_logging():
                 "datefmt": "%Y-%m-%d %H:%M:%S",
                 "()": configure_utc_formatter
             },
-            "actor": {
-                "fmt": "%(asctime)s,%(msecs)d PID:%(process)d %(name)s %(levelname)s %(actorAddress)s => %(message)s",
-                "datefmt": "%Y-%m-%d %H:%M:%S",
-                "()": configure_utc_formatter
-            }
         },
         "filters": {
             "isActorLog": {
-                "()": ActorLogFilter
+                "()": 'thespian.director.ActorAddressLogFilter'
             },
-            "notActorLog": {
-                "()": NotActorLogFilter
-            }
         },
         "handlers": {
             "rally_log_handler": {
@@ -182,22 +162,12 @@ def configure_actor_logging():
                 "backupCount": 14,
                 "encoding": "UTF-8",
                 "formatter": "normal",
-                "filters": ["notActorLog"],
-                "level": root_log_level
-            },
-            "actor_log_handler": {
-                "class": "logging.handlers.TimedRotatingFileHandler",
-                "filename": "%s/rally-actor-messages.log" % log_dir,
-                "when": "midnight",
-                "backupCount": 14,
-                "encoding": "UTF-8",
-                "formatter": "actor",
                 "filters": ["isActorLog"],
                 "level": root_log_level
-            }
+            },
         },
         "root": {
-            "handlers": ["rally_log_handler", "actor_log_handler"],
+            "handlers": ["rally_log_handler"],
             "level": root_log_level
         },
         "loggers": {

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -109,7 +109,7 @@ class RallyActor(thespian.actors.Actor):
         if self.is_current_status_expected(expected_status):
             logger.info("Transitioning from [%s] to [%s]." % (self.status, new_status))
             self.status = new_status
-            for m in self.children:
+            for m in filter(None, self.children):
                 self.send(m, msg)
         else:
             raise exceptions.RallyAssertionError("Received [%s] from [%s] but we are in status [%s] instead of [%s]." %

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -32,7 +32,7 @@ class BenchmarkCancelled:
     pass
 
 
-class RallyActor(thespian.actors.Actor):
+class RallyActor(thespian.actors.ActorTypeDispatcher):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         # allow to see a thread-dump on SIGQUIT

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -33,8 +33,8 @@ class BenchmarkCancelled:
 
 
 class RallyActor(thespian.actors.Actor):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
         # allow to see a thread-dump on SIGQUIT
         faulthandler.register(signal.SIGQUIT, file=sys.stderr)
         self.children = []

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -144,9 +144,9 @@ def configure_actor_logging():
         "version": 1,
         "formatters": {
             "normal": {
-                "fmt": "%(asctime)s,%(msecs)d PID:%(process)d %(name)s %(levelname)s %(message)s",
+                "format": "%(asctime)s,%(msecs)d %(actorAddress)s/PID:%(process)d %(name)s %(levelname)s %(message)s",
                 "datefmt": "%Y-%m-%d %H:%M:%S",
-                "()": configure_utc_formatter
+                #"()": 'esrally.actor.configure_utc_formatter'
             },
         },
         "filters": {

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -226,7 +226,7 @@ class MechanicActor(actor.RallyActor):
         self.cluster_launcher = None
         self.cluster = None
 
-    def receiveMessage(self, msg, sender):
+    def receiveUnrecognizedMessage(self, msg, sender):
         try:
             logger.info("MechanicActor#receiveMessage(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
             if isinstance(msg, StartEngine):
@@ -457,7 +457,7 @@ class NodeMechanicActor(actor.RallyActor):
         self.running = False
         self.host = None
 
-    def receiveMessage(self, msg, sender):
+    def receiveUnrecognizedMessage(self, msg, sender):
         # at the moment, we implement all message handling blocking. This is not ideal but simple to get started with. Besides, the caller
         # needs to block anyway. The only reason we implement mechanic as an actor is to distribute them.
         # noinspection PyBroadException
@@ -536,7 +536,7 @@ class NodeMechanicActor(actor.RallyActor):
         except BaseException as e:
             self.running = False
             logger.exception("Cannot process message [%s]" % msg)
-            self.send(sender, actor.BenchmarkFailure("Error on host %s" % str(self.host), e))
+            self.send(getattr(msg, "reply_to", sender), actor.BenchmarkFailure("Error on host %s" % str(self.host), e))
 
 
 #####################################################

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -500,16 +500,17 @@ class NodeMechanicActor(actor.RallyActor):
             ex_type, ex_value, ex_traceback = sys.exc_info()
             self.send(sender, actor.BenchmarkFailure(ex_value, traceback.format_exc()))
 
+    def receiveMsg_ApplyMetricsMetaInfo(self, msg, sender):
+        self.metrics_store.merge_meta_info(msg.meta_info)
+        self.send(sender, MetricsMetaInfoApplied())
+
     def receiveUnrecognizedMessage(self, msg, sender):
         # at the moment, we implement all message handling blocking. This is not ideal but simple to get started with. Besides, the caller
         # needs to block anyway. The only reason we implement mechanic as an actor is to distribute them.
         # noinspection PyBroadException
         try:
             logger.debug("NodeMechanicActor#receiveMessage(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
-            if isinstance(msg, ApplyMetricsMetaInfo):
-                self.metrics_store.merge_meta_info(msg.meta_info)
-                self.send(sender, MetricsMetaInfoApplied())
-            elif isinstance(msg, ResetRelativeTime):
+            if isinstance(msg, ResetRelativeTime):
                 logger.info("Resetting relative time of system metrics store on host [%s]." % self.host)
                 self.metrics_store.reset_relative_time()
             elif isinstance(msg, OnBenchmarkStart):

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -501,7 +501,7 @@ class NodeMechanicActor(actor.RallyActor):
             # avoid "can't pickle traceback objects"
             import traceback
             ex_type, ex_value, ex_traceback = sys.exc_info()
-            self.send(sender, actor.BenchmarkFailure(ex_value, traceback.format_exc()))
+            self.send(getattr(msg, "reply_to", sender), actor.BenchmarkFailure(ex_value, traceback.format_exc()))
 
     def receiveMsg_ApplyMetricsMetaInfo(self, msg, sender):
         self.metrics_store.merge_meta_info(msg.meta_info)

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -451,8 +451,8 @@ class Dispatcher(thespian.actors.ActorTypeDispatcher):
     def receiveUnrecognizedMessage(self, msg, sender):
         logger.info("mechanic.Dispatcher#receiveMessage unrecognized(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
 
-    # def receiveMsg_ChildActorExited ...
-    # def receiveMsg_PoisonMessage ...
+    def receiveMsg_PoisonMessage(self, msg, sender):
+        self.send(self.start_sender, actor.BenchmarkFailure(msg.details))
 
 
 class NodeMechanicActor(actor.RallyActor):

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -92,6 +92,11 @@ class BenchmarkActor(actor.RallyActor):
         self.mechanic = None
         self.main_driver = None
 
+    def receiveMsg_PoisonMessage(self, msg, sender):
+        logger.info("BenchmarkActor got notified of poison message [%s] (forwarding)." % (str(msg)))
+        self.error = True
+        self.send(self.start_sender, msg)
+
     def receiveUnrecognizedMessage(self, msg, sender):
         logger.info("BenchmarkActor received unknown message [%s] (ignoring)." % (str(msg)))
 
@@ -164,9 +169,7 @@ class BenchmarkActor(actor.RallyActor):
 
     def setup(self, msg, sender):
         self.start_sender = sender
-        self.mechanic = self.createActor(mechanic.MechanicActor,
-                                         #globalName="/rally/mechanic/coordinator",
-                                         targetActorRequirements={"coordinator": True})
+        self.mechanic = self.createActor(mechanic.MechanicActor, targetActorRequirements={"coordinator": True})
 
         self.cfg = msg.cfg
         # to load the track we need to know the correct cluster distribution version. Usually, this value should be set but there are rare
@@ -208,9 +211,7 @@ class BenchmarkActor(actor.RallyActor):
         self.metrics_store.lap = lap
         logger.info("Telling mechanic of benchmark start.")
         self.send(self.mechanic, mechanic.OnBenchmarkStart(lap))
-        self.main_driver = self.createActor(driver.DriverActor,
-                                            #globalName="/rally/driver/coordinator",
-                                            targetActorRequirements={"coordinator": True})
+        self.main_driver = self.createActor(driver.DriverActor, targetActorRequirements={"coordinator": True})
         logger.info("Telling driver to start benchmark.")
         self.send(self.main_driver, driver.StartBenchmark(self.cfg, self.race.track, self.metrics_store.meta_info, lap))
 


### PR DESCRIPTION
With this PR we improve the internal handling of actor messages in Rally in several ways:

* We switch to type-specific message dispatch which makes individual message handlers shorter.
* We leverage thespian's `PoisonMessage` mechanism in several places instead of handling exceptions ourselves.
* We add a new `Dispatcher` actor in the mechanic component to improve responsiveness and resiliency when remote actor system are not yet up (or disappearing midway)

Huge thanks go to @kquick who contributed this code (I have just integrated the changes with the latest Rally code base).