### PR TITLE
Remove automatic index management

### DIFF
--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -100,11 +100,11 @@ For details on the allowed syntax, see the Elasticsearch documentation on `mappi
 Finally, add a file called ``track.json`` in the tutorial directory::
 
     {
+      "version": 2,
       "description": "Tutorial benchmark for Rally",
       "indices": [
         {
           "name": "geonames",
-          "auto-managed": false,
           "body": "index.json",
           "types": [ "docs" ]
         }
@@ -285,11 +285,11 @@ Structuring your track
 Now modify ``track.json`` so it knows about your new file::
 
     {
+      "version": 2,
       "description": "Tutorial benchmark for Rally",
       "indices": [
         {
           "name": "geonames",
-          "auto-managed": false,
           "body": "index.json",
           "types": [ "docs" ]
         }
@@ -316,11 +316,11 @@ We replaced the challenge content with  ``{% include "challenges/index-and-query
 If you want to reuse operation definitions across challenges, you can also define them in a separate ``operations`` block and just refer to them by name in the corresponding challenge::
 
     {
+      "version": 2,
       "description": "Tutorial benchmark for Rally",
       "indices": [
         {
           "name": "geonames",
-          "auto-managed": false,
           "body": "index.json",
           "types": [ "docs" ]
         }
@@ -416,11 +416,11 @@ If your track consists of multiple challenges, it can be cumbersome to include t
 
     {% import "rally.helpers" as rally %}
     {
+      "version": 2,
       "description": "Tutorial benchmark for Rally",
       "indices": [
         {
           "name": "geonames",
-          "auto-managed": false,
           "body": "index.json",
           "types": [ "docs" ]
         }
@@ -512,6 +512,7 @@ Then upload ``documents.json.bz2`` and ``documents-1k.json.bz2`` to the remote l
 Finally, specify the compressed file name in your ``track.json`` file in the ``source-file`` property and also add the ``base-url`` property::
 
     {
+      "version": 2,
       "description": "Tutorial benchmark for Rally",
       "corpora": [
         {

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -445,22 +445,6 @@ Rally usually installs and launches an Elasticsearch cluster internally and wipe
 .. note::
    This option does only affect clusters that are provisioned by Rally. More specifically, if you use the pipeline ``benchmark-only``, this option is ineffective as Rally does not provision a cluster in this case.
 
-``cluster-health``
-~~~~~~~~~~~~~~~~~~
-
-.. warning::
-   This option is deprecated and will be removed in a future version of Rally. For details, please see the respective `Github ticket #364 <https://github.com/elastic/rally/issues/364>`_.
-
-Rally checks whether the cluster health is "green" before it runs a benchmark against it. The main reason is that we don't want to benchmark a cluster which is shuffling shards around or might start doing so. If you really need to run a benchmark against a cluster that is "yellow" or "red", then you can explicitly override Rally's default behavior. It is even possible to skip this check entirely by providing ``--cluster-health=skip``. But please think twice before doing so and rather eliminate the root cause.
-
-**Example**
-
- ::
-
-   esrally --cluster-health=yellow
-
-
-
 ``advanced-config``
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -9,6 +9,41 @@ Removal of operation type ``index``
 
 We have removed the operation type ``index`` which has been deprecated with Rally 0.8.0. Please use ``bulk`` instead as operation type.
 
+Removal of the command line parameter ``--cluster-health``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We have removed the command line parameter ``--cluster-health`` which has been deprecated with Rally 0.8.0. When using Rally's standard tracks, specify the expected cluster health as a track parameter instead, e.g.: ``--track-params="cluster_health:'yellow'"``.
+
+Removal of index-automanagement
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We have removed the possibility that Rally automatically deletes and creates indices. Therefore, you need to add the following definitions explicitly at the beginning of a schedule if you want Rally to create declared indices::
+
+        "schedule": [
+          {
+            "operation": "delete-index"
+          },
+          {
+            "operation": {
+              "operation-type": "create-index",
+              "settings": {
+                "index.number_of_replicas": 0
+              }
+            }
+          },
+          {
+            "operation": {
+              "operation-type": "cluster-health",
+              "request-params": {
+                "wait_for_status": "green"
+              }
+            }
+          }
+
+The example above also shows how to provide per-challenge index settings. If per-challenge index settings are not required, you can just specify them in the index definition file.
+
+This behavior applies similarly to index templates as well.
+
 Migrating to Rally 0.9.0
 ------------------------
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -144,7 +144,7 @@ The ``version`` property has been introduced with Rally 0.7.3. Rally versions be
 Example::
 
     {
-        "version": 1,
+        "version": 2,
         "description": "POIs from Geonames"
     }
 
@@ -171,13 +171,12 @@ E.g. a key defined on a task, will override the same key defined on a challenge.
 indices
 .......
 
-The ``indices`` section contains a list of all indices that are used by this track. By default Rally will assume that it can destroy and create these indices at will.
+The ``indices`` section contains a list of all indices that are used by this track.
 
 Each index in this list consists of the following properties:
 
 * ``name`` (mandatory): The name of the index.
 * ``body`` (optional): File name of the corresponding index definition that will be used as body in the create index API call.
-* ``auto-managed`` (optional, defaults to ``true``): Controls whether Rally or the user takes care of creating / destroying the index. If this setting is ``false``, Rally will neither create nor delete this index but just assume its presence.
 * ``types`` (optional): A list of type names in this index.
 
 Example::
@@ -666,7 +665,7 @@ Each challenge consists of the following properties:
 * ``name`` (mandatory): A descriptive name of the challenge. Should not contain spaces in order to simplify handling on the command line for users.
 * ``description`` (optional): A human readable description of the challenge.
 * ``default`` (optional): If true, Rally selects this challenge by default if the user did not specify a challenge on the command line. If your track only defines one challenge, it is implicitly selected as default, otherwise you need define ``"default": true`` on exactly one challenge.
-* ``index-settings`` (optional): Defines the index settings of the benchmark candidate when an index is created. Note that these settings are only applied if the index is auto-managed.
+* ``index-settings`` (optional): Defines the index settings of the benchmark candidate when an index is created.
 * ``schedule`` (mandatory): Defines the concrete execution order of operations. It is described in more detail below.
 
 .. note::

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -322,13 +322,6 @@ def create_arg_parser():
                        choices=["continue", "abort"],
                        help="Either 'continue' or 'abort' when Rally gets an error response (default: continue)",
                        default="continue")
-        # TODO #380: Remove this. We will turn off index auto management and our standard tracks will provide a track parameter for this.
-        # This parameter is deprecated. We will replace this with an explicit call in our tracks.
-        p.add_argument(
-            "--cluster-health",
-            choices=["red", "yellow", "green", "skip"],
-            help="Expected cluster health at the beginning of the benchmark (default: green)",
-            default="green")
         p.add_argument(
             "--telemetry",
             help="enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry devices "
@@ -392,12 +385,6 @@ def create_arg_parser():
             "--effective-start-date",
             help=argparse.SUPPRESS,
             type=lambda s: datetime.datetime.strptime(s, "%Y-%m-%d %H:%M:%S"),
-            default=None)
-        # TODO: Remove in Rally 0.10.0 (there will be no index auto-management anymore)
-        p.add_argument(
-            "--auto-manage-indices",
-            choices=["true", "false"],
-            help=argparse.SUPPRESS,
             default=None)
         # keeps the cluster running after the benchmark, only relevant if Rally provisions the cluster
         p.add_argument(
@@ -730,7 +717,6 @@ def main():
     cfg.add(config.Scope.applicationOverride, "track", "challenge.name", args.challenge)
     cfg.add(config.Scope.applicationOverride, "track", "include.tasks", csv_to_list(args.include_tasks))
     cfg.add(config.Scope.applicationOverride, "track", "test.mode.enabled", args.test_mode)
-    cfg.add(config.Scope.applicationOverride, "track", "auto_manage_indices", to_bool(args.auto_manage_indices))
 
     cfg.add(config.Scope.applicationOverride, "reporting", "format", args.report_format)
     cfg.add(config.Scope.applicationOverride, "reporting", "values", args.show_in_report)
@@ -752,9 +738,6 @@ def main():
             # other options are stored elsewhere already
             cfg.add(config.Scope.applicationOverride, "generator", "node.count", args.node_count)
 
-    cfg.add(config.Scope.applicationOverride, "driver", "cluster.health", args.cluster_health)
-    if args.cluster_health != "green":
-        console.warn("--cluster-health is deprecated and will be removed in a future version of Rally.")
     cfg.add(config.Scope.applicationOverride, "driver", "profiling", args.enable_driver_profiling)
     cfg.add(config.Scope.applicationOverride, "driver", "on.error", args.on_error)
     cfg.add(config.Scope.applicationOverride, "driver", "load_driver_hosts", csv_to_list(args.load_driver_hosts))

--- a/esrally/resources/track-schema.json
+++ b/esrally/resources/track-schema.json
@@ -251,10 +251,6 @@
             "type": "string",
             "description": "Name of the index to create."
           },
-          "auto-managed": {
-            "type": "boolean",
-            "description": "If 'true' then Rally will automatically create / destroy this index. If 'false' users need to ensure that the index exists prior to running the track (optional, defaults to true)."
-          },
           "types": {
             "type": "array",
             "minItems": 1,

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -67,11 +67,9 @@ def load_track(cfg):
         track_dir = repo.track_dir(track_name)
         reader = TrackFileReader(cfg)
         included_tasks = cfg.opts("track", "include.tasks")
-        expected_cluster_health = cfg.opts("driver", "cluster.health")
 
         current_track = reader.read(track_name, repo.track_file(track_name), track_dir)
         current_track = filter_included_tasks(current_track, filters_from_included_tasks(included_tasks))
-        current_track = post_process_for_index_auto_management(current_track, expected_cluster_health)
         plugin_reader = TrackPluginReader(track_dir)
         current_track.has_plugins = plugin_reader.can_load()
 
@@ -522,78 +520,6 @@ def filters_from_included_tasks(included_tasks):
     return filters
 
 
-def post_process_for_index_auto_management(t, expected_cluster_health):
-    auto_managed_indices = any([index.auto_managed for index in t.indices])
-    # spare users this warning for our default tracks
-    if auto_managed_indices and t.name not in DEFAULT_TRACKS:
-        console.warn("Track [%s] uses index auto-management which will be removed soon. Please add [delete-index] and [create-index] "
-                     "tasks at the beginning of each relevant challenge and turn off index auto-management for each index. For details "
-                     "please see the migration guide in the docs." % t.name)
-    if auto_managed_indices or len(t.templates) > 0:
-        for challenge in t.challenges:
-            tasks = []
-            # TODO: Remove the index settings element. We can do this much better now with the create-index operation.
-            create_index_params = {"include-in-reporting": False}
-            if challenge.index_settings:
-                if t.name not in DEFAULT_TRACKS:
-                    console.warn("Track [%s] defines the deprecated property 'index-settings'. Please create indices explicitly with "
-                                 "[create-index] and define the respective index settings there instead." % t.name)
-                create_index_params["settings"] = challenge.index_settings
-            if len(t.templates) > 0:
-                # check if the user has defined a create index template operation
-                user_creates_templates = any(task.matches(track.TaskOpTypeFilter(track.OperationType.CreateIndexTemplate.name))
-                                             for task in challenge.schedule)
-                # We attempt to still do this automatically but issue a warning so that the user will create it themselves.
-                if not user_creates_templates:
-                    console.warn("Track [%s] defines %d index template(s) but soon Rally will not create them implicitly anymore. Please "
-                                 "add [delete-index-template] and [create-index-template] tasks at the beginning of the challenge %s."
-                                 % (t.name, len(t.templates), challenge.name), logger=logger)
-                    tasks.append(track.Task(name="auto-delete-index-templates",
-                                            operation=track.Operation(name="auto-delete-index-templates",
-                                                                      operation_type=track.OperationType.DeleteIndexTemplate.name,
-                                                                      params={
-                                                                          "include-in-reporting": False,
-                                                                          "only-if-exists": True
-                                                                      })))
-                    tasks.append(track.Task(name="auto-create-index-templates",
-                                            operation=track.Operation(name="auto-create-index-templates",
-                                                                      operation_type=track.OperationType.CreateIndexTemplate.name,
-                                                                      params=create_index_params.copy())))
-
-            if auto_managed_indices:
-                tasks.append(track.Task(name="auto-delete-indices",
-                                        operation=track.Operation(name="auto-delete-indices",
-                                                                  operation_type=track.OperationType.DeleteIndex.name,
-                                                                  params={
-                                                                      "include-in-reporting": False,
-                                                                      "only-if-exists": True
-                                                                  })))
-                tasks.append(track.Task(name="auto-create-indices",
-                                        operation=track.Operation(name="auto-create-indices",
-                                                                  operation_type=track.OperationType.CreateIndex.name,
-                                                                  params=create_index_params.copy())))
-
-            # check if the user has already defined a cluster-health operation
-            user_checks_cluster_health = any(task.matches(track.TaskOpTypeFilter(track.OperationType.ClusterHealth.name))
-                                             for task in challenge.schedule)
-
-            if expected_cluster_health != "skip" and not user_checks_cluster_health:
-                tasks.append(track.Task(name="auto-check-cluster-health",
-                                        operation=track.Operation(name="auto-check-cluster-health",
-                                                                  operation_type=track.OperationType.ClusterHealth.name,
-                                                                  params={
-                                                                      "include-in-reporting": False,
-                                                                      "request-params": {
-                                                                          "wait_for_status": expected_cluster_health
-                                                                      }
-                                                                  })))
-
-            challenge.prepend_tasks(tasks)
-        return t
-    else:
-        return t
-
-
 def post_process_for_test_mode(t):
     logger.info("Preparing track [%s] for test mode." % str(t))
     for corpus in t.corpora:
@@ -643,19 +569,18 @@ def post_process_for_test_mode(t):
 
 
 class TrackFileReader:
-    # TODO #380: We will increase the version with 0.10.0 in our standard tracks but Rally 0.9.0 will already be prepared for this change.
+    MINIMUM_SUPPORTED_TRACK_VERSION = 2
     MAXIMUM_SUPPORTED_TRACK_VERSION = 2
     """
     Creates a track from a track file.
     """
 
     def __init__(self, cfg):
-        track_schema_file = "%s/resources/track-schema.json" % (cfg.opts("node", "rally.root"))
+        track_schema_file = os.path.join(cfg.opts("node", "rally.root"), "resources", "track-schema.json")
         with open(track_schema_file, mode="rt", encoding="utf-8") as f:
             self.track_schema = json.loads(f.read())
-        override_auto_manage_indices = cfg.opts("track", "auto_manage_indices")
         self.track_params = cfg.opts("track", "params")
-        self.read_track = TrackSpecificationReader(override_auto_manage_indices)
+        self.read_track = TrackSpecificationReader()
 
     def read(self, track_name, track_spec_file, mapping_dir):
         """
@@ -667,47 +592,38 @@ class TrackFileReader:
         :return: A corresponding track instance if the track file is valid.
         """
 
-        logger.info("Reading track specification file [%s]." % track_spec_file)
+        logger.info("Reading track specification file [{}].".format(track_spec_file))
         try:
             rendered = render_template_from_file(track_spec_file, self.track_params)
-            logger.info("Final rendered track for '%s': %s" % (track_spec_file, rendered))
+            logger.info("Final rendered track for '{}': {}".format(track_spec_file, rendered))
             track_spec = json.loads(rendered)
         except jinja2.exceptions.TemplateNotFound:
-            logger.exception("Could not load [%s]." % track_spec_file)
-            raise exceptions.SystemSetupError("Track %s does not exist" % track_name)
+            logger.exception("Could not load [{}]".format(track_spec_file))
+            raise exceptions.SystemSetupError("Track {} does not exist".format(track_name))
         except (json.JSONDecodeError, jinja2.exceptions.TemplateError) as e:
-            logger.exception("Could not load [%s]." % track_spec_file)
-            # TODO: Check whether we can improve this.
-            # Jinja classes cause serialization problems:
-            #
-            # File "/usr/local/lib/python3.6/site-packages/thespian-3.8.3-py3.6.egg/thespian/system/transport/TCPTransport.py", line 1431, in _addedDataToIncoming
-            # rdata, extra = inc.data
-            # File "/usr/local/lib/python3.6/site-packages/thespian-3.8.3-py3.6.egg/thespian/system/transport/TCPTransport.py", line 185, in data
-            # def data(self): return self._rData.completed()
-            # File "/usr/local/lib/python3.6/site-packages/thespian-3.8.3-py3.6.egg/thespian/system/transport/streamBuffer.py", line 80, in completed
-            # return self._deserialize(self._buf), self._extra
-            # TypeError: __init__() missing 1 required positional argument: 'lineno'
-            # (rdata="", extra="")
-            #
-            # => Convert to string early on:
-            raise TrackSyntaxError("Could not load '%s'" % track_spec_file, str(e))
+            logger.exception("Could not load [{}].".format(track_spec_file))
+            # Convert to string early on to avoid serialization errors with Jinja exceptions.
+            raise TrackSyntaxError("Could not load '{}'".format(track_spec_file), str(e))
         # check the track version before even attempting to validate the JSON format to avoid bogus errors.
         raw_version = track_spec.get("version", TrackFileReader.MAXIMUM_SUPPORTED_TRACK_VERSION)
         try:
             track_version = int(raw_version)
         except ValueError:
             raise exceptions.InvalidSyntax("version identifier for track %s must be numeric but was [%s]" % (track_name, str(raw_version)))
+        if TrackFileReader.MINIMUM_SUPPORTED_TRACK_VERSION > track_version:
+            raise exceptions.RallyError("Track {} is on version {} but needs to be updated at least to version {} to work with the "
+                                        "current version of Rally.".format(track_name, track_version,
+                                                                           TrackFileReader.MINIMUM_SUPPORTED_TRACK_VERSION))
         if TrackFileReader.MAXIMUM_SUPPORTED_TRACK_VERSION < track_version:
-            raise exceptions.RallyError("Track %s requires a newer version of Rally. Please upgrade Rally (supported track version: %d, "
-                                        "required track version: %d)" %
-                                        (track_name, TrackFileReader.MAXIMUM_SUPPORTED_TRACK_VERSION, track_version))
+            raise exceptions.RallyError("Track {} requires a newer version of Rally. Please upgrade Rally (supported track version: {}, "
+                                        "required track version: {}).".format(track_name, TrackFileReader.MAXIMUM_SUPPORTED_TRACK_VERSION,
+                                                                             track_version))
         try:
             jsonschema.validate(track_spec, self.track_schema)
         except jsonschema.exceptions.ValidationError as ve:
             raise TrackSyntaxError(
-                "Track '%s' is invalid.\n\nError details: %s\nInstance: %s\nPath: %s\nSchema path: %s"
-                % (track_name, ve.message,
-                   json.dumps(ve.instance, indent=4, sort_keys=True), ve.absolute_path, ve.absolute_schema_path))
+                "Track '{}' is invalid.\n\nError details: {}\nInstance: {}\nPath: {}\nSchema path: {}".format(
+                    track_name, ve.message, json.dumps(ve.instance, indent=4, sort_keys=True), ve.absolute_path, ve.absolute_schema_path))
         return self.read_track(track_name, track_spec, mapping_dir)
 
 
@@ -757,9 +673,8 @@ class TrackSpecificationReader:
     Creates a track instances based on its parsed JSON description.
     """
 
-    def __init__(self, override_auto_manage_indices=None, track_params=None, source=io.FileSource):
+    def __init__(self, track_params=None, source=io.FileSource):
         self.name = None
-        self.override_auto_manage_indices = override_auto_manage_indices
         self.track_params = track_params if track_params else {}
         self.source = source
         self.index_op_type_warning_issued = False
@@ -774,16 +689,6 @@ class TrackSpecificationReader:
         templates = [self._create_index_template(tpl, mapping_dir)
                      for tpl in self._r(track_specification, "templates", mandatory=False, default_value=[])]
         corpora = self._create_corpora(self._r(track_specification, "corpora", mandatory=False, default_value=[]), indices)
-        # TODO: Remove this in Rally 0.10.0
-        if corpora:
-            logger.info("Track [%s] defines a 'corpora' block. Ignoring any legacy corpora definitions on document types." % self.name)
-        else:
-            corpora = self._create_legacy_corpora(track_specification)
-            # Check whether we have legacy documents; otherwise there is no need for a warning...
-            if corpora:
-                console.warn("Track %s defines corpora together with document types. Please use a dedicated 'corpora' block now. "
-                             "See the migration guide for details." % self.name, logger=logger)
-
         challenges = self._create_challenges(track_specification)
 
         return track.Track(name=self.name, meta_data=meta_data, description=description, challenges=challenges, indices=indices,
@@ -819,17 +724,7 @@ class TrackSpecificationReader:
         else:
             body = None
 
-        if self.override_auto_manage_indices is not None:
-            auto_managed = self.override_auto_manage_indices
-            logger.info("User explicitly forced auto-managed indices to [%s] on the command line." % str(auto_managed))
-        else:
-            auto_managed = self._r(index_spec, "auto-managed", mandatory=False, default_value=True)
-            logger.info("Using index auto-management setting from track which is set to [%s]." % str(auto_managed))
-
-        types = [self._create_type(type_spec, mapping_dir)
-                 for type_spec in self._r(index_spec, "types", mandatory=auto_managed, default_value=[])]
-
-        return track.Index(name=index_name, body=body, auto_managed=auto_managed, types=types)
+        return track.Index(name=index_name, body=body, types=self._r(index_spec, "types", mandatory=False, default_value=[]))
 
     def _create_index_template(self, tpl_spec, mapping_dir):
         name = self._r(tpl_spec, "name")
@@ -873,7 +768,7 @@ class TrackSpecificationReader:
                 corpus_target_idx = self._r(corpus_spec, "target-index", mandatory=False)
 
             if len(indices) == 1 and len(indices[0].types) == 1:
-                corpus_target_type = self._r(corpus_spec, "target-type", mandatory=False, default_value=indices[0].types[0].name)
+                corpus_target_type = self._r(corpus_spec, "target-type", mandatory=False, default_value=indices[0].types[0])
             else:
                 corpus_target_type = self._r(corpus_spec, "target-type", mandatory=False)
 
@@ -920,62 +815,6 @@ class TrackSpecificationReader:
 
             document_corpora.append(corpus)
         return document_corpora
-
-    def _create_legacy_corpora(self, track_specification):
-        base_url = self._r(track_specification, "data-url", mandatory=False)
-        legacy_corpus = track.DocumentCorpus(name=self.name)
-        for idx in self._r(track_specification, "indices", mandatory=False, default_value=[]):
-            index_name = self._r(idx, "name")
-            for type_spec in self._r(idx, "types", mandatory=False, default_value=[]):
-                # only do this if this is a legacy type definition - otherwise this is a new type definition and we don't define
-                # any corpora for this track.
-                if isinstance(type_spec, dict):
-                    type_name = self._r(type_spec, "name")
-                    docs = self._r(type_spec, "documents", mandatory=False)
-                    if docs:
-                        if io.is_archive(docs):
-                            document_archive = docs
-                            document_file = io.splitext(docs)[0]
-                        else:
-                            document_archive = None
-                            document_file = docs
-                        number_of_documents = self._r(type_spec, "document-count")
-                        compressed_bytes = self._r(type_spec, "compressed-bytes", mandatory=False)
-                        uncompressed_bytes = self._r(type_spec, "uncompressed-bytes", mandatory=False)
-
-                        docs = track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                               document_file=document_file,
-                                               document_archive=document_archive,
-                                               base_url=base_url,
-                                               includes_action_and_meta_data=self._r(type_spec, "includes-action-and-meta-data",
-                                                                                     mandatory=False,
-                                                                                     default_value=False),
-                                               number_of_documents=number_of_documents,
-                                               compressed_size_in_bytes=compressed_bytes,
-                                               uncompressed_size_in_bytes=uncompressed_bytes,
-                                               target_index=index_name, target_type=type_name)
-                        legacy_corpus.documents.append(docs)
-
-        if legacy_corpus.documents:
-            logger.warning("Track [%s] does not define a 'corpora' block. Creating corpora definitions based on document types (will "
-                           "be removed with the next minor release)." % self.name)
-            return [legacy_corpus]
-        else:
-            return []
-
-    def _create_type(self, type_spec, mapping_dir):
-        # TODO: Allow only strings in Rally 0.10.0 (we still needs this atm in order to allow users to define mapping files)
-        if isinstance(type_spec, str):
-            return track.Type(name=type_spec)
-        else:
-            mapping_file = self._r(type_spec, "mapping", mandatory=False)
-            if mapping_file:
-                with self.source(os.path.join(mapping_dir, mapping_file), "rt") as f:
-                    mapping = json.load(f)
-            else:
-                mapping = None
-
-            return track.Type(name=self._r(type_spec, "name"), mapping=mapping)
 
     def _create_challenges(self, track_spec):
         ops = self.parse_operations(self._r(track_spec, "operations", mandatory=False, default_value=[]))

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -166,21 +166,10 @@ class CreateIndexParamSource(ParamSource):
                             body["settings"].update(settings)
                         else:
                             body["settings"] = settings
-                    elif not body:
-                        # this is just needed because we will output this in the middle of the benchmark and will thus write
-                        # this on the same line as the progress message.
-                        console.println("")
-                        console.warn("Creating index %s based on deprecated type mappings. Please specify an index body instead. "
-                                     "For details please see the migration guide in the docs." % idx.name, logger=logger)
-                        # TODO #366: Deprecate this syntax. We should only specify all mappings in the body property.
-                        # check all types and merge their mappings
+                    elif not body and settings:
                         body = {
-                            "mappings": {}
+                            "settings": settings
                         }
-                        if settings:
-                            body["settings"] = settings
-                        for t in idx.types:
-                            body["mappings"].update(t.mapping)
 
                     self.index_definitions.append((idx.name, body))
         else:
@@ -351,7 +340,7 @@ class SearchParamSource(ParamSource):
         if len(track.indices) == 1:
             default_index = track.indices[0].name
             if len(track.indices[0].types) == 1:
-                default_type = track.indices[0].types[0].name
+                default_type = track.indices[0].types[0]
             else:
                 default_type = None
         else:

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -11,14 +11,13 @@ class Index:
     Defines an index in Elasticsearch.
     """
 
-    def __init__(self, name, body=None, auto_managed=False, types=None):
+    def __init__(self, name, body=None, types=None):
         """
 
         Creates a new index.
 
         :param name: The index name. Mandatory.
         :param body: A dict representation of the index body. Optional.
-        :param auto_managed: True iff Rally should automatically manage this index (i.e. it can create and delete it at will).
         :param types: A list of types. Should contain at least one type.
         """
         if types is None:
@@ -27,7 +26,6 @@ class Index:
             body = {}
         self.name = name
         self.body = body
-        self.auto_managed = auto_managed
         self.types = types
 
     def matches(self, pattern):
@@ -75,40 +73,6 @@ class IndexTemplate:
         self.pattern = pattern
         self.content = content
         self.delete_matching_indices = delete_matching_indices
-
-    def __str__(self, *args, **kwargs):
-        return self.name
-
-    def __repr__(self):
-        r = []
-        for prop, value in vars(self).items():
-            r.append("%s = [%s]" % (prop, repr(value)))
-        return ", ".join(r)
-
-    def __hash__(self):
-        return hash(self.name)
-
-    def __eq__(self, other):
-        return self.name == other.name
-
-
-class Type:
-    """
-    Defines a type in Elasticsearch.
-    """
-
-    def __init__(self, name, mapping=None):
-        """
-
-        Creates a new type. Mappings are mandatory but the document_archive (and associated properties) are optional.
-
-        :param name: The name of this type. Mandatory.
-        :param mapping: The type's mapping. Optional.
-        """
-        if mapping is None:
-            mapping = {}
-        self.name = name
-        self.mapping = mapping
 
     def __str__(self, *args, **kwargs):
         return self.name

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -667,7 +667,7 @@ class EsResultsStoreTests(TestCase):
         ]
 
         t = track.Track(name="unittest-track",
-                        indices=[track.Index(name="tests", auto_managed=True, types=["test-type"])],
+                        indices=[track.Index(name="tests", types=["test-type"])],
                         challenges=[track.Challenge(name="index", default=True, index_settings=None, schedule=schedule)])
 
         c = cluster.Cluster([], [], None)


### PR DESCRIPTION
With this commit we remove the ability that Rally automatically deletes
and creates indices and users need to add explicit tasks now to their
tracks in order to make this work.

The rationale behind all this work is that we want the core of Rally to
be agnostic to the tasks that it executes.

Closes #380