### PR TITLE
esrally must not log clear text user passwords

### DIFF
--- a/esrally/client.py
+++ b/esrally/client.py
@@ -12,7 +12,10 @@ class EsClientFactory:
     Abstracts how the Elasticsearch client is created. Intended for testing.
     """
     def __init__(self, hosts, client_options):
-        logger.info("Creating ES client connected to %s with options [%s]" % (hosts, client_options))
+        masked_client_options = dict(client_options)
+        if masked_client_options.has_key("basic_auth_password"):
+            masked_client_options["basic_auth_password"] = "*****"
+        logger.info("Creating ES client connected to %s with options [%s]" % (hosts, masked_client_options))
         self.hosts = hosts
         self.client_options = client_options
 

--- a/esrally/client.py
+++ b/esrally/client.py
@@ -15,6 +15,8 @@ class EsClientFactory:
         masked_client_options = dict(client_options)
         if masked_client_options.has_key("basic_auth_password"):
             masked_client_options["basic_auth_password"] = "*****"
+        if masked_client_options.has_key("http_auth"):
+            masked_client_options["http_auth"] = (client_options["basic_auth_user"], "*****")
         logger.info("Creating ES client connected to %s with options [%s]" % (hosts, masked_client_options))
         self.hosts = hosts
         self.client_options = client_options

--- a/esrally/client.py
+++ b/esrally/client.py
@@ -13,11 +13,11 @@ class EsClientFactory:
     """
     def __init__(self, hosts, client_options):
         masked_client_options = dict(client_options)
-        if masked_client_options.has_key("basic_auth_password"):
+        if "basic_auth_password" in masked_client_options:
             masked_client_options["basic_auth_password"] = "*****"
-        if masked_client_options.has_key("http_auth"):
-            masked_client_options["http_auth"] = (client_options["basic_auth_user"], "*****")
-        logger.info("Creating ES client connected to %s with options [%s]" % (hosts, masked_client_options))
+        if "http_auth" in masked_client_options:
+            masked_client_options["http_auth"] = (client_options["http_auth"][0], "*****")
+        logger.info("Creating ES client connected to %s with options [%s]", hosts, masked_client_options)
         self.hosts = hosts
         self.client_options = client_options
 


### PR DESCRIPTION
esrally 0.9.4 logs the basic auth password in clear text:

```
2018-04-08 07:00:00,100 PID:42 rally.client INFO Creating ES client connected to [{'host': '1.2.3.4', 'port': 9200}, {'host': '1.2.3.5', 'port': 9200}] with options [{'use_ssl': True, 'verify_certs': False, 'basic_auth_user': 'me', 'basic_auth_password': 'mypassword', 'http_auth': ('me', 'password')}]
```

esrally must not do this to enable usage in enterprise environments.

Please accept PR (following).