### PR TITLE
Remove operation type "index"

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,14 @@
 Migration Guide
 ===============
 
+Migrating to Rally 0.10.0
+-------------------------
+
+Removal of operation type ``index``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We have removed the operation type ``index`` which has been deprecated with Rally 0.8.0. Please use ``bulk`` instead as operation type.
+
 Migrating to Rally 0.9.0
 ------------------------
 

--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -1185,8 +1185,7 @@ def generate_index_ops(chart_type, race_config, environment):
             plugins = combination.get("plugins")
             for task in t.find_challenge_or_default(challenge).schedule:
                 for sub_task in task:
-                    # TODO: Remove "index" after some grace period
-                    if sub_task.operation.type in [track.OperationType.Bulk.name, track.OperationType.Index.name]:
+                    if sub_task.operation.type == track.OperationType.Bulk.name:
                         cci.append((combination_name, combination_label, challenge, car, plugins, node_count, sub_task.name))
         return t.name, cci
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -808,10 +808,6 @@ class Retry(Runner):
         return "retryable %s" % repr(self.delegate)
 
 
-# TODO #435: Remove this registration
-# Old (deprecated) name
-register_runner(track.OperationType.Index.name, BulkIndex())
-# New name
 register_runner(track.OperationType.Bulk.name, BulkIndex())
 register_runner(track.OperationType.ForceMerge.name, ForceMerge())
 register_runner(track.OperationType.IndicesStats.name, IndicesStats())

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -825,10 +825,6 @@ class IndexDataReader:
         return False
 
 
-# TODO #435: Remove this registration.
-# Old name - deprecated
-register_param_source_for_operation(track.OperationType.Index, BulkIndexParamSource)
-# New name
 register_param_source_for_operation(track.OperationType.Bulk, BulkIndexParamSource)
 register_param_source_for_operation(track.OperationType.Search, SearchParamSource)
 register_param_source_for_operation(track.OperationType.CreateIndex, CreateIndexParamSource)

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -426,7 +426,6 @@ class Challenge:
 
 @unique
 class OperationType(Enum):
-    Index = 0
     # for the time being we are not considering this action as administrative
     IndicesStats = 1
     NodesStats = 2
@@ -449,9 +448,7 @@ class OperationType(Enum):
 
     @classmethod
     def from_hyphenated_string(cls, v):
-        if v == "index":
-            return OperationType.Index
-        elif v == "force-merge":
+        if v == "force-merge":
             return OperationType.ForceMerge
         elif v == "index-stats":
             return OperationType.IndicesStats


### PR DESCRIPTION
With this commit we remove the operation type `index` that has been
deprecated with Rally 0.8.0. It is replaced by the operation type `bulk`
(which has also been introduced in the same release).

Closes #435
Relates #369