### PR TITLE
Require java-10 to build Elasticsearch from source

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -66,7 +66,7 @@ As you can see above, Rally autodetects if git, Gradle and a JDK are installed. 
 
 As you can see, Rally tells you that you cannot build Elasticsearch from sources but you can still benchmark official binary distributions.
 
-It's also possible that Rally cannot automatically find your JDK 8 or JDK 9 home directory. In that case, it will ask you later in the configuration process. If you do not provide a JDK home directory, Rally cannot start Elasticsearch on this machine but you can still use it as a load generator to :doc:`benchmark remote clusters </recipes>`.
+It's also possible that Rally cannot automatically find your JDK 8 or JDK 10 home directory. In that case, it will ask you later in the configuration process. If you do not provide a JDK home directory, Rally cannot start Elasticsearch on this machine but you can still use it as a load generator to :doc:`benchmark remote clusters </recipes>`.
 
 After running the initial detection, Rally will try to autodetect your Elasticsearch project directory (either in the current directory or in ``../elasticsearch``) or will choose a default directory::
 
@@ -122,7 +122,7 @@ Rally will ask you a few more things in the advanced setup:
 
 * **Benchmark data directory**: Rally stores all benchmark related data in this directory which can take up to several tens of GB. If you want to use a dedicated partition, you can specify a different data directory here.
 * **Elasticsearch project directory**: This is the directory where the Elasticsearch sources are located. If you don't actively develop on Elasticsearch you can just leave the default but if you want to benchmark local changes you should point Rally to your project directory. Note that Rally will run builds with Gradle in this directory (it runs ``gradle clean`` and ``gradle :distribution:tar:assemble``).
-* **JDK root directory**: Rally will only ask this if it could not autodetect the JDK home by itself. Just enter the root directory of the JDK you want to use. By default, Rally will choose Java 8 if available and fallback to Java 9.
+* **JDK root directory**: Rally will only ask this if it could not autodetect the JDK home by itself. Just enter the root directory of the JDK you want to use. By default, Rally will choose Java 8 if available and fallback to Java 10.
 * **Metrics store type**: You can choose between ``in-memory`` which requires no additional setup or ``elasticsearch`` which requires that you start a dedicated Elasticsearch instance to store metrics but gives you much more flexibility to analyse results.
 * **Metrics store settings** (only for metrics store type ``elasticsearch``): Provide the connection details to the Elasticsearch metrics store. This should be an instance that you use just for Rally but it can be a rather small one. A single node cluster with default setting should do it. When using self-signed certificates on the Elasticsearch metrics store, certificate verification can be turned off by setting the ``datastore.ssl.verification_mode`` setting to ``none``. Alternatively you can enter the path to the certificate authority's signing certificate in ``datastore.ssl.certificate_authorities``. Both settings are optional.
 * **Name for this benchmark environment** (only for metrics store type ``elasticsearch``): You can use the same metrics store for multiple environments (e.g. local, continuous integration etc.) so you can separate metrics from different environments by choosing a different name.

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -27,9 +27,9 @@ def create(cfg, sources, distribution, build, challenge_root_path, plugins):
 
     if build_needed:
         gradle = cfg.opts("build", "gradle.bin")
-        java9_home = _java9_home(cfg)
+        java10_home = _java10_home(cfg)
         es_src_dir = os.path.join(_src_dir(cfg), _config_value(src_config, "elasticsearch.src.subdir"))
-        builder = Builder(es_src_dir, gradle, java9_home, challenge_root_path)
+        builder = Builder(es_src_dir, gradle, java10_home, challenge_root_path)
     else:
         builder = None
 
@@ -68,14 +68,14 @@ def create(cfg, sources, distribution, build, challenge_root_path, plugins):
     return CompositeSupplier(suppliers)
 
 
-def _java9_home(cfg):
+def _java10_home(cfg):
     from esrally import config
     try:
-        return cfg.opts("runtime", "java9.home")
+        return cfg.opts("runtime", "java10.home")
     except config.ConfigError:
-        logger.exception("Cannot determine Java 9 home.")
-        raise exceptions.SystemSetupError("No JDK 9 is configured. You cannot benchmark source builds of Elasticsearch on this machine. "
-                                          "Please install a JDK 9 and reconfigure Rally with %s configure" % PROGRAM_NAME)
+        logger.exception("Cannot determine Java 10 home.")
+        raise exceptions.SystemSetupError("No JDK 10 is configured. You cannot benchmark source builds of Elasticsearch on this machine. "
+                                          "Please install a JDK 10 and reconfigure Rally with %s configure" % PROGRAM_NAME)
 
 
 def _required_version(version):
@@ -427,13 +427,6 @@ class SourceRepository:
 
 
 class Builder:
-    # Tested with Gradle 4.1 on Java 9-ea+161
-    JAVA_9_GRADLE_OPTS = "--add-opens=java.base/java.io=ALL-UNNAMED " \
-                         "--add-opens=java.base/java.lang=ALL-UNNAMED " \
-                         "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED " \
-                         "--add-opens=java.base/java.util=ALL-UNNAMED " \
-                         "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED " \
-                         "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED"
     """
     A builder is responsible for creating an installable binary from the source files.
 
@@ -460,14 +453,8 @@ class Builder:
         log_file = "%s/build.log" % self.log_dir
 
         # we capture all output to a dedicated build log file
-        jvm_major_version = jvm.major_version(self.java_home)
-        if jvm_major_version > 8:
-            logger.info("Detected JVM with major version [%d]. Adjusting JDK module access options for the build." % jvm_major_version)
-            gradle_opts = "export GRADLE_OPTS=\"%s\"; " % Builder.JAVA_9_GRADLE_OPTS
-        else:
-            gradle_opts = ""
 
-        build_cmd = "%sexport JAVA_HOME=%s; cd %s; %s %s >> %s 2>&1" % (gradle_opts, self.java_home, src_dir, self.gradle, task, log_file)
+        build_cmd = "export JAVA_HOME=%s; cd %s; %s %s >> %s 2>&1" % (self.java_home, src_dir, self.gradle, task, log_file)
         logger.info("Running build command [%s]" % build_cmd)
 
         if process.run_subprocess(build_cmd):

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -134,20 +134,19 @@ class BuilderTests(TestCase):
 
     @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.jvm.major_version")
-    def test_build_on_jdk_9(self, jvm_major_version, mock_run_subprocess):
-        jvm_major_version.return_value = 9
+    def test_build_on_jdk_10(self, jvm_major_version, mock_run_subprocess):
+        jvm_major_version.return_value = 10
         mock_run_subprocess.return_value = False
 
-        b = supplier.Builder(src_dir="/src", gradle="/usr/local/gradle", java_home="/opt/jdk9", log_dir="logs")
+        b = supplier.Builder(src_dir="/src", gradle="/usr/local/gradle", java_home="/opt/jdk10", log_dir="logs")
         b.build([supplier.CLEAN_TASK, supplier.ASSEMBLE_TASK])
 
         calls = [
             # Actual call
-            mock.call("export GRADLE_OPTS=\"%s\"; export JAVA_HOME=/opt/jdk9; cd /src; /usr/local/gradle clean >> logs/build.log 2>&1" %
-                      supplier.Builder.JAVA_9_GRADLE_OPTS),
+            mock.call("export JAVA_HOME=/opt/jdk10; cd /src; /usr/local/gradle clean >> logs/build.log 2>&1"),
             # Return value check
-            mock.call("export GRADLE_OPTS=\"%s\"; export JAVA_HOME=/opt/jdk9; cd /src; /usr/local/gradle "
-                      ":distribution:archives:tar:assemble >> logs/build.log 2>&1" % supplier.Builder.JAVA_9_GRADLE_OPTS),
+            mock.call("export JAVA_HOME=/opt/jdk10; cd /src; /usr/local/gradle "
+                      ":distribution:archives:tar:assemble >> logs/build.log 2>&1"),
         ]
 
         mock_run_subprocess.assert_has_calls(calls)
@@ -335,7 +334,7 @@ class CreateSupplierTests(TestCase):
         cfg.add(config.Scope.application, "distributions", "release.url",
                 "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz")
         cfg.add(config.Scope.application, "distributions", "release.cache", True)
-        cfg.add(config.Scope.application, "runtime", "java9.home", "/usr/local/bin/java9/")
+        cfg.add(config.Scope.application, "runtime", "java10.home", "/usr/local/bin/java10/")
         cfg.add(config.Scope.application, "node", "root.dir", "/opt/rally")
 
         composite_supplier = supplier.create(cfg, sources=False, distribution=True, build=False, challenge_root_path="/", plugins=[])
@@ -352,7 +351,7 @@ class CreateSupplierTests(TestCase):
         cfg.add(config.Scope.application, "distributions", "release.url",
                 "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz")
         cfg.add(config.Scope.application, "distributions", "release.cache", True)
-        cfg.add(config.Scope.application, "runtime", "java9.home", "/usr/local/bin/java9/")
+        cfg.add(config.Scope.application, "runtime", "java10.home", "/usr/local/bin/java10/")
         cfg.add(config.Scope.application, "node", "root.dir", "/opt/rally")
         cfg.add(config.Scope.application, "source", "plugin.community-plugin.src.dir", "/home/user/Projects/community-plugin")
 
@@ -383,7 +382,7 @@ class CreateSupplierTests(TestCase):
         cfg.add(config.Scope.application, "distributions", "release.url",
                 "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz")
         cfg.add(config.Scope.application, "distributions", "release.cache", True)
-        cfg.add(config.Scope.application, "runtime", "java9.home", "/usr/local/bin/java9/")
+        cfg.add(config.Scope.application, "runtime", "java10.home", "/usr/local/bin/java10/")
         cfg.add(config.Scope.application, "node", "root.dir", "/opt/rally")
 
         core_plugin = team.PluginDescriptor("analysis-icu", core_plugin=True)
@@ -406,7 +405,7 @@ class CreateSupplierTests(TestCase):
         cfg.add(config.Scope.application, "distributions", "release.url",
                 "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz")
         cfg.add(config.Scope.application, "distributions", "release.cache", True)
-        cfg.add(config.Scope.application, "runtime", "java9.home", "/usr/local/bin/java9/")
+        cfg.add(config.Scope.application, "runtime", "java10.home", "/usr/local/bin/java10/")
         cfg.add(config.Scope.application, "node", "root.dir", "/opt/rally")
         cfg.add(config.Scope.application, "node", "src.root.dir", "/opt/rally/src")
         cfg.add(config.Scope.application, "build", "gradle.bin", "/opt/gradle")
@@ -437,7 +436,7 @@ class CreateSupplierTests(TestCase):
         cfg.add(config.Scope.application, "distributions", "release.url",
                 "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz")
         cfg.add(config.Scope.application, "distributions", "release.cache", True)
-        cfg.add(config.Scope.application, "runtime", "java9.home", "/usr/local/bin/java9/")
+        cfg.add(config.Scope.application, "runtime", "java10.home", "/usr/local/bin/java10/")
         cfg.add(config.Scope.application, "node", "root.dir", "/opt/rally")
         cfg.add(config.Scope.application, "node", "src.root.dir", "/opt/rally/src")
         cfg.add(config.Scope.application, "build", "gradle.bin", "/opt/gradle")


### PR DESCRIPTION
Similar to the work done for #387, following the merge of the
Elasticsearch PR[1], Rally needs to require java-10 to build
Elasticsearch from source.

Bump the configuration version to 14 and adjust migration of existing
configs to support building with java-10. Also add needed test cases
and update docs.

Note that building from source with java-10 requires, at minimum,
gradle 4.5[2]. This helps us remove a number of additional gradle
options that were needed for java-9. So for now, building will fail
with gradle <4.5, which will won't be a worry at all once we start
using `./gradlew`; this is tracked in issue#412.

Closes #450

[1] https://github.com/elastic/elasticsearch/pull/29174
[2] https://github.com/gradle/gradle/pull/3892