### PR TITLE
Default to upgrading packages with setuptools

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -18,9 +18,9 @@ install_esrally_with_setuptools () {
     fi
 
     if [[ ${IN_VIRTUALENV} == 0 ]]; then
-        python3 setup.py -q develop --user
+        python3 setup.py -q develop --user --upgrade
     else
-        python3 setup.py -q develop
+        python3 setup.py -q develop --upgrade
     fi
 }
 


### PR DESCRIPTION
Currently if a PyPi package version changes in setup.py,
e.g. upgrading the version of the elasticsearch Python client,
`run.sh` will not upgrade packages.

Always try to upgrade packages with setuptools before running the
Rally binary.

Relates #395