### PR TITLE
Add record_process_stats() for process.* stats

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -84,6 +84,7 @@ The node-stats telemetry devices regularly calls the node-stats API and records 
 * JVM buffer pool stats (key ``jvm.buffer_pools`` in the node-stats API)
 * Circuit breaker stats (key ``breakers`` in the node-stats API)
 * Network-related stats (key ``transport`` in the node-stats API)
+* Process cpu stats (key ``process.cpu`` in the node-stats API)
 
 Supported telemetry parameters:
 
@@ -93,3 +94,5 @@ Supported telemetry parameters:
 * ``node-stats-include-buffer-pools`` (default: ``true``): A boolean indicating whether buffer pool stats should be included.
 * ``node-stats-include-breakers`` (default: ``true``): A boolean indicating whether circuit breaker stats should be included.
 * ``node-stats-include-network`` (default: ``true``): A boolean indicating whether network-related stats should be included.
+* ``node-stats-include-process`` (default: ``true``): A boolean indicating whether process cpu stats should be
+included.

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -318,6 +318,7 @@ class NodeStatsRecorder:
         self.include_buffer_pools = telemetry_params.get("node-stats-include-buffer-pools", True)
         self.include_breakers = telemetry_params.get("node-stats-include-breakers", True)
         self.include_network = telemetry_params.get("node-stats-include-network", True)
+        self.include_process = telemetry_params.get("node-stats-include-process", True)
         self.client = client
         self.metrics_store = metrics_store
 
@@ -340,6 +341,8 @@ class NodeStatsRecorder:
                 self.record_jvm_buffer_pool_stats(node_name, node_stats)
             if self.include_network:
                 self.record_network_stats(node_name, node_stats)
+            if self.include_process:
+                self.record_process_stats(node_name, node_stats)
 
         time.sleep(self.sample_interval)
 
@@ -386,6 +389,15 @@ class NodeStatsRecorder:
             for metric_name, metric_value in transport_stats.items():
                 self.put_value(node_name,
                                metric_name="transport_{}".format(metric_name),
+                               node_stats_metric_name=metric_name,
+                               metric_value=metric_value)
+
+    def record_process_stats(self, node_name, node_stats):
+        process_stats = node_stats["process"]["cpu"]
+        if process_stats:
+            for metric_name, metric_value in process_stats.items():
+                self.put_value(node_name,
+                               metric_name="process_cpu_{}".format(metric_name),
                                node_stats_metric_name=metric_name,
                                metric_value=metric_value)
 

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -306,6 +306,18 @@ class NodStatsRecorderTests(TestCase):
                             "total_unloaded_count" : 0
                         }
                     },
+                    "process": {
+                        "timestamp": 1526045135857,
+                        "open_file_descriptors": 312,
+                        "max_file_descriptors": 1048576,
+                        "cpu": {
+                            "percent": 10,
+                            "total_in_millis": 56520
+                        },
+                        "mem": {
+                            "total_virtual_in_bytes": 2472173568
+                        }
+                    },
                     "thread_pool" : {
                         "generic" : {
                             "threads" : 4,
@@ -457,6 +469,18 @@ class NodStatsRecorderTests(TestCase):
                             "total_unloaded_count" : 0
                         }
                     },
+                    "process": {
+                        "timestamp": 1526045135857,
+                        "open_file_descriptors": 312,
+                        "max_file_descriptors": 1048576,
+                        "cpu": {
+                            "percent": 10,
+                            "total_in_millis": 56520
+                        },
+                        "mem": {
+                            "total_virtual_in_bytes": 2472173568
+                        }
+                    },
                     "thread_pool" : {
                         "generic" : {
                             "threads" : 4,
@@ -527,6 +551,7 @@ class NodStatsRecorderTests(TestCase):
             mock.call(node_name="rally0", name="transport_server_open", count=12),
             mock.call(node_name="rally0", name="transport_rx_count", count=77),
             mock.call(node_name="rally0", name="transport_tx_count", count=88),
+            mock.call(node_name="rally0", name="process_cpu_percent", count=10),
             mock.call(node_name="rally0", name="breaker_parent_overhead", count=1.0),
             mock.call(node_name="rally0", name="breaker_parent_tripped", count=0),
             mock.call(node_name="rally0", name="jvm_buffer_pool_mapped_count", count=7),
@@ -546,6 +571,7 @@ class NodStatsRecorderTests(TestCase):
             mock.call(node_name="rally0", name="indices_request_cache_memory_size_in_bytes", value=0, unit="byte"),
             mock.call(node_name="rally0", name="transport_rx_size_in_bytes", value=98723498, unit="byte"),
             mock.call(node_name="rally0", name="transport_tx_size_in_bytes", value=23879803, unit="byte"),
+            mock.call(node_name="rally0", name="process_cpu_total_in_millis", value=56520, unit="ms"),
             mock.call(node_name="rally0", name="breaker_parent_limit_size_in_bytes", value=726571417, unit="byte"),
             mock.call(node_name="rally0", name="breaker_parent_estimated_size_in_bytes", value=0, unit="byte"),
             mock.call(node_name="rally0", name="jvm_buffer_pool_mapped_used_in_bytes", value=3120, unit="byte"),


### PR DESCRIPTION
This PR adds the Elasticsearch node process stats (https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html#process-statsnode-stats-include-process) so that CPU metrics can be recorded when running in `pipeline=benchmark-only` mode.

There is a new `node-stats-include-process` telemetry parameter flag to control whether these stats are collected (defaults to `true`).