### PR TITLE
Don't require git

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -69,7 +69,12 @@ We recommend that you use `Homebrew <https://brew.sh/>`_::
 git
 ~~~
 
-``git 1.9`` or better is required. Verify with ``git --version``.
+Git is not required if **all** of the following conditions are met:
+
+* You are using Rally only as a load generator (``--pipeline=benchmark-only``) or you are referring to Elasticsearch configurations with ``--team-path``
+* You create your own tracks and refer to them with ``--track-path``
+
+In all other cases, Rally requires ``git 1.9`` or better. Verify with ``git --version``.
 
 **Debian / Ubuntu**
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -71,8 +71,8 @@ git
 
 Git is not required if **all** of the following conditions are met:
 
-* You are using Rally only as a load generator (``--pipeline=benchmark-only``) or you are referring to Elasticsearch configurations with ``--team-path``
-* You create your own tracks and refer to them with ``--track-path``
+* You are using Rally only as a load generator (``--pipeline=benchmark-only``) or you are referring to Elasticsearch configurations with ``--team-path``.
+* You create your own tracks and refer to them with ``--track-path``.
 
 In all other cases, Rally requires ``git 1.9`` or better. Verify with ``git --version``.
 

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -8,8 +8,8 @@ from esrally.utils import io, process
 def probed(f):
     def probe(src, *args, **kwargs):
         # Probe for -C
-        if not process.exit_status_as_bool(lambda: process.run_subprocess_with_logging("git -C %s --version" % src, level=logging.DEBUG),
-                                           quiet=True):
+        if not process.exit_status_as_bool(lambda: process.run_subprocess_with_logging(
+                "git -C {} --version".format(src), level=logging.DEBUG), quiet=True):
             version = process.run_subprocess_with_output("git --version")
             if version:
                 version = str(version).strip()

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -8,7 +8,8 @@ from esrally.utils import io, process
 def probed(f):
     def probe(src, *args, **kwargs):
         # Probe for -C
-        if not process.exit_status_as_bool(lambda: process.run_subprocess_with_logging("git -C %s --version" % src, level=logging.DEBUG)):
+        if not process.exit_status_as_bool(lambda: process.run_subprocess_with_logging("git -C %s --version" % src, level=logging.DEBUG),
+                                           quiet=True):
             version = process.run_subprocess_with_output("git --version")
             if version:
                 version = str(version).strip()
@@ -25,7 +26,7 @@ def is_working_copy(src):
     :param src: A directory. May or may not exist.
     :return: True iff the given directory is a git working copy.
     """
-    return os.path.exists(src) and os.path.exists("%s/.git" % src)
+    return os.path.exists(src) and os.path.exists(os.path.join(src, ".git"))
 
 
 def clone(src, remote):

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -28,17 +28,19 @@ def run_subprocess_with_output(command_line):
     return lines
 
 
-def exit_status_as_bool(runnable):
+def exit_status_as_bool(runnable, quiet=False):
     """
 
     :param runnable: A runnable returning an int as exit status assuming ``0`` is meaning success.
+    :param quiet: Suppress any output (default: False).
     :return: True iff the runnable has terminated successfully.
     """
     try:
         return_code = runnable()
         return return_code == 0 or return_code is None
     except OSError:
-        logger.exception("Could not execute command.")
+        if not quiet:
+            logger.exception("Could not execute command.")
         return False
 
 


### PR DESCRIPTION
With this commit we silence a spurious log message when git is not
present and document under which circumstances it is ok *not* to have
git installed.

Closes #339