### PR TITLE
Add a unique race id

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -11,6 +11,10 @@ Here is a typical metrics record::
 
     {
           "environment": "nightly",
+          "trial-timestamp": "20160421T042749Z",
+          "trial-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
+          "@timestamp": 1461213093093,
+          "relative-time": 10507328,
           "track": "geonames",
           "track-params": {
             "shard-count": 3
@@ -18,9 +22,6 @@ Here is a typical metrics record::
           "challenge": "append-no-conflicts",
           "car": "defaults",
           "sample-type": "normal",
-          "trial-timestamp": "20160421T042749Z",
-          "@timestamp": 1461213093093,
-          "relative-time": 10507328,
           "name": "throughput",
           "value": 27385,
           "unit": "docs/s",
@@ -38,7 +39,7 @@ Here is a typical metrics record::
             "node_name": "rally-node0",
             "source_revision": "a6c0a81",
             "distribution_version": "5.0.0-SNAPSHOT",
-            "tag_reference": "Github ticket 1234",
+            "tag_reference": "Github ticket 1234"
           }
         }
 
@@ -66,7 +67,12 @@ Rally runs warmup trials but records all samples. Normally, we are just interest
 trial-timestamp
 ~~~~~~~~~~~~~~~
 
-A constant timestamp (always in UTC) that is determined when Rally is invoked. It is intended to group all samples of a benchmark trial.
+A constant timestamp (always in UTC) that is determined when Rally is invoked.
+
+trial-id
+~~~~~~~~
+
+A UUID that changes on every invocation of Rally. It is intended to group all samples of a benchmark trial.
 
 @timestamp
 ~~~~~~~~~~

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -344,8 +344,8 @@ class Driver:
         car_name = self.config.opts("mechanic", "car.names")
 
         logger.info("Benchmark for track [%s], challenge [%s] and car %s is about to start." % (track_name, challenge_name, car_name))
-        invocation = self.config.opts("system", "time.start")
-        self.metrics_store.open(invocation, track_name, challenge_name, car_name)
+        trial_timestamp = self.config.opts("system", "time.start")
+        self.metrics_store.open(trial_timestamp, track_name, challenge_name, car_name)
 
         allocator = Allocator(self.challenge.schedule)
         self.allocations = allocator.allocations

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -326,9 +326,12 @@ class Driver:
         self.challenge = select_challenge(self.config, self.track)
         self.quiet = self.config.opts("system", "quiet.mode", mandatory=False, default_value=False)
         self.throughput_calculator = ThroughputCalculator()
-        # create - but do not yet open - the metrics store as an internal timer starts when we open it.
-        cls = metrics.metrics_store_class(self.config)
-        self.metrics_store = cls(cfg=self.config, meta_info=metrics_meta_info, lap=lap)
+        self.metrics_store = metrics.metrics_store(cfg=self.config,
+                                                   track=self.track.name,
+                                                   challenge=self.challenge.name,
+                                                   meta_info=metrics_meta_info,
+                                                   lap=lap,
+                                                   read_only=False)
         for host in self.config.opts("driver", "load_driver_hosts"):
             if host != "localhost":
                 self.load_driver_hosts.append(net.resolve(host))
@@ -339,13 +342,9 @@ class Driver:
         self.target.on_prepare_track(preps, self.config, self.track)
 
     def after_track_prepared(self):
-        track_name = self.track.name
-        challenge_name = self.challenge.name
-        car_name = self.config.opts("mechanic", "car.names")
-
-        logger.info("Benchmark for track [%s], challenge [%s] and car %s is about to start." % (track_name, challenge_name, car_name))
-        trial_timestamp = self.config.opts("system", "time.start")
-        self.metrics_store.open(trial_timestamp, track_name, challenge_name, car_name)
+        logger.info("Benchmark is about to start.")
+        # ensure relative time starts when the benchmark starts.
+        self.reset_relative_time()
 
         allocator = Allocator(self.challenge.schedule)
         self.allocations = allocator.allocations

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -190,7 +190,7 @@ class MetaInfoScope(Enum):
     """
 
 
-def metrics_store(cfg, read_only=True, invocation=None, track=None, challenge=None, car=None):
+def metrics_store(cfg, read_only=True, track=None, challenge=None, car=None):
     """
     Creates a proper metrics store based on the current configuration.
 
@@ -202,10 +202,10 @@ def metrics_store(cfg, read_only=True, invocation=None, track=None, challenge=No
     store = cls(cfg)
     logger.info("Creating %s" % str(store))
 
-    selected_invocation = cfg.opts("system", "time.start") if invocation is None else invocation
+    invocation = cfg.opts("system", "time.start")
     selected_car = cfg.opts("mechanic", "car.names") if car is None else car
 
-    store.open(selected_invocation, track, challenge, selected_car, create=not read_only)
+    store.open(invocation, track, challenge, selected_car, create=not read_only)
     return store
 
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -5,6 +5,7 @@ import logging.handlers
 import os
 import sys
 import time
+import uuid
 import faulthandler
 import signal
 
@@ -666,6 +667,7 @@ def main():
         cfg.add(config.Scope.application, "system", "time.start.user_provided", False)
 
     cfg.add(config.Scope.applicationOverride, "system", "quiet.mode", args.quiet)
+    cfg.add(config.Scope.applicationOverride, "system", "trial.id", str(uuid.uuid4()))
 
     # per node?
     cfg.add(config.Scope.applicationOverride, "system", "offline.mode", args.offline)

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -543,8 +543,8 @@ class ComparisonReporter:
         self.plain = False
 
     def report(self, r1, r2):
-        logger.info("Generating comparison report for baseline (invocation=[%s], track=[%s], challenge=[%s], car=[%s]) and "
-                    "contender (invocation=[%s], track=[%s], challenge=[%s], car=[%s])" %
+        logger.info("Generating comparison report for baseline (trial timestamp=[%s], track=[%s], challenge=[%s], car=[%s]) and "
+                    "contender (trial timestamp=[%s], track=[%s], challenge=[%s], car=[%s])" %
                     (r1.trial_timestamp, r1.track, r1.challenge, r1.car,
                      r2.trial_timestamp, r2.track, r2.challenge, r2.car))
         # we don't verify anything about the races as it is possible that the user benchmarks two different tracks intentionally

--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -32,6 +32,9 @@
         "relative-time": {
           "type": "long"
         },
+        "trial-id": {
+          "type": "keyword"
+        },
         "trial-timestamp": {
           "type": "date",
           "format": "basic_date_time_no_millis",

--- a/esrally/resources/races-template.json
+++ b/esrally/resources/races-template.json
@@ -25,6 +25,9 @@
         "enabled": true
       },
       "properties": {
+        "trial-id": {
+          "type": "keyword"
+        },
         "trial-timestamp": {
           "type": "date",
           "format": "basic_date_time_no_millis",

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -25,6 +25,9 @@
         "enabled": true
       },
       "properties": {
+        "trial-id": {
+          "type": "keyword"
+        },
         "trial-timestamp": {
           "type": "date",
           "format": "basic_date_time_no_millis",

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -57,6 +57,7 @@ class DriverTests(TestCase):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
         self.cfg.add(config.Scope.application, "system", "time.start", datetime(year=2017, month=8, day=20, hour=1, minute=0, second=0))
+        self.cfg.add(config.Scope.application, "system", "trial.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
         self.cfg.add(config.Scope.application, "track", "challenge.name", "default")
         self.cfg.add(config.Scope.application, "track", "params", {})
         self.cfg.add(config.Scope.application, "track", "test.mode.enabled", True)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -167,6 +167,7 @@ class EsClientTests(TestCase):
 
 class EsMetricsTests(TestCase):
     TRIAL_TIMESTAMP = datetime.datetime(2016, 1, 31)
+    TRIAL_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
     def setUp(self):
         self.cfg = config.Config()
@@ -182,12 +183,13 @@ class EsMetricsTests(TestCase):
 
     def test_put_value_without_meta_info(self):
         throughput = 5000
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append", "defaults", create=True)
         self.metrics_store.lap = 1
 
         self.metrics_store.put_count_cluster_level("indexing_throughput", throughput, "docs/s")
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
+            "trial-id": EsMetricsTests.TRIAL_ID,
             "trial-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
@@ -197,7 +199,7 @@ class EsMetricsTests(TestCase):
                 "shard-count": 3
             },
             "lap": 1,
-            "challenge": "append-no-conflicts",
+            "challenge": "append",
             "car": "defaults",
             "name": "indexing_throughput",
             "value": throughput,
@@ -211,13 +213,14 @@ class EsMetricsTests(TestCase):
 
     def test_put_value_with_explicit_timestamps(self):
         throughput = 5000
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append", "defaults", create=True)
         self.metrics_store.lap = 1
 
         self.metrics_store.put_count_cluster_level(name="indexing_throughput", count=throughput, unit="docs/s",
                                                    absolute_time=0, relative_time=10)
         expected_doc = {
             "@timestamp": 0,
+            "trial-id": EsMetricsTests.TRIAL_ID,
             "trial-timestamp": "20160131T000000Z",
             "relative-time": 10000000,
             "environment": "unittest",
@@ -227,7 +230,7 @@ class EsMetricsTests(TestCase):
                 "shard-count": 3
             },
             "lap": 1,
-            "challenge": "append-no-conflicts",
+            "challenge": "append",
             "car": "defaults",
             "name": "indexing_throughput",
             "value": throughput,
@@ -243,7 +246,7 @@ class EsMetricsTests(TestCase):
         throughput = 5000
         # add a user-defined tag
         self.cfg.add(config.Scope.application, "race", "user.tag", "intention:testing,disk_type:hdd")
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append", "defaults", create=True)
         self.metrics_store.lap = 1
 
         # Ensure we also merge in cluster level meta info
@@ -257,6 +260,7 @@ class EsMetricsTests(TestCase):
         self.metrics_store.put_value_node_level("node0", "indexing_throughput", throughput, "docs/s")
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
+            "trial-id": EsMetricsTests.TRIAL_ID,
             "trial-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
@@ -266,7 +270,7 @@ class EsMetricsTests(TestCase):
                 "shard-count": 3
             },
             "lap": 1,
-            "challenge": "append-no-conflicts",
+            "challenge": "append",
             "car": "defaults",
             "name": "indexing_throughput",
             "value": throughput,
@@ -301,7 +305,7 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
@@ -309,27 +313,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-timestamp": "20160131T000000Z"
-                            }
-                        },
-                        {
-                            "term": {
-                                "environment": "unittest"
-                            }
-                        },
-                        {
-                            "term": {
-                                "track": "test"
-                            }
-                        },
-                        {
-                            "term": {
-                                "challenge": "append-no-conflicts"
-                            }
-                        },
-                        {
-                            "term": {
-                                "car": "defaults"
+                                "trial-id": EsMetricsTests.TRIAL_ID
                             }
                         },
                         {
@@ -369,7 +353,7 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
@@ -377,27 +361,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-timestamp": "20160131T000000Z"
-                            }
-                        },
-                        {
-                            "term": {
-                                "environment": "unittest"
-                            }
-                        },
-                        {
-                            "term": {
-                                "track": "test"
-                            }
-                        },
-                        {
-                            "term": {
-                                "challenge": "append-no-conflicts"
-                            }
-                        },
-                        {
-                            "term": {
-                                "car": "defaults"
+                                "trial-id": EsMetricsTests.TRIAL_ID
                             }
                         },
                         {
@@ -523,7 +487,7 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
@@ -531,27 +495,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-timestamp": "20160131T000000Z"
-                            }
-                        },
-                        {
-                            "term": {
-                                "environment": "unittest"
-                            }
-                        },
-                        {
-                            "term": {
-                                "track": "test"
-                            }
-                        },
-                        {
-                            "term": {
-                                "challenge": "append-no-conflicts"
-                            }
-                        },
-                        {
-                            "term": {
-                                "car": "defaults"
+                                "trial-id": EsMetricsTests.TRIAL_ID
                             }
                         },
                         {
@@ -589,6 +533,7 @@ class EsMetricsTests(TestCase):
 
 class EsRaceStoreTests(TestCase):
     TRIAL_TIMESTAMP = datetime.datetime(2016, 1, 31)
+    TRIAL_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
     class DictHolder:
         def __init__(self, d):
@@ -617,7 +562,8 @@ class EsRaceStoreTests(TestCase):
                         indices=[track.Index(name="tests", types=["test-type"])],
                         challenges=[track.Challenge(name="index", default=True, schedule=schedule)])
 
-        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", trial_timestamp=EsRaceStoreTests.TRIAL_TIMESTAMP,
+        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", trial_id=EsRaceStoreTests.TRIAL_ID,
+                            trial_timestamp=EsRaceStoreTests.TRIAL_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params={"shard-count": 3},
                             challenge=t.default_challenge, car="4gheap",
                             total_laps=12,
@@ -653,6 +599,7 @@ class EsRaceStoreTests(TestCase):
         expected_doc = {
             "rally-version": "0.4.4",
             "environment": "unittest",
+            "trial-id": EsRaceStoreTests.TRIAL_ID,
             "trial-timestamp": "20160131T000000Z",
             "pipeline": "from-sources",
             "user-tags": {
@@ -697,6 +644,7 @@ class EsRaceStoreTests(TestCase):
 
 class EsResultsStoreTests(TestCase):
     TRIAL_TIMESTAMP = datetime.datetime(2016, 1, 31)
+    TRIAL_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
     def setUp(self):
         self.cfg = config.Config()
@@ -727,7 +675,8 @@ class EsResultsStoreTests(TestCase):
         node = c.add_node("localhost", "rally-node-0")
         node.plugins.append("x-pack")
 
-        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", trial_timestamp=EsResultsStoreTests.TRIAL_TIMESTAMP,
+        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", trial_id=EsResultsStoreTests.TRIAL_ID,
+                            trial_timestamp=EsResultsStoreTests.TRIAL_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params=None,
                             challenge=t.default_challenge, car="4gheap",
                             total_laps=12,
@@ -764,6 +713,7 @@ class EsResultsStoreTests(TestCase):
             {
                 "rally-version": "0.4.4",
                 "environment": "unittest",
+                "trial-id": EsResultsStoreTests.TRIAL_ID,
                 "trial-timestamp": "20160131T000000Z",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
@@ -784,6 +734,7 @@ class EsResultsStoreTests(TestCase):
             {
                 "rally-version": "0.4.4",
                 "environment": "unittest",
+                "trial-id": EsResultsStoreTests.TRIAL_ID,
                 "trial-timestamp": "20160131T000000Z",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
@@ -805,6 +756,7 @@ class EsResultsStoreTests(TestCase):
             {
                 "rally-version": "0.4.4",
                 "environment": "unittest",
+                "trial-id": EsResultsStoreTests.TRIAL_ID,
                 "trial-timestamp": "20160131T000000Z",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
@@ -830,6 +782,7 @@ class EsResultsStoreTests(TestCase):
             {
                 "rally-version": "0.4.4",
                 "environment": "unittest",
+                "trial-id": EsResultsStoreTests.TRIAL_ID,
                 "trial-timestamp": "20160131T000000Z",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
@@ -852,6 +805,9 @@ class EsResultsStoreTests(TestCase):
 
 
 class InMemoryMetricsStoreTests(TestCase):
+    TRIAL_TIMESTAMP = datetime.datetime(2016, 1, 31)
+    TRIAL_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
+
     def setUp(self):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
@@ -864,7 +820,8 @@ class InMemoryMetricsStoreTests(TestCase):
 
     def test_get_value(self):
         throughput = 5000
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.lap = 1
         self.metrics_store.put_count_cluster_level("indexing_throughput", 1, "docs/s", sample_type=metrics.SampleType.Warmup)
         self.metrics_store.put_count_cluster_level("indexing_throughput", throughput, "docs/s")
@@ -872,20 +829,23 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults")
 
         self.assertEqual(1, self.metrics_store.get_one("indexing_throughput", sample_type=metrics.SampleType.Warmup))
         self.assertEqual(throughput, self.metrics_store.get_one("indexing_throughput", sample_type=metrics.SampleType.Normal))
 
     def test_get_percentile(self):
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.lap = 1
         for i in range(1, 1001):
             self.metrics_store.put_value_cluster_level("query_latency", float(i), "ms")
 
         self.metrics_store.close()
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults")
 
         self.assert_equal_percentiles("query_latency", [100.0], {100.0: 1000.0})
         self.assert_equal_percentiles("query_latency", [99.0], {99.0: 990.0})
@@ -895,14 +855,16 @@ class InMemoryMetricsStoreTests(TestCase):
         self.assert_equal_percentiles("query_latency", [99, 99.9, 100], {99: 990.0, 99.9: 999.0, 100: 1000.0})
 
     def test_get_median(self):
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.lap = 1
         for i in range(1, 1001):
             self.metrics_store.put_value_cluster_level("query_latency", float(i), "ms")
 
         self.metrics_store.close()
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults")
 
         self.assertAlmostEqual(500.5, self.metrics_store.get_median("query_latency", lap=1))
 
@@ -914,7 +876,8 @@ class InMemoryMetricsStoreTests(TestCase):
                                    msg=str(percentile) + "th percentile differs")
 
     def test_externalize_and_bulk_add(self):
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.lap = 1
         self.metrics_store.put_count_cluster_level("final_index_size", 1000, "GB")
 
@@ -932,7 +895,8 @@ class InMemoryMetricsStoreTests(TestCase):
         self.assertEqual(1000, self.metrics_store.get_one("final_index_size"))
 
     def test_meta_data_per_document(self):
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.lap = 1
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "cluster-name", "test")
 
@@ -955,16 +919,19 @@ class InMemoryMetricsStoreTests(TestCase):
         }, self.metrics_store.docs[1]["meta"])
 
     def test_get_error_rate_zero_without_samples(self):
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.lap = 1
         self.metrics_store.close()
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults")
 
         self.assertEqual(0.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal))
 
     def test_get_error_rate_by_sample_type(self):
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.lap = 1
         self.metrics_store.put_value_cluster_level("service_time", 3.0, "ms", task="term-query", sample_type=metrics.SampleType.Warmup,
                                                    meta_data={"success": False})
@@ -973,13 +940,15 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults")
 
         self.assertEqual(1.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Warmup))
         self.assertEqual(0.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal))
 
     def test_get_error_rate_mixed(self):
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults", create=True)
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.lap = 1
         self.metrics_store.put_value_cluster_level("service_time", 3.0, "ms", task="term-query", sample_type=metrics.SampleType.Normal,
                                                    meta_data={"success": True})
@@ -994,7 +963,8 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+                                "test", "append-no-conflicts", "defaults")
 
         self.assertEqual(0.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Warmup))
         self.assertEqual(0.2, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal))
@@ -1002,6 +972,7 @@ class InMemoryMetricsStoreTests(TestCase):
 
 class FileRaceStoreTests(TestCase):
     TRIAL_TIMESTAMP = datetime.datetime(2016, 1, 31)
+    TRIAL_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
     class DictHolder:
         def __init__(self, d):
@@ -1030,7 +1001,8 @@ class FileRaceStoreTests(TestCase):
                         indices=[track.Index(name="tests", types=["test-type"])],
                         challenges=[track.Challenge(name="index", default=True, schedule=schedule)])
 
-        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", trial_timestamp=FileRaceStoreTests.TRIAL_TIMESTAMP,
+        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", trial_id=FileRaceStoreTests.TRIAL_ID,
+                            trial_timestamp=FileRaceStoreTests.TRIAL_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params={"clients": 12},
                             challenge=t.default_challenge, car="4gheap",
                             total_laps=12,

--- a/tests/reporter_test.py
+++ b/tests/reporter_test.py
@@ -10,6 +10,7 @@ class StatsCalculatorTests(TestCase):
         cfg = config.Config()
         cfg.add(config.Scope.application, "system", "env.name", "unittest")
         cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.now())
+        cfg.add(config.Scope.application, "system", "trial.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
         cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")
         cfg.add(config.Scope.application, "mechanic", "car.names", ["unittest_car"])
         cfg.add(config.Scope.application, "race", "laps", 1)


### PR DESCRIPTION
With this commit we add a new property 'trial-id' in addition to
'trial-timestamp'. The main reason for this change is that we set the
same effective start date in some environments. If we run the same
combination of track/challenge/car but use track-params or team-params,
Rally will mix up results. If we use a unique id per race, this cannot
happen.

Closes #431