### PR TITLE
Add parameter support to telemetry devices

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -272,6 +272,17 @@ Activates the provided :doc:`telemetry devices </telemetry>` for this race.
 
 This activates Java flight recorder and the JIT compiler telemetry devices.
 
+``telemetry-params``
+~~~~~~~~~~~~~~~~~~~~
+
+Allows to set parameters for telemetry devices. It accepts a list of comma-separated key-value pairs or a JSON file name. The key-value pairs have to be delimited by a colon. See the :doc:`telemetry devices </telemetry>` documentation for a list of supported parameters.
+
+Example::
+
+    esrally --telemetry=jfr --telemetry-params="recording-template:'profile'"
+
+This enables the Java flight recorder telemetry device and sets the ``recording-template`` parameter to "profile".
+
 .. _clr_revision:
 
 ``revision``

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -39,7 +39,7 @@ To enable ``jfr``, invoke Rally with ``esrally --telemetry jfr``. ``jfr`` will t
 
 Supported telemetry parameters:
 
-* ``recording-template``: The name of a custom flight recording template. It is up to you to correctly install those recording template on each target machine. If none is specified, the default recording template of Java flight recorder is used.
+* ``recording-template``: The name of a custom flight recording template. It is up to you to correctly install these recording templates on each target machine. If none is specified, the default recording template of Java flight recorder is used.
 
 .. note::
 

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -37,6 +37,10 @@ To enable ``jfr``, invoke Rally with ``esrally --telemetry jfr``. ``jfr`` will t
 .. image:: jfr-es.png
    :alt: Sample Java Flight Recording
 
+Supported telemetry parameters:
+
+* ``recording-template``: The name of a custom flight recording template. It is up to you to correctly install those recording template on each target machine. If none is specified, the default recording template of Java flight recorder is used.
+
 .. note::
 
    The licensing terms of Java flight recorder do not allow you to run it in production environments without a valid license (for details, please refer to the `Oracle Java SE Advanced & Suite Products page <http://www.oracle.com/technetwork/java/javaseproducts/overview/index.html>`_). However, running in a QA environment is fine.

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -220,8 +220,9 @@ class InProcessLauncher:
         logger.info("Starting node [%s] based on car [%s]." % (node_name, car))
 
         enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
+        telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
         node_telemetry = [
-            telemetry.FlightRecorder(node_telemetry_dir, java_major_version),
+            telemetry.FlightRecorder(telemetry_params, node_telemetry_dir, java_major_version),
             telemetry.JitCompiler(node_telemetry_dir),
             telemetry.Gc(node_telemetry_dir, java_major_version),
             telemetry.PerfStat(node_telemetry_dir),

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -335,6 +335,11 @@ def create_arg_parser():
                  "with `%s list telemetry`" % PROGRAM_NAME,
             default="")
         p.add_argument(
+            "--telemetry-params",
+            help="define a comma-separated list of key:value pairs that are injected verbatim to the telemetry devices as parameters",
+            default=""
+        )
+        p.add_argument(
             "--distribution-repository",
             help="define the repository from where the Elasticsearch distribution should be downloaded (default: release).",
             default="release")
@@ -705,6 +710,7 @@ def main():
         cfg.add(config.Scope.applicationOverride, "mechanic", "keep.running", False)
         cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
     cfg.add(config.Scope.applicationOverride, "mechanic", "telemetry.devices", csv_to_list(args.telemetry))
+    cfg.add(config.Scope.applicationOverride, "mechanic", "telemetry.params", to_dict(args.telemetry_params))
 
     cfg.add(config.Scope.applicationOverride, "race", "pipeline", args.pipeline)
     cfg.add(config.Scope.applicationOverride, "race", "laps", args.laps)


### PR DESCRIPTION
With this commit we add a new command line flag `--telemetry-params`
which allows users to inject parameters to telemetry devices.

We also enhance the `jfr` telemetry device to choose the recording
template based on such a parameter.