### PR TITLE
Get distribution download URL from car config

### DIFF
--- a/docs/car.rst
+++ b/docs/car.rst
@@ -57,6 +57,7 @@ The default car definitions of Rally are stored in ``~/.rally/benchmarks/teams/d
         │           └── jvm.options
         ├── ea.ini
         └── vanilla
+            ├── config.ini
             └── templates
                 └── config
                     ├── elasticsearch.yml
@@ -68,8 +69,12 @@ The top-level directory "v1" denotes the configuration format in version 1. Belo
     [variables]
     clean_command=./gradlew clean
 
-This defines the variable ``clean_command`` for all cars that reference this configuration.
+This defines the variable ``clean_command`` for all cars that reference this configuration. Rally will treat the following variable names specially:
 
+* `clean_command`: The command to clean the Elasticsearch project directory.
+* `build_command`: The command to build an Elasticsearch source distribution.
+* `artifact_path_pattern`: A glob pattern to find a previously built source distribution within the project directory.
+* `release_url`: A download URL for Elasticsearch distributions. The placeholder ``{{VERSION}}`` is replaced by Rally with the actual Elasticsearch version.
 
 Let's have a look at the ``1gheap`` car by inspecting ``1gheap.ini``::
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -64,6 +64,41 @@ Starting with Rally 0.11.0, Rally will look for a directory "v1" within ``cars``
                 │           └── elasticsearch.yml
                 └── transport.ini
 
+It is also required that you create a file ``variables.ini`` for all your car config bases (optional for mixins). Therefore, the full directory structure is::
+
+    .
+    ├── cars
+    │   └── v1
+    │       ├── 1gheap.ini
+    │       ├── 2gheap.ini
+    │       ├── defaults.ini
+    │       ├── ea
+    │       │   └── templates
+    │       │       └── config
+    │       │           └── jvm.options
+    │       ├── ea.ini
+    │       └── vanilla
+    │           ├── config.ini
+    │           └── templates
+    │               └── config
+    │                   ├── elasticsearch.yml
+    │                   ├── jvm.options
+    │                   └── log4j2.properties
+    └── plugins
+        └── v1
+            ├── core-plugins.txt
+            └── transport_nio
+                ├── default
+                │   └── templates
+                │       └── config
+                │           └── elasticsearch.yml
+                └── transport.ini
+
+For distribution-based builds, ``config.ini`` file needs to contain a section ``variables`` and a ``release_url`` property::
+
+    [variables]
+    release_url=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-{{VERSION}}.tar.gz
+
 
 Migrating to Rally 0.10.0
 -------------------------

--- a/esrally/config.py
+++ b/esrally/config.py
@@ -108,7 +108,7 @@ def auto_load_local_config(base_config, additional_sections=None, config_file_cl
 class Config:
     EARLIEST_SUPPORTED_VERSION = 12
 
-    CURRENT_CONFIG_VERSION = 15
+    CURRENT_CONFIG_VERSION = 16
 
     """
     Config is the main entry point to retrieve and set benchmark properties. It provides multiple scopes to allow overriding of values on
@@ -457,11 +457,6 @@ class ConfigFactory:
         config["defaults"]["preserve_benchmark_candidate"] = str(preserve_install)
 
         config["distributions"] = {}
-        config["distributions"]["release.1.url"] = "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-" \
-                                                   "{{VERSION}}.tar.gz"
-        config["distributions"]["release.2.url"] = "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/" \
-                                                   "distribution/tar/elasticsearch/{{VERSION}}/elasticsearch-{{VERSION}}.tar.gz"
-        config["distributions"]["release.url"] = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz"
         config["distributions"]["release.cache"] = "true"
 
         config_file.store(config)
@@ -706,6 +701,15 @@ def migrate(config_file, current_version, target_version, out=print, i=input):
         warn_if_plugin_build_task_is_in_use(config)
 
         current_version = 15
+        config["meta"]["config.version"] = str(current_version)
+
+    if current_version == 15 and target_version > current_version:
+        if "distributions" in config:
+            # Remove obsolete settings
+            config["distributions"].pop("release.1.url", None)
+            config["distributions"].pop("release.2.url", None)
+            config["distributions"].pop("release.url", None)
+        current_version = 16
         config["meta"]["config.version"] = str(current_version)
 
     # all migrations done


### PR DESCRIPTION
With this commit we read the download URL for an Elasticsearch
distribution from the car (and similarly for plugins). This is necessary
because with Elasticsearch 6.3 there will be two Elasticsearch
distributions: A pure OSS one and one that includes x-pack. Handling
this in rally.ini would have been possible but it is cleaner leveraging
our team repository infrastructure for this task.