### PR TITLE
Record "took" for bulk indexing

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -184,6 +184,7 @@ class BulkIndex(Runner):
         * ``success``: A boolean indicating whether the bulk request has succeeded.
         * ``success-count``: Number of successfully processed items for this request (denoted in ``unit``).
         * ``error-count``: Number of failed items for this request (denoted in ``unit``).
+        * ``took``` Value of the the ``took`` property in the bulk response.
 
         If ``detailed-results`` is ``True`` the following meta data are returned in addition:
 
@@ -207,7 +208,8 @@ class BulkIndex(Runner):
                 "bulk-size": 5000,
                 "success": True,
                 "success-count": 5000,
-                "error-count": 0
+                "error-count": 0,
+                "took": 20
             }
 
         Whereas the response will look as follow if there are bulk errors::
@@ -219,7 +221,8 @@ class BulkIndex(Runner):
                 "bulk-size": 5000,
                 "success": False,
                 "success-count": 4000,
-                "error-count": 1000
+                "error-count": 1000,
+                "took": 20
             }
 
         If ``detailed-results`` is ``True`` a typical return value is::
@@ -235,6 +238,7 @@ class BulkIndex(Runner):
                 "success": True,
                 "success-count": 5000,
                 "error-count": 0,
+                "took": 20,
                 "ops": {
                     "index": {
                         "item-count": 5000,
@@ -266,6 +270,7 @@ class BulkIndex(Runner):
                 "success": False,
                 "success-count": 4000,
                 "error-count": 1000,
+                "took": 20,
                 "ops": {
                     "index": {
                         "item-count": 5000,
@@ -390,6 +395,7 @@ class BulkIndex(Runner):
                 bulk_error_count += 1
                 self.extract_error_details(error_details, data)
         stats = {
+            "took": response.get("took"),
             "success": bulk_error_count == 0,
             "success-count": bulk_size - bulk_error_count,
             "error-count": bulk_error_count,
@@ -413,6 +419,7 @@ class BulkIndex(Runner):
                     bulk_error_count += 1
                     self.extract_error_details(error_details, data)
         stats = {
+            "took": response.get("took"),
             "success": bulk_error_count == 0,
             "success-count": bulk_size - bulk_error_count,
             "error-count": bulk_error_count

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -101,7 +101,6 @@ class RegisterRunnerTests(TestCase):
         self.assertEqual("user-defined multi-cluster enabled runner for [UnitTestMultiClusterRunner]", repr(returned_runner))
 
 
-
 class BulkIndexRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     def test_bulk_index_missing_params(self, es):
@@ -127,30 +126,6 @@ class BulkIndexRunnerTests(TestCase):
                          "Please add it to your parameter source.", ctx.exception.args[0])
 
     @mock.patch("elasticsearch.Elasticsearch")
-    def test_bulk_index_missing_params(self, es):
-        es.bulk.return_value = {
-            "errors": False
-        }
-        bulk = runner.BulkIndex()
-
-        bulk_params = {
-            "body": [
-                "action_meta_data",
-                "index_line",
-                "action_meta_data",
-                "index_line",
-                "action_meta_data",
-                "index_line"
-            ],
-            "action_metadata_present": True,
-        }
-
-        with self.assertRaises(exceptions.DataError) as ctx:
-            bulk(es, bulk_params)
-        self.assertEqual("Parameter source for operation 'bulk-index' did not provide the mandatory parameter 'bulk-size'. "
-                         "Please add it to your parameter source.", ctx.exception.args[0])
-
-    @mock.patch("elasticsearch.Elasticsearch")
     def test_bulk_index_success_with_metadata(self, es):
         es.bulk.return_value = {
             "errors": False
@@ -172,6 +147,7 @@ class BulkIndexRunnerTests(TestCase):
 
         result = bulk(es, bulk_params)
 
+        self.assertIsNone(result["took"])
         self.assertIsNone(result["index"])
         self.assertEqual(3, result["weight"])
         self.assertEqual(3, result["bulk-size"])
@@ -203,6 +179,7 @@ class BulkIndexRunnerTests(TestCase):
 
         result = bulk(es, bulk_params)
 
+        self.assertIsNone(result["took"])
         self.assertEqual("test-index", result["index"])
         self.assertEqual(3, result["weight"])
         self.assertEqual(3, result["bulk-size"])
@@ -216,6 +193,7 @@ class BulkIndexRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     def test_bulk_index_error(self, es):
         es.bulk.return_value = {
+            "took": 5,
             "errors": True,
             "items": [
                 {
@@ -269,6 +247,7 @@ class BulkIndexRunnerTests(TestCase):
         result = bulk(es, bulk_params)
 
         self.assertEqual("test", result["index"])
+        self.assertEqual(5, result["took"])
         self.assertEqual(3, result["weight"])
         self.assertEqual(3, result["bulk-size"])
         self.assertEqual("docs", result["unit"])
@@ -374,6 +353,7 @@ class BulkIndexRunnerTests(TestCase):
         result = bulk(es, bulk_params)
 
         self.assertEqual("test", result["index"])
+        self.assertEqual(30, result["took"])
         self.assertEqual(4, result["weight"])
         self.assertEqual(4, result["bulk-size"])
         self.assertEqual("docs", result["unit"])
@@ -517,6 +497,7 @@ class BulkIndexRunnerTests(TestCase):
         result = bulk(es, bulk_params)
 
         self.assertEqual("test", result["index"])
+        self.assertEqual(30, result["took"])
         self.assertEqual(6, result["weight"])
         self.assertEqual(6, result["bulk-size"])
         self.assertEqual("docs", result["unit"])


### PR DESCRIPTION
With this commit we record the value of "took" from bulk indexing
responses. So far this value has only been recorded for queries but it
is useful for bulks as well.