### PR TITLE
Fix misleading error message when gradle is present but jdk9 is not

### DIFF
--- a/esrally/config.py
+++ b/esrally/config.py
@@ -447,6 +447,7 @@ class ConfigFactory:
             # the Elasticsearch directory is just the last path component (relative to the source root directory)
             config["source"]["elasticsearch.src.subdir"] = io.basename(source_dir)
 
+        if gradle_bin:
             config["build"] = {}
             config["build"]["gradle.bin"] = gradle_bin
 


### PR DESCRIPTION
Currently when `esrally configure` is run, the gradle binary path is
persisted to rally.ini only if jdk9 is also installed.  However, when
`esrally` is run in benchmark_from_source mode (e.g., no args provided),
the gradle binary path in rally.ini is referenced before any jdk9 checks
take place -- leading to the following message:
`No value for mandatory configuration: section=build, key=gradle.bin`

This commit persists the gradle binary path to rally.ini whenever it exists,
allowing existing logic around jdk9 to emit a sensible error.

Fixes #423