### PR TITLE
Remove Python faulthandler

### DIFF
--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -1,7 +1,4 @@
-import faulthandler
 import logging
-import signal
-import sys
 import time
 import os
 
@@ -35,8 +32,6 @@ class BenchmarkCancelled:
 class RallyActor(thespian.actors.ActorTypeDispatcher):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
-        # allow to see a thread-dump on SIGQUIT
-        faulthandler.register(signal.SIGQUIT, file=sys.stderr)
         self.children = []
         self.received_responses = []
         self.status = None

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -5,8 +5,6 @@ import logging.handlers
 import os
 import sys
 import time
-import faulthandler
-import signal
 
 from esrally import version, actor, config, paths, racecontrol, reporter, metrics, track, chart_generator, exceptions, time as rtime
 from esrally import PROGRAM_NAME, DOC_LINK, BANNER, SKULL, check_python_version
@@ -644,8 +642,6 @@ def main():
 
     # Early init of console output so we start to show everything consistently.
     console.init(quiet=False)
-    # allow to see a thread-dump on SIGQUIT
-    faulthandler.register(signal.SIGQUIT, file=sys.stderr)
 
     pre_configure_logging()
     arg_parser = create_arg_parser()


### PR DESCRIPTION
With this commit we remove the faulthandler code from Rally and all
Rally actors. Originally it was meant to get diagnostic information on
SIGQUIT. However, we can instead use gdb and the py-bt helper in order
to get the same information more reliably.