### PR TITLE
Fix venv detection with venv and Rally execution on non master

### DIFF
--- a/rally
+++ b/rally
@@ -27,3 +27,4 @@ __RALLY_INTERNAL_BINARY_NAME="esrally"
 __RALLY_INTERNAL_HUMAN_NAME="Rally"
 
 source run.sh
+

--- a/run.sh
+++ b/run.sh
@@ -11,13 +11,33 @@
 readonly BINARY_NAME="${__RALLY_INTERNAL_BINARY_NAME}"
 readonly HUMAN_NAME="${__RALLY_INTERNAL_HUMAN_NAME}"
 
+function install_esrally_with_setuptools() {
+    # Check if optional parameter with Rally binary path, points to an existing executable file.
+    if [[ -n $1 ]]; then
+     if [[ -f $1 && -x $1 ]]; then return; fi
+    fi
+
+    if [[ ${IN_VIRTUALENV} == 0 ]]; then
+        python3 setup.py -q develop --user
+    else
+        python3 setup.py -q develop
+    fi
+}
+
 # Attempt to update Rally itself by default but allow user to skip it.
 SELF_UPDATE=YES
 # Assume that the "main remote" is called "origin"
 REMOTE="origin"
 
 # While we could also check via the presence of `VIRTUAL_ENV` this is a bit more reliable.
-python3 -c 'import sys; print(sys.real_prefix)' >/dev/null 2>&1 && IN_VIRTUALENV=1 || IN_VIRTUALENV=0
+# Check for both pyvenv and normal venv environments
+# https://legacy.python.org/dev/peps/pep-0405/
+if python3 -c 'import sys; sys.exit(0) if ".pyenv" in sys.base_prefix else exit(0) if hasattr(sys,"real_path") else exit(1)' >/dev/null 2>&1
+then
+    IN_VIRTUALENV=1
+else
+    IN_VIRTUALENV=0
+fi
 
 # Check for parameters that are intended for this script. Note that they only work if they're specified at the beginning (due to how
 # the shell builtin `shift` works. We could make it work for arbitrary positions but that's not worth the complexity for such an
@@ -45,7 +65,7 @@ case ${i} in
 esac
 done
 
-if [ ${SELF_UPDATE} == YES ]
+if [[ $SELF_UPDATE == YES ]]
 then
     # see http://unix.stackexchange.com/a/155077
     if output=$(git status --porcelain) && [ -z "$output" ] && on_master=$(git rev-parse --abbrev-ref HEAD) && [ "$on_master" == "master" ]
@@ -56,17 +76,11 @@ then
       git fetch ${REMOTE} --quiet >/dev/null 2>&1
       exit_code=$?
       set -e
-      if [ ${exit_code} == 0 ]
+      if [[ $exit_code == 0 ]]
       then
         echo "Auto-updating Rally from ${REMOTE}"
         git rebase ${REMOTE}/master --quiet
-        # if we're running in a virtualenv then the --user prefix is not defined (and makes no sense)
-        if [ ${IN_VIRTUALENV} == 0 ]
-        then
-            python3 setup.py -q develop --user
-        else
-            python3 setup.py -q develop
-        fi
+        install_esrally_with_setuptools
       #else
       # offline - skipping update
       fi
@@ -85,16 +99,18 @@ export THESPLOG_FILE_MAXSIZE=${THESPLOG_FILE_MAXSIZE:-204800}
 
 # Provide a consistent binary name to the user and hide the fact that we call another binary under the hood.
 export RALLY_ALTERNATIVE_BINARY_NAME=$(basename "$0")
-if [ ${IN_VIRTUALENV} == 0 ]
+if [[ $IN_VIRTUALENV == 0 ]]
 then
     RALLY_ROOT=$(python3 -c "import site; print(site.USER_BASE)")
     RALLY_BIN=${RALLY_ROOT}/bin/${BINARY_NAME}
-    if [ -x "$RALLY_BIN" ]
-    then
+    install_esrally_with_setuptools "${RALLY_BIN}"
+    if [[ -x $RALLY_BIN ]]; then
         ${RALLY_BIN} "$@"
     else
         echo "Cannot execute ${HUMAN_NAME} in ${RALLY_BIN}."
     fi
 else
+    install_esrally_with_setuptools "${BINARY_NAME}"
+
     ${BINARY_NAME} "$@"
 fi

--- a/run.sh
+++ b/run.sh
@@ -31,8 +31,8 @@ REMOTE="origin"
 
 # While we could also check via the presence of `VIRTUAL_ENV` this is a bit more reliable.
 # Check for both pyvenv and normal venv environments
-# https://legacy.python.org/dev/peps/pep-0405/
-if python3 -c 'import sys; sys.exit(0) if ".pyenv" in sys.base_prefix else exit(0) if hasattr(sys,"real_path") else exit(1)' >/dev/null 2>&1
+# https://www.python.org/dev/peps/pep-0405/
+if python3 -c 'import os, sys; sys.exit(0) if "VIRTUAL_ENV" in os.environ else sys.exit(1)' >/dev/null 2>&1
 then
     IN_VIRTUALENV=1
 else


### PR DESCRIPTION
This commit fixes two issues. Firstly, let `./rally` start when
executed for the first time with self update disabled (e.g. from a non
master branch in a fork) by ensuring the `esrally` binary has been
installed with setuptools.

Secondly, fix virtualenv detection when pyenv is in use. On some
configurations when pyenv is present, creating a Python3 virtualenv
uses pyvenv instead of Python3's own virtualenv[1] which fails the
current check for a virtualenv in the `run.sh` script.

[1] https://legacy.python.org/dev/peps/pep-0405/

Closes #447
Closes #448