### PR TITLE
Remove 'index-settings' property

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -82,45 +82,44 @@ Consider the following track snippet showing a single challenge::
 
     {
       "name": "index-only",
-      "index-settings": {
-        "index.number_of_replicas": {{ replica_count|default(0) }},
-        "index.number_of_shards": {{ shard_count|default(5) }},
-      },
       "schedule": [
-        {
-          "operation": "bulk-index",
-          "warmup-time-period": 120,
-          "clients": 8
-        }
+         {
+           "operation": {
+             "operation-type": "bulk",
+             "bulk-size": {{ bulk_size|default(5000) }}
+           },
+           "warmup-time-period": 120,
+           "clients": {{ clients|default(8) }}
+         }
       ]
     }
 
 Rally tracks can use the Jinja templating language and the construct ``{{ some_variable|default(0) }}`` that you can see above is a `feature of Jinja <http://jinja.pocoo.org/docs/2.10/templates/#default>`_ to define default values for variables.
 
-We can see that it defines two variables:
+We can see that it defines a variables:
 
-* ``replica_count`` with a default value of 0
-* ``shard_count`` with a default value of 5
+* ``bulk_size`` with a default value of 5000
+* ``clients`` with a default value of 8
 
 When we run this track, we can override these defaults:
 
-* ``--track-params="replica_count:1,shard_count:3"`` will set the number of replicas to 1 and the number of shards to 3.
-* ``--track-params="replica_count:1"`` will just set the number of replicas to 1 and just keep the default value of 5 shards.
+* ``--track-params="bulk_size:2000,clients:16"`` will set the bulk size to 2000 and the number of clients for bulk indexing to 8.
+* ``--track-params="bulk_size:8000"`` will just set the bulk size to 8000 and keep the default value of 8 clients.
 * ``--track-params="params.json"`` will read the track parameters from a JSON file (defined below)
 
 Example JSON file::
 
    {
-      "replica_count": 1,
-      "shard_count": 3
+      "bulk_size": 2000,
+      "clients": 16
    }
 
 All track parameters are recorded for each metrics record in the metrics store. Also, when you run ``esrally list races``, it will show all track parameters::
 
-    Race Timestamp    Track    Track Parameters               Challenge            Car       User Tag
-    ----------------  -------  ------------------------------ -------------------  --------  ---------
-    20160518T122341Z  pmc      replica_count=1                append-no-conflicts  defaults
-    20160518T112341Z  pmc      replica_count=1,shard_count=3  append-no-conflicts  defaults
+    Race Timestamp    Track    Track Parameters          Challenge            Car       User Tag
+    ----------------  -------  ------------------------- -------------------  --------  ---------
+    20160518T122341Z  pmc      bulk_size=8000            append-no-conflicts  defaults
+    20160518T112341Z  pmc      bulk_size=2000,clients=16 append-no-conflicts  defaults
 
 Note that the default values are not recorded or shown (Rally does not know about them).
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -96,14 +96,14 @@ Consider the following track snippet showing a single challenge::
 
 Rally tracks can use the Jinja templating language and the construct ``{{ some_variable|default(0) }}`` that you can see above is a `feature of Jinja <http://jinja.pocoo.org/docs/2.10/templates/#default>`_ to define default values for variables.
 
-We can see that it defines a variables:
+We can see that it defines two variables:
 
 * ``bulk_size`` with a default value of 5000
 * ``clients`` with a default value of 8
 
 When we run this track, we can override these defaults:
 
-* ``--track-params="bulk_size:2000,clients:16"`` will set the bulk size to 2000 and the number of clients for bulk indexing to 8.
+* ``--track-params="bulk_size:2000,clients:16"`` will set the bulk size to 2000 and the number of clients for bulk indexing to 16.
 * ``--track-params="bulk_size:8000"`` will just set the bulk size to 8000 and keep the default value of 8 clients.
 * ``--track-params="params.json"`` will read the track parameters from a JSON file (defined below)
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -665,7 +665,6 @@ Each challenge consists of the following properties:
 * ``name`` (mandatory): A descriptive name of the challenge. Should not contain spaces in order to simplify handling on the command line for users.
 * ``description`` (optional): A human readable description of the challenge.
 * ``default`` (optional): If true, Rally selects this challenge by default if the user did not specify a challenge on the command line. If your track only defines one challenge, it is implicitly selected as default, otherwise you need define ``"default": true`` on exactly one challenge.
-* ``index-settings`` (optional): Defines the index settings of the benchmark candidate when an index is created.
 * ``schedule`` (mandatory): Defines the concrete execution order of operations. It is described in more detail below.
 
 .. note::

--- a/esrally/resources/track-schema.json
+++ b/esrally/resources/track-schema.json
@@ -29,10 +29,6 @@
           "type": "object",
           "description": "Defines the cluster settings of the benchmark candidate."
         },
-        "index-settings": {
-          "type": "object",
-          "description": "Defines the index settings of the benchmark candidate when an index is created."
-        },
         "schedule": {
           "type": "array",
           "minItems": 1,

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -829,13 +829,7 @@ class TrackSpecificationReader:
             meta_data = self._r(challenge_spec, "meta", error_ctx=name, mandatory=False)
             # if we only have one challenge it is treated as default challenge, no matter what the user has specified
             default = number_of_challenges == 1 or self._r(challenge_spec, "default", error_ctx=name, mandatory=False)
-            # TODO #381: Remove this setting
-            index_settings = self._r(challenge_spec, "index-settings", error_ctx=name, mandatory=False)
             cluster_settings = self._r(challenge_spec, "cluster-settings", error_ctx=name, mandatory=False)
-
-            if index_settings and self.name not in DEFAULT_TRACKS:
-                console.warn("Challenge [%s] in track [%s] defines the [index-settings] property which will be removed soon. For details "
-                             "please see the migration guide in the docs." % (name, self.name))
 
             if default and default_challenge is not None:
                 self._error("Both '%s' and '%s' are defined as default challenges. Please define only one of them as default."
@@ -867,7 +861,6 @@ class TrackSpecificationReader:
                                         meta_data=meta_data,
                                         description=description,
                                         user_info=user_info,
-                                        index_settings=index_settings,
                                         cluster_settings=cluster_settings,
                                         default=default,
                                         schedule=schedule)

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -349,7 +349,6 @@ class Challenge:
                  name,
                  description=None,
                  user_info=None,
-                 index_settings=None,
                  cluster_settings=None,
                  default=False,
                  meta_data=None,
@@ -358,7 +357,6 @@ class Challenge:
         self.meta_data = meta_data if meta_data else {}
         self.description = description
         self.user_info = user_info
-        self.index_settings = index_settings if index_settings else {}
         self.cluster_settings = cluster_settings if cluster_settings else {}
         self.default = default
         self.schedule = schedule if schedule else []
@@ -379,13 +377,13 @@ class Challenge:
         return ", ".join(r)
 
     def __hash__(self):
-        return hash(self.name) ^ hash(self.description) ^ hash(self.index_settings) ^ hash(self.cluster_settings) ^ hash(self.default) ^ \
+        return hash(self.name) ^ hash(self.description) ^ hash(self.cluster_settings) ^ hash(self.default) ^ \
                hash(self.meta_data) ^ hash(self.schedule)
 
     def __eq__(self, othr):
         return (isinstance(othr, type(self)) and
-                (self.name, self.description, self.index_settings, self.cluster_settings, self.default, self.meta_data, self.schedule) ==
-                (othr.name, othr.description, othr.index_settings, othr.cluster_settings, othr.default, othr.meta_data, othr.schedule))
+                (self.name, self.description, self.cluster_settings, self.default, self.meta_data, self.schedule) ==
+                (othr.name, othr.description, othr.cluster_settings, othr.default, othr.meta_data, othr.schedule))
 
 
 @unique

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -668,7 +668,7 @@ class EsResultsStoreTests(TestCase):
 
         t = track.Track(name="unittest-track",
                         indices=[track.Index(name="tests", types=["test-type"])],
-                        challenges=[track.Challenge(name="index", default=True, index_settings=None, schedule=schedule)])
+                        challenges=[track.Challenge(name="index", default=True, schedule=schedule)])
 
         c = cluster.Cluster([], [], None)
         c.distribution_version = "5.0.0"

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -691,7 +691,6 @@ class TrackPostProcessingTests(TestCase):
                 {
                     "name": "default-challenge",
                     "description": "Default challenge",
-                    "index-settings": {},
                     "schedule": [
                         {
                             "clients": 8,
@@ -764,7 +763,6 @@ class TrackPostProcessingTests(TestCase):
                 {
                     "name": "default-challenge",
                     "description": "Default challenge",
-                    "index-settings": {},
                     "schedule": [
                         {
                             "clients": 8,
@@ -1024,7 +1022,6 @@ class TrackSpecificationReaderTests(TestCase):
             "challenges": [
                 {
                     "name": "default-challenge",
-                    "index-settings": {},
                     "schedule": [
                         {
                             "clients": 8,
@@ -1148,7 +1145,6 @@ class TrackSpecificationReaderTests(TestCase):
             "challenges": [
                 {
                     "name": "default-challenge",
-                    "index-settings": {},
                     "schedule": [
                         {
                             "clients": 8,
@@ -1327,9 +1323,6 @@ class TrackSpecificationReaderTests(TestCase):
                         "mixed": True,
                         "max-clients": 8
                     },
-                    "index-settings": {
-                        "index.number_of_replicas": 2
-                    },
                     "schedule": [
                         {
                             "clients": 8,
@@ -1414,8 +1407,6 @@ class TrackSpecificationReaderTests(TestCase):
         self.assertEqual(1, len(resulting_track.challenges))
         self.assertEqual("default-challenge", resulting_track.challenges[0].name)
         self.assertEqual("Default challenge", resulting_track.challenges[0].description)
-        self.assertEqual(1, len(resulting_track.challenges[0].index_settings))
-        self.assertEqual(2, resulting_track.challenges[0].index_settings["index.number_of_replicas"])
         self.assertEqual({"mixed": True, "max-clients": 8}, resulting_track.challenges[0].meta_data)
         self.assertEqual({"append": True}, resulting_track.challenges[0].schedule[0].operation.meta_data)
         self.assertEqual({"operation-index": 0}, resulting_track.challenges[0].schedule[0].meta_data)


### PR DESCRIPTION
With this commit we remove the deprecated track property
`index-settings`. Since Rally 0.9.0, index settings can be provided via
the `settings` property of the `create-index` operation hence making a
specific property obsolete.

Closes #381