### PR TITLE
Don't pass type implicitly for queries

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -354,7 +354,7 @@ search
 With the operation type ``search`` you can execute `request body searches <http://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html>`_. It supports the following properties:
 
 * ``index`` (optional): An `index pattern <https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html>`_ that defines which indices should be targeted by this query. Only needed if the ``index`` section contains more than one index. Otherwise, Rally will automatically derive the index to use. If you have defined multiple indices and want to query all of them, just specify ``"index": "_all"``.
-* ``type`` (optional): Defines the type within the specified index for this query.
+* ``type`` (optional): Defines the type within the specified index for this query. By default, no ``type`` will be used and the query will be performed across all types in the provided index.
 * ``cache`` (optional): Whether to use the query request cache. By default, Rally will define no value thus the default depends on the benchmark candidate settings and Elasticsearch version.
 * ``request-params`` (optional): A structure containing arbitrary request parameters. The supported parameters names are documented in the `Python ES client API docs <http://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.search>`_. Parameters that are implicitly set by Rally (e.g. `body` or `request_cache`) are not supported (i.e. you should not try to set them and if so expect unspecified behavior).
 * ``body`` (mandatory): The query body.

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -339,16 +339,11 @@ class SearchParamSource(ParamSource):
         super().__init__(track, params, **kwargs)
         if len(track.indices) == 1:
             default_index = track.indices[0].name
-            if len(track.indices[0].types) == 1:
-                default_type = track.indices[0].types[0]
-            else:
-                default_type = None
         else:
             default_index = None
-            default_type = None
 
         index_name = params.get("index", default_index)
-        type_name = params.get("type", default_type)
+        type_name = params.get("type")
         request_cache = params.get("cache", False)
         query_body = params.get("body", None)
         query_body_params = params.get("body-params", None)

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1273,7 +1273,7 @@ class SearchParamSourceTests(TestCase):
 
         self.assertEqual(7, len(p))
         self.assertEqual("index1", p["index"])
-        self.assertEqual("type1", p["type"])
+        self.assertIsNone(p["type"])
         self.assertEqual({
             "_source_include": "some_field"
         }, p["request-params"])
@@ -1289,6 +1289,33 @@ class SearchParamSourceTests(TestCase):
             "_source_include": "some_field"
         }, p["request_params"])
 
+    def test_user_specified_overrides_defaults(self):
+        index1 = track.Index(name="index1", types=["type1"])
+
+        source = params.SearchParamSource(track=track.Track(name="unit-test", indices=[index1]), params={
+            "index": "_all",
+            "type": "type1",
+            "body": {
+                "query": {
+                    "match_all": {}
+                }
+            }
+        })
+        p = source.params()
+
+        self.assertEqual(7, len(p))
+        self.assertEqual("_all", p["index"])
+        self.assertEqual("type1", p["type"])
+        self.assertDictEqual({}, p["request-params"])
+        self.assertFalse(p["cache"])
+        self.assertEqual({
+            "query": {
+                "match_all": {}
+            }
+        }, p["body"])
+        # backwards-compatibility options
+        self.assertFalse(p["use_request_cache"])
+        self.assertDictEqual({}, p["request_params"])
 
     def test_replaces_body_params(self):
         import copy


### PR DESCRIPTION
With this commit users need to explicitly define that a type should be
passed when issuing a query against Elasticsearch. The reason is that
types are deprecated with Elasticsearch 7 and will be removed in
Elasticsearch 8. Hence we already change the behavior in Rally to avoid
deprecation warnings when benchmarking against master.