### PR TITLE
Improve release process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.6
+
+ARG NEW_USER_UID
+ARG NEW_USER
+
+RUN apt-get -y update && \
+    apt-get install -y vim openssh-client python-tox && \
+    pip3 install twine sphinx sphinx_rtd_theme wheel && \
+    pip3 install --pre github3.py
+
+RUN useradd -u ${NEW_USER_UID} -U -d /home/${NEW_USER} -s /bin/bash -m ${NEW_USER}
+
+USER ${NEW_USER}
+WORKDIR /home/${NEW_USER}
+
+# Also add a venv, in case it becomes useful later on. Strictly speaking venv shouldn't be needed inside a container.
+RUN python3 -m venv venv

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,11 @@ release-checks:
 release: release-checks clean docs it
 	./release.sh $(release_version) $(next_version)
 
-.PHONY: clean docs test it it34 it35 it36 benchmark coverage release release-checks
+# still run `it` tests locally as Docker on macOS runs in a vm (and is slower)
+release-in-docker: release-checks clean docs it
+	export UID; \
+	export USER; \
+	docker-compose build --pull; `# add --pull here to rebuild a fresh image` \
+	docker-compose run --rm rally-release ./release.sh $(release_version) $(next_version)
+
+.PHONY: clean docs test it it34 it35 it36 benchmark coverage release release-checks release-in-docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '2.2'
+services:
+  rally-release:
+    build:
+      context: .
+      args:
+        NEW_USER_UID: ${UID}
+        NEW_USER: ${USER}
+    container_name: rally-runner
+    volumes:
+      - $SSH_AUTH_SOCK:/ssh-agent
+      - $HOME/.gitconfig:/home/${USER}/.gitconfig
+      - $HOME/.github:/home/${USER}/.github
+      - $HOME/.gnupg:/home/${USER}/.gnupg
+      - $PWD/.:/home/${USER}/rally
+    environment:
+      SSH_AUTH_SOCK: '/ssh-agent'
+    image: rally-release
+    user: ${UID}
+    working_dir: /home/${USER}/rally

--- a/release.sh
+++ b/release.sh
@@ -38,7 +38,7 @@ echo "$RELEASE_VERSION" > version.txt
 git commit -a -m "Bump version to $RELEASE_VERSION"
 
 # --upgrade is required for virtualenv
-python3 setup.py develop --upgrade
+python3 setup.py develop --upgrade --user
 
 # Check version
 if ! [[ $(esrally --version) =~ "esrally ${RELEASE_VERSION} (git revision" ]]
@@ -60,7 +60,7 @@ git push --tags
 echo "$NEXT_RELEASE" > version.txt
 
 # Install locally for development
-python3 setup.py develop --upgrade
+python3 setup.py develop --upgrade --user
 
 git commit -a -m "Continue in $NEXT_RELEASE"
 git push origin master


### PR DESCRIPTION
Commit `Dockerfile`, `docker-compose` and new `release-in-docker` make target
to allow running the release process from within a Docker container.

The container tries to use the same username/uid as the local user and
bind-mounts the needed files for gpg, ssh-agent and github release
token.

The execution of `make it` is still a task left outside of the container
primarily due to execution time on macOS.

Relates #483 