### PR TITLE
Bump pytest* versions and beautify make test output

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = --verbose --color=yes
+testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ install_requires = [
 ]
 
 tests_require = [
-    "pytest==3.0.6",
-    "pytest-benchmark==3.0.0"
+    "pytest==3.4.2",
+    "pytest-benchmark==3.1.1"
 ]
 
 # we call the tool rally, but it will be published as esrally on pypi


### PR DESCRIPTION
Take advantage of the colored and verbose output options of newer
versions of pytest to make the output of `make test`/`make
coverage`/`make benchmark` easier to follow.

Also bump pytest to the latest version to support progress
percentage[1]. While at it, also bump pytest-benchmark to the latest
version.

With these changes `make test` looks like:

![image](https://user-images.githubusercontent.com/1754575/37245885-a147fa66-24a7-11e8-8b4d-6a5dc4d8f65b.png)

as opposed to the current output looking like:

![image](https://user-images.githubusercontent.com/1754575/37245878-83cd6dea-24a7-11e8-8c4c-4b2453180984.png)

[1]
https://docs.pytest.org/en/latest/changelog.html#pytest-3-3-0-2017-11-23