### PR TITLE
Rename telemetry device that gathers GC stats

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -44,7 +44,7 @@ class ClusterLauncher:
         t = telemetry.Telemetry(devices=[
             telemetry.ClusterMetaDataInfo(es),
             telemetry.ClusterEnvironmentInfo(es, self.metrics_store),
-            telemetry.NodeStats(es, self.metrics_store),
+            telemetry.GcTimesSummary(es, self.metrics_store),
             telemetry.IndexStats(es, self.metrics_store),
             telemetry.MlBucketProcessingTime(es, self.metrics_store)
         ])

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -637,9 +637,9 @@ class ClusterMetaDataInfo(InternalTelemetryDevice):
                 }
 
 
-class NodeStats(InternalTelemetryDevice):
+class GcTimesSummary(InternalTelemetryDevice):
     """
-    Gathers statistics via the Elasticsearch nodes stats API
+    Gathers a summary of the total young gen/old gen GC runtime during the whole race.
     """
     def __init__(self, client, metrics_store):
         super().__init__()

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -640,7 +640,7 @@ class ClusterMetaDataInfoTests(TestCase):
         self.assertEqual("unknown", n.fs[1]["spins"])
 
 
-class NodeStatsTests(TestCase):
+class GcTimesSummaryTests(TestCase):
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
     def test_stores_only_diff_of_gc_times(self, metrics_store_node_level, metrics_store_cluster_level):
@@ -669,7 +669,7 @@ class NodeStatsTests(TestCase):
         cfg = create_config()
 
         metrics_store = metrics.EsMetricsStore(cfg)
-        device = telemetry.NodeStats(client, metrics_store)
+        device = telemetry.GcTimesSummary(client, metrics_store)
         t = telemetry.Telemetry(cfg, devices=[device])
         t.on_benchmark_start()
         # now we'd need to change the node stats response


### PR DESCRIPTION
With this commit we rename the internal telemetry device name that
gathers GC summary statistics from `NodeStats` to `GcTimesSummary` as
the latter name better conveys our intent.