### PR TITLE
Add generic node-stats telemetry device

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -16,12 +16,13 @@ You probably want to gain additional insights from a race. Therefore, we have ad
 
    Available telemetry devices:
 
-   Command    Name                   Description
-   ---------  ---------------------  -----------------------------------------------------
-   jit        JIT Compiler Profiler  Enables JIT compiler logs.
-   gc         GC log                 Enables GC logs.
-   jfr        Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK)
-   perf       perf stat              Reads CPU PMU counters (requires Linux and perf)
+   Command     Name                   Description
+   ----------  ---------------------  -----------------------------------------------------
+   jit         JIT Compiler Profiler  Enables JIT compiler logs.
+   gc          GC log                 Enables GC logs.
+   jfr         Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK)
+   perf        perf stat              Reads CPU PMU counters (requires Linux and perf)
+   node-stats  Node Stats             Regularly samples node stats
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 
@@ -68,3 +69,25 @@ perf
 ----
 
 The ``perf`` telemetry device runs ``perf stat`` on each benchmarked node and writes the output to a log file. It can be used to capture low-level CPU statistics. Note that the perf tool, which is only available on Linux, must be installed before using this telemetry device.
+
+node-stats
+----------
+
+.. warning::
+
+    This telemetry device will record a lot of metrics and likely skew your measurement results.
+
+The node-stats telemetry devices regularly calls the node-stats API and records metrics from the following sections:
+
+* Indices stats (key ``indices`` in the node-stats API)
+* Thread pool stats (key ``jvm.thread_pool`` in the node-stats API)
+* JVM buffer pool stats (key ``jvm.buffer_pools`` in the node-stats API)
+* Circuit breaker stats (key ``breakers`` in the node-stats API)
+
+Supported telemetry parameters:
+
+* ``node-stats-sample-interval`` (default: 1): A positive number greater than zero denoting the sampling interval in seconds.
+* ``node-stats-include-indices`` (default: ``false``): A boolean indicating whether indices stats should be included.
+* ``node-stats-include-thread-pools`` (default: ``true``): A boolean indicating whether thread pool stats should be included.
+* ``node-stats-include-buffer-pools`` (default: ``true``): A boolean indicating whether buffer pool stats should be included.
+* ``node-stats-include-breakers`` (default: ``true``): A boolean indicating whether circuit breaker stats should be included.

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -37,11 +37,14 @@ class ClusterLauncher:
         self.client_factory = client_factory_class
 
     def start(self):
+        enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
+        telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
         hosts = self.cfg.opts("client", "hosts")
         client_options = self.cfg.opts("client", "options")
         es = self.client_factory(hosts, client_options).create()
 
-        t = telemetry.Telemetry(devices=[
+        t = telemetry.Telemetry(enabled_devices, devices=[
+            telemetry.NodeStats(telemetry_params, es, self.metrics_store),
             telemetry.ClusterMetaDataInfo(es),
             telemetry.ClusterEnvironmentInfo(es, self.metrics_store),
             telemetry.GcTimesSummary(es, self.metrics_store),


### PR DESCRIPTION
With this commit we add a telemetry device that can be enabled by the
user to capture node stats regularly.