### PR TITLE
Add new Makefile target to run it tests inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:16.04
+
+ARG NEW_USER_UID
+ARG NEW_USER
+
+RUN apt-get -y update && \
+    apt-get install -y curl python3 python3-pip vim openssh-client \
+    git make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+    openjdk-8-jdk
+
+RUN pip3 install tox virtualenvwrapper twine sphinx sphinx_rtd_theme wheel
+RUN pip3 install --pre github3.py
+
+RUN curl --progress-bar -o openjdk-10.0.1_linux-x64_bin.tar.gz \
+    https://download.java.net/java/GA/jdk10/10.0.1/fb4372174a714e6b8c52526dc134031e/10/openjdk-10.0.1_linux-x64_bin.tar.gz && \
+    mkdir -p /opt/jdk-10 ; tar xzf openjdk-10.0.1_linux-x64_bin.tar.gz -C /opt/jdk-10 --strip-components 1 && rm openjdk-10.0.1_linux-x64_bin.tar.gz
+
+RUN useradd -u ${NEW_USER_UID} -U -d /home/${NEW_USER} -s /bin/bash -m ${NEW_USER}
+
+USER ${NEW_USER}
+WORKDIR /home/${NEW_USER}
+
+RUN git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+
+ENV HOME /home/${NEW_USER}
+ENV PYENV_ROOT=/home/${NEW_USER}/.pyenv
+ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+ENV JAVA_HOME=/opt/jdk-10
+ENV RUNTIME_JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+
+RUN pyenv install 3.4.8
+RUN pyenv install 3.5.5
+RUN pyenv install 3.6.5
+RUN pyenv global 3.6.5 3.5.5 3.4.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get -y update && \
     openjdk-8-jdk
 
 RUN pip3 install tox virtualenvwrapper twine sphinx sphinx_rtd_theme wheel
-RUN pip3 install --pre github3.py
 
 RUN curl --progress-bar -o openjdk-10.0.1_linux-x64_bin.tar.gz \
     https://download.java.net/java/GA/jdk10/10.0.1/fb4372174a714e6b8c52526dc134031e/10/openjdk-10.0.1_linux-x64_bin.tar.gz && \

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ release: release-checks clean docs it
 	./release.sh $(release_version) $(next_version)
 
 docker-it: nondocs-clean python-caches-clean
-	@if ! export | grep UID; then export UID=$(shell id -u); fi ; \
+	@if ! export | grep UID; then -export UID=$(shell id -u) || export UID; fi ; \
 	if ! export | grep USER; then export USER=$(shell echo $$USER); fi ; \
 	if ! export | grep PWD; then export PWD=$(shell pwd); fi ; \
 	docker-compose build --pull; `# add --pull here to rebuild a fresh image` \

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ release: release-checks clean docs it
 	./release.sh $(release_version) $(next_version)
 
 docker-it: nondocs-clean python-caches-clean
-	@if ! export | grep UID; then -export UID=$(shell id -u) || export UID; fi ; \
+	@if ! export | grep UID; then export UID=$(shell id -u); fi ; \
 	if ! export | grep USER; then export USER=$(shell echo $$USER); fi ; \
 	if ! export | grep PWD; then export PWD=$(shell pwd); fi ; \
 	docker-compose build --pull; `# add --pull here to rebuild a fresh image` \

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ docs-clean:
 
 # Avoid conflicts between .pyc/pycache related files created by local Python interpreters and other interpreters in Docker
 python-caches-clean:
-	-find ./ -name "__pycache__" -exec rm -rf -- \{\} \;
-	-find ./ -name ".pyc" -exec rm -rf -- \{\} \;
+	-@find . -name "__pycache__" -exec rm -rf -- \{\} \;
+	-@find . -name ".pyc" -exec rm -rf -- \{\} \;
 
 docs:
 	cd docs && $(MAKE) html

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ docs:
 test:
 	python3 setup.py test
 
-it:
+it: python-caches-clean
 	tox
 
-it34:
+it34: python-caches-clean
 	tox -e py34
 
-it35:
+it35: python-caches-clean
 	tox -e py35
 
 it36:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
-clean:
+clean: nondocs-clean docs-clean
+
+nondocs-clean:
 	rm -rf .benchmarks .eggs .tox .rally_it .cache build dist esrally.egg-info logs junit-py*.xml
+
+docs-clean:
 	cd docs && $(MAKE) clean
+
+# Avoid conflicts between .pyc/pycache related files created by local Python interpreters and other interpreters in Docker
+python-caches-clean:
+	-find ./ -name "__pycache__" -exec rm -rf -- \{\} \;
+	-find ./ -name ".pyc" -exec rm -rf -- \{\} \;
 
 docs:
 	cd docs && $(MAKE) html
@@ -34,4 +43,11 @@ release-checks:
 release: release-checks clean docs it
 	./release.sh $(release_version) $(next_version)
 
-.PHONY: clean docs test it it34 it35 it36 benchmark coverage release release-checks
+docker-it: nondocs-clean python-caches-clean
+	@if ! export | grep UID; then export UID=$(shell id -u); fi ; \
+	if ! export | grep USER; then export USER=$(shell echo $$USER); fi ; \
+	if ! export | grep PWD; then export PWD=$(shell pwd); fi ; \
+	docker-compose build --pull; `# add --pull here to rebuild a fresh image` \
+	docker-compose run --rm rally-tests /bin/bash -c "make docs-clean && make it"
+
+.PHONY: clean nondocs-clean docs-clean python-caches-clean docs test docker-it it it34 it35 it36 benchmark coverage release release-checks

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ it34: python-caches-clean
 it35: python-caches-clean
 	tox -e py35
 
-it36:
+it36: python-caches-clean
 	tox -e py36
 
 benchmark:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2.2'
+services:
+  rally-tests:
+    build:
+      context: .
+      args:
+        - NEW_USER_UID=${UID}
+        - NEW_USER=${USER}
+    container_name: rally-tests
+    volumes:
+      - $HOME/.gitconfig:/home/${USER}/.gitconfig
+      - $HOME/.github:/home/${USER}/.github
+      - $HOME/.gnupg:/home/${USER}/.gnupg
+      - ${PWD}/.:/home/${USER}/rally
+    image: rally-tests
+    user: ${UID}
+    working_dir: /home/${USER}/rally
+    stdin_open: true
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,6 @@ services:
         - NEW_USER=${USER}
     container_name: rally-tests
     volumes:
-      - $HOME/.gitconfig:/home/${USER}/.gitconfig
-      - $HOME/.github:/home/${USER}/.github
-      - $HOME/.gnupg:/home/${USER}/.gnupg
       - ${PWD}/.:/home/${USER}/rally
     image: rally-tests
     user: ${UID}


### PR DESCRIPTION
`it` tests and `tox` relying on a number of Python 3 versions via
pyenv are a good candidate for running through Docker, as setting up
pyenv and the needed Python versions (as well as required
JAVA_HOME/RUNTIME_JAVA_HOME) can be fiddly.

This is an easier task than https://github.com/elastic/rally/pull/484
as it doesn't rely on passing ssh credentials via the ssh-agent. Only
issue is that on operating systems where Docker runs as a VM (macOS,
Windows) the default configured memory will not to be increased in
order to run the entirety of the integration tests, as Rally uses the
4GB car for Elasticsearch (on top of additional tasks). However, this
target is especially suitable for running integration tests inside a
powerful server/workstation Linux environment without having to worry
about configuring all the dependencies.