### PR TITLE
Report store and translog size

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -149,4 +149,6 @@ Rally stores the following metrics:
 * ``indexing_throttle_time``: Total time that indexing has been throttled as reported by the indices stats API. Note that this is not Wall clock time.
 * ``refresh_total_time``: Total time used for index refresh as reported by the indices stats API. Note that this is not Wall clock time.
 * ``flush_total_time``: Total time used for index flush as reported by the indices stats API. Note that this is not Wall clock time.
-* ``final_index_size_bytes``: Final resulting index size after the benchmark.
+* ``final_index_size_bytes``: Final resulting index size on the file system after all nodes have been shutdown at the end of the benchmark. It includes all files in the nodes' data directories (actual index files and translog).
+* ``store_size_in_bytes``: The size in bytes of the index (excluding the translog) as reported by the indices stats API.
+* ``translog_size_in_bytes``: The size in bytes of the translog as reported by the indices stats API.

--- a/docs/summary_report.rst
+++ b/docs/summary_report.rst
@@ -81,8 +81,20 @@ Total Old Gen GC
 Index size
 ----------
 
-* **Definition**: Final resulting index size after the benchmark.
+* **Definition**: Final resulting index size on the file system after all nodes have been shutdown at the end of the benchmark. It includes all files in the nodes' data directories (actual index files and translog).
 * **Corresponding metrics key**: ``final_index_size_bytes``
+
+Store size
+----------
+
+* **Definition**: The size in bytes of the index (excluding the translog) as reported by the indices stats API.
+* **Corresponding metrics key**: ``store_size_in_bytes``
+
+Translog size
+-------------
+
+* **Definition**: The size in bytes of the translog as reported by the indices stats API.
+* **Corresponding metrics key**: ``translog_size_in_bytes``
 
 Totally written
 ---------------

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -728,6 +728,17 @@ class IndexStatsTests(TestCase):
                     "flush": {
                         "total_time_in_millis": 100
                     }
+                },
+                "total": {
+                    "store": {
+                        "size_in_bytes": 2113867510
+                    },
+                    "translog": {
+                        "operations": 6840000,
+                        "size_in_bytes": 2647984713,
+                        "uncommitted_operations": 0,
+                        "uncommitted_size_in_bytes": 430
+                    }
                 }
             }
         })
@@ -748,7 +759,8 @@ class IndexStatsTests(TestCase):
             mock.call("segments_stored_fields_memory_in_bytes", 1024, "byte"),
             mock.call("segments_terms_memory_in_bytes", 256, "byte"),
             # we don't have norms, so nothing should have been called
-            mock.call("segments_points_memory_in_bytes", 512, "byte"),
+            mock.call("store_size_in_bytes", 2113867510, "byte"),
+            mock.call("translog_size_in_bytes", 2647984713, "byte"),
         ], any_order=True)
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")


### PR DESCRIPTION
With this commit we capture and report two new metrics:

* Store size
* Translog size

as reported by the indices stats API. While store size + translog size
is very close to what is reported so far as index size, we use different
approaches to get these data, hence there might be (very small)
differences. However, by querying the indices stats API we can get these
data even when the `benchmark-only` pipeline has been used.

Closes #252