### PR TITLE
Allow to pass parameters via a file

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -74,7 +74,7 @@ Selects the track that Rally should run. By default the ``geonames`` track is ru
 
 With this parameter you can inject variables into tracks. The supported variables depend on the track and you should check the track JSON file to see which variables can be provided.
 
-It accepts a list of comma-separated key-value pairs. The key-value pairs have to be delimited by a colon.
+It accepts a list of comma-separated key-value pairs or a JSON file name. The key-value pairs have to be delimited by a colon.
 
 **Examples**:
 
@@ -106,6 +106,14 @@ When we run this track, we can override these defaults:
 
 * ``--track-params="replica_count:1,shard_count:3"`` will set the number of replicas to 1 and the number of shards to 3.
 * ``--track-params="replica_count:1"`` will just set the number of replicas to 1 and just keep the default value of 5 shards.
+* ``--track-params="params.json"`` will read the track parameters from a JSON file (defined below)
+
+Example JSON file::
+
+   {
+      "replica_count": 1,
+      "shard_count": 3
+   }
 
 All track parameters are recorded for each metrics record in the metrics store. Also, when you run ``esrally list races``, it will show all track parameters::
 
@@ -167,7 +175,7 @@ Rally will configure Elasticsearch with 4GB of heap (``4gheap``) and enable Java
 ``car-params``
 ~~~~~~~~~~~~~~
 
-Allows to override config variables of Elasticsearch.
+Allows to override config variables of Elasticsearch. It accepts a list of comma-separated key-value pairs or a JSON file name. The key-value pairs have to be delimited by a colon.
 
 **Example**
 
@@ -175,7 +183,7 @@ Allows to override config variables of Elasticsearch.
 
    esrally --car="4gheap" --car-params="data_paths:'/opt/elasticsearch'"
 
-The variables that are exposed depend on the `car's configuration <https://github.com/elastic/rally-teams/tree/master/cars>`__. In addition, Rally implements special handling for the variable ``data_paths`` (by default the values for variable is determined by Rally).
+The variables that are exposed depend on the `car's configuration <https://github.com/elastic/rally-teams/tree/master/cars>`__. In addition, Rally implements special handling for the variable ``data_paths`` (by default the value for this variable is determined by Rally).
 
 
 ``elasticsearch-plugins``
@@ -192,7 +200,7 @@ In this example, Rally will install the ``analysis-icu`` plugin and the ``x-pack
 ``plugin-params``
 ~~~~~~~~~~~~~~~~~
 
-Allows to override variables of Elasticsearch plugins.
+Allows to override variables of Elasticsearch plugins. It accepts a list of comma-separated key-value pairs or a JSON file name. The key-value pairs have to be delimited by a colon.
 
 Example::
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -6,6 +6,7 @@ import os
 import sys
 import time
 import uuid
+import json
 
 from esrally import version, actor, config, paths, racecontrol, reporter, metrics, track, chart_generator, exceptions, time as rtime
 from esrally import PROGRAM_NAME, DOC_LINK, BANNER, SKULL, check_python_version
@@ -589,7 +590,6 @@ def dispatch_sub_command(cfg, sub_command):
 
 def to_dict(arg):
     if io.has_extension(arg, ".json"):
-        import json
         with open(io.normalize_path(arg), mode="rt", encoding="utf-8") as f:
             return json.load(f)
     else:

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -587,6 +587,15 @@ def dispatch_sub_command(cfg, sub_command):
         return False
 
 
+def to_dict(arg):
+    if io.has_extension(arg, ".json"):
+        import json
+        with open(io.normalize_path(arg), mode="rt", encoding="utf-8") as f:
+            return json.load(f)
+    else:
+        return kv_to_map(csv_to_list(arg))
+
+
 def csv_to_list(csv):
     if csv is None:
         return None
@@ -684,8 +693,8 @@ def main():
     else:
         cfg.add(config.Scope.applicationOverride, "mechanic", "repository.name", args.team_repository)
     cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", csv_to_list(args.elasticsearch_plugins))
-    cfg.add(config.Scope.applicationOverride, "mechanic", "car.params", kv_to_map(csv_to_list(args.car_params)))
-    cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", kv_to_map(csv_to_list(args.plugin_params)))
+    cfg.add(config.Scope.applicationOverride, "mechanic", "car.params", to_dict(args.car_params))
+    cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", to_dict(args.plugin_params))
     if args.keep_cluster_running:
         cfg.add(config.Scope.applicationOverride, "mechanic", "keep.running", True)
         # force-preserve the cluster nodes.
@@ -715,7 +724,7 @@ def main():
         chosen_track = args.track if args.track else "geonames"
         cfg.add(config.Scope.applicationOverride, "track", "track.name", chosen_track)
 
-    cfg.add(config.Scope.applicationOverride, "track", "params", kv_to_map(csv_to_list(args.track_params)))
+    cfg.add(config.Scope.applicationOverride, "track", "params", to_dict(args.track_params))
     cfg.add(config.Scope.applicationOverride, "track", "challenge.name", args.challenge)
     cfg.add(config.Scope.applicationOverride, "track", "include.tasks", csv_to_list(args.include_tasks))
     cfg.add(config.Scope.applicationOverride, "track", "test.mode.enabled", args.test_mode)


### PR DESCRIPTION
Previously we allowed users to pass track, car and plugin parameters via
a list of key-value pairs. While this covers a lot of use cases, we can
give users even more flexibility by letting them provide a file to
Rally. This allows users to pass also nested structures which is e.g.
handy to specify index settings.