### PR TITLE
Create unique ids even for random conflicts

### DIFF
--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -565,17 +565,16 @@ def number_of_bulks(corpora, partition_index, total_partitions, bulk_size):
     return bulks
 
 
-def build_conflicting_ids(conflicts, docs_to_index, offset, rand=random.randint):
+def build_conflicting_ids(conflicts, docs_to_index, offset, shuffle=random.shuffle):
     if conflicts is None or conflicts == IndexIdConflict.NoConflicts:
         return None
     logger.info("building ids with id conflicts of type [%s]" % conflicts)
     all_ids = [0] * docs_to_index
     for i in range(docs_to_index):
         # always consider the offset as each client will index its own range and we don't want uncontrolled conflicts across clients
-        if conflicts == IndexIdConflict.SequentialConflicts:
-            all_ids[i] = "%10d" % (offset + i)
-        else:  # RandomConflicts
-            all_ids[i] = "%10d" % rand(offset, offset + docs_to_index)
+        all_ids[i] = "%10d" % (offset + i)
+    if conflicts == IndexIdConflict.RandomConflicts:
+        shuffle(all_ids)
     return all_ids
 
 

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -79,22 +79,24 @@ class ConflictingIdsBuilderTests(TestCase):
         )
 
     def test_random_conflicts(self):
+        predictable_shuffle = list.reverse
+
         self.assertEqual(
             [
-                "         3",
-                "         3",
-                "         3"
+                "         2",
+                "         1",
+                "         0"
             ],
-            params.build_conflicting_ids(params.IndexIdConflict.RandomConflicts, 3, 0, rand=lambda x, y: y)
+            params.build_conflicting_ids(params.IndexIdConflict.RandomConflicts, 3, 0, shuffle=predictable_shuffle)
         )
 
         self.assertEqual(
             [
-                "         8",
-                "         8",
-                "         8"
+                "         7",
+                "         6",
+                "         5"
             ],
-            params.build_conflicting_ids(params.IndexIdConflict.RandomConflicts, 3, 5, rand=lambda x, y: y)
+            params.build_conflicting_ids(params.IndexIdConflict.RandomConflicts, 3, 5, shuffle=predictable_shuffle)
         )
 
 


### PR DESCRIPTION
With this commit we ensure that generated ids are always unique, even
when generating random conflicts for bulk requests. The general strategy
to simulate conflicts is as follows:

1. Generate a list of ids upfront.
2. Iterate through this list and pick a duplicate in 25% of all cases.

In order to avoid accidentally creating more conflicts than expected,
the list of ids generated in step one needs to contain *unique* ids.
However, we create ids at random without considering which ids have
already been generated. This is now changed by first generating all ids
and then shuffling them.