### PR TITLE
Allow to use track parameters in index definition

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -580,7 +580,7 @@ class TrackFileReader:
         with open(track_schema_file, mode="rt", encoding="utf-8") as f:
             self.track_schema = json.loads(f.read())
         self.track_params = cfg.opts("track", "params")
-        self.read_track = TrackSpecificationReader()
+        self.read_track = TrackSpecificationReader(self.track_params)
 
     def read(self, track_name, track_spec_file, mapping_dir):
         """


### PR DESCRIPTION
Previously we forgot to pass track parameters to the
`TrackSpecificationReader`. As a consequence, we could not use track
parameters in index definitions as they were always empty.

With this commit we finally pass them there as well fixing the issue
above.