### PR TITLE
 Use file-based logging configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -142,3 +142,53 @@ To verify that Rally will connect via the proxy server you can check the log fil
 .. note::
 
    Rally will use this proxy server only for downloading benchmark-related data. It will not use this proxy for the actual benchmark.
+
+Logging
+-------
+
+Logging in Rally is configured in ``~/.rally/logging.json``. For more information about the log file format please refer to the following documents:
+
+* `Python logging cookbook <https://docs.python.org/3/howto/logging-cookbook.html>`_ provides general tips and tricks.
+* The Python reference documentation on the `logging configuration schema <https://docs.python.org/3/library/logging.config.html#logging-config-dictschema>`_ explains the file format.
+* The `logging handler documentation <https://docs.python.org/3/library/logging.handlers.html>`_ describes how to customize where log output is written to.
+
+By default, Rally will log all output to ``~/.rally/logs/rally.log`` and rotate this file daily.
+
+Example
+~~~~~~~
+
+With the following configuration Rally will log all output to standard error::
+
+    {
+      "version": 1,
+      "formatters": {
+        "normal": {
+          "format": "%(asctime)s,%(msecs)d %(actorAddress)s/PID:%(process)d %(name)s %(levelname)s %(message)s",
+          "datefmt": "%Y-%m-%d %H:%M:%S",
+          "()": "esrally.log.configure_utc_formatter"
+        }
+      },
+      "filters": {
+        "isActorLog": {
+          "()": "thespian.director.ActorAddressLogFilter"
+        }
+      },
+      "handlers": {
+        "console_log_handler": {
+            "class": "logging.StreamHandler",
+            "formatter": "normal",
+            "filters": ["isActorLog"]
+        }
+      },
+      "root": {
+        "handlers": ["console_log_handler"],
+        "level": "INFO"
+      },
+      "loggers": {
+        "elasticsearch": {
+          "handlers": ["console_log_handler"],
+          "level": "WARNING",
+          "propagate": false
+        }
+      }
+    }

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -91,9 +91,9 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
             current = capabilities.get(name, None)
             if current != value:
                 # A mismatch by is not a problem by itself as long as at least one actor system instance matches the requirements.
-                logger.info("Checking capabilities [%s] against requirements [%s] failed." % (capabilities, requirements))
+                logger.info("Checking capabilities [%s] against requirements [%s] failed.", capabilities, requirements)
                 return False
-        logger.info("Capabilities [%s] match requirements [%s]." % (capabilities, requirements))
+        logger.info("Capabilities [%s] match requirements [%s].", capabilities, requirements)
         return True
 
     def transition_when_all_children_responded(self, sender, msg, expected_status, new_status, transition):
@@ -139,7 +139,7 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
         :param new_status: The new status.
         """
         if self.is_current_status_expected(expected_status):
-            self.logger.info("Transitioning from [%s] to [%s]." % (self.status, new_status))
+            self.logger.info("Transitioning from [%s] to [%s].", self.status, new_status)
             self.status = new_status
             for m in filter(None, self.children):
                 self.send(m, msg)
@@ -188,10 +188,10 @@ def bootstrap_actor_system(try_join=False, prefer_local_only=False, local_ip=Non
     try:
         if try_join:
             if actor_system_already_running():
-                logger.info("Joining already running actor system with system base [%s]." % system_base)
+                logger.info("Joining already running actor system with system base [%s].", system_base)
                 return thespian.actors.ActorSystem(system_base)
             else:
-                logger.info("Creating new actor system with system base [%s] on coordinator node." % system_base)
+                logger.info("Creating new actor system with system base [%s] on coordinator node.", system_base)
                 # if we try to join we can only run on the coordinator...
                 return thespian.actors.ActorSystem(system_base, logDefs=log.load_configuration(), capabilities={"coordinator": True})
         elif prefer_local_only:
@@ -222,7 +222,7 @@ def bootstrap_actor_system(try_join=False, prefer_local_only=False, local_ip=Non
         if coordinator_ip:
             # Make the coordinator node the convention leader
             capabilities["Convention Address.IPv4"] = "%s:1900" % coordinator_ip
-        logger.info("Starting actor system with system base [%s] and capabilities [%s]." % (system_base, capabilities))
+        logger.info("Starting actor system with system base [%s] and capabilities [%s].", system_base, capabilities)
         return thespian.actors.ActorSystem(system_base,
                                            logDefs=log.load_configuration(),
                                            capabilities=capabilities)

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -1,16 +1,9 @@
 import logging
-import time
-import os
 
 import thespian.actors
 import thespian.system.messages.status
-from esrally import exceptions
-from esrally.utils import console, io, net
-
-logger = logging.getLogger("rally.actor")
-
-root_log_level = logging.INFO
-es_log_level = logging.WARNING
+from esrally import exceptions, log
+from esrally.utils import console, net
 
 
 class BenchmarkFailure:
@@ -75,7 +68,7 @@ def no_retry(f, actor_name):
         except BaseException as e:
             msg = "Error in {}".format(actor_name)
             # log here as the full trace might get lost.
-            logger.exception(msg)
+            logging.getLogger(__name__).exception(msg)
             self.send(sender, BenchmarkFailure(msg, e))
     return guard
 
@@ -86,20 +79,14 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
         self.children = []
         self.received_responses = []
         self.status = None
-
-    @staticmethod
-    def configure_logging(actor_logger):
-        # see rally#configure_logging() for more details.
-        logging.captureWarnings(True)
-        # configure each actor's root logger
-        actor_logger.parent.setLevel(root_log_level)
-        # Also ensure that the elasticsearch logger is properly configured
-        logging.getLogger("elasticsearch").setLevel(es_log_level)
+        log.post_configure_actor_logging()
+        self.logger = logging.getLogger(__name__)
 
     # The method name is required by the actor framework
     # noinspection PyPep8Naming
     @staticmethod
     def actorSystemCapabilityCheck(capabilities, requirements):
+        logger = logging.getLogger(__name__)
         for name, value in requirements.items():
             current = capabilities.get(name, None)
             if current != value:
@@ -125,11 +112,10 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
             response_count = len(self.received_responses)
             expected_count = len(self.children)
 
-            logger.info("[%d] of [%d] child actors have responded for transition from [%s] to [%s]." %
-                        (response_count, expected_count, self.status, new_status))
+            self.logger.info("[%d] of [%d] child actors have responded for transition from [%s] to [%s].",
+                             response_count, expected_count, self.status, new_status)
             if response_count == expected_count:
-                logger.info("All [%d] child actors have responded. Transitioning now from [%s] to [%s]." %
-                            (expected_count, self.status, new_status))
+                self.logger.info("All [%d] child actors have responded. Transitioning now from [%s] to [%s].", expected_count, self.status, new_status)
                 # all nodes have responded, change status
                 self.status = new_status
                 self.received_responses = []
@@ -153,7 +139,7 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
         :param new_status: The new status.
         """
         if self.is_current_status_expected(expected_status):
-            logger.info("Transitioning from [%s] to [%s]." % (self.status, new_status))
+            self.logger.info("Transitioning from [%s] to [%s]." % (self.status, new_status))
             self.status = new_status
             for m in filter(None, self.children):
                 self.send(m, msg)
@@ -170,61 +156,6 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
             return self.status in expected_status
         else:
             return self.status == expected_status
-
-
-# Defined on top-level to allow pickling
-def configure_utc_formatter(*args, **kwargs):
-    formatter = logging.Formatter(fmt=kwargs["format"], datefmt=kwargs["datefmt"])
-    formatter.converter = time.gmtime
-    return formatter
-
-
-def configure_actor_logging():
-    log_dir = "%s/.rally/logs" % os.path.expanduser("~")
-    io.ensure_dir(log_dir)
-
-    return {
-        "version": 1,
-        "formatters": {
-            "normal": {
-                "format": "%(asctime)s,%(msecs)d %(actorAddress)s/PID:%(process)d %(name)s %(levelname)s %(message)s",
-                "datefmt": "%Y-%m-%d %H:%M:%S",
-                # paraphrasing from 70a4bc8: If we use thespian directory functionality, we need to remove the callable formatter.
-                # A potential other solution would then be to enforce UTC timezones by setting the TZ env variable before we start
-                # the actor system.
-                "()": "esrally.actor.configure_utc_formatter"
-            },
-        },
-        "filters": {
-            "isActorLog": {
-                "()": 'thespian.director.ActorAddressLogFilter'
-            },
-        },
-        "handlers": {
-            "rally_log_handler": {
-                "class": "logging.handlers.TimedRotatingFileHandler",
-                "filename": "%s/rally-actor-messages.log" % log_dir,
-                "when": "midnight",
-                "backupCount": 14,
-                "encoding": "UTF-8",
-                "formatter": "normal",
-                "filters": ["isActorLog"],
-                "level": root_log_level
-            },
-        },
-        "root": {
-            "handlers": ["rally_log_handler"],
-            "level": root_log_level
-        },
-        "loggers": {
-            "elasticsearch": {
-                "handlers": ["rally_log_handler"],
-                "level": es_log_level,
-                # don't let the root logger handle it again
-                "propagate": 0
-            }
-        }
-    }
 
 
 def actor_system_already_running(ip="127.0.0.1"):
@@ -252,6 +183,7 @@ def use_offline_actor_system():
 
 
 def bootstrap_actor_system(try_join=False, prefer_local_only=False, local_ip=None, coordinator_ip=None):
+    logger = logging.getLogger(__name__)
     system_base = __SYSTEM_BASE
     try:
         if try_join:
@@ -261,7 +193,7 @@ def bootstrap_actor_system(try_join=False, prefer_local_only=False, local_ip=Non
             else:
                 logger.info("Creating new actor system with system base [%s] on coordinator node." % system_base)
                 # if we try to join we can only run on the coordinator...
-                return thespian.actors.ActorSystem(system_base, logDefs=configure_actor_logging(), capabilities={"coordinator": True})
+                return thespian.actors.ActorSystem(system_base, logDefs=log.load_configuration(), capabilities={"coordinator": True})
         elif prefer_local_only:
             coordinator = True
             if system_base != "multiprocQueueBase":
@@ -292,7 +224,7 @@ def bootstrap_actor_system(try_join=False, prefer_local_only=False, local_ip=Non
             capabilities["Convention Address.IPv4"] = "%s:1900" % coordinator_ip
         logger.info("Starting actor system with system base [%s] and capabilities [%s]." % (system_base, capabilities))
         return thespian.actors.ActorSystem(system_base,
-                                           logDefs=configure_actor_logging(),
+                                           logDefs=log.load_configuration(),
                                            capabilities=capabilities)
     except thespian.actors.ActorSystemException:
         logger.exception("Could not initialize internal actor system. Terminating.")

--- a/esrally/client.py
+++ b/esrally/client.py
@@ -4,8 +4,6 @@ import logging
 import certifi
 import urllib3
 
-logger = logging.getLogger("rally.client")
-
 
 class EsClientFactory:
     """
@@ -15,45 +13,46 @@ class EsClientFactory:
         self.hosts = hosts
         self.client_options = dict(client_options)
         self.ssl_context = None
+        self.logger = logging.getLogger(__name__)
 
         masked_client_options = dict(client_options)
         if "basic_auth_password" in masked_client_options:
             masked_client_options["basic_auth_password"] = "*****"
         if "http_auth" in masked_client_options:
             masked_client_options["http_auth"] = (masked_client_options["http_auth"][0], "*****")
-        logger.info("Creating ES client connected to %s with options [%s]", hosts, masked_client_options)
+        self.logger.info("Creating ES client connected to %s with options [%s]", hosts, masked_client_options)
 
         # we're using an SSL context now and it is not allowed to have use_ssl present in client options anymore
         if self.client_options.pop("use_ssl", False):
             import ssl
             from elasticsearch.connection import create_ssl_context
-            logger.info("SSL support: on")
+            self.logger.info("SSL support: on")
             self.client_options["scheme"] = "https"
 
             self.ssl_context = create_ssl_context(cafile=self.client_options.pop("ca_certs", certifi.where()))
 
             if not self.client_options.pop("verify_certs", True):
-                logger.info("SSL certificate verification: off")
+                self.logger.info("SSL certificate verification: off")
                 self.ssl_context.check_hostname = False
                 self.ssl_context.verify_mode = ssl.CERT_NONE
 
-                logger.warning("User has enabled SSL but disabled certificate verification. This is dangerous but may be ok for a "
-                               "benchmark. Disabling urllib warnings now to avoid a logging storm. "
-                               "See https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings for details.")
+                self.logger.warning("User has enabled SSL but disabled certificate verification. This is dangerous but may be ok for a "
+                                    "benchmark. Disabling urllib warnings now to avoid a logging storm. "
+                                    "See https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings for details.")
                 # disable:  "InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly \
                 # advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings"
                 urllib3.disable_warnings()
             else:
-                logger.info("SSL certificate verification: on")
+                self.logger.info("SSL certificate verification: on")
         else:
-            logger.info("SSL support: off")
+            self.logger.info("SSL support: off")
             self.client_options["scheme"] = "http"
 
         if self._is_set(self.client_options, "basic_auth_user") and self._is_set(self.client_options, "basic_auth_password"):
-            logger.info("HTTP basic authentication: on")
+            self.logger.info("HTTP basic authentication: on")
             self.client_options["http_auth"] = (self.client_options.pop("basic_auth_user"), self.client_options.pop("basic_auth_password"))
         else:
-            logger.info("HTTP basic authentication: off")
+            self.logger.info("HTTP basic authentication: off")
 
     def _is_set(self, client_opts, k):
         try:
@@ -81,11 +80,11 @@ class EsClientFactory:
             def __init__(self, compressed=False, **kwargs):
                 super(ConfigurableHttpConnection, self).__init__(**kwargs)
                 if compressed:
-                    logger.info("HTTP compression: on")
+                    logging.getLogger(__name__).info("HTTP compression: on")
                     self.headers.update(urllib3.make_headers(accept_encoding=True))
                     self.headers.update({"Content-Encoding": "gzip"})
                 else:
-                    logger.info("HTTP compression: off")
+                    logging.getLogger(__name__).info("HTTP compression: off")
                 self.pool = PoolWrap(self.pool, **kwargs)
 
         return elasticsearch.Elasticsearch(hosts=self.hosts, connection_class=ConfigurableHttpConnection,

--- a/esrally/config.py
+++ b/esrally/config.py
@@ -50,7 +50,7 @@ class ConfigFile:
 
     def backup(self):
         config_file = self.location
-        logging.getLogger(__name__).info("Creating a backup of the current config file at [%s]." % config_file)
+        logging.getLogger(__name__).info("Creating a backup of the current config file at [%s].", config_file)
         shutil.copyfile(config_file, "%s.bak" % config_file)
 
     @property
@@ -296,9 +296,9 @@ class ConfigFactory:
 
         if config_file.present:
             self.o("\nWARNING: Will overwrite existing config file at [%s]\n" % config_file.location)
-            self.logger.debug("Detected an existing configuration file at [%s]" % config_file.location)
+            self.logger.debug("Detected an existing configuration file at [%s]", config_file.location)
         else:
-            self.logger.debug("Did not detect a configuration file at [%s]. Running initial configuration routine." % config_file.location)
+            self.logger.debug("Did not detect a configuration file at [%s]. Running initial configuration routine.", config_file.location)
 
         # Autodetect settings
         self.o("* Autodetecting available third-party software")
@@ -346,10 +346,10 @@ class ConfigFactory:
         guess = self._guess_es_src_dir()
         if guess:
             source_dir = guess
-            self.logger.debug("Autodetected Elasticsearch project directory at [%s]." % source_dir)
+            self.logger.debug("Autodetected Elasticsearch project directory at [%s].", source_dir)
         else:
             default_src_dir = os.path.join(root_dir, "src", "elasticsearch")
-            self.logger.debug("Could not autodetect Elasticsearch project directory. Providing [%s] as default." % default_src_dir)
+            self.logger.debug("Could not autodetect Elasticsearch project directory. Providing [%s] as default.", default_src_dir)
             source_dir = default_src_dir
 
         if advanced_config:
@@ -483,7 +483,7 @@ class ConfigFactory:
         self.o("* Ask a question on the forum at %s" % console.format.link("https://discuss.elastic.co/c/elasticsearch/rally"))
 
     def print_detection_result(self, what, result, warn_if_missing=False, additional_message=None):
-        self.logger.debug("Autodetected %s at [%s]" % (what, result))
+        self.logger.debug("Autodetected %s at [%s]", what, result)
         if additional_message:
             message = " (%s)" % additional_message
         else:
@@ -588,7 +588,7 @@ def migrate(config_file, current_version, target_version, out=print, i=input):
                           .format(config_file.location, PROGRAM_NAME))
 
     prompter = Prompter(i=i, o=out, assume_defaults=False)
-    logger.info("Upgrading configuration from version [%s] to [%s]." % (current_version, target_version))
+    logger.info("Upgrading configuration from version [%s] to [%s].", current_version, target_version)
     # Something is really fishy. We don't want to downgrade the configuration.
     if current_version >= target_version:
         raise ConfigError("The existing config file is available in a later version already. Expected version <= [%s] but found [%s]"
@@ -603,7 +603,7 @@ def migrate(config_file, current_version, target_version, out=print, i=input):
             java_9_home = io.guess_java_home(major_version=9)
             from esrally.utils import jvm
             if java_9_home and not jvm.is_early_access_release(java_9_home):
-                logger.debug("Autodetected a JDK 9 installation at [%s]" % java_9_home)
+                logger.debug("Autodetected a JDK 9 installation at [%s]", java_9_home)
                 if "runtime" not in config:
                     config["runtime"] = {}
                 config["runtime"]["java9.home"] = java_9_home
@@ -641,7 +641,7 @@ def migrate(config_file, current_version, target_version, out=print, i=input):
             java_10_home = io.guess_java_home(major_version=10)
             from esrally.utils import jvm
             if java_10_home and not jvm.is_early_access_release(java_10_home):
-                logger.debug("Autodetected a JDK 10 installation at [%s]" % java_10_home)
+                logger.debug("Autodetected a JDK 10 installation at [%s]", java_10_home)
                 if "runtime" not in config:
                     config["runtime"] = {}
                 config["runtime"]["java10.home"] = java_10_home
@@ -714,4 +714,4 @@ def migrate(config_file, current_version, target_version, out=print, i=input):
 
     # all migrations done
     config_file.store(config)
-    logger.info("Successfully self-upgraded configuration to version [%s]" % target_version)
+    logger.info("Successfully self-upgraded configuration to version [%s]", target_version)

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -10,9 +10,6 @@ from esrally import actor, config, exceptions, metrics, track, client, paths, PR
 from esrally.driver import runner, scheduler
 from esrally.utils import convert, console, net
 
-logger = logging.getLogger("rally.driver")
-profile_logger = logging.getLogger("rally.profile")
-
 
 ##################################
 #
@@ -143,29 +140,28 @@ class DriverActor(actor.RallyActor):
 
     def __init__(self):
         super().__init__()
-        actor.RallyActor.configure_logging(logger)
         self.start_sender = None
         self.coordinator = None
         self.status = "init"
         self.post_process_timer = 0
 
     def receiveMsg_PoisonMessage(self, poisonmsg, sender):
-        logger.error("Main driver received a fatal indication from a load generator (%s). Shutting down.", poisonmsg.details)
+        self.logger.error("Main driver received a fatal indication from a load generator (%s). Shutting down.", poisonmsg.details)
         self.coordinator.close()
         self.send(self.start_sender, actor.BenchmarkFailure("Fatal track or load generator indication", poisonmsg.details))
 
     def receiveMsg_BenchmarkFailure(self, msg, sender):
-        logger.error("Main driver received a fatal exception from a load generator. Shutting down.")
+        self.logger.error("Main driver received a fatal exception from a load generator. Shutting down.")
         self.coordinator.close()
         self.send(self.start_sender, msg)
 
     def receiveMsg_BenchmarkCancelled(self, msg, sender):
-        logger.info("Main driver received a notification that the benchmark has been cancelled.")
+        self.logger.info("Main driver received a notification that the benchmark has been cancelled.")
         self.coordinator.close()
         self.send(self.start_sender, msg)
 
     def receiveMsg_ActorExitRequest(self, msg, sender):
-        logger.info("Main driver received ActorExitRequest and will terminate all load generators.")
+        self.logger.info("Main driver received ActorExitRequest and will terminate all load generators.")
         self.status = "exiting"
 
     def receiveMsg_ChildActorExited(self, msg, sender):
@@ -173,15 +169,15 @@ class DriverActor(actor.RallyActor):
         if msg.childAddress in self.coordinator.drivers:
             driver_index = self.coordinator.drivers.index(msg.childAddress)
             if self.status == "exiting":
-                logger.info("Load generator [%d] has exited." % driver_index)
+                self.logger.info("Load generator [%d] has exited." % driver_index)
             else:
-                logger.error("Load generator [%d] has exited prematurely. Aborting benchmark." % driver_index)
+                self.logger.error("Load generator [%d] has exited prematurely. Aborting benchmark." % driver_index)
                 self.send(self.start_sender, actor.BenchmarkFailure("Load generator [%d] has exited prematurely." % driver_index))
         else:
-            logger.info("A track preparator has exited.")
+            self.logger.info("A track preparator has exited.")
 
     def receiveUnrecognizedMessage(self, msg, sender):
-        logger.info("Main driver received unknown message [%s] (ignoring)." % (str(msg)))
+        self.logger.info("Main driver received unknown message [%s] (ignoring)." % (str(msg)))
 
     @actor.no_retry("driver")
     def receiveMsg_StartBenchmark(self, msg, sender):
@@ -276,13 +272,12 @@ def load_local_config(coordinator_config):
 class TrackPreparationActor(actor.RallyActor):
     def __init__(self):
         super().__init__()
-        actor.RallyActor.configure_logging(logger)
 
     @actor.no_retry("track preparator")
     def receiveMsg_PrepareTrack(self, msg, sender):
         # load node-specific config to have correct paths available
         cfg = load_local_config(msg.config)
-        logger.info("Preparing track [%s]" % msg.track.name)
+        self.logger.info("Preparing track [%s]" % msg.track.name)
         # for "proper" track repositories this will ensure that all state is identical to the coordinator node. For simple tracks
         # the track is usually self-contained but in some cases (plugins are defined) we still need to ensure that the track
         # is present on all machines.
@@ -304,6 +299,7 @@ class Driver:
         :param target: A target that will be notified of important events.
         :param config: The current config object.
         """
+        self.logger = logging.getLogger(__name__)
         self.target = target
         self.config = config
         self.track = None
@@ -348,7 +344,7 @@ class Driver:
         self.target.on_prepare_track(preps, self.config, self.track)
 
     def after_track_prepared(self):
-        logger.info("Benchmark is about to start.")
+        self.logger.info("Benchmark is about to start.")
         # ensure relative time starts when the benchmark starts.
         self.reset_relative_time()
 
@@ -357,16 +353,16 @@ class Driver:
         self.number_of_steps = len(allocator.join_points) - 1
         self.tasks_per_join_point = allocator.tasks_per_joinpoint
 
-        logger.info("Benchmark consists of [%d] steps executed by (at most) [%d] clients as specified by the allocation matrix:\n%s" %
+        self.logger.info("Benchmark consists of [%d] steps executed by (at most) [%d] clients as specified by the allocation matrix:\n%s" %
                     (self.number_of_steps, len(self.allocations), self.allocations))
 
         for client_id in range(allocator.clients):
             # allocate clients round-robin to all defined hosts
             host = self.load_driver_hosts[client_id % len(self.load_driver_hosts)]
-            logger.info("Allocating load generator [%d] on [%s]" % (client_id, host))
+            self.logger.info("Allocating load generator [%d] on [%s]" % (client_id, host))
             self.drivers.append(self.target.create_client(client_id, host))
         for client_id, driver in enumerate(self.drivers):
-            logger.info("Starting load generator [%d]." % client_id)
+            self.logger.info("Starting load generator [%d]." % client_id)
             self.target.start_load_generator(driver, client_id, self.config, self.track, self.allocations[client_id])
 
         self.update_progress_message()
@@ -374,10 +370,10 @@ class Driver:
     def joinpoint_reached(self, client_id, client_local_timestamp, task):
         self.currently_completed += 1
         self.clients_completed_current_step[client_id] = (client_local_timestamp, time.perf_counter())
-        logger.info("[%d/%d] drivers reached join point [%d/%d]." %
+        self.logger.info("[%d/%d] drivers reached join point [%d/%d]." %
                     (self.currently_completed, len(self.drivers), self.current_step + 1, self.number_of_steps))
         if self.currently_completed == len(self.drivers):
-            logger.info("All drivers completed their operations until join point [%d/%d]." %
+            self.logger.info("All drivers completed their operations until join point [%d/%d]." %
                         (self.current_step + 1, self.number_of_steps))
             # we can go on to the next step
             self.currently_completed = 0
@@ -390,17 +386,17 @@ class Driver:
             self.most_recent_sample_per_client = {}
             self.current_step += 1
 
-            logger.info("Postprocessing samples...")
+            self.logger.info("Postprocessing samples...")
             self.post_process_samples()
             m = self.metrics_store.to_externalizable(clear=True)
 
             if self.finished():
-                logger.info("All steps completed.")
-                logger.info("Closing metrics store...")
+                self.logger.info("All steps completed.")
+                self.logger.info("Closing metrics store...")
                 self.metrics_store.close()
                 # immediately clear as we don't need it anymore and it can consume a significant amount of memory
                 del self.metrics_store
-                logger.info("Sending benchmark results...")
+                self.logger.info("Sending benchmark results...")
                 self.target.on_benchmark_complete(m)
             else:
                 if self.config.opts("track", "test.mode.enabled"):
@@ -419,32 +415,32 @@ class Driver:
                 for client_id, driver in enumerate(self.drivers):
                     client_ended_task_at, master_received_msg_at = clients_curr_step[client_id]
                     client_start_timestamp = client_ended_task_at + (start_next_task - master_received_msg_at)
-                    logger.info("Scheduling next task for client id [%d] at their timestamp [%f] (master timestamp [%f])" %
+                    self.logger.info("Scheduling next task for client id [%d] at their timestamp [%f] (master timestamp [%f])" %
                                 (client_id, client_start_timestamp, start_next_task))
                     self.target.drive_at(driver, client_start_timestamp)
         else:
             current_join_point = task
             # we need to actively send CompleteCurrentTask messages to all remaining clients.
             if current_join_point.preceding_task_completes_parent and not self.complete_current_task_sent:
-                logger.info("Tasks before [%s] are able to complete the parent structure. Checking if clients [%s] have finished yet."
+                self.logger.info("Tasks before [%s] are able to complete the parent structure. Checking if clients [%s] have finished yet."
                             % (current_join_point, current_join_point.clients_executing_completing_task))
                 # are all clients executing said task already done? if so we need to notify the remaining clients
                 all_clients_finished = True
                 for client_id in current_join_point.clients_executing_completing_task:
                     if client_id not in self.clients_completed_current_step:
-                        logger.info("Client id [%s] did not yet finish." % client_id)
+                        self.logger.info("Client id [%s] did not yet finish." % client_id)
                         # do not break here so we can see all remaining clients in the log output.
                         all_clients_finished = False
                 if all_clients_finished:
                     # As we are waiting for other clients to finish, we would send this message over and over again. Hence we need to
                     # memorize whether we have already sent it for the current step.
                     self.complete_current_task_sent = True
-                    logger.info("All affected clients have finished. Notifying all clients to complete their current tasks.")
+                    self.logger.info("All affected clients have finished. Notifying all clients to complete their current tasks.")
                     for client_id, driver in enumerate(self.drivers):
                         self.target.complete_current_task(driver)
 
     def reset_relative_time(self):
-        logger.info("Resetting relative time of request metrics store.")
+        self.logger.info("Resetting relative time of request metrics store.")
         self.metrics_store.reset_relative_time()
 
     def finished(self):
@@ -508,11 +504,11 @@ class Driver:
                                                        relative_time=sample.relative_time, meta_data=meta_data)
 
         end = time.perf_counter()
-        logger.info("Storing latency and service time took [%f] seconds." % (end - start))
+        self.logger.info("Storing latency and service time took [%f] seconds." % (end - start))
         start = end
         aggregates = self.throughput_calculator.calculate(raw_samples)
         end = time.perf_counter()
-        logger.info("Calculating throughput took [%f] seconds." % (end - start))
+        self.logger.info("Calculating throughput took [%f] seconds." % (end - start))
         start = end
         for task, samples in aggregates.items():
             meta_data = self.merge(
@@ -527,7 +523,7 @@ class Driver:
                                                            sample_type=sample_type, absolute_time=absolute_time,
                                                            relative_time=relative_time, meta_data=meta_data)
         end = time.perf_counter()
-        logger.info("Storing throughput took [%f] seconds." % (end - start))
+        self.logger.info("Storing throughput took [%f] seconds." % (end - start))
         start = end
         # this will be a noop for the in-memory metrics store. If we use an ES metrics store however, this will ensure that we already send
         # the data and also clear the in-memory buffer. This allows users to see data already while running the benchmark. In cases where
@@ -537,8 +533,8 @@ class Driver:
         # no need for frequent refreshes.
         self.metrics_store.flush(refresh=False)
         end = time.perf_counter()
-        logger.info("Flushing the metrics store took [%f] seconds." % (end - start))
-        logger.info("Postprocessing [%d] raw samples took [%f] seconds in total." % (len(raw_samples), (end - total_start)))
+        self.logger.info("Flushing the metrics store took [%f] seconds." % (end - start))
+        self.logger.info("Postprocessing [%d] raw samples took [%f] seconds in total." % (len(raw_samples), (end - total_start)))
 
     def merge(self, *args):
         result = {}
@@ -559,7 +555,6 @@ class LoadGenerator(actor.RallyActor):
 
     def __init__(self):
         super().__init__()
-        actor.RallyActor.configure_logging(logger)
         self.master = None
         self.client_id = None
         self.es = None
@@ -588,7 +583,7 @@ class LoadGenerator(actor.RallyActor):
                 es[cluster_name] = client.EsClientFactory(cluster_hosts, all_client_options[cluster_name]).create()
             return es
 
-        logger.info("LoadGenerator[%d] is about to start." % msg.client_id)
+        self.logger.info("LoadGenerator[%d] is about to start." % msg.client_id)
         self.master = sender
         self.client_id = msg.client_id
         self.config = load_local_config(msg.config)
@@ -603,6 +598,7 @@ class LoadGenerator(actor.RallyActor):
         # we need to wake up more often in test mode
         if self.config.opts("track", "test.mode.enabled"):
             self.wakeup_interval = 0.5
+        runner.register_default_runners()
         if self.track.has_plugins:
             track.load_track_plugins(self.config, runner.register_runner, scheduler.register_scheduler)
         self.drive()
@@ -610,7 +606,7 @@ class LoadGenerator(actor.RallyActor):
     @actor.no_retry("load generator")
     def receiveMsg_Drive(self, msg, sender):
         sleep_time = datetime.timedelta(seconds=msg.client_start_timestamp - time.perf_counter())
-        logger.info("LoadGenerator[%d] is continuing its work at task index [%d] on [%f], that is in [%s]." %
+        self.logger.info("LoadGenerator[%d] is continuing its work at task index [%d] on [%f], that is in [%s]." %
                     (self.client_id, self.current_task_index, msg.client_start_timestamp, sleep_time))
         self.start_driving = True
         self.wakeupAfter(sleep_time)
@@ -620,10 +616,10 @@ class LoadGenerator(actor.RallyActor):
         # finish now ASAP. Remaining samples will be sent with the next WakeupMessage. We will also need to skip to the next
         # JoinPoint. But if we are already at a JoinPoint at the moment, there is nothing to do.
         if self.at_joinpoint():
-            logger.info("LoadGenerator[%s] has received CompleteCurrentTask but is currently at [%s]. Ignoring."
+            self.logger.info("LoadGenerator[%s] has received CompleteCurrentTask but is currently at [%s]. Ignoring."
                         % (str(self.client_id), self.current_task))
         else:
-            logger.info("LoadGenerator[%s] has received CompleteCurrentTask. Completing current task [%s]."
+            self.logger.info("LoadGenerator[%s] has received CompleteCurrentTask. Completing current task [%s]."
                         % (str(self.client_id), self.current_task))
             self.complete.set()
 
@@ -631,41 +627,41 @@ class LoadGenerator(actor.RallyActor):
     def receiveMsg_WakeupMessage(self, msg, sender):
         # it would be better if we could send ourselves a message at a specific time, simulate this with a boolean...
         if self.start_driving:
-            logger.info("LoadGenerator[%s] starts driving now." % str(self.client_id))
+            self.logger.info("LoadGenerator[%s] starts driving now." % str(self.client_id))
             self.start_driving = False
             self.drive()
         else:
             current_samples = self.send_samples()
             if self.cancel.is_set():
-                logger.info("LoadGenerator[%s] has detected that benchmark has been cancelled. Notifying master..." %
+                self.logger.info("LoadGenerator[%s] has detected that benchmark has been cancelled. Notifying master..." %
                             str(self.client_id))
                 self.send(self.master, actor.BenchmarkCancelled())
             elif self.executor_future is not None and self.executor_future.done():
                 e = self.executor_future.exception(timeout=0)
                 if e:
-                    logger.info("LoadGenerator[%s] has detected a benchmark failure. Notifying master..." % str(self.client_id))
+                    self.logger.info("LoadGenerator[%s] has detected a benchmark failure. Notifying master..." % str(self.client_id))
                     # the exception might be user-defined and not be on the load path of the master driver. Hence, it cannot be
                     # deserialized on the receiver so we convert it here to a plain string.
                     self.send(self.master, actor.BenchmarkFailure("Error in load generator [{}]".format(self.client_id), str(e)))
                 else:
-                    logger.info("LoadGenerator[%s] is ready for the next task." % str(self.client_id))
+                    self.logger.info("LoadGenerator[%s] is ready for the next task." % str(self.client_id))
                     self.executor_future = None
                     self.drive()
             else:
                 if current_samples and len(current_samples) > 0:
                     most_recent_sample = current_samples[-1]
                     if most_recent_sample.percent_completed is not None:
-                        logger.info("LoadGenerator[%s] is executing [%s] (%.2f%% complete)." %
+                        self.logger.info("LoadGenerator[%s] is executing [%s] (%.2f%% complete)." %
                                     (str(self.client_id), most_recent_sample.task, most_recent_sample.percent_completed * 100.0))
                     else:
-                        logger.info("LoadGenerator[%s] is executing [%s] (dependent eternal task)." %
+                        self.logger.info("LoadGenerator[%s] is executing [%s] (dependent eternal task)." %
                                     (str(self.client_id), most_recent_sample.task))
                 else:
-                    logger.info("LoadGenerator[%s] is executing (no samples)." % (str(self.client_id)))
+                    self.logger.info("LoadGenerator[%s] is executing (no samples)." % (str(self.client_id)))
                 self.wakeupAfter(datetime.timedelta(seconds=self.wakeup_interval))
 
     def receiveMsg_ActorExitRequest(self, msg, sender):
-        logger.info("LoadGenerator[%s] is exiting due to ActorExitRequest." % str(self.client_id))
+        self.logger.info("LoadGenerator[%s] is exiting due to ActorExitRequest." % str(self.client_id))
         if self.executor_future is not None and self.executor_future.running():
             self.cancel.set()
             self.pool.shutdown()
@@ -675,7 +671,7 @@ class LoadGenerator(actor.RallyActor):
         self.send(self.master, msg)
 
     def receiveUnrecognizedMessage(self, msg, sender):
-        logger.info("LoadGenerator[%d] received unknown message [%s] (ignoring)." % (self.client_id, str(msg)))
+        self.logger.info("LoadGenerator[%d] received unknown message [%s] (ignoring)." % (self.client_id, str(msg)))
 
     def drive(self):
         profiling_enabled = self.config.opts("driver", "profiling")
@@ -686,7 +682,7 @@ class LoadGenerator(actor.RallyActor):
         self.current_task = task_allocation
 
         if isinstance(task_allocation, JoinPoint):
-            logger.info("LoadGenerator[%d] reached join point [%s]." % (self.client_id, task_allocation))
+            self.logger.info("LoadGenerator[%d] reached join point [%s]." % (self.client_id, task_allocation))
             # clients that don't execute tasks don't need to care about waiting
             if self.executor_future is not None:
                 self.executor_future.result()
@@ -701,10 +697,10 @@ class LoadGenerator(actor.RallyActor):
             # There may be a situation where there are more (parallel) tasks than clients. If we were asked to complete all tasks, we not
             # only need to complete actively running tasks but actually all scheduled tasks until we reach the next join point.
             if self.complete.is_set():
-                logger.info("LoadGenerator[%d] is skipping [%s] because it has been asked to complete all tasks until next join point." %
-                            (self.client_id, task))
+                self.logger.info("LoadGenerator[%d] is skipping [%s] because it has been asked to complete all tasks until next join "
+                                 "point." % (self.client_id, task))
             else:
-                logger.info("LoadGenerator[%d] is executing [%s]." % (self.client_id, task))
+                self.logger.info("LoadGenerator[%d] is executing [%s]." % (self.client_id, task))
                 self.sampler = Sampler(self.client_id, task, start_timestamp=time.perf_counter())
                 # We cannot use the global client index here because we need to support parallel execution of tasks with multiple clients.
                 #
@@ -752,6 +748,7 @@ class Sampler:
         self.task = task
         self.start_timestamp = start_timestamp
         self.q = queue.Queue(maxsize=16384)
+        self.logger = logging.getLogger(__name__)
 
     def add(self, sample_type, request_meta_data, latency_ms, service_time_ms, total_ops, total_ops_unit, time_period, percent_completed):
         try:
@@ -759,7 +756,7 @@ class Sampler:
                                      sample_type, request_meta_data, latency_ms, service_time_ms, total_ops, total_ops_unit, time_period,
                                      percent_completed))
         except queue.Full:
-            logger.warning("Dropping sample for [%s] due to a full sampling queue." % self.task.operation.name)
+            self.logger.warning("Dropping sample for [%s] due to a full sampling queue." % self.task.operation.name)
 
     @property
     def samples(self):
@@ -935,9 +932,9 @@ class Profiler:
         self.target = target
         self.client_id = client_id
         self.task = task
+        self.profile_logger = logging.getLogger("rally.profile")
 
     def __call__(self, *args, **kwargs):
-        logger.debug("Enabling Python profiler for [%s]" % str(self.task))
         import cProfile
         import pstats
         import io as python_io
@@ -955,7 +952,7 @@ class Profiler:
             profile = "\n=== Profile START for client [%s] and task [%s] ===\n" % (str(self.client_id), str(self.task))
             profile += s.getvalue()
             profile += "=== Profile END for client [%s] and task [%s] ===" % (str(self.client_id), str(self.task))
-            profile_logger.info(profile)
+            self.profile_logger.info(profile)
 
 
 class Executor:
@@ -978,6 +975,7 @@ class Executor:
         self.cancel = cancel
         self.complete = complete
         self.abort_on_error = abort_on_error
+        self.logger = logging.getLogger(__name__)
 
     def __call__(self, *args, **kwargs):
         total_start = time.perf_counter()
@@ -985,7 +983,7 @@ class Executor:
         try:
             for expected_scheduled_time, sample_type, percent_completed, runner, params in self.schedule:
                 if self.cancel.is_set():
-                    logger.info("User cancelled execution.")
+                    self.logger.info("User cancelled execution.")
                     break
                 absolute_expected_schedule_time = total_start + expected_scheduled_time
                 throughput_throttled = expected_scheduled_time > 0
@@ -1006,10 +1004,10 @@ class Executor:
                                  total_ops, total_ops_unit, (stop - total_start), completed)
 
                 if self.complete.is_set():
-                    logger.info("Task is considered completed due to external event.")
+                    self.logger.info("Task is considered completed due to external event.")
                     break
         except BaseException:
-            logger.exception("Could not execute schedule")
+            self.logger.exception("Could not execute schedule")
             raise
         finally:
             # Actively set it if this task completes its parent
@@ -1055,7 +1053,7 @@ def execute_single(runner, es, params, abort_on_error=False):
         else:
             request_meta_data["error-description"] = e.error
     except KeyError as e:
-        logger.exception("Cannot execute runner [%s]; most likely due to missing parameters." % str(runner))
+        logging.getLogger(__name__).exception("Cannot execute runner [%s]; most likely due to missing parameters." % str(runner))
         msg = "Cannot execute [%s]. Provided parameters are: %s. Error: [%s]." % (str(runner), list(params.keys()), str(e))
         raise exceptions.SystemSetupError(msg)
 
@@ -1239,6 +1237,7 @@ def schedule_for(current_track, task, client_index):
     :param client_index: The current client index.  Must be in the range [0, `task.clients').
     :return: A generator for the operations the given client needs to perform for this task.
     """
+    logger = logging.getLogger(__name__)
     op = task.operation
     num_clients = task.clients
     sched = scheduler.scheduler_for(task.schedule, task.params)

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -169,15 +169,15 @@ class DriverActor(actor.RallyActor):
         if msg.childAddress in self.coordinator.drivers:
             driver_index = self.coordinator.drivers.index(msg.childAddress)
             if self.status == "exiting":
-                self.logger.info("Load generator [%d] has exited." % driver_index)
+                self.logger.info("Load generator [%d] has exited.", driver_index)
             else:
-                self.logger.error("Load generator [%d] has exited prematurely. Aborting benchmark." % driver_index)
-                self.send(self.start_sender, actor.BenchmarkFailure("Load generator [%d] has exited prematurely." % driver_index))
+                self.logger.error("Load generator [%d] has exited prematurely. Aborting benchmark.", driver_index)
+                self.send(self.start_sender, actor.BenchmarkFailure("Load generator [%d] has exited prematurely.", driver_index))
         else:
             self.logger.info("A track preparator has exited.")
 
     def receiveUnrecognizedMessage(self, msg, sender):
-        self.logger.info("Main driver received unknown message [%s] (ignoring)." % (str(msg)))
+        self.logger.info("Main driver received unknown message [%s] (ignoring).", str(msg))
 
     @actor.no_retry("driver")
     def receiveMsg_StartBenchmark(self, msg, sender):
@@ -277,7 +277,7 @@ class TrackPreparationActor(actor.RallyActor):
     def receiveMsg_PrepareTrack(self, msg, sender):
         # load node-specific config to have correct paths available
         cfg = load_local_config(msg.config)
-        self.logger.info("Preparing track [%s]" % msg.track.name)
+        self.logger.info("Preparing track [%s]", msg.track.name)
         # for "proper" track repositories this will ensure that all state is identical to the coordinator node. For simple tracks
         # the track is usually self-contained but in some cases (plugins are defined) we still need to ensure that the track
         # is present on all machines.
@@ -353,16 +353,16 @@ class Driver:
         self.number_of_steps = len(allocator.join_points) - 1
         self.tasks_per_join_point = allocator.tasks_per_joinpoint
 
-        self.logger.info("Benchmark consists of [%d] steps executed by (at most) [%d] clients as specified by the allocation matrix:\n%s" %
-                    (self.number_of_steps, len(self.allocations), self.allocations))
+        self.logger.info("Benchmark consists of [%d] steps executed by (at most) [%d] clients as specified by the allocation matrix:\n%s",
+                         self.number_of_steps, len(self.allocations), self.allocations)
 
         for client_id in range(allocator.clients):
             # allocate clients round-robin to all defined hosts
             host = self.load_driver_hosts[client_id % len(self.load_driver_hosts)]
-            self.logger.info("Allocating load generator [%d] on [%s]" % (client_id, host))
+            self.logger.info("Allocating load generator [%d] on [%s]", client_id, host)
             self.drivers.append(self.target.create_client(client_id, host))
         for client_id, driver in enumerate(self.drivers):
-            self.logger.info("Starting load generator [%d]." % client_id)
+            self.logger.info("Starting load generator [%d].", client_id)
             self.target.start_load_generator(driver, client_id, self.config, self.track, self.allocations[client_id])
 
         self.update_progress_message()
@@ -370,11 +370,10 @@ class Driver:
     def joinpoint_reached(self, client_id, client_local_timestamp, task):
         self.currently_completed += 1
         self.clients_completed_current_step[client_id] = (client_local_timestamp, time.perf_counter())
-        self.logger.info("[%d/%d] drivers reached join point [%d/%d]." %
-                    (self.currently_completed, len(self.drivers), self.current_step + 1, self.number_of_steps))
+        self.logger.info("[%d/%d] drivers reached join point [%d/%d].",
+                         self.currently_completed, len(self.drivers), self.current_step + 1, self.number_of_steps)
         if self.currently_completed == len(self.drivers):
-            self.logger.info("All drivers completed their operations until join point [%d/%d]." %
-                        (self.current_step + 1, self.number_of_steps))
+            self.logger.info("All drivers completed their tasks until join point [%d/%d].", self.current_step + 1, self.number_of_steps)
             # we can go on to the next step
             self.currently_completed = 0
             self.complete_current_task_sent = False
@@ -415,8 +414,8 @@ class Driver:
                 for client_id, driver in enumerate(self.drivers):
                     client_ended_task_at, master_received_msg_at = clients_curr_step[client_id]
                     client_start_timestamp = client_ended_task_at + (start_next_task - master_received_msg_at)
-                    self.logger.info("Scheduling next task for client id [%d] at their timestamp [%f] (master timestamp [%f])" %
-                                (client_id, client_start_timestamp, start_next_task))
+                    self.logger.info("Scheduling next task for client id [%d] at their timestamp [%f] (master timestamp [%f])",
+                                     client_id, client_start_timestamp, start_next_task)
                     self.target.drive_at(driver, client_start_timestamp)
         else:
             current_join_point = task
@@ -428,7 +427,7 @@ class Driver:
                 all_clients_finished = True
                 for client_id in current_join_point.clients_executing_completing_task:
                     if client_id not in self.clients_completed_current_step:
-                        self.logger.info("Client id [%s] did not yet finish." % client_id)
+                        self.logger.info("Client id [%s] did not yet finish.", client_id)
                         # do not break here so we can see all remaining clients in the log output.
                         all_clients_finished = False
                 if all_clients_finished:
@@ -504,11 +503,11 @@ class Driver:
                                                        relative_time=sample.relative_time, meta_data=meta_data)
 
         end = time.perf_counter()
-        self.logger.info("Storing latency and service time took [%f] seconds." % (end - start))
+        self.logger.info("Storing latency and service time took [%f] seconds.", (end - start))
         start = end
         aggregates = self.throughput_calculator.calculate(raw_samples)
         end = time.perf_counter()
-        self.logger.info("Calculating throughput took [%f] seconds." % (end - start))
+        self.logger.info("Calculating throughput took [%f] seconds.", (end - start))
         start = end
         for task, samples in aggregates.items():
             meta_data = self.merge(
@@ -523,7 +522,7 @@ class Driver:
                                                            sample_type=sample_type, absolute_time=absolute_time,
                                                            relative_time=relative_time, meta_data=meta_data)
         end = time.perf_counter()
-        self.logger.info("Storing throughput took [%f] seconds." % (end - start))
+        self.logger.info("Storing throughput took [%f] seconds.", (end - start))
         start = end
         # this will be a noop for the in-memory metrics store. If we use an ES metrics store however, this will ensure that we already send
         # the data and also clear the in-memory buffer. This allows users to see data already while running the benchmark. In cases where
@@ -533,8 +532,8 @@ class Driver:
         # no need for frequent refreshes.
         self.metrics_store.flush(refresh=False)
         end = time.perf_counter()
-        self.logger.info("Flushing the metrics store took [%f] seconds." % (end - start))
-        self.logger.info("Postprocessing [%d] raw samples took [%f] seconds in total." % (len(raw_samples), (end - total_start)))
+        self.logger.info("Flushing the metrics store took [%f] seconds.", (end - start))
+        self.logger.info("Postprocessing [%d] raw samples took [%f] seconds in total.", len(raw_samples), (end - total_start))
 
     def merge(self, *args):
         result = {}
@@ -583,7 +582,7 @@ class LoadGenerator(actor.RallyActor):
                 es[cluster_name] = client.EsClientFactory(cluster_hosts, all_client_options[cluster_name]).create()
             return es
 
-        self.logger.info("LoadGenerator[%d] is about to start." % msg.client_id)
+        self.logger.info("LoadGenerator[%d] is about to start.", msg.client_id)
         self.master = sender
         self.client_id = msg.client_id
         self.config = load_local_config(msg.config)
@@ -606,8 +605,8 @@ class LoadGenerator(actor.RallyActor):
     @actor.no_retry("load generator")
     def receiveMsg_Drive(self, msg, sender):
         sleep_time = datetime.timedelta(seconds=msg.client_start_timestamp - time.perf_counter())
-        self.logger.info("LoadGenerator[%d] is continuing its work at task index [%d] on [%f], that is in [%s]." %
-                    (self.client_id, self.current_task_index, msg.client_start_timestamp, sleep_time))
+        self.logger.info("LoadGenerator[%d] is continuing its work at task index [%d] on [%f], that is in [%s].",
+                         self.client_id, self.current_task_index, msg.client_start_timestamp, sleep_time)
         self.start_driving = True
         self.wakeupAfter(sleep_time)
 
@@ -616,52 +615,52 @@ class LoadGenerator(actor.RallyActor):
         # finish now ASAP. Remaining samples will be sent with the next WakeupMessage. We will also need to skip to the next
         # JoinPoint. But if we are already at a JoinPoint at the moment, there is nothing to do.
         if self.at_joinpoint():
-            self.logger.info("LoadGenerator[%s] has received CompleteCurrentTask but is currently at [%s]. Ignoring."
-                        % (str(self.client_id), self.current_task))
+            self.logger.info("LoadGenerator[%s] has received CompleteCurrentTask but is currently at [%s]. Ignoring.",
+                             str(self.client_id), self.current_task)
         else:
-            self.logger.info("LoadGenerator[%s] has received CompleteCurrentTask. Completing current task [%s]."
-                        % (str(self.client_id), self.current_task))
+            self.logger.info("LoadGenerator[%s] has received CompleteCurrentTask. Completing current task [%s].",
+                             str(self.client_id), self.current_task)
             self.complete.set()
 
     @actor.no_retry("load generator")
     def receiveMsg_WakeupMessage(self, msg, sender):
         # it would be better if we could send ourselves a message at a specific time, simulate this with a boolean...
         if self.start_driving:
-            self.logger.info("LoadGenerator[%s] starts driving now." % str(self.client_id))
+            self.logger.info("LoadGenerator[%s] starts driving now.", str(self.client_id))
             self.start_driving = False
             self.drive()
         else:
             current_samples = self.send_samples()
             if self.cancel.is_set():
-                self.logger.info("LoadGenerator[%s] has detected that benchmark has been cancelled. Notifying master..." %
-                            str(self.client_id))
+                self.logger.info("LoadGenerator[%s] has detected that benchmark has been cancelled. Notifying master...",
+                                 str(self.client_id))
                 self.send(self.master, actor.BenchmarkCancelled())
             elif self.executor_future is not None and self.executor_future.done():
                 e = self.executor_future.exception(timeout=0)
                 if e:
-                    self.logger.info("LoadGenerator[%s] has detected a benchmark failure. Notifying master..." % str(self.client_id))
+                    self.logger.info("LoadGenerator[%s] has detected a benchmark failure. Notifying master...", str(self.client_id))
                     # the exception might be user-defined and not be on the load path of the master driver. Hence, it cannot be
                     # deserialized on the receiver so we convert it here to a plain string.
                     self.send(self.master, actor.BenchmarkFailure("Error in load generator [{}]".format(self.client_id), str(e)))
                 else:
-                    self.logger.info("LoadGenerator[%s] is ready for the next task." % str(self.client_id))
+                    self.logger.info("LoadGenerator[%s] is ready for the next task.", str(self.client_id))
                     self.executor_future = None
                     self.drive()
             else:
                 if current_samples and len(current_samples) > 0:
                     most_recent_sample = current_samples[-1]
                     if most_recent_sample.percent_completed is not None:
-                        self.logger.info("LoadGenerator[%s] is executing [%s] (%.2f%% complete)." %
-                                    (str(self.client_id), most_recent_sample.task, most_recent_sample.percent_completed * 100.0))
+                        self.logger.info("LoadGenerator[%s] is executing [%s] (%.2f%% complete).",
+                                         str(self.client_id), most_recent_sample.task, most_recent_sample.percent_completed * 100.0)
                     else:
-                        self.logger.info("LoadGenerator[%s] is executing [%s] (dependent eternal task)." %
-                                    (str(self.client_id), most_recent_sample.task))
+                        self.logger.info("LoadGenerator[%s] is executing [%s] (dependent eternal task).",
+                                         str(self.client_id), most_recent_sample.task)
                 else:
-                    self.logger.info("LoadGenerator[%s] is executing (no samples)." % (str(self.client_id)))
+                    self.logger.info("LoadGenerator[%s] is executing (no samples).", str(self.client_id))
                 self.wakeupAfter(datetime.timedelta(seconds=self.wakeup_interval))
 
     def receiveMsg_ActorExitRequest(self, msg, sender):
-        self.logger.info("LoadGenerator[%s] is exiting due to ActorExitRequest." % str(self.client_id))
+        self.logger.info("LoadGenerator[%s] is exiting due to ActorExitRequest.", str(self.client_id))
         if self.executor_future is not None and self.executor_future.running():
             self.cancel.set()
             self.pool.shutdown()
@@ -671,7 +670,7 @@ class LoadGenerator(actor.RallyActor):
         self.send(self.master, msg)
 
     def receiveUnrecognizedMessage(self, msg, sender):
-        self.logger.info("LoadGenerator[%d] received unknown message [%s] (ignoring)." % (self.client_id, str(msg)))
+        self.logger.info("LoadGenerator[%d] received unknown message [%s] (ignoring).", self.client_id, str(msg))
 
     def drive(self):
         profiling_enabled = self.config.opts("driver", "profiling")
@@ -682,7 +681,7 @@ class LoadGenerator(actor.RallyActor):
         self.current_task = task_allocation
 
         if isinstance(task_allocation, JoinPoint):
-            self.logger.info("LoadGenerator[%d] reached join point [%s]." % (self.client_id, task_allocation))
+            self.logger.info("LoadGenerator[%d] reached join point [%s].", self.client_id, task_allocation)
             # clients that don't execute tasks don't need to care about waiting
             if self.executor_future is not None:
                 self.executor_future.result()
@@ -700,7 +699,7 @@ class LoadGenerator(actor.RallyActor):
                 self.logger.info("LoadGenerator[%d] is skipping [%s] because it has been asked to complete all tasks until next join "
                                  "point." % (self.client_id, task))
             else:
-                self.logger.info("LoadGenerator[%d] is executing [%s]." % (self.client_id, task))
+                self.logger.info("LoadGenerator[%d] is executing [%s].", self.client_id, task)
                 self.sampler = Sampler(self.client_id, task, start_timestamp=time.perf_counter())
                 # We cannot use the global client index here because we need to support parallel execution of tasks with multiple clients.
                 #
@@ -756,7 +755,7 @@ class Sampler:
                                      sample_type, request_meta_data, latency_ms, service_time_ms, total_ops, total_ops_unit, time_period,
                                      percent_completed))
         except queue.Full:
-            self.logger.warning("Dropping sample for [%s] due to a full sampling queue." % self.task.operation.name)
+            self.logger.warning("Dropping sample for [%s] due to a full sampling queue.", self.task.operation.name)
 
     @property
     def samples(self):
@@ -1053,7 +1052,7 @@ def execute_single(runner, es, params, abort_on_error=False):
         else:
             request_meta_data["error-description"] = e.error
     except KeyError as e:
-        logging.getLogger(__name__).exception("Cannot execute runner [%s]; most likely due to missing parameters." % str(runner))
+        logging.getLogger(__name__).exception("Cannot execute runner [%s]; most likely due to missing parameters.", str(runner))
         msg = "Cannot execute [%s]. Provided parameters are: %s. Error: [%s]." % (str(runner), list(params.keys()), str(e))
         raise exceptions.SystemSetupError(msg)
 
@@ -1241,14 +1240,14 @@ def schedule_for(current_track, task, client_index):
     op = task.operation
     num_clients = task.clients
     sched = scheduler.scheduler_for(task.schedule, task.params)
-    logger.info("Choosing [%s] for [%s]." % (sched, task))
+    logger.info("Choosing [%s] for [%s].", sched, task)
     runner_for_op = runner.runner_for(op.type)
     params_for_op = track.operation_parameters(current_track, op).partition(client_index, num_clients)
 
     if task.warmup_time_period is not None or task.time_period is not None:
         warmup_time_period = task.warmup_time_period if task.warmup_time_period else 0
         logger.info("Creating time-period based schedule with [%s] distribution for [%s] with a warmup period of [%s] seconds and a "
-                    "time period of [%s] seconds." % (task.schedule, task, str(warmup_time_period), str(task.time_period)))
+                    "time period of [%s] seconds.", task.schedule, task, str(warmup_time_period), str(task.time_period))
         return time_period_based(sched, warmup_time_period, task.time_period, runner_for_op, params_for_op)
     else:
         warmup_iterations = task.warmup_iterations if task.warmup_iterations else 0

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -39,20 +39,20 @@ def register_runner(operation_type, runner):
     logger = logging.getLogger(__name__)
     if getattr(runner, "multi_cluster", False) == True:
         if "__enter__" in dir(runner) and "__exit__" in dir(runner):
-            logger.info("Registering runner object [%s] for [%s]." % (str(runner), str(operation_type)))
+            logger.info("Registering runner object [%s] for [%s].", str(runner), str(operation_type))
             __RUNNERS[operation_type] = MultiClusterDelegatingRunner(runner, str(runner), context_manager_enabled=True)
         else:
-            logger.info("Registering context-manager capable runner object [%s] for [%s]." % (str(runner), str(operation_type)))
+            logger.info("Registering context-manager capable runner object [%s] for [%s].", str(runner), str(operation_type))
             __RUNNERS[operation_type] = MultiClusterDelegatingRunner(runner, str(runner))
     # we'd rather use callable() but this will erroneously also classify a class as callable...
     elif isinstance(runner, types.FunctionType):
-        logger.info("Registering runner function [%s] for [%s]." % (str(runner), str(operation_type)))
+        logger.info("Registering runner function [%s] for [%s].", str(runner), str(operation_type))
         __RUNNERS[operation_type] = SingleClusterDelegatingRunner(runner, runner.__name__)
     elif "__enter__" in dir(runner) and "__exit__" in dir(runner):
-        logger.info("Registering context-manager capable runner object [%s] for [%s]." % (str(runner), str(operation_type)))
+        logger.info("Registering context-manager capable runner object [%s] for [%s].", str(runner), str(operation_type))
         __RUNNERS[operation_type] = SingleClusterDelegatingRunner(runner, str(runner), context_manager_enabled=True)
     else:
-        logger.info("Registering runner object [%s] for [%s]." % (str(runner), str(operation_type)))
+        logger.info("Registering runner object [%s] for [%s].", str(runner), str(operation_type))
         __RUNNERS[operation_type] = SingleClusterDelegatingRunner(runner, str(runner))
 
 
@@ -813,7 +813,7 @@ class DeleteIndex(Runner):
                 es.indices.delete(index=index_name, **request_params)
                 ops += 1
             elif only_if_exists and es.indices.exists(index=index_name):
-                self.logger.info("Index [%s] already exists. Deleting it." % index_name)
+                self.logger.info("Index [%s] already exists. Deleting it.", index_name)
                 es.indices.delete(index=index_name, **request_params)
                 ops += 1
 
@@ -857,7 +857,7 @@ class DeleteIndexTemplate(Runner):
                 es.indices.delete_template(name=template_name, **request_params)
                 ops_count += 1
             elif only_if_exists and es.indices.exists_template(template_name):
-                self.logger.info("Index template [%s] already exists. Deleting it." % template_name)
+                self.logger.info("Index template [%s] already exists. Deleting it.", template_name)
                 es.indices.delete_template(name=template_name, **request_params)
                 ops_count += 1
             # ensure that we do not provide an empty index pattern by accident
@@ -942,7 +942,7 @@ class Retry(Runner):
                 if last_attempt or not retry_on_timeout:
                     raise e
                 elif e.status_code == 408:
-                    self.logger.debug("%s has timed out." % repr(self.delegate))
+                    self.logger.debug("%s has timed out.", repr(self.delegate))
                     time.sleep(sleep_time)
                 else:
                     raise e

--- a/esrally/driver/scheduler.py
+++ b/esrally/driver/scheduler.py
@@ -3,8 +3,6 @@ import types
 import random
 from esrally import exceptions
 
-logger = logging.getLogger("rally.driver")
-
 # Mapping from task to scheduler
 __SCHEDULERS = {}
 
@@ -32,6 +30,7 @@ def register_scheduler(name, scheduler):
     :param scheduler: Either a unary function ``float`` -> ``float`` or a class with the same interface as ``Scheduler``.
     
     """
+    logger = logging.getLogger(__name__)
     if name in __SCHEDULERS:
         raise exceptions.SystemSetupError("A scheduler with the name [%s] is already registered." % name)
     # we'd rather use callable() but this will erroneously also classify a class as callable...

--- a/esrally/driver/scheduler.py
+++ b/esrally/driver/scheduler.py
@@ -35,11 +35,11 @@ def register_scheduler(name, scheduler):
         raise exceptions.SystemSetupError("A scheduler with the name [%s] is already registered." % name)
     # we'd rather use callable() but this will erroneously also classify a class as callable...
     if isinstance(scheduler, types.FunctionType):
-        logger.debug("Registering function [%s] for [%s]." % (str(scheduler), str(name)))
+        logger.debug("Registering function [%s] for [%s].", str(scheduler), str(name))
         # lazy initialize a delegating scheduler
         __SCHEDULERS[name] = lambda params: DelegatingScheduler(params, scheduler)
     else:
-        logger.debug("Registering object [%s] for [%s]." % (str(scheduler), str(name)))
+        logger.debug("Registering object [%s] for [%s].", str(scheduler), str(name))
         __SCHEDULERS[name] = scheduler
 
 

--- a/esrally/log.py
+++ b/esrally/log.py
@@ -1,0 +1,113 @@
+import logging
+import logging.config
+import json
+import time
+import os
+
+from esrally.utils import io
+
+
+def configure_utc_formatter(*args, **kwargs):
+    """
+    Logging formatter that renders timestamps in UTC to ensure consistent
+    timestamps across all deployments regardless of machine settings.
+    """
+    formatter = logging.Formatter(fmt=kwargs["format"], datefmt=kwargs["datefmt"])
+    formatter.converter = time.gmtime
+    return formatter
+
+
+def log_config_path():
+    """
+    :return: The absolute path to Rally's log configuration file.
+    """
+    return os.path.join(os.path.expanduser("~"), ".rally", "logging.json")
+
+
+def default_log_path():
+    """
+    :return: The absolute path to the directory that contains Rally's log file.
+    """
+    return os.path.join(os.path.expanduser("~"), ".rally", "logs")
+
+
+def install_default_log_config():
+    """
+    Ensures a log configuration file is present on this machine. The default
+    log configuration is based on the template in resources/logging.json.
+
+    It also ensures that the default log path has been created so log files
+    can be successfully opened in that directory.
+    """
+    log_config = log_config_path()
+    if not io.exists(log_config):
+        io.ensure_dir(io.dirname(log_config))
+        source_path = io.normalize_path(os.path.join(os.path.dirname(__file__), "resources", "logging.json"))
+        with open(log_config, "w", encoding="UTF-8") as target:
+            with open(source_path, "r", encoding="UTF-8") as src:
+                contents = src.read().replace("${LOG_PATH}", default_log_path())
+                target.write(contents)
+    io.ensure_dir(default_log_path())
+
+
+def load_configuration():
+    """
+    Loads the logging configuration. This is a low-level method and usually
+    `configure_logging()` should be used instead.
+
+    :return: The logging configuration as `dict` instance.
+    """
+    with open(log_config_path()) as f:
+        return json.load(f)
+
+
+def post_configure_actor_logging():
+    """
+    Reconfigures all loggers in actor processes.
+
+    See https://groups.google.com/forum/#!topic/thespianpy/FntU9umtvhc for the rationale.
+    """
+    # see configure_logging()
+    logging.captureWarnings(True)
+
+    # at this point we can assume that a log configuration exists. It has been created already during startup.
+    logger_configuration = load_configuration()
+    if "root" in logger_configuration and "level" in logger_configuration["root"]:
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logger_configuration["root"]["level"])
+
+    if "loggers" in logger_configuration:
+        for lgr, cfg in load_configuration()["loggers"].items():
+            if "level" in cfg:
+                logging.getLogger(lgr).setLevel(cfg["level"])
+
+
+def configure_logging():
+    """
+    Configures logging for the current process.
+    """
+
+    logging.config.dictConfig(load_configuration())
+
+    # Avoid failures such as the following (shortened a bit):
+    #
+    # ---------------------------------------------------------------------------------------------
+    # "esrally/driver/driver.py", line 220, in create_client
+    # "thespian-3.8.0-py3.5.egg/thespian/actors.py", line 187, in createActor
+    # [...]
+    # "thespian-3.8.0-py3.5.egg/thespian/system/multiprocCommon.py", line 348, in _startChildActor
+    # "python3.5/multiprocessing/process.py", line 105, in start
+    # "python3.5/multiprocessing/context.py", line 267, in _Popen
+    # "python3.5/multiprocessing/popen_fork.py", line 18, in __init__
+    # sys.stderr.flush()
+    #
+    # OSError: [Errno 5] Input/output error
+    # ---------------------------------------------------------------------------------------------
+    #
+    # This is caused by urllib3 wanting to send warnings about insecure SSL connections to stderr when we disable them (in client.py) with:
+    #
+    #   urllib3.disable_warnings()
+    #
+    # The filtering functionality of the warnings module causes the error above on some systems. If we instead redirect the warning output
+    # to our logs instead of stderr (which is the warnings module's default), we can disable warnings safely.
+    logging.captureWarnings(True)

--- a/esrally/mechanic/cluster.py
+++ b/esrally/mechanic/cluster.py
@@ -1,8 +1,3 @@
-import logging
-
-logger = logging.getLogger("rally.cluster")
-
-
 class Node:
     """
     Represents an Elasticsearch cluster node.

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -144,7 +144,7 @@ class DockerLauncher:
         t.setDaemon(True)
         t.start()
         if startup_event.wait(timeout=DockerLauncher.PROCESS_WAIT_TIMEOUT_SECONDS):
-            self.logger.info("Started node=%s with pid=%s" % (node_name, p.pid))
+            self.logger.info("Started node=%s with pid=%s", node_name, p.pid)
             return p
         else:
             msg = "Could not start node '%s' within timeout period of %s seconds." % (
@@ -163,14 +163,14 @@ class DockerLauncher:
             l = l.rstrip()
 
             if l.find("Initialization Failed") != -1:
-                self.logger.warning("[%s] has started with initialization errors." % node_name)
+                self.logger.warning("[%s] has started with initialization errors.", node_name)
                 startup_event.set()
             # don't log each output line as it is contained in the node's log files anyway and we just risk spamming our own log.
             if not startup_event.isSet():
-                self.logger.info("%s: %s" % (node_name, l.replace("\n", "\n%s (stdout): " % node_name)))
+                self.logger.info("%s: %s", node_name, l.replace("\n", "\n%s (stdout): " % node_name))
             if l.endswith("] started") and not startup_event.isSet():
                 startup_event.set()
-                self.logger.info("[%s] has successfully started." % node_name)
+                self.logger.info("[%s] has successfully started.", node_name)
 
     def stop(self, nodes):
         if self.keep_running:
@@ -208,7 +208,7 @@ class ExternalLauncher:
         user_defined_version = self.cfg.opts("mechanic", "distribution.version", mandatory=False)
         distribution_version = es.info()["version"]["number"]
         if not user_defined_version or user_defined_version.strip() == "":
-            self.logger.info("Distribution version was not specified by user. Rally-determined version is [%s]" % distribution_version)
+            self.logger.info("Distribution version was not specified by user. Rally-determined version is [%s]", distribution_version)
             self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", distribution_version)
         elif user_defined_version != distribution_version:
             console.warn(
@@ -244,7 +244,7 @@ class InProcessLauncher:
         # We also do this only once per host otherwise we would kill instances that we've just launched.
         process.kill_running_es_instances(self.races_root_dir)
         java_major_version = jvm.major_version(self.java_home)
-        self.logger.info("Detected Java major version [%s]." % java_major_version)
+        self.logger.info("Detected Java major version [%s].", java_major_version)
 
         node_count_on_host = len(node_configurations)
         return [self._start_node(node_configuration, node_count_on_host, java_major_version) for node_configuration in node_configurations]
@@ -257,7 +257,7 @@ class InProcessLauncher:
         data_paths = node_configuration.data_paths
         node_telemetry_dir = "%s/telemetry" % node_configuration.node_root_path
 
-        self.logger.info("Starting node [%s] based on car [%s]." % (node_name, car))
+        self.logger.info("Starting node [%s] based on car [%s].", node_name, car)
 
         enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
         telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
@@ -279,9 +279,9 @@ class InProcessLauncher:
         t.on_pre_node_start(node_name)
         node_process = self._start_process(env, node_name, binary_path)
         node = cluster.Node(node_process, host_name, node_name, t)
-        self.logger.info("Node [%s] has successfully started. Attaching telemetry devices." % node_name)
+        self.logger.info("Node [%s] has successfully started. Attaching telemetry devices.", node_name)
         t.attach_to_node(node)
-        self.logger.info("Telemetry devices are now attached to node [%s]." % node_name)
+        self.logger.info("Telemetry devices are now attached to node [%s].", node_name)
 
         return node
 
@@ -305,7 +305,7 @@ class InProcessLauncher:
         else:
             self.logger.info("JVM does not support [%s]. Please consider a JDK upgrade.", exit_on_oome_flag)
 
-        self.logger.info("env for [%s]: %s" % (node_name, str(env)))
+        self.logger.info("env for [%s]: %s", node_name, str(env))
         return env
 
     def _set_env(self, env, k, v, separator=' '):
@@ -333,7 +333,7 @@ class InProcessLauncher:
                 self.logger.error(msg)
                 raise exceptions.LaunchError(msg)
             else:
-                self.logger.info("Started node [%s] with PID [%s]" % (node_name, process.pid))
+                self.logger.info("Started node [%s] with PID [%s]", node_name, process.pid)
                 return process
         else:
             msg = "Could not start node [%s] within timeout period of [%s] seconds." % (
@@ -355,7 +355,7 @@ class InProcessLauncher:
         while True:
             line = server.stdout.readline().decode("utf-8")
             if len(line) == 0:
-                self.logger.info("%s (stdout): No more output. Process has likely terminated." % node_name)
+                self.logger.info("%s (stdout): No more output. Process has likely terminated.", node_name)
                 self.await_termination(server)
                 startup_event.set()
                 break
@@ -366,19 +366,19 @@ class InProcessLauncher:
                 lines_to_log = 10
             # don't log each output line as it is contained in the node's log files anyway and we just risk spamming our own log.
             if not startup_event.isSet() or lines_to_log > 0:
-                self.logger.info("%s (stdout): %s" % (node_name, line))
+                self.logger.info("%s (stdout): %s", node_name, line)
                 lines_to_log -= 1
 
             # no need to check as soon as we have detected node startup
             if not startup_event.isSet():
                 if line.find("Initialization Failed") != -1 or line.find("A fatal exception has occurred") != -1:
-                    self.logger.error("[%s] encountered initialization errors." % node_name)
+                    self.logger.error("[%s] encountered initialization errors.", node_name)
                     # wait a moment to ensure the process has terminated before we signal that we detected a (failed) startup.
                     self.await_termination(server)
                     startup_event.set()
                 if line.endswith("started") and not startup_event.isSet():
                     startup_event.set()
-                    self.logger.info("[%s] has successfully started." % node_name)
+                    self.logger.info("[%s] has successfully started.", node_name)
 
     def await_termination(self, server, timeout=5):
         # wait a moment to ensure the process has terminated
@@ -390,9 +390,9 @@ class InProcessLauncher:
 
     def stop(self, nodes):
         if self.keep_running:
-            self.logger.info("Keeping [%d] nodes on this host running." % len(nodes))
+            self.logger.info("Keeping [%d] nodes on this host running.", len(nodes))
         else:
-            self.logger.info("Shutting down [%d] nodes on this host." % len(nodes))
+            self.logger.info("Shutting down [%d] nodes on this host.", len(nodes))
         for node in nodes:
             process = node.process
             node_name = node.node_name
@@ -403,26 +403,26 @@ class InProcessLauncher:
                 try:
                     os.kill(process.pid, signal.SIGINT)
                     process.wait(10.0)
-                    self.logger.info("Done shutdown node [%s] in [%.1f] s." % (node_name, stop_watch.split_time()))
+                    self.logger.info("Done shutdown node [%s] in [%.1f] s.", node_name, stop_watch.split_time())
                 except ProcessLookupError:
-                    self.logger.warning("No process found with PID [%s] for node [%s]" % (process.pid, node_name))
+                    self.logger.warning("No process found with PID [%s] for node [%s]", process.pid, node_name)
                 except subprocess.TimeoutExpired:
                     # kill -9
                     self.logger.warning("Node [%s] did not shut down after 10 seconds; now kill -QUIT node, to see threads:", node_name)
                     try:
                         os.kill(process.pid, signal.SIGQUIT)
                     except OSError:
-                        self.logger.warning("No process found with PID [%s] for node [%s]" % (process.pid, node_name))
+                        self.logger.warning("No process found with PID [%s] for node [%s]", process.pid, node_name)
                         break
                     try:
                         process.wait(120.0)
-                        self.logger.info("Done shutdown node [%s] in [%.1f] s." % (node_name, stop_watch.split_time()))
+                        self.logger.info("Done shutdown node [%s] in [%.1f] s.", node_name, stop_watch.split_time())
                         break
                     except subprocess.TimeoutExpired:
                         pass
-                    self.logger.info("kill -KILL node [%s]" % node_name)
+                    self.logger.info("kill -KILL node [%s]", node_name)
                     try:
                         process.kill()
                     except ProcessLookupError:
-                        self.logger.warning("No process found with PID [%s] for node [%s]" % (process.pid, node_name))
+                        self.logger.warning("No process found with PID [%s] for node [%s]", process.pid, node_name)
                 node.telemetry.detach_from_node(node, running=False)

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -9,8 +9,6 @@ from esrally import config, time, exceptions, client
 from esrally.mechanic import telemetry, cluster
 from esrally.utils import console, process, jvm
 
-logger = logging.getLogger("rally.launcher")
-
 
 def wait_for_rest_layer(es, max_attempts=20):
     for attempt in range(max_attempts):
@@ -20,10 +18,8 @@ def wait_for_rest_layer(es, max_attempts=20):
             return True
         except elasticsearch.TransportError as e:
             if e.status_code == 503 or isinstance(e, elasticsearch.ConnectionError):
-                logger.debug("Elasticsearch REST API is not available yet (probably cluster block).")
                 time.sleep(1)
             elif e.status_code == 401:
-                logger.debug("Could not authenticate yet (probably x-pack initializing).")
                 time.sleep(1)
             else:
                 raise e
@@ -50,6 +46,7 @@ class ClusterLauncher:
         self.metrics_store = metrics_store
         self.on_post_launch = on_post_launch
         self.client_factory = client_factory_class
+        self.logger = logging.getLogger(__name__)
 
     def start(self):
         """
@@ -85,14 +82,14 @@ class ClusterLauncher:
         # The list of nodes will be populated by ClusterMetaDataInfo, so no need to do it here
         c = cluster.Cluster(default_hosts, [], t)
 
-        logger.info("All cluster nodes have successfully started. Checking if REST API is available.")
+        self.logger.info("All cluster nodes have successfully started. Checking if REST API is available.")
         if wait_for_rest_layer(es_default, max_attempts=40):
-            logger.info("REST API is available. Attaching telemetry devices to cluster.")
+            self.logger.info("REST API is available. Attaching telemetry devices to cluster.")
             t.attach_to_cluster(c)
-            logger.info("Telemetry devices are now attached to the cluster.")
+            self.logger.info("Telemetry devices are now attached to the cluster.")
         else:
             # Just stop the cluster here and raise. The caller is responsible for terminating individual nodes.
-            logger.error("REST API layer is not yet available. Forcefully terminating cluster.")
+            self.logger.error("REST API layer is not yet available. Forcefully terminating cluster.")
             self.stop(c)
             raise exceptions.LaunchError("Elasticsearch REST API layer is not available. Forcefully terminated cluster.")
         if self.on_post_launch:
@@ -118,6 +115,7 @@ class DockerLauncher:
         self.binary_paths = {}
         self.node_name = None
         self.keep_running = self.cfg.opts("mechanic", "keep.running")
+        self.logger = logging.getLogger(__name__)
 
     def start(self, node_configurations):
         nodes = []
@@ -146,12 +144,12 @@ class DockerLauncher:
         t.setDaemon(True)
         t.start()
         if startup_event.wait(timeout=DockerLauncher.PROCESS_WAIT_TIMEOUT_SECONDS):
-            logger.info("Started node=%s with pid=%s" % (node_name, p.pid))
+            self.logger.info("Started node=%s with pid=%s" % (node_name, p.pid))
             return p
         else:
             msg = "Could not start node '%s' within timeout period of %s seconds." % (
                 node_name, InProcessLauncher.PROCESS_WAIT_TIMEOUT_SECONDS)
-            logger.error(msg)
+            self.logger.error(msg)
             raise exceptions.LaunchError("%s Please check the logs in '%s' for more details." % (msg, log_dir))
 
     def _read_output(self, node_name, server, startup_event):
@@ -165,20 +163,20 @@ class DockerLauncher:
             l = l.rstrip()
 
             if l.find("Initialization Failed") != -1:
-                logger.warning("[%s] has started with initialization errors." % node_name)
+                self.logger.warning("[%s] has started with initialization errors." % node_name)
                 startup_event.set()
             # don't log each output line as it is contained in the node's log files anyway and we just risk spamming our own log.
             if not startup_event.isSet():
-                logger.info("%s: %s" % (node_name, l.replace("\n", "\n%s (stdout): " % node_name)))
+                self.logger.info("%s: %s" % (node_name, l.replace("\n", "\n%s (stdout): " % node_name)))
             if l.endswith("] started") and not startup_event.isSet():
                 startup_event.set()
-                logger.info("[%s] has successfully started." % node_name)
+                self.logger.info("[%s] has successfully started." % node_name)
 
     def stop(self, nodes):
         if self.keep_running:
-            logger.info("Keeping Docker container running.")
+            self.logger.info("Keeping Docker container running.")
         else:
-            logger.info("Stopping Docker container")
+            self.logger.info("Stopping Docker container")
             for node in nodes:
                 node.telemetry.detach_from_node(node, running=True)
                 process.run_subprocess_with_logging("docker-compose -f %s down" % self.binary_paths[node.node_name])
@@ -190,6 +188,7 @@ class ExternalLauncher:
         self.cfg = cfg
         self.metrics_store = metrics_store
         self.client_factory = client_factory_class
+        self.logger = logging.getLogger(__name__)
 
     def start(self, node_configurations=None):
         hosts = self.cfg.opts("client", "hosts").default
@@ -209,12 +208,12 @@ class ExternalLauncher:
         user_defined_version = self.cfg.opts("mechanic", "distribution.version", mandatory=False)
         distribution_version = es.info()["version"]["number"]
         if not user_defined_version or user_defined_version.strip() == "":
-            logger.info("Distribution version was not specified by user. Rally-determined version is [%s]" % distribution_version)
+            self.logger.info("Distribution version was not specified by user. Rally-determined version is [%s]" % distribution_version)
             self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", distribution_version)
         elif user_defined_version != distribution_version:
             console.warn(
                 "Specified distribution version '%s' on the command line differs from version '%s' reported by the cluster." %
-                (user_defined_version, distribution_version), logger=logger)
+                (user_defined_version, distribution_version), logger=self.logger)
         t.attach_to_cluster(c)
         return c.nodes
 
@@ -236,6 +235,7 @@ class InProcessLauncher:
         self.races_root_dir = races_root_dir
         self.java_home = self.cfg.opts("runtime", "java.home")
         self.keep_running = self.cfg.opts("mechanic", "keep.running")
+        self.logger = logging.getLogger(__name__)
 
     def start(self, node_configurations):
         # we're very specific which nodes we kill as there is potentially also an Elasticsearch based metrics store running on this machine
@@ -244,7 +244,7 @@ class InProcessLauncher:
         # We also do this only once per host otherwise we would kill instances that we've just launched.
         process.kill_running_es_instances(self.races_root_dir)
         java_major_version = jvm.major_version(self.java_home)
-        logger.info("Detected Java major version [%s]." % java_major_version)
+        self.logger.info("Detected Java major version [%s]." % java_major_version)
 
         node_count_on_host = len(node_configurations)
         return [self._start_node(node_configuration, node_count_on_host, java_major_version) for node_configuration in node_configurations]
@@ -257,7 +257,7 @@ class InProcessLauncher:
         data_paths = node_configuration.data_paths
         node_telemetry_dir = "%s/telemetry" % node_configuration.node_root_path
 
-        logger.info("Starting node [%s] based on car [%s]." % (node_name, car))
+        self.logger.info("Starting node [%s] based on car [%s]." % (node_name, car))
 
         enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
         telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
@@ -279,9 +279,9 @@ class InProcessLauncher:
         t.on_pre_node_start(node_name)
         node_process = self._start_process(env, node_name, binary_path)
         node = cluster.Node(node_process, host_name, node_name, t)
-        logger.info("Node [%s] has successfully started. Attaching telemetry devices." % node_name)
+        self.logger.info("Node [%s] has successfully started. Attaching telemetry devices." % node_name)
         t.attach_to_node(node)
-        logger.info("Telemetry devices are now attached to node [%s]." % node_name)
+        self.logger.info("Telemetry devices are now attached to node [%s]." % node_name)
 
         return node
 
@@ -300,12 +300,12 @@ class InProcessLauncher:
 
         exit_on_oome_flag = "-XX:+ExitOnOutOfMemoryError"
         if jvm.supports_option(self.java_home, exit_on_oome_flag):
-            logger.info("JVM supports [%s]. Setting this option to detect out of memory errors during the benchmark." % exit_on_oome_flag)
+            self.logger.info("Setting [%s] to detect out of memory errors during the benchmark.", exit_on_oome_flag)
             self._set_env(env, "ES_JAVA_OPTS", exit_on_oome_flag)
         else:
-            logger.info("JVM does not support [%s]. Cannot detect out of memory errors. Please consider a JDK upgrade." % exit_on_oome_flag)
+            self.logger.info("JVM does not support [%s]. Please consider a JDK upgrade.", exit_on_oome_flag)
 
-        logger.info("env for [%s]: %s" % (node_name, str(env)))
+        self.logger.info("env for [%s]: %s" % (node_name, str(env)))
         return env
 
     def _set_env(self, env, k, v, separator=' '):
@@ -330,10 +330,10 @@ class InProcessLauncher:
             # has the process terminated?
             if process.returncode:
                 msg = "Node [%s] has terminated with exit code [%s]." % (node_name, str(process.returncode))
-                logger.error(msg)
+                self.logger.error(msg)
                 raise exceptions.LaunchError(msg)
             else:
-                logger.info("Started node [%s] with PID [%s]" % (node_name, process.pid))
+                self.logger.info("Started node [%s] with PID [%s]" % (node_name, process.pid))
                 return process
         else:
             msg = "Could not start node [%s] within timeout period of [%s] seconds." % (
@@ -344,7 +344,7 @@ class InProcessLauncher:
                 msg += " The process has already terminated with exit code [%s]." % str(process.returncode)
             else:
                 msg += " The process seems to be still running with PID [%s]." % process.pid
-            logger.error(msg)
+            self.logger.error(msg)
             raise exceptions.LaunchError(msg)
 
     def _read_output(self, node_name, server, startup_event):
@@ -355,7 +355,7 @@ class InProcessLauncher:
         while True:
             line = server.stdout.readline().decode("utf-8")
             if len(line) == 0:
-                logger.info("%s (stdout): No more output. Process has likely terminated." % node_name)
+                self.logger.info("%s (stdout): No more output. Process has likely terminated." % node_name)
                 self.await_termination(server)
                 startup_event.set()
                 break
@@ -366,19 +366,19 @@ class InProcessLauncher:
                 lines_to_log = 10
             # don't log each output line as it is contained in the node's log files anyway and we just risk spamming our own log.
             if not startup_event.isSet() or lines_to_log > 0:
-                logger.info("%s (stdout): %s" % (node_name, line))
+                self.logger.info("%s (stdout): %s" % (node_name, line))
                 lines_to_log -= 1
 
             # no need to check as soon as we have detected node startup
             if not startup_event.isSet():
                 if line.find("Initialization Failed") != -1 or line.find("A fatal exception has occurred") != -1:
-                    logger.error("[%s] encountered initialization errors." % node_name)
+                    self.logger.error("[%s] encountered initialization errors." % node_name)
                     # wait a moment to ensure the process has terminated before we signal that we detected a (failed) startup.
                     self.await_termination(server)
                     startup_event.set()
                 if line.endswith("started") and not startup_event.isSet():
                     startup_event.set()
-                    logger.info("[%s] has successfully started." % node_name)
+                    self.logger.info("[%s] has successfully started." % node_name)
 
     def await_termination(self, server, timeout=5):
         # wait a moment to ensure the process has terminated
@@ -390,9 +390,9 @@ class InProcessLauncher:
 
     def stop(self, nodes):
         if self.keep_running:
-            logger.info("Keeping [%d] nodes on this host running." % len(nodes))
+            self.logger.info("Keeping [%d] nodes on this host running." % len(nodes))
         else:
-            logger.info("Shutting down [%d] nodes on this host." % len(nodes))
+            self.logger.info("Shutting down [%d] nodes on this host." % len(nodes))
         for node in nodes:
             process = node.process
             node_name = node.node_name
@@ -403,26 +403,26 @@ class InProcessLauncher:
                 try:
                     os.kill(process.pid, signal.SIGINT)
                     process.wait(10.0)
-                    logger.info("Done shutdown node [%s] in [%.1f] s." % (node_name, stop_watch.split_time()))
+                    self.logger.info("Done shutdown node [%s] in [%.1f] s." % (node_name, stop_watch.split_time()))
                 except ProcessLookupError:
-                    logger.warning("No process found with PID [%s] for node [%s]" % (process.pid, node_name))
+                    self.logger.warning("No process found with PID [%s] for node [%s]" % (process.pid, node_name))
                 except subprocess.TimeoutExpired:
                     # kill -9
-                    logger.warning("Node [%s] did not shut down itself after 10 seconds; now kill -QUIT node, to see threads:" % node_name)
+                    self.logger.warning("Node [%s] did not shut down after 10 seconds; now kill -QUIT node, to see threads:", node_name)
                     try:
                         os.kill(process.pid, signal.SIGQUIT)
                     except OSError:
-                        logger.warning("No process found with PID [%s] for node [%s]" % (process.pid, node_name))
+                        self.logger.warning("No process found with PID [%s] for node [%s]" % (process.pid, node_name))
                         break
                     try:
                         process.wait(120.0)
-                        logger.info("Done shutdown node [%s] in [%.1f] s." % (node_name, stop_watch.split_time()))
+                        self.logger.info("Done shutdown node [%s] in [%.1f] s." % (node_name, stop_watch.split_time()))
                         break
                     except subprocess.TimeoutExpired:
                         pass
-                    logger.info("kill -KILL node [%s]" % node_name)
+                    self.logger.info("kill -KILL node [%s]" % node_name)
                     try:
                         process.kill()
                     except ProcessLookupError:
-                        logger.warning("No process found with PID [%s] for node [%s]" % (process.pid, node_name))
+                        self.logger.warning("No process found with PID [%s] for node [%s]" % (process.pid, node_name))
                 node.telemetry.detach_from_node(node, running=False)

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -303,7 +303,7 @@ class InProcessLauncher:
             self.logger.info("Setting [%s] to detect out of memory errors during the benchmark.", exit_on_oome_flag)
             self._set_env(env, "ES_JAVA_OPTS", exit_on_oome_flag)
         else:
-            self.logger.info("JVM does not support [%s]. Please consider a JDK upgrade.", exit_on_oome_flag)
+            self.logger.info("JVM does not support [%s]. A JDK upgrade is recommended.", exit_on_oome_flag)
 
         self.logger.info("env for [%s]: %s", node_name, str(env))
         return env

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -649,9 +649,9 @@ def create(cfg, metrics_store, all_node_ips, cluster_settings=None, sources=Fals
         l = launcher.InProcessLauncher(cfg, metrics_store, races_root)
     elif external:
         if cluster_settings:
-            logging.getLogger(__name__)\
-                .warning("Cannot apply challenge-specific cluster settings [%s] for an externally provisioned cluster. Please ensure "
-                           "that the cluster settings are present or the benchmark may fail or behave unexpectedly." % cluster_settings)
+            logging.getLogger(__name__).warning(
+                "Cannot apply challenge-specific cluster settings [%s] for an externally provisioned cluster. Please ensure that the cluster "
+                "settings are present or the benchmark may fail or behave unexpectedly." % cluster_settings)
         if len(plugins) > 0:
             raise exceptions.SystemSetupError("You cannot specify any plugins for externally provisioned clusters. Please remove "
                                               "\"--elasticsearch-plugins\" and try again.")

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -233,18 +233,18 @@ class MechanicActor(actor.RallyActor):
         self.car = None
 
     def receiveUnrecognizedMessage(self, msg, sender):
-        self.logger.info("MechanicActor#receiveMessage unrecognized(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
+        self.logger.info("MechanicActor#receiveMessage unrecognized(msg = [%s] sender = [%s])", str(type(msg)), str(sender))
 
     def receiveMsg_ChildActorExited(self, msg, sender):
         if self.is_current_status_expected(["cluster_stopping", "cluster_stopped"]):
-            self.logger.info("Child actor exited while engine is stopping or stopped: [%s]" % msg)
+            self.logger.info("Child actor exited while engine is stopping or stopped: [%s]", msg)
             return
         failmsg = "Child actor exited with [%s] while in status [%s]." % (msg, self.status)
         self.logger.error(failmsg)
         self.send(self.race_control, actor.BenchmarkFailure(failmsg))
 
     def receiveMsg_PoisonMessage(self, msg, sender):
-        self.logger.info("MechanicActor#receiveMessage poison(msg = [%s] sender = [%s])" % (str(msg.poisonMessage), str(sender)))
+        self.logger.info("MechanicActor#receiveMessage poison(msg = [%s] sender = [%s])", str(msg.poisonMessage), str(sender))
         # something went wrong with a child actor (or another actor with which we have communicated)
         if isinstance(msg.poisonMessage, StartEngine):
             failmsg = "Could not start benchmark candidate. Are Rally daemons on all targeted machines running?"
@@ -276,7 +276,7 @@ class MechanicActor(actor.RallyActor):
             self.children.append(m)
             self.send(m, msg.for_nodes(ip=hosts))
         else:
-            self.logger.info("Cluster consisting of %s will be provisioned by Rally." % hosts)
+            self.logger.info("Cluster consisting of %s will be provisioned by Rally.", hosts)
             msg.hosts = hosts
             # Initialize the children array to have the right size to
             # ensure waiting for all responses
@@ -476,7 +476,7 @@ class Dispatcher(actor.RallyActor):
             self.start_sender(actor.BenchmarkFailure("Remote Rally node [%s] has been shutdown prematurely." % convmsg.remoteAdminAddress))
         else:
             remote_ip = convmsg.remoteCapabilities.get('ip', None)
-            self.logger.info("Remote Rally node [%s] has started." % remote_ip)
+            self.logger.info("Remote Rally node [%s] has started.", remote_ip)
 
             for eachmsg in self.remotes[remote_ip]:
                 self.pending.append((self.createActor(NodeMechanicActor,
@@ -503,7 +503,7 @@ class Dispatcher(actor.RallyActor):
         self.send(self.start_sender, actor.BenchmarkFailure(msg.details))
 
     def receiveUnrecognizedMessage(self, msg, sender):
-        self.logger.info("mechanic.Dispatcher#receiveMessage unrecognized(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
+        self.logger.info("mechanic.Dispatcher#receiveMessage unrecognized(msg = [%s] sender = [%s])", str(type(msg)), str(sender))
 
 
 class NodeMechanicActor(actor.RallyActor):
@@ -524,9 +524,9 @@ class NodeMechanicActor(actor.RallyActor):
         try:
             self.host = msg.ip
             if msg.external:
-                self.logger.info("Connecting to externally provisioned nodes on [%s]." % msg.ip)
+                self.logger.info("Connecting to externally provisioned nodes on [%s].", msg.ip)
             else:
-                self.logger.info("Starting node(s) %s on [%s]." % (msg.node_ids, msg.ip))
+                self.logger.info("Starting node(s) %s on [%s].", msg.node_ids, msg.ip)
 
             # Load node-specific configuration
             self.config = config.auto_load_local_config(msg.cfg, additional_sections=[
@@ -556,7 +556,7 @@ class NodeMechanicActor(actor.RallyActor):
             self.running = True
             self.send(getattr(msg, "reply_to", sender), NodesStarted([NodeMetaInfo(node) for node in nodes], self.metrics_store.meta_info))
         except Exception:
-            self.logger.exception("Cannot process message [%s]" % msg)
+            self.logger.exception("Cannot process message [%s]", msg)
             # avoid "can't pickle traceback objects"
             import traceback
             ex_type, ex_value, ex_traceback = sys.exc_info()
@@ -578,9 +578,9 @@ class NodeMechanicActor(actor.RallyActor):
         # needs to block anyway. The only reason we implement mechanic as an actor is to distribute them.
         # noinspection PyBroadException
         try:
-            self.logger.debug("NodeMechanicActor#receiveMessage(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
+            self.logger.debug("NodeMechanicActor#receiveMessage(msg = [%s] sender = [%s])", str(type(msg)), str(sender))
             if isinstance(msg, ResetRelativeTime):
-                self.logger.info("Resetting relative time of system metrics store on host [%s]." % self.host)
+                self.logger.info("Resetting relative time of system metrics store on host [%s].", self.host)
                 self.metrics_store.reset_relative_time()
             elif isinstance(msg, OnBenchmarkStart):
                 self.metrics_store.lap = msg.lap
@@ -589,7 +589,7 @@ class NodeMechanicActor(actor.RallyActor):
                 self.send(sender, BenchmarkStarted())
             elif isinstance(msg, thespian.actors.WakeupMessage):
                 if self.running:
-                    self.logger.info("Flushing system metrics store on host [%s]." % self.host)
+                    self.logger.info("Flushing system metrics store on host [%s].", self.host)
                     self.metrics_store.flush(refresh=False)
                     self.wakeupAfter(METRIC_FLUSH_INTERVAL_SECONDS)
             elif isinstance(msg, OnBenchmarkStop):
@@ -598,7 +598,7 @@ class NodeMechanicActor(actor.RallyActor):
                 # clear metrics store data to not send duplicate system metrics data
                 self.send(sender, BenchmarkStopped(self.metrics_store.to_externalizable(clear=True)))
             elif isinstance(msg, StopNodes):
-                self.logger.info("Stopping nodes %s." % self.mechanic.nodes)
+                self.logger.info("Stopping nodes %s.", self.mechanic.nodes)
                 self.mechanic.stop_engine()
                 self.send(sender, NodesStopped(self.metrics_store.to_externalizable()))
                 # clear all state as the mechanic might get reused later
@@ -609,12 +609,12 @@ class NodeMechanicActor(actor.RallyActor):
                 self.metrics_store = None
             elif isinstance(msg, thespian.actors.ActorExitRequest):
                 if self.running:
-                    self.logger.info("Stopping nodes %s (due to ActorExitRequest)" % self.mechanic.nodes)
+                    self.logger.info("Stopping nodes %s (due to ActorExitRequest)", self.mechanic.nodes)
                     self.mechanic.stop_engine()
                     self.running = False
         except BaseException as e:
             self.running = False
-            self.logger.exception("Cannot process message [%s]" % msg)
+            self.logger.exception("Cannot process message [%s]", msg)
             self.send(getattr(msg, "reply_to", sender), actor.BenchmarkFailure("Error on host %s" % str(self.host), e))
 
 

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -8,7 +8,6 @@ from esrally import actor, client, paths, config, metrics, exceptions
 from esrally.utils import net
 from esrally.mechanic import supplier, provisioner, launcher, team
 
-logger = logging.getLogger("rally.mechanic")
 
 METRIC_FLUSH_INTERVAL_SECONDS = 30
 
@@ -226,7 +225,6 @@ class MechanicActor(actor.RallyActor):
 
     def __init__(self):
         super().__init__()
-        actor.RallyActor.configure_logging(logger)
         self.cfg = None
         self.metrics_store = None
         self.race_control = None
@@ -235,29 +233,29 @@ class MechanicActor(actor.RallyActor):
         self.car = None
 
     def receiveUnrecognizedMessage(self, msg, sender):
-        logger.info("MechanicActor#receiveMessage unrecognized(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
+        self.logger.info("MechanicActor#receiveMessage unrecognized(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
 
     def receiveMsg_ChildActorExited(self, msg, sender):
         if self.is_current_status_expected(["cluster_stopping", "cluster_stopped"]):
-            logger.info("Child actor exited while engine is stopping or stopped: [%s]" % msg)
+            self.logger.info("Child actor exited while engine is stopping or stopped: [%s]" % msg)
             return
         failmsg = "Child actor exited with [%s] while in status [%s]." % (msg, self.status)
-        logger.error(failmsg)
+        self.logger.error(failmsg)
         self.send(self.race_control, actor.BenchmarkFailure(failmsg))
 
     def receiveMsg_PoisonMessage(self, msg, sender):
-        logger.info("MechanicActor#receiveMessage poison(msg = [%s] sender = [%s])" % (str(msg.poisonMessage), str(sender)))
+        self.logger.info("MechanicActor#receiveMessage poison(msg = [%s] sender = [%s])" % (str(msg.poisonMessage), str(sender)))
         # something went wrong with a child actor (or another actor with which we have communicated)
         if isinstance(msg.poisonMessage, StartEngine):
             failmsg = "Could not start benchmark candidate. Are Rally daemons on all targeted machines running?"
         else:
             failmsg = msg.details
-        logger.error(failmsg)
+        self.logger.error(failmsg)
         self.send(self.race_control, actor.BenchmarkFailure(failmsg))
 
     @actor.no_retry("mechanic")
     def receiveMsg_StartEngine(self, msg, sender):
-        logger.info("Received signal from race control to start engine.")
+        self.logger.info("Received signal from race control to start engine.")
         self.race_control = sender
         self.cfg = msg.cfg
         cls = metrics.metrics_store_class(self.cfg)
@@ -271,14 +269,14 @@ class MechanicActor(actor.RallyActor):
             raise exceptions.LaunchError("No target hosts are configured.")
 
         if msg.external:
-            logger.info("Cluster will not be provisioned by Rally.")
+            self.logger.info("Cluster will not be provisioned by Rally.")
             # just create one actor for this special case and run it on the coordinator node (i.e. here)
             m = self.createActor(NodeMechanicActor,
                                  targetActorRequirements={"coordinator": True})
             self.children.append(m)
             self.send(m, msg.for_nodes(ip=hosts))
         else:
-            logger.info("Cluster consisting of %s will be provisioned by Rally." % hosts)
+            self.logger.info("Cluster consisting of %s will be provisioned by Rally." % hosts)
             msg.hosts = hosts
             # Initialize the children array to have the right size to
             # ensure waiting for all responses
@@ -327,7 +325,7 @@ class MechanicActor(actor.RallyActor):
         if msg.payload == MechanicActor.WAKEUP_RESET_RELATIVE_TIME:
             self.reset_relative_time()
         elif msg.payload == MechanicActor.WAKEUP_FLUSH_METRICS:
-            logger.info("Flushing cluster-wide system metrics store.")
+            self.logger.info("Flushing cluster-wide system metrics store.")
             self.metrics_store.flush(refresh=False)
             self.wakeupAfter(METRIC_FLUSH_INTERVAL_SECONDS, payload=MechanicActor.WAKEUP_FLUSH_METRICS)
         else:
@@ -390,7 +388,7 @@ class MechanicActor(actor.RallyActor):
         self.send(self.race_control, BenchmarkStarted())
 
     def reset_relative_time(self):
-        logger.info("Resetting relative time of cluster system metrics store.")
+        self.logger.info("Resetting relative time of cluster system metrics store.")
         self.metrics_store.reset_relative_time()
         for m in self.children:
             self.send(m, ResetRelativeTime(0))
@@ -426,7 +424,7 @@ class PostLaunchHandler:
 
 
 @thespian.actors.requireCapability('coordinator')
-class Dispatcher(thespian.actors.ActorTypeDispatcher):
+class Dispatcher(actor.RallyActor):
     def __init__(self):
         super().__init__()
         self.start_sender = None
@@ -474,11 +472,11 @@ class Dispatcher(thespian.actors.ActorTypeDispatcher):
 
     def receiveMsg_ActorSystemConventionUpdate(self, convmsg, sender):
         if not convmsg.remoteAdded:
-            logger.warning("Remote Rally node [%s] exited during NodeMechanicActor startup process.", convmsg.remoteAdminAddress)
+            self.logger.warning("Remote Rally node [%s] exited during NodeMechanicActor startup process.", convmsg.remoteAdminAddress)
             self.start_sender(actor.BenchmarkFailure("Remote Rally node [%s] has been shutdown prematurely." % convmsg.remoteAdminAddress))
         else:
             remote_ip = convmsg.remoteCapabilities.get('ip', None)
-            logger.info("Remote Rally node [%s] has started." % remote_ip)
+            self.logger.info("Remote Rally node [%s] has started." % remote_ip)
 
             for eachmsg in self.remotes[remote_ip]:
                 self.pending.append((self.createActor(NodeMechanicActor,
@@ -505,7 +503,7 @@ class Dispatcher(thespian.actors.ActorTypeDispatcher):
         self.send(self.start_sender, actor.BenchmarkFailure(msg.details))
 
     def receiveUnrecognizedMessage(self, msg, sender):
-        logger.info("mechanic.Dispatcher#receiveMessage unrecognized(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
+        self.logger.info("mechanic.Dispatcher#receiveMessage unrecognized(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
 
 
 class NodeMechanicActor(actor.RallyActor):
@@ -516,7 +514,6 @@ class NodeMechanicActor(actor.RallyActor):
 
     def __init__(self):
         super().__init__()
-        actor.RallyActor.configure_logging(logger)
         self.config = None
         self.metrics_store = None
         self.mechanic = None
@@ -527,9 +524,9 @@ class NodeMechanicActor(actor.RallyActor):
         try:
             self.host = msg.ip
             if msg.external:
-                logger.info("Connecting to externally provisioned nodes on [%s]." % msg.ip)
+                self.logger.info("Connecting to externally provisioned nodes on [%s]." % msg.ip)
             else:
-                logger.info("Starting node(s) %s on [%s]." % (msg.node_ids, msg.ip))
+                self.logger.info("Starting node(s) %s on [%s]." % (msg.node_ids, msg.ip))
 
             # Load node-specific configuration
             self.config = config.auto_load_local_config(msg.cfg, additional_sections=[
@@ -559,7 +556,7 @@ class NodeMechanicActor(actor.RallyActor):
             self.running = True
             self.send(getattr(msg, "reply_to", sender), NodesStarted([NodeMetaInfo(node) for node in nodes], self.metrics_store.meta_info))
         except Exception:
-            logger.exception("Cannot process message [%s]" % msg)
+            self.logger.exception("Cannot process message [%s]" % msg)
             # avoid "can't pickle traceback objects"
             import traceback
             ex_type, ex_value, ex_traceback = sys.exc_info()
@@ -581,9 +578,9 @@ class NodeMechanicActor(actor.RallyActor):
         # needs to block anyway. The only reason we implement mechanic as an actor is to distribute them.
         # noinspection PyBroadException
         try:
-            logger.debug("NodeMechanicActor#receiveMessage(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
+            self.logger.debug("NodeMechanicActor#receiveMessage(msg = [%s] sender = [%s])" % (str(type(msg)), str(sender)))
             if isinstance(msg, ResetRelativeTime):
-                logger.info("Resetting relative time of system metrics store on host [%s]." % self.host)
+                self.logger.info("Resetting relative time of system metrics store on host [%s]." % self.host)
                 self.metrics_store.reset_relative_time()
             elif isinstance(msg, OnBenchmarkStart):
                 self.metrics_store.lap = msg.lap
@@ -592,7 +589,7 @@ class NodeMechanicActor(actor.RallyActor):
                 self.send(sender, BenchmarkStarted())
             elif isinstance(msg, thespian.actors.WakeupMessage):
                 if self.running:
-                    logger.info("Flushing system metrics store on host [%s]." % self.host)
+                    self.logger.info("Flushing system metrics store on host [%s]." % self.host)
                     self.metrics_store.flush(refresh=False)
                     self.wakeupAfter(METRIC_FLUSH_INTERVAL_SECONDS)
             elif isinstance(msg, OnBenchmarkStop):
@@ -601,7 +598,7 @@ class NodeMechanicActor(actor.RallyActor):
                 # clear metrics store data to not send duplicate system metrics data
                 self.send(sender, BenchmarkStopped(self.metrics_store.to_externalizable(clear=True)))
             elif isinstance(msg, StopNodes):
-                logger.info("Stopping nodes %s." % self.mechanic.nodes)
+                self.logger.info("Stopping nodes %s." % self.mechanic.nodes)
                 self.mechanic.stop_engine()
                 self.send(sender, NodesStopped(self.metrics_store.to_externalizable()))
                 # clear all state as the mechanic might get reused later
@@ -612,12 +609,12 @@ class NodeMechanicActor(actor.RallyActor):
                 self.metrics_store = None
             elif isinstance(msg, thespian.actors.ActorExitRequest):
                 if self.running:
-                    logger.info("Stopping nodes %s (due to ActorExitRequest)" % self.mechanic.nodes)
+                    self.logger.info("Stopping nodes %s (due to ActorExitRequest)" % self.mechanic.nodes)
                     self.mechanic.stop_engine()
                     self.running = False
         except BaseException as e:
             self.running = False
-            logger.exception("Cannot process message [%s]" % msg)
+            self.logger.exception("Cannot process message [%s]" % msg)
             self.send(getattr(msg, "reply_to", sender), actor.BenchmarkFailure("Error on host %s" % str(self.host), e))
 
 
@@ -652,7 +649,8 @@ def create(cfg, metrics_store, all_node_ips, cluster_settings=None, sources=Fals
         l = launcher.InProcessLauncher(cfg, metrics_store, races_root)
     elif external:
         if cluster_settings:
-            logger.warning("Cannot apply challenge-specific cluster settings [%s] for an externally provisioned cluster. Please ensure "
+            logging.getLogger(__name__)\
+                .warning("Cannot apply challenge-specific cluster settings [%s] for an externally provisioned cluster. Please ensure "
                            "that the cluster settings are present or the benchmark may fail or behave unexpectedly." % cluster_settings)
         if len(plugins) > 0:
             raise exceptions.SystemSetupError("You cannot specify any plugins for externally provisioned clusters. Please remove "

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -83,22 +83,22 @@ def plain_text(file):
 def cleanup(preserve, install_dir, data_paths):
     logger = logging.getLogger(__name__)
     if preserve:
-        logger.info("Preserving benchmark candidate installation at [%s]." % install_dir)
+        logger.info("Preserving benchmark candidate installation at [%s].", install_dir)
         console.info("Keeping benchmark candidate including index at [%s] (will need several GB)." % install_dir)
     else:
-        logger.info("Wiping benchmark candidate installation at [%s]." % install_dir)
+        logger.info("Wiping benchmark candidate installation at [%s].", install_dir)
         for path in data_paths:
             if os.path.exists(path):
                 try:
                     shutil.rmtree(path)
                 except OSError:
-                    logger.exception("Could not delete [%s]. Skipping..." % path)
+                    logger.exception("Could not delete [%s]. Skipping...", path)
 
         if os.path.exists(install_dir):
             try:
                 shutil.rmtree(install_dir)
             except OSError:
-                logger.exception("Could not delete [%s]. Skipping..." % install_dir)
+                logger.exception("Could not delete [%s]. Skipping...", install_dir)
 
 
 def _apply_config(source_root_path, target_root_path, config_vars):
@@ -114,12 +114,12 @@ def _apply_config(source_root_path, target_root_path, config_vars):
             source_file = os.path.join(root, name)
             target_file = os.path.join(absolute_target_root, name)
             if plain_text(source_file):
-                logger.info("Reading config template file [%s] and writing to [%s]." % (source_file, target_file))
+                logger.info("Reading config template file [%s] and writing to [%s].", source_file, target_file)
                 # automatically merge config snippets from plugins (e.g. if they want to add config to elasticsearch.yml)
                 with open(target_file, mode="a", encoding="utf-8") as f:
                     f.write(_render_template(env, config_vars, source_file))
             else:
-                logger.info("Treating [%s] as binary and copying as is to [%s]." % (source_file, target_file))
+                logger.info("Treating [%s] as binary and copying as is to [%s].", source_file, target_file)
                 shutil.copy(source_file, target_file)
 
 
@@ -222,19 +222,19 @@ class ElasticsearchInstaller:
         self.logger = logging.getLogger(__name__)
 
     def install(self, binary):
-        self.logger.info("Preparing candidate locally in [%s]." % self.install_dir)
+        self.logger.info("Preparing candidate locally in [%s].", self.install_dir)
         io.ensure_dir(self.install_dir)
         io.ensure_dir(self.node_log_dir)
         io.ensure_dir(self.heap_dump_dir)
 
-        self.logger.info("Unzipping %s to %s" % (binary, self.install_dir))
+        self.logger.info("Unzipping %s to %s", binary, self.install_dir)
         io.decompress(binary, self.install_dir)
         self.es_home_path = glob.glob("%s/elasticsearch*" % self.install_dir)[0]
         self.data_paths = self._data_paths()
 
     def delete_pre_bundled_configuration(self):
         config_path = os.path.join(self.es_home_path, "config")
-        self.logger.info("Deleting pre-bundled Elasticsearch configuration at [%s]" % config_path)
+        self.logger.info("Deleting pre-bundled Elasticsearch configuration at [%s]", config_path)
         shutil.rmtree(config_path)
 
     def invoke_install_hook(self, phase, variables):
@@ -301,16 +301,16 @@ class PluginInstaller:
     def install(self, es_home_path, plugin_url=None):
         installer_binary_path = os.path.join(es_home_path, "bin", "elasticsearch-plugin")
         if plugin_url:
-            self.logger.info("Installing [%s] into [%s] from [%s]" % (self.plugin_name, es_home_path, plugin_url))
+            self.logger.info("Installing [%s] into [%s] from [%s]", self.plugin_name, es_home_path, plugin_url)
             install_cmd = '%s install --batch "%s"' % (installer_binary_path, plugin_url)
         else:
-            self.logger.info("Installing [%s] into [%s]" % (self.plugin_name, es_home_path))
+            self.logger.info("Installing [%s] into [%s]", self.plugin_name, es_home_path)
             install_cmd = '%s install --batch "%s"' % (installer_binary_path, self.plugin_name)
 
         return_code = process.run_subprocess_with_logging(install_cmd)
         # see: https://www.elastic.co/guide/en/elasticsearch/plugins/current/_other_command_line_parameters.html
         if return_code == 0:
-            self.logger.info("Successfully installed [%s]." % self.plugin_name)
+            self.logger.info("Successfully installed [%s].", self.plugin_name)
         elif return_code == 64:
             # most likely this is an unknown plugin
             raise exceptions.SystemSetupError("Unknown plugin [%s]" % self.plugin_name)
@@ -424,15 +424,15 @@ class DockerProvisioner:
                     target_file = os.path.join(absolute_target_root, name)
                     mounts[target_file] = os.path.join("/usr/share/elasticsearch", relative_root, name)
                     if plain_text(source_file):
-                        self.logger.info("Reading config template file [%s] and writing to [%s]." % (source_file, target_file))
+                        self.logger.info("Reading config template file [%s] and writing to [%s].", source_file, target_file)
                         with open(target_file, mode="a", encoding="utf-8") as f:
                             f.write(_render_template(env, self.config_vars, source_file))
                     else:
-                        self.logger.info("Treating [%s] as binary and copying as is to [%s]." % (source_file, target_file))
+                        self.logger.info("Treating [%s] as binary and copying as is to [%s].", source_file, target_file)
                         shutil.copy(source_file, target_file)
 
         docker_cfg = self._render_template_from_file(self.docker_vars(mounts))
-        self.logger.info("Starting Docker container with configuration:\n%s" % docker_cfg)
+        self.logger.info("Starting Docker container with configuration:\n%s", docker_cfg)
 
         with open(self.binary_path, mode="wt", encoding="utf-8") as f:
             f.write(docker_cfg)

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -9,8 +9,6 @@ from esrally import exceptions
 from esrally.mechanic import team
 from esrally.utils import io, console, process, versions
 
-logger = logging.getLogger("rally.provisioner")
-
 
 def local_provisioner(cfg, car, plugins, cluster_settings, all_node_ips, target_root, node_id):
     distribution_version = cfg.opts("mechanic", "distribution.version", mandatory=False)
@@ -83,6 +81,7 @@ def plain_text(file):
 
 
 def cleanup(preserve, install_dir, data_paths):
+    logger = logging.getLogger(__name__)
     if preserve:
         logger.info("Preserving benchmark candidate installation at [%s]." % install_dir)
         console.info("Keeping benchmark candidate including index at [%s] (will need several GB)." % install_dir)
@@ -103,6 +102,7 @@ def cleanup(preserve, install_dir, data_paths):
 
 
 def _apply_config(source_root_path, target_root_path, config_vars):
+    logger = logging.getLogger(__name__)
     for root, dirs, files in os.walk(source_root_path):
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(root))
 
@@ -219,21 +219,22 @@ class ElasticsearchInstaller:
             self.hook_handler.load()
         self.es_home_path = None
         self.data_paths = None
+        self.logger = logging.getLogger(__name__)
 
     def install(self, binary):
-        logger.info("Preparing candidate locally in [%s]." % self.install_dir)
+        self.logger.info("Preparing candidate locally in [%s]." % self.install_dir)
         io.ensure_dir(self.install_dir)
         io.ensure_dir(self.node_log_dir)
         io.ensure_dir(self.heap_dump_dir)
 
-        logger.info("Unzipping %s to %s" % (binary, self.install_dir))
+        self.logger.info("Unzipping %s to %s" % (binary, self.install_dir))
         io.decompress(binary, self.install_dir)
         self.es_home_path = glob.glob("%s/elasticsearch*" % self.install_dir)[0]
         self.data_paths = self._data_paths()
 
     def delete_pre_bundled_configuration(self):
         config_path = os.path.join(self.es_home_path, "config")
-        logger.info("Deleting pre-bundled Elasticsearch configuration at [%s]" % config_path)
+        self.logger.info("Deleting pre-bundled Elasticsearch configuration at [%s]" % config_path)
         shutil.rmtree(config_path)
 
     def invoke_install_hook(self, phase, variables):
@@ -295,20 +296,21 @@ class PluginInstaller:
         self.hook_handler = hook_handler_class(self.plugin)
         if self.hook_handler.can_load():
             self.hook_handler.load()
+        self.logger = logging.getLogger(__name__)
 
     def install(self, es_home_path, plugin_url=None):
         installer_binary_path = os.path.join(es_home_path, "bin", "elasticsearch-plugin")
         if plugin_url:
-            logger.info("Installing [%s] into [%s] from [%s]" % (self.plugin_name, es_home_path, plugin_url))
+            self.logger.info("Installing [%s] into [%s] from [%s]" % (self.plugin_name, es_home_path, plugin_url))
             install_cmd = '%s install --batch "%s"' % (installer_binary_path, plugin_url)
         else:
-            logger.info("Installing [%s] into [%s]" % (self.plugin_name, es_home_path))
+            self.logger.info("Installing [%s] into [%s]" % (self.plugin_name, es_home_path))
             install_cmd = '%s install --batch "%s"' % (installer_binary_path, self.plugin_name)
 
         return_code = process.run_subprocess_with_logging(install_cmd)
         # see: https://www.elastic.co/guide/en/elasticsearch/plugins/current/_other_command_line_parameters.html
         if return_code == 0:
-            logger.info("Successfully installed [%s]." % self.plugin_name)
+            self.logger.info("Successfully installed [%s]." % self.plugin_name)
         elif return_code == 64:
             # most likely this is an unknown plugin
             raise exceptions.SystemSetupError("Unknown plugin [%s]" % self.plugin_name)
@@ -366,6 +368,7 @@ class DockerProvisioner:
         self.data_paths = ["%s/data/%s" % (node_root_dir, uuid.uuid4())]
         self.preserve = preserve
         self.binary_path = "%s/docker-compose.yml" % self.install_dir
+        self.logger = logging.getLogger(__name__)
 
         # Merge cluster config from the track. These may not be dynamically updateable so we need to define them in the config file.
         merged_cluster_settings = cluster_settings.copy()
@@ -421,15 +424,15 @@ class DockerProvisioner:
                     target_file = os.path.join(absolute_target_root, name)
                     mounts[target_file] = os.path.join("/usr/share/elasticsearch", relative_root, name)
                     if plain_text(source_file):
-                        logger.info("Reading config template file [%s] and writing to [%s]." % (source_file, target_file))
+                        self.logger.info("Reading config template file [%s] and writing to [%s]." % (source_file, target_file))
                         with open(target_file, mode="a", encoding="utf-8") as f:
                             f.write(_render_template(env, self.config_vars, source_file))
                     else:
-                        logger.info("Treating [%s] as binary and copying as is to [%s]." % (source_file, target_file))
+                        self.logger.info("Treating [%s] as binary and copying as is to [%s]." % (source_file, target_file))
                         shutil.copy(source_file, target_file)
 
         docker_cfg = self._render_template_from_file(self.docker_vars(mounts))
-        logger.info("Starting Docker container with configuration:\n%s" % docker_cfg)
+        self.logger.info("Starting Docker container with configuration:\n%s" % docker_cfg)
 
         with open(self.binary_path, mode="wt", encoding="utf-8") as f:
             f.write(docker_cfg)

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -58,17 +58,17 @@ def create(cfg, sources, distribution, build, challenge_root_path, car, plugins=
 
         if supplier_type == "source":
             if CorePluginSourceSupplier.can_handle(plugin):
-                logger.info("Adding core plugin source supplier for [%s]." % plugin.name)
+                logger.info("Adding core plugin source supplier for [%s].", plugin.name)
                 assert es_src_dir is not None, "Cannot build core plugin %s when Elasticsearch is not built from source." % plugin.name
                 suppliers.append(CorePluginSourceSupplier(plugin, es_src_dir, builder))
             elif ExternalPluginSourceSupplier.can_handle(plugin):
-                logger.info("Adding external plugin source supplier for [%s]." % plugin.name)
+                logger.info("Adding external plugin source supplier for [%s].", plugin.name)
                 suppliers.append(ExternalPluginSourceSupplier(plugin, plugin_version, _src_dir(cfg, mandatory=False), src_config, builder))
             else:
                 raise exceptions.RallyError("Plugin %s can neither be treated as core nor as external plugin. Requirements: %s" %
                                             (plugin.name, supply_requirements[plugin.name]))
         else:
-            logger.info("Adding plugin distribution supplier for [%s]." % plugin.name)
+            logger.info("Adding plugin distribution supplier for [%s].", plugin.name)
             assert repo is not None, "Cannot benchmark plugin %s from a distribution version but Elasticsearch from sources" % plugin.name
             suppliers.append(PluginDistributionSupplier(repo, plugin))
 
@@ -301,22 +301,21 @@ class ElasticsearchDistributionSupplier:
         io.ensure_dir(self.distributions_root)
         distribution_path = "%s/elasticsearch-%s.tar.gz" % (self.distributions_root, self.version)
         download_url = self.repo.download_url
-        self.logger.info("Resolved download URL [%s] for version [%s]" % (download_url, self.version))
+        self.logger.info("Resolved download URL [%s] for version [%s]", download_url, self.version)
         if not os.path.isfile(distribution_path) or not self.repo.cache:
             try:
-                self.logger.info("Starting download of Elasticsearch [%s]" % self.version)
+                self.logger.info("Starting download of Elasticsearch [%s]", self.version)
                 progress = net.Progress("[INFO] Downloading Elasticsearch %s" % self.version)
                 net.download(download_url, distribution_path, progress_indicator=progress)
                 progress.finish()
-                self.logger.info("Successfully downloaded Elasticsearch [%s]." % self.version)
+                self.logger.info("Successfully downloaded Elasticsearch [%s].", self.version)
             except urllib.error.HTTPError:
                 console.println("[FAILED]")
-                logging.exception("Cannot download Elasticsearch distribution for version [%s] from [%s]." % (self.version, download_url))
+                self.logger.exception("Cannot download Elasticsearch distribution for version [%s] from [%s].", self.version, download_url)
                 raise exceptions.SystemSetupError("Cannot download Elasticsearch distribution from [%s]. Please check that the specified "
                                                   "version [%s] is correct." % (download_url, self.version))
         else:
-            self.logger.info("Skipping download for version [%s]. Found an existing binary locally at [%s]." %
-                             (self.version, distribution_path))
+            self.logger.info("Skipping download for version [%s]. Found an existing binary at [%s].", self.version, distribution_path)
 
         self.distribution_path = distribution_path
 
@@ -408,32 +407,32 @@ class SourceRepository:
                 console.println("Downloading sources for %s from %s to %s." % (self.name, self.remote_url, self.src_dir))
                 git.clone(self.src_dir, self.remote_url)
             elif os.path.isdir(self.src_dir) and may_skip_init:
-                self.logger.info("Skipping repository initialization for %s." % self.name)
+                self.logger.info("Skipping repository initialization for %s.", self.name)
             else:
                 exceptions.SystemSetupError("A remote repository URL is mandatory for %s" % self.name)
 
     def _update(self, revision):
         if self.has_remote() and revision == "latest":
-            self.logger.info("Fetching latest sources for %s from origin." % self.name)
+            self.logger.info("Fetching latest sources for %s from origin.", self.name)
             git.pull(self.src_dir)
         elif revision == "current":
-            self.logger.info("Skip fetching sources for %s." % self.name)
+            self.logger.info("Skip fetching sources for %s.", self.name)
         elif self.has_remote() and revision.startswith("@"):
             # convert timestamp annotated for Rally to something git understands -> we strip leading and trailing " and the @.
             git_ts_revision = revision[1:]
-            self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s." % (git_ts_revision, self.name))
+            self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s.", git_ts_revision, self.name)
             git.pull_ts(self.src_dir, git_ts_revision)
         elif self.has_remote():  # assume a git commit hash
-            self.logger.info("Fetching from remote and checking out revision [%s] for %s." % (revision, self.name))
+            self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
             git.pull_revision(self.src_dir, revision)
         else:
-            self.logger.info("Checking out local revision [%s] for %s." % (revision, self.name))
+            self.logger.info("Checking out local revision [%s] for %s.", revision, self.name)
             git.checkout(self.src_dir, revision)
         if git.is_working_copy(self.src_dir):
             git_revision = git.head_revision(self.src_dir)
-            self.logger.info("User-specified revision [%s] for [%s] results in git revision [%s]" % (revision, self.name, git_revision))
+            self.logger.info("User-specified revision [%s] for [%s] results in git revision [%s]", revision, self.name, git_revision)
         else:
-            self.logger.info("Skipping git revision resolution for %s (%s is not a git repository)." % (self.name, self.src_dir))
+            self.logger.info("Skipping git revision resolution for %s (%s is not a git repository).", self.name, self.src_dir)
 
     @classmethod
     def is_commit_hash(cls, revision):

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -8,13 +8,12 @@ from esrally import exceptions, PROGRAM_NAME
 from esrally.utils import git, console, io, process, net, versions, convert
 from esrally.exceptions import BuildError, SystemSetupError
 
-logger = logging.getLogger("rally.supplier")
-
 # e.g. my-plugin:current - we cannot simply use String#split(":") as this would not work for timestamp-based revisions
 REVISION_PATTERN = r"(\w.*?):(.*)"
 
 
 def create(cfg, sources, distribution, build, challenge_root_path, car, plugins=None):
+    logger = logging.getLogger(__name__)
     if plugins is None:
         plugins = []
     revisions = _extract_revisions(cfg.opts("mechanic", "source.revision"))
@@ -81,7 +80,6 @@ def _java10_home(cfg):
     try:
         return cfg.opts("runtime", "java10.home")
     except config.ConfigError:
-        logger.exception("Cannot determine Java 10 home.")
         raise exceptions.SystemSetupError("No JDK 10 is configured. You cannot benchmark source builds of Elasticsearch on this machine. "
                                           "Please install a JDK 10 and reconfigure Rally with %s configure" % PROGRAM_NAME)
 
@@ -140,7 +138,7 @@ def _supply_requirements(sources, distribution, build, plugins, revisions, distr
                     if not plugin_revision or SourceRepository.is_commit_hash(plugin_revision):
                         raise exceptions.SystemSetupError("No revision specified for plugin [%s]." % plugin.name)
                     else:
-                        logger.info("Revision for [%s] is not explicitly defined. Using catch-all revision [%s]."
+                        logging.getLogger(__name__).info("Revision for [%s] is not explicitly defined. Using catch-all revision [%s]."
                                     % (plugin.name, plugin_revision))
                 supply_requirements[plugin.name] = ("source", plugin_revision, plugin_needs_build)
             else:
@@ -154,7 +152,6 @@ def _src_dir(cfg, mandatory=True):
     try:
         return cfg.opts("node", "src.root.dir", mandatory=mandatory)
     except config.ConfigError:
-        logger.exception("Cannot determine source directory")
         raise exceptions.SystemSetupError("You cannot benchmark Elasticsearch from sources. Did you install Gradle? Please install"
                                           " all prerequisites and reconfigure Rally with %s configure" % PROGRAM_NAME)
 
@@ -298,26 +295,28 @@ class ElasticsearchDistributionSupplier:
         self.distributions_root = distributions_root
         # will be defined in the prepare phase
         self.distribution_path = None
+        self.logger = logging.getLogger(__name__)
 
     def fetch(self):
         io.ensure_dir(self.distributions_root)
         distribution_path = "%s/elasticsearch-%s.tar.gz" % (self.distributions_root, self.version)
         download_url = self.repo.download_url
-        logger.info("Resolved download URL [%s] for version [%s]" % (download_url, self.version))
+        self.logger.info("Resolved download URL [%s] for version [%s]" % (download_url, self.version))
         if not os.path.isfile(distribution_path) or not self.repo.cache:
             try:
-                logger.info("Starting download of Elasticsearch [%s]" % self.version)
+                self.logger.info("Starting download of Elasticsearch [%s]" % self.version)
                 progress = net.Progress("[INFO] Downloading Elasticsearch %s" % self.version)
                 net.download(download_url, distribution_path, progress_indicator=progress)
                 progress.finish()
-                logger.info("Successfully downloaded Elasticsearch [%s]." % self.version)
+                self.logger.info("Successfully downloaded Elasticsearch [%s]." % self.version)
             except urllib.error.HTTPError:
                 console.println("[FAILED]")
                 logging.exception("Cannot download Elasticsearch distribution for version [%s] from [%s]." % (self.version, download_url))
                 raise exceptions.SystemSetupError("Cannot download Elasticsearch distribution from [%s]. Please check that the specified "
                                                   "version [%s] is correct." % (download_url, self.version))
         else:
-            logger.info("Skipping download for version [%s]. Found an existing binary locally at [%s]." % (self.version, distribution_path))
+            self.logger.info("Skipping download for version [%s]. Found an existing binary locally at [%s]." %
+                             (self.version, distribution_path))
 
         self.distribution_path = distribution_path
 
@@ -393,6 +392,7 @@ class SourceRepository:
         self.name = name
         self.remote_url = remote_url
         self.src_dir = src_dir
+        self.logger = logging.getLogger(__name__)
 
     def fetch(self, revision):
         # if and only if we want to benchmark the current revision, Rally may skip repo initialization (if it is already present)
@@ -408,32 +408,32 @@ class SourceRepository:
                 console.println("Downloading sources for %s from %s to %s." % (self.name, self.remote_url, self.src_dir))
                 git.clone(self.src_dir, self.remote_url)
             elif os.path.isdir(self.src_dir) and may_skip_init:
-                logger.info("Skipping repository initialization for %s." % self.name)
+                self.logger.info("Skipping repository initialization for %s." % self.name)
             else:
                 exceptions.SystemSetupError("A remote repository URL is mandatory for %s" % self.name)
 
     def _update(self, revision):
         if self.has_remote() and revision == "latest":
-            logger.info("Fetching latest sources for %s from origin." % self.name)
+            self.logger.info("Fetching latest sources for %s from origin." % self.name)
             git.pull(self.src_dir)
         elif revision == "current":
-            logger.info("Skip fetching sources for %s." % self.name)
+            self.logger.info("Skip fetching sources for %s." % self.name)
         elif self.has_remote() and revision.startswith("@"):
             # convert timestamp annotated for Rally to something git understands -> we strip leading and trailing " and the @.
             git_ts_revision = revision[1:]
-            logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s." % (git_ts_revision, self.name))
+            self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s." % (git_ts_revision, self.name))
             git.pull_ts(self.src_dir, git_ts_revision)
         elif self.has_remote():  # assume a git commit hash
-            logger.info("Fetching from remote and checking out revision [%s] for %s." % (revision, self.name))
+            self.logger.info("Fetching from remote and checking out revision [%s] for %s." % (revision, self.name))
             git.pull_revision(self.src_dir, revision)
         else:
-            logger.info("Checking out local revision [%s] for %s." % (revision, self.name))
+            self.logger.info("Checking out local revision [%s] for %s." % (revision, self.name))
             git.checkout(self.src_dir, revision)
         if git.is_working_copy(self.src_dir):
             git_revision = git.head_revision(self.src_dir)
-            logger.info("User-specified revision [%s] for [%s] results in git revision [%s]" % (revision, self.name, git_revision))
+            self.logger.info("User-specified revision [%s] for [%s] results in git revision [%s]" % (revision, self.name, git_revision))
         else:
-            logger.info("Skipping git revision resolution for %s (%s is not a git repository)." % (self.name, self.src_dir))
+            self.logger.info("Skipping git revision resolution for %s (%s is not a git repository)." % (self.name, self.src_dir))
 
     @classmethod
     def is_commit_hash(cls, revision):
@@ -451,6 +451,7 @@ class Builder:
         self.src_dir = src_dir
         self.java_home = java_home
         self.log_dir = log_dir
+        self.logger = logging.getLogger(__name__)
 
     def build(self, commands, override_src_dir=None):
         for command in commands:
@@ -459,15 +460,13 @@ class Builder:
     def run(self, command, override_src_dir=None):
         src_dir = self.src_dir if override_src_dir is None else override_src_dir
 
-        logger.info("Building from sources in [%s].", src_dir)
-        logger.info("Executing %s...", command)
         io.ensure_dir(self.log_dir)
         log_file = os.path.join(self.log_dir, "build.log")
 
         # we capture all output to a dedicated build log file
 
         build_cmd = "export JAVA_HOME={}; cd {}; {} >> {} 2>&1".format(self.java_home, src_dir, command, log_file)
-        logger.info("Running build command [%s]", build_cmd)
+        self.logger.info("Running build command [%s]", build_cmd)
 
         if process.run_subprocess(build_cmd):
             msg = "Executing '{}' failed. The last 20 lines in the build log file are:\n".format(command)

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -8,8 +8,6 @@ import tabulate
 from esrally import exceptions, PROGRAM_NAME
 from esrally.utils import console, repo, io, modules
 
-logger = logging.getLogger("rally.team")
-
 TEAM_FORMAT_VERSION = 1
 
 
@@ -90,10 +88,6 @@ def list_plugins(cfg):
 
 
 def load_plugin(repo, name, config, plugin_params=None):
-    if config is not None:
-        logger.info("Loading plugin [%s] with configuration(s) [%s]." % (name, config))
-    else:
-        logger.info("Loading plugin [%s] with default configuration." % name)
     return PluginLoader(repo).load_plugin(name, config, plugin_params)
 
 
@@ -135,6 +129,7 @@ def team_path(cfg):
 class CarLoader:
     def __init__(self, team_root_path):
         self.cars_dir = _path_for(team_root_path, "cars")
+        self.logger = logging.getLogger(__name__)
 
     def car_names(self):
         def __car_name(path):
@@ -172,7 +167,7 @@ class CarLoader:
 
         # it's possible that some cars don't have a config base, e.g. mixins which only override variables
         if len(config_paths) == 0:
-            logger.info("Car [%s] does not define any config paths. Assuming that it is used as a mixin.", name)
+            self.logger.info("Car [%s] does not define any config paths. Assuming that it is used as a mixin.", name)
         variables = self._copy_section(config, "variables", {})
         # add all car params here to override any defaults
         if car_params:
@@ -270,6 +265,7 @@ class Car:
 class PluginLoader:
     def __init__(self, team_root_path):
         self.plugins_root_path = _path_for(team_root_path, "plugins")
+        self.logger = logging.getLogger(__name__)
 
     def plugins(self):
         known_plugins = self._core_plugins() + self._configured_plugins()
@@ -323,6 +319,11 @@ class PluginLoader:
         return next((p for p in self._core_plugins() if p.name == name and p.config is None), None)
 
     def load_plugin(self, name, config_names, plugin_params=None):
+        if config_names is not None:
+            self.logger.info("Loading plugin [%s] with configuration(s) [%s].", name, config_names)
+        else:
+            self.logger.info("Loading plugin [%s] with default configuration.", name)
+
         root_path = self._plugin_root_path(name)
         if not config_names:
             # maybe we only have a config folder but nothing else (e.g. if there is only an install hook)
@@ -334,8 +335,8 @@ class PluginLoader:
                     return core_plugin
                 # If we just have a plugin name then we assume that this is a community plugin and the user has specified a download URL
                 else:
-                    logger.info("The plugin [%s] is neither a configured nor an official plugin. Assuming that this is a community "
-                                "plugin not requiring any configuration and you have set a proper download URL." % name)
+                    self.logger.info("The plugin [%s] is neither a configured nor an official plugin. Assuming that this is a community "
+                                     "plugin not requiring any configuration and you have set a proper download URL.", name)
                     return PluginDescriptor(name)
         else:
             variables = {}
@@ -446,6 +447,7 @@ class BootstrapHookHandler:
         # Rally's Python load path. We may need to define a more advanced strategy in the future.
         self.loader = loader_class(root_path=self.component.root_path, component_entry_point=self.component.entry_point, recurse=False)
         self.hooks = {}
+        self.logger = logging.getLogger(__name__)
 
     def can_load(self):
         return self.loader.can_load()
@@ -460,11 +462,11 @@ class BootstrapHookHandler:
             raise
         except BaseException:
             msg = "Could not load bootstrap hooks in [{}]".format(self.loader.root_path)
-            logger.exception(msg)
+            self.logger.exception(msg)
             raise exceptions.SystemSetupError(msg)
 
     def register(self, phase, hook):
-        logger.info("Registering bootstrap hook [%s] for phase [%s] in component [%s]", hook.__name__, phase, self.component.name)
+        self.logger.info("Registering bootstrap hook [%s] for phase [%s] in component [%s]", hook.__name__, phase, self.component.name)
         if not BootstrapPhase.valid(phase):
             raise exceptions.SystemSetupError("Unknown bootstrap phase [{}]. Valid phases are: {}.".format(phase, BootstrapPhase.names()))
         if phase not in self.hooks:
@@ -473,11 +475,11 @@ class BootstrapHookHandler:
 
     def invoke(self, phase, **kwargs):
         if phase in self.hooks:
-            logger.info("Invoking phase [%s] for component [%s] in config [%s]", phase, self.component.name, self.component.config)
+            self.logger.info("Invoking phase [%s] for component [%s] in config [%s]", phase, self.component.name, self.component.config)
             for hook in self.hooks[phase]:
-                logger.info("Invoking bootstrap hook [%s].", hook.__name__)
+                self.logger.info("Invoking bootstrap hook [%s].", hook.__name__)
                 # hooks should only take keyword arguments to be forwards compatible with Rally!
                 hook(config_names=self.component.config, **kwargs)
         else:
-            logger.debug("Component [%s] in config [%s] has no hook registered for phase [%s].",
+            self.logger.debug("Component [%s] in config [%s] has no hook registered for phase [%s].",
                          self.component.name, self.component.config, phase)

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -267,7 +267,7 @@ class PerfStat(TelemetryDevice):
 
     def detach_from_node(self, node, running):
         if self.attached and running:
-            self.logger.info("Dumping PMU counters for node [%s]" % node.node_name)
+            self.logger.info("Dumping PMU counters for node [%s]", node.node_name)
             os.kill(self.process.pid, signal.SIGINT)
             try:
                 self.process.wait(10.0)
@@ -464,7 +464,7 @@ class MergeParts(InternalTelemetryDevice):
         for log_file in os.listdir(self.node_log_dir):
             log_path = "%s/%s" % (self.node_log_dir, log_file)
             if io.is_archive(log_path):
-                self.logger.info("Decompressing [%s] to analyze merge times..." % log_path)
+                self.logger.info("Decompressing [%s] to analyze merge times...", log_path)
                 io.decompress(log_path, self.node_log_dir)
 
         # we need to add up times from all files
@@ -472,14 +472,14 @@ class MergeParts(InternalTelemetryDevice):
         for log_file in os.listdir(self.node_log_dir):
             log_path = "%s/%s" % (self.node_log_dir, log_file)
             if not io.is_archive(log_file):
-                self.logger.debug("Analyzing merge times in [%s]" % log_path)
+                self.logger.debug("Analyzing merge times in [%s]", log_path)
                 with open(log_path, mode="rt", encoding="utf-8") as f:
                     self._extract_merge_times(f, merge_times)
             else:
-                self.logger.debug("Skipping archived logs in [%s]." % log_path)
+                self.logger.debug("Skipping archived logs in [%s].", log_path)
         if merge_times:
             self._store_merge_times(merge_times)
-        self.logger.info("Finished analyzing merge times. Extracted [%s] different merge time components." % len(merge_times))
+        self.logger.info("Finished analyzing merge times. Extracted [%s] different merge time components.", len(merge_times))
 
     def _extract_merge_times(self, file, merge_times):
         for line in file.readlines():
@@ -887,7 +887,7 @@ class IndexStats(InternalTelemetryDevice):
         import json
         self.logger.info("Gathering indices stats for all primaries on benchmark stop.")
         index_stats = self.index_stats()
-        self.logger.info("Returned indices stats:\n%s" % json.dumps(index_stats, indent=2))
+        self.logger.info("Returned indices stats:\n%s", json.dumps(index_stats, indent=2))
         if "primaries" not in index_stats:
             return
         p = index_stats["primaries"]
@@ -896,7 +896,7 @@ class IndexStats(InternalTelemetryDevice):
         self.add_metrics(self.extract_value(p, ["segments", "memory_in_bytes"]), "segments_memory_in_bytes", "byte")
 
         for metric_key, value in self.index_times(p).items():
-            self.logger.info("Adding [%s] = [%s] to metrics store." % (str(metric_key), str(value)))
+            self.logger.info("Adding [%s] = [%s] to metrics store.", str(metric_key), str(value))
             self.add_metrics(value, metric_key, "ms")
 
         self.add_metrics(self.extract_value(p, ["segments", "doc_values_memory_in_bytes"]), "segments_doc_values_memory_in_bytes", "byte")

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -9,8 +9,6 @@ import tabulate
 from esrally import metrics, time, exceptions
 from esrally.utils import io, sysstats, process, console, versions
 
-logger = logging.getLogger("rally.telemetry")
-
 
 def list_telemetry():
     console.println("Available telemetry devices:\n")
@@ -87,6 +85,9 @@ class Telemetry:
 ########################################################################################
 
 class TelemetryDevice:
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+
     def instrument_env(self, car, candidate_id):
         return {}
 
@@ -132,8 +133,8 @@ class SamplerThread(threading.Thread):
             while not self.stop:
                 self.recorder.record()
                 time.sleep(self.recorder.sample_interval)
-        except BaseException as e:
-            logger.exception("Could not determine {}".format(self.recorder))
+        except BaseException:
+            logging.getLogger(__name__).exception("Could not determine {}".format(self.recorder))
 
 
 class FlightRecorder(TelemetryDevice):
@@ -162,11 +163,11 @@ class FlightRecorder(TelemetryDevice):
 
         time.sleep(3)
 
-        console.info("%s: Writing flight recording to [%s]" % (self.human_name, log_file), logger=logger)
+        console.info("%s: Writing flight recording to [%s]" % (self.human_name, log_file), logger=self.logger)
 
         java_opts = self.java_opts(log_file)
 
-        logger.info("jfr: Adding JVM arguments: [%s].", java_opts)
+        self.logger.info("jfr: Adding JVM arguments: [%s].", java_opts)
         return {"ES_JAVA_OPTS": java_opts}
 
     def java_opts(self, log_file):
@@ -178,17 +179,17 @@ class FlightRecorder(TelemetryDevice):
             java_opts += "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath={} ".format(log_file)
             java_opts += "-XX:StartFlightRecording=defaultrecording=true"
             if recording_template:
-                logger.info("jfr: Using recording template [%s].", recording_template)
+                self.logger.info("jfr: Using recording template [%s].", recording_template)
                 java_opts += ",settings={}".format(recording_template)
             else:
-                logger.info("jfr: Using default recording template.")
+                self.logger.info("jfr: Using default recording template.")
         else:
             java_opts += "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename={}".format(log_file)
             if recording_template:
-                logger.info("jfr: Using recording template [%s].", recording_template)
+                self.logger.info("jfr: Using recording template [%s].", recording_template)
                 java_opts += ",settings={}".format(recording_template)
             else:
-                logger.info("jfr: Using default recording template.")
+                self.logger.info("jfr: Using default recording template.")
         return java_opts
 
 
@@ -205,7 +206,7 @@ class JitCompiler(TelemetryDevice):
     def instrument_env(self, car, candidate_id):
         io.ensure_dir(self.log_root)
         log_file = "%s/%s-%s.jit.log" % (self.log_root, car.safe_name, candidate_id)
-        console.info("%s: Writing JIT compiler log to [%s]" % (self.human_name, log_file), logger=logger)
+        console.info("%s: Writing JIT compiler log to [%s]" % (self.human_name, log_file), logger=self.logger)
         return {"ES_JAVA_OPTS": "-XX:+UnlockDiagnosticVMOptions -XX:+TraceClassLoading -XX:+LogCompilation "
                                 "-XX:LogFile=%s -XX:+PrintAssembly" % log_file}
 
@@ -224,7 +225,7 @@ class Gc(TelemetryDevice):
     def instrument_env(self, car, candidate_id):
         io.ensure_dir(self.log_root)
         log_file = "%s/%s-%s.gc.log" % (self.log_root, car.safe_name, candidate_id)
-        console.info("%s: Writing GC log to [%s]" % (self.human_name, log_file), logger=logger)
+        console.info("%s: Writing GC log to [%s]" % (self.human_name, log_file), logger=self.logger)
         return self.java_opts(log_file)
 
     def java_opts(self, log_file):
@@ -255,7 +256,7 @@ class PerfStat(TelemetryDevice):
         io.ensure_dir(self.log_root)
         log_file = "%s/%s.perf.log" % (self.log_root, node.node_name)
 
-        console.info("%s: Writing perf logs to [%s]" % (self.human_name, log_file), logger=logger)
+        console.info("%s: Writing perf logs to [%s]" % (self.human_name, log_file), logger=self.logger)
 
         self.log = open(log_file, "wb")
 
@@ -266,12 +267,12 @@ class PerfStat(TelemetryDevice):
 
     def detach_from_node(self, node, running):
         if self.attached and running:
-            logger.info("Dumping PMU counters for node [%s]" % node.node_name)
+            self.logger.info("Dumping PMU counters for node [%s]" % node.node_name)
             os.kill(self.process.pid, signal.SIGINT)
             try:
                 self.process.wait(10.0)
             except subprocess.TimeoutExpired:
-                logger.warning("perf stat did not terminate")
+                self.logger.warning("perf stat did not terminate")
             self.log.close()
             self.attached = False
 
@@ -422,13 +423,14 @@ class NodeStatsRecorder:
         try:
             stats = self.client.nodes.stats(metric="_all")
         except elasticsearch.TransportError:
-            logger.exception("Could not retrieve node stats.")
+            logging.getLogger(__name__).exception("Could not retrieve node stats.")
             return {}
         return stats["nodes"].values()
 
 
 class StartupTime(InternalTelemetryDevice):
     def __init__(self, metrics_store, stopwatch=time.StopWatch):
+        super().__init__()
         self.metrics_store = metrics_store
         self.timer = stopwatch()
 
@@ -457,12 +459,12 @@ class MergeParts(InternalTelemetryDevice):
         self.node = node
 
     def on_benchmark_stop(self):
-        logger.info("Analyzing merge times.")
+        self.logger.info("Analyzing merge times.")
         # first decompress all logs. They have unique names so it's safe to do that. It's easier to first decompress everything
         for log_file in os.listdir(self.node_log_dir):
             log_path = "%s/%s" % (self.node_log_dir, log_file)
             if io.is_archive(log_path):
-                logger.info("Decompressing [%s] to analyze merge times..." % log_path)
+                self.logger.info("Decompressing [%s] to analyze merge times..." % log_path)
                 io.decompress(log_path, self.node_log_dir)
 
         # we need to add up times from all files
@@ -470,14 +472,14 @@ class MergeParts(InternalTelemetryDevice):
         for log_file in os.listdir(self.node_log_dir):
             log_path = "%s/%s" % (self.node_log_dir, log_file)
             if not io.is_archive(log_file):
-                logger.debug("Analyzing merge times in [%s]" % log_path)
+                self.logger.debug("Analyzing merge times in [%s]" % log_path)
                 with open(log_path, mode="rt", encoding="utf-8") as f:
                     self._extract_merge_times(f, merge_times)
             else:
-                logger.debug("Skipping archived logs in [%s]." % log_path)
+                self.logger.debug("Skipping archived logs in [%s]." % log_path)
         if merge_times:
             self._store_merge_times(merge_times)
-        logger.info("Finished analyzing merge times. Extracted [%s] different merge time components." % len(merge_times))
+        self.logger.info("Finished analyzing merge times. Extracted [%s] different merge time components." % len(merge_times))
 
     def _extract_merge_times(self, file, merge_times):
         for line in file.readlines():
@@ -518,13 +520,13 @@ class DiskIo(InternalTelemetryDevice):
         if self.process is not None:
             self.process_start = sysstats.process_io_counters(self.process)
             if self.process_start:
-                logger.info("Using more accurate process-based I/O counters.")
+                self.logger.info("Using more accurate process-based I/O counters.")
             else:
                 try:
                     self.disk_start = sysstats.disk_io_counters()
-                    logger.warning("Process I/O counters are unsupported on this platform. Falling back to less accurate disk I/O counters.")
+                    self.logger.warning("Process I/O counters are unsupported on this platform. Falling back to less accurate disk I/O counters.")
                 except RuntimeError:
-                    logger.exception("Could not determine I/O stats at benchmark start.")
+                    self.logger.exception("Could not determine I/O stats at benchmark start.")
 
     def on_benchmark_stop(self):
         if self.process is not None:
@@ -539,7 +541,7 @@ class DiskIo(InternalTelemetryDevice):
                     write_bytes = process_end.write_bytes - self.process_start.write_bytes
                 elif self.disk_start:
                     if self.node_count_on_host > 1:
-                        logger.info("There are [%d] nodes on this host and Rally fell back to disk I/O counters. "
+                        self.logger.info("There are [%d] nodes on this host and Rally fell back to disk I/O counters. "
                                     "Attributing [1/%d] of total I/O to [%s]." %
                                     (self.node_count_on_host, self.node_count_on_host, self.node.node_name))
 
@@ -553,7 +555,7 @@ class DiskIo(InternalTelemetryDevice):
                 self.metrics_store.put_count_node_level(self.node.node_name, "disk_io_read_bytes", read_bytes, "byte")
             # Catching RuntimeException is not sufficient as psutil might raise AccessDenied et.al. which is derived from Exception
             except BaseException:
-                logger.exception("Could not determine I/O stats at benchmark end.")
+                self.logger.exception("Could not determine I/O stats at benchmark end.")
 
 
 class CpuUsage(InternalTelemetryDevice):
@@ -646,7 +648,6 @@ def extract_value(node, path, fallback="unknown"):
         for k in path:
             value = value[k]
     except KeyError:
-        logger.warning("Could not determine meta-data at path [%s]." % ",".join(path))
         value = fallback
     return value
 
@@ -834,7 +835,7 @@ class GcTimesSummary(InternalTelemetryDevice):
                 self.metrics_store.put_value_node_level(node_name, "node_young_gen_gc_time", young_gc_time, "ms")
                 self.metrics_store.put_value_node_level(node_name, "node_old_gen_gc_time", old_gc_time, "ms")
             else:
-                logger.warning("Cannot determine GC times for node [%s]. It was not part of the cluster at the start of the benchmark.")
+                self.logger.warning("Cannot determine GC times for [%s] (not in the cluster at the start of the benchmark).", node_name)
 
         self.metrics_store.put_value_cluster_level("node_total_young_gen_gc_time", total_young_gen_collection_time, "ms")
         self.metrics_store.put_value_cluster_level("node_total_old_gen_gc_time", total_old_gen_collection_time, "ms")
@@ -842,13 +843,13 @@ class GcTimesSummary(InternalTelemetryDevice):
         self.gc_times_per_node = None
 
     def gc_times(self):
-        logger.debug("Gathering GC times")
+        self.logger.debug("Gathering GC times")
         gc_times = {}
         import elasticsearch
         try:
             stats = self.client.nodes.stats(metric="_all")
         except elasticsearch.TransportError:
-            logger.exception("Could not retrieve GC times.")
+            self.logger.exception("Could not retrieve GC times.")
             return gc_times
         nodes = stats["nodes"]
         for node in nodes.values():
@@ -879,14 +880,14 @@ class IndexStats(InternalTelemetryDevice):
             for k, v in index_times.items():
                 if v > 0:
                     console.warn("%s is %d ms indicating that the cluster is not in a defined clean state. Recorded index time "
-                                 "metrics may be misleading." % (k, v), logger=logger)
+                                 "metrics may be misleading." % (k, v), logger=self.logger)
             self.first_time = False
 
     def on_benchmark_stop(self):
         import json
-        logger.info("Gathering indices stats for all primaries on benchmark stop.")
+        self.logger.info("Gathering indices stats for all primaries on benchmark stop.")
         index_stats = self.index_stats()
-        logger.info("Returned indices stats:\n%s" % json.dumps(index_stats, indent=2))
+        self.logger.info("Returned indices stats:\n%s" % json.dumps(index_stats, indent=2))
         if "primaries" not in index_stats:
             return
         p = index_stats["primaries"]
@@ -895,7 +896,7 @@ class IndexStats(InternalTelemetryDevice):
         self.add_metrics(self.extract_value(p, ["segments", "memory_in_bytes"]), "segments_memory_in_bytes", "byte")
 
         for metric_key, value in self.index_times(p).items():
-            logger.info("Adding [%s] = [%s] to metrics store." % (str(metric_key), str(value)))
+            self.logger.info("Adding [%s] = [%s] to metrics store." % (str(metric_key), str(value)))
             self.add_metrics(value, metric_key, "ms")
 
         self.add_metrics(self.extract_value(p, ["segments", "doc_values_memory_in_bytes"]), "segments_doc_values_memory_in_bytes", "byte")
@@ -912,7 +913,7 @@ class IndexStats(InternalTelemetryDevice):
             stats = self.client.indices.stats(metric="_all", level="shards")
             return stats["_all"]
         except BaseException:
-            logger.exception("Could not retrieve index stats.")
+            self.logger.exception("Could not retrieve index stats.")
             return {}
 
     def index_times(self, p):
@@ -939,7 +940,7 @@ class IndexStats(InternalTelemetryDevice):
                 value = value[k]
             return value
         except KeyError:
-            logger.warning("Could not determine value at path [%s]. Returning default value [%s]" % (",".join(path), str(default_value)))
+            self.logger.warning("Could not determine value at path [%s]. Returning default value [%s]", ",".join(path), str(default_value))
             return default_value
 
 
@@ -970,7 +971,7 @@ class MlBucketProcessingTime(InternalTelemetryDevice):
                 }
             })
         except elasticsearch.TransportError:
-            logger.exception("Could not retrieve ML bucket processing time.")
+            self.logger.exception("Could not retrieve ML bucket processing time.")
             return
         try:
             value = results["aggregations"]["max_bucket_processing_time"]["value"]

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -11,8 +11,6 @@ import tabulate
 from esrally import time, exceptions, config, version, paths
 from esrally.utils import console, io, versions
 
-logger = logging.getLogger("rally.metrics")
-
 
 class EsClient:
     """
@@ -21,6 +19,7 @@ class EsClient:
 
     def __init__(self, client):
         self._client = client
+        self.logger = logging.getLogger(__name__)
 
     def put_template(self, name, template):
         return self.guarded(self._client.indices.put_template, name, template)
@@ -66,7 +65,7 @@ class EsClient:
                 msg = "The configured user could not authenticate against your Elasticsearch metrics store running on host [%s] at " \
                       "port [%s] (wrong password?). Please fix the configuration in [%s]." % \
                       (node["host"], node["port"], config.ConfigFile().location)
-                logger.exception(msg)
+                self.logger.exception(msg)
                 raise exceptions.SystemSetupError(msg)
             except elasticsearch.exceptions.AuthorizationException:
                 node = self._client.transport.hosts[0]
@@ -74,16 +73,16 @@ class EsClient:
                       "store running on host [%s] at port [%s]. Please adjust your x-pack configuration or specify a user with enough " \
                       "privileges in the configuration in [%s]." % \
                       (target.__name__, node["host"], node["port"], config.ConfigFile().location)
-                logger.exception(msg)
+                self.logger.exception(msg)
                 raise exceptions.SystemSetupError(msg)
             except elasticsearch.exceptions.ConnectionTimeout:
                 if execution_count < max_execution_count:
-                    logger.info("Received a connection timeout from the metrics store in attempt [%d/%d]." %
+                    self.logger.info("Received a connection timeout from the metrics store in attempt [%d/%d]." %
                                 (execution_count, max_execution_count))
                     time.sleep(1)
                 else:
                     operation = target.__name__
-                    logger.exception("Got a connection timeout while running [%s] (retried %d times)." % (operation, max_execution_count))
+                    self.logger.exception("Got a connection timeout while running [%s] (retried %d times).", operation, max_execution_count)
                     node = self._client.transport.hosts[0]
                     msg = "A connection timeout occurred while running the operation [%s] against your Elasticsearch metrics store on " \
                           "host [%s] at port [%s]." % (operation, node["host"], node["port"])
@@ -92,26 +91,26 @@ class EsClient:
                 node = self._client.transport.hosts[0]
                 msg = "Could not connect to your Elasticsearch metrics store. Please check that it is running on host [%s] at port [%s]" \
                       " or fix the configuration in [%s]." % (node["host"], node["port"], config.ConfigFile().location)
-                logger.exception(msg)
+                self.logger.exception(msg)
                 raise exceptions.SystemSetupError(msg)
             except elasticsearch.TransportError as e:
                 # gateway timeout - let's wait a bit and retry
                 if e.status_code == 504 and execution_count < max_execution_count:
-                    logger.info("Received a gateway timeout from the metrics store in attempt [%d/%d]." %
+                    self.logger.info("Received a gateway timeout from the metrics store in attempt [%d/%d]." %
                                 (execution_count, max_execution_count))
                     time.sleep(1)
                 else:
                     node = self._client.transport.hosts[0]
                     msg = "A transport error occurred while running the operation [%s] against your Elasticsearch metrics store on " \
                           "host [%s] at port [%s]." % (target.__name__, node["host"], node["port"])
-                    logger.exception(msg)
+                    self.logger.exception(msg)
                     raise exceptions.RallyError(msg)
 
             except elasticsearch.exceptions.ElasticsearchException:
                 node = self._client.transport.hosts[0]
                 msg = "An unknown error occurred while running the operation [%s] against your Elasticsearch metrics store on host [%s] " \
                       "at port [%s]." % (target.__name__, node["host"], node["port"])
-                logger.exception(msg)
+                self.logger.exception(msg)
                 # this does not necessarily mean it's a system setup problem...
                 raise exceptions.RallyError(msg)
 
@@ -146,7 +145,6 @@ class EsClientFactory:
             client_options["basic_auth_user"] = user
             client_options["basic_auth_password"] = password
 
-        logger.info("Creating connection to metrics store at %s:%s", host, port)
         factory = client.EsClientFactory(hosts=[{"host": host, "port": port}], client_options=client_options)
         self._client = factory.create()
 
@@ -205,7 +203,7 @@ def metrics_store(cfg, read_only=True, track=None, challenge=None, car=None, met
     """
     cls = metrics_store_class(cfg)
     store = cls(cfg=cfg, meta_info=meta_info, lap=lap)
-    logger.info("Creating %s" % str(store))
+    logging.getLogger(__name__).info("Creating %s" % str(store))
 
     trial_id = cfg.opts("system", "trial.id")
     trial_timestamp = cfg.opts("system", "time.start")
@@ -248,7 +246,7 @@ def extract_user_tags_from_string(user_tags):
                 user_tags_dict[user_tag_key] = user_tag_value
         except ValueError:
             msg = "User tag keys and values have to separated by a ':'. Invalid value [%s]" % user_tags
-            logger.exception(msg)
+            logging.getLogger(__name__).exception(msg)
             raise exceptions.SystemSetupError(msg)
     return user_tags_dict
 
@@ -292,6 +290,7 @@ class MetricsStore:
             self._meta_info = meta_info
         self._clock = clock
         self._stop_watch = self._clock.stop_watch()
+        self.logger = logging.getLogger(__name__)
 
     def open(self, trial_id=None, trial_timestamp=None, track_name=None, challenge_name=None, car_name=None, ctx=None, create=False):
         """
@@ -326,8 +325,8 @@ class MetricsStore:
 
         self._car_name = "+".join(self._car) if isinstance(self._car, list) else self._car
 
-        logger.info("Opening metrics store for trial timestamp=[%s], track=[%s], challenge=[%s], car=[%s]" %
-                    (self._trial_timestamp, self._track, self._challenge, self._car))
+        self.logger.info("Opening metrics store for trial timestamp=[%s], track=[%s], challenge=[%s], car=[%s]" %
+                         (self._trial_timestamp, self._track, self._challenge, self._car))
 
         user_tags = extract_user_tags_from_config(self._config)
         for k, v in user_tags.items():
@@ -359,7 +358,7 @@ class MetricsStore:
         raise NotImplementedError("abstract method")
 
     def close(self):
-        logger.info("Closing metrics store.")
+        self.logger.info("Closing metrics store.")
         """
         Closes the metric store. Note that it is mandatory to close the metrics store when it is no longer needed as it only persists
         metrics on close (in order to avoid additional latency during the benchmark).
@@ -570,7 +569,7 @@ class MetricsStore:
         :param memento: The external representation as returned by #to_externalizable().
         """
         if memento:
-            logger.info("Restoring in-memory representation of metrics store.")
+            self.logger.info("Restoring in-memory representation of metrics store.")
             for doc in pickle.loads(zlib.decompress(memento)):
                 self._add(doc)
 
@@ -764,8 +763,8 @@ class EsMetricsStore(MetricsStore):
     def flush(self, refresh=True):
         if self._docs:
             self._client.bulk_index(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, items=self._docs)
-            logger.info("Successfully added %d metrics documents for trial timestamp=[%s], track=[%s], challenge=[%s], car=[%s]." %
-                        (len(self._docs), self._trial_timestamp, self._track, self._challenge, self._car))
+            self.logger.info("Successfully added %d metrics documents for trial timestamp=[%s], track=[%s], challenge=[%s], car=[%s]." %
+                             (len(self._docs), self._trial_timestamp, self._track, self._challenge, self._car))
         self._docs = []
         # ensure we can search immediately after flushing
         if refresh:
@@ -778,9 +777,10 @@ class EsMetricsStore(MetricsStore):
         query = {
             "query": self._query_by_name(name, task, operation_type, sample_type, lap)
         }
-        logger.debug("Issuing get against index=[%s], doc_type=[%s], query=[%s]" % (self._index, EsMetricsStore.METRICS_DOC_TYPE, query))
+        self.logger.debug("Issuing get against index=[%s], doc_type=[%s], query=[%s]",
+                          (self._index, EsMetricsStore.METRICS_DOC_TYPE, query))
         result = self._client.search(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, body=query)
-        logger.debug("Metrics query produced [%s] results." % result["hits"]["total"])
+        self.logger.debug("Metrics query produced [%s] results." % result["hits"]["total"])
         return [mapper(v["_source"]) for v in result["hits"]["hits"]]
 
     def get_error_rate(self, task, operation_type=None, sample_type=None, lap=None):
@@ -795,23 +795,23 @@ class EsMetricsStore(MetricsStore):
                 }
             }
         }
-        logger.debug("Issuing get_error_rate against index=[%s], doc_type=[%s], query=[%s]" %
-                     (self._index, EsMetricsStore.METRICS_DOC_TYPE, query))
+        self.logger.debug("Issuing get_error_rate against index=[%s], doc_type=[%s], query=[%s]",
+                          self._index, EsMetricsStore.METRICS_DOC_TYPE, query)
         result = self._client.search(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, body=query)
         buckets = result["aggregations"]["error_rate"]["buckets"]
-        logger.debug("Query returned [%d] buckets." % len(buckets))
+        self.logger.debug("Query returned [%d] buckets." % len(buckets))
         count_success = 0
         count_errors = 0
         for bucket in buckets:
             k = bucket["key_as_string"]
             doc_count = int(bucket["doc_count"])
-            logger.debug("Processing key [%s] with [%d] docs." % (k, doc_count))
+            self.logger.debug("Processing key [%s] with [%d] docs." % (k, doc_count))
             if k == "true":
                 count_success = doc_count
             elif k == "false":
                 count_errors = doc_count
             else:
-                logger.warning("Unrecognized bucket key [%s] with [%d] docs." % (k, doc_count))
+                self.logger.warning("Unrecognized bucket key [%s] with [%d] docs." % (k, doc_count))
 
         if count_errors == 0:
             return 0.0
@@ -838,8 +838,8 @@ class EsMetricsStore(MetricsStore):
                 }
             }
         }
-        logger.debug("Issuing get_stats against index=[%s], doc_type=[%s], query=[%s]" %
-                     (self._index, EsMetricsStore.METRICS_DOC_TYPE, query))
+        self.logger.debug("Issuing get_stats against index=[%s], doc_type=[%s], query=[%s]",
+                          self._index, EsMetricsStore.METRICS_DOC_TYPE, query)
         result = self._client.search(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, body=query)
         return result["aggregations"]["metric_stats"]
 
@@ -858,11 +858,11 @@ class EsMetricsStore(MetricsStore):
                 }
             }
         }
-        logger.debug("Issuing get_percentiles against index=[%s], doc_type=[%s], query=[%s]" %
-                     (self._index, EsMetricsStore.METRICS_DOC_TYPE, query))
+        self.logger.debug("Issuing get_percentiles against index=[%s], doc_type=[%s], query=[%s]",
+                          self._index, EsMetricsStore.METRICS_DOC_TYPE, query)
         result = self._client.search(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, body=query)
         hits = result["hits"]["total"]
-        logger.debug("get_percentiles produced %d hits" % hits)
+        self.logger.debug("get_percentiles produced %d hits" % hits)
         if hits > 0:
             raw = result["aggregations"]["percentile_stats"]["values"]
             return collections.OrderedDict(sorted(raw.items(), key=lambda t: float(t[0])))
@@ -951,8 +951,8 @@ class InMemoryMetricsStore(MetricsStore):
         if clear:
             self.docs = []
         compressed = zlib.compress(pickle.dumps(docs))
-        logger.info("Compression changed size of metric store from [%d] bytes to [%d] bytes" %
-                    (sys.getsizeof(docs, -1), sys.getsizeof(compressed, -1)))
+        self.logger.info("Compression changed size of metric store from [%d] bytes to [%d] bytes" %
+                         (sys.getsizeof(docs, -1), sys.getsizeof(compressed, -1)))
         return compressed
 
     def get_percentiles(self, name, task=None, operation_type=None, sample_type=None, lap=None, percentiles=None):
@@ -1040,10 +1040,10 @@ def race_store(cfg):
     :return: A race store implementation.
     """
     if cfg.opts("reporting", "datastore.type") == "elasticsearch":
-        logger.info("Creating ES race store")
+        logging.getLogger(__name__).info("Creating ES race store")
         return CompositeRaceStore(EsRaceStore(cfg), EsResultsStore(cfg), FileRaceStore(cfg))
     else:
-        logger.info("Creating file race store")
+        logging.getLogger(__name__).info("Creating file race store")
         return FileRaceStore(cfg)
 
 
@@ -1298,7 +1298,7 @@ class FileRaceStore(RaceStore):
                 with open(result, mode="rt", encoding="utf-8") as f:
                     races.append(Race.from_dict(json.loads(f.read())))
             except BaseException:
-                logger.exception("Could not load race file [%s] (incompatible format?) Skipping..." % result)
+                logging.getLogger(__name__).exception("Could not load race file [%s] (incompatible format?) Skipping..." % result)
         return sorted(races, key=lambda r: r.trial_timestamp, reverse=True)
 
 

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -8,8 +8,6 @@ import thespian.actors
 from esrally import actor, config, exceptions, track, driver, mechanic, reporter, metrics, time, PROGRAM_NAME
 from esrally.utils import console, convert, opts
 
-logger = logging.getLogger("rally.racecontrol")
-
 # benchmarks with external candidates are really scary and we should warn users.
 BOGUS_RESULTS_WARNING = """
 ************************************************************************
@@ -80,7 +78,6 @@ class Success:
 class BenchmarkActor(actor.RallyActor):
     def __init__(self):
         super().__init__()
-        actor.RallyActor.configure_logging(logger)
         self.cfg = None
         self.race = None
         self.metrics_store = None
@@ -93,18 +90,18 @@ class BenchmarkActor(actor.RallyActor):
         self.main_driver = None
 
     def receiveMsg_PoisonMessage(self, msg, sender):
-        logger.info("BenchmarkActor got notified of poison message [%s] (forwarding)." % (str(msg)))
+        self.logger.info("BenchmarkActor got notified of poison message [%s] (forwarding)." % (str(msg)))
         self.error = True
         self.send(self.start_sender, msg)
 
     def receiveUnrecognizedMessage(self, msg, sender):
-        logger.info("BenchmarkActor received unknown message [%s] (ignoring)." % (str(msg)))
+        self.logger.info("BenchmarkActor received unknown message [%s] (ignoring)." % (str(msg)))
 
     def receiveMsg_Setup(self, msg, sender):
         self.setup(msg, sender)
 
     def receiveMsg_EngineStarted(self, msg, sender):
-        logger.info("Mechanic has started engine successfully.")
+        self.logger.info("Mechanic has started engine successfully.")
         self.metrics_store.meta_info = msg.system_meta_info
         cluster = msg.cluster_meta_info
         self.race.cluster = cluster
@@ -114,8 +111,8 @@ class BenchmarkActor(actor.RallyActor):
         self.run()
 
     def receiveMsg_TaskFinished(self, msg, sender):
-        logger.info("Task has finished.")
-        logger.info("Bulk adding request metrics to metrics store.")
+        self.logger.info("Task has finished.")
+        self.logger.info("Bulk adding request metrics to metrics store.")
         self.metrics_store.bulk_add(msg.metrics)
         # We choose *NOT* to reset our own metrics store's timer as this one is only used to collect complete metrics records from
         # other stores (used by driver and mechanic). Hence there is no need to reset the timer in our own metrics store.
@@ -128,24 +125,24 @@ class BenchmarkActor(actor.RallyActor):
         self.send(self.start_sender, msg)
 
     def receiveMsg_BenchmarkFailure(self, msg, sender):
-        logger.info("Received a benchmark failure from [%s] and will forward it now." % sender)
+        self.logger.info("Received a benchmark failure from [%s] and will forward it now." % sender)
         self.error = True
         self.send(self.start_sender, msg)
 
     def receiveMsg_BenchmarkComplete(self, msg, sender):
-        logger.info("Benchmark is complete.")
-        logger.info("Bulk adding request metrics to metrics store.")
+        self.logger.info("Benchmark is complete.")
+        self.logger.info("Bulk adding request metrics to metrics store.")
         self.metrics_store.bulk_add(msg.metrics)
         self.send(self.main_driver, thespian.actors.ActorExitRequest())
         self.main_driver = None
         self.send(self.mechanic, mechanic.OnBenchmarkStop())
 
     def receiveMsg_BenchmarkStopped(self, msg, sender):
-        logger.info("Bulk adding system metrics to metrics store.")
+        self.logger.info("Bulk adding system metrics to metrics store.")
         self.metrics_store.bulk_add(msg.system_metrics)
-        logger.info("Flushing metrics data...")
+        self.logger.info("Flushing metrics data...")
         self.metrics_store.flush()
-        logger.info("Flushing done")
+        self.logger.info("Flushing done")
         self.lap_counter.after_lap()
         if self.lap_counter.has_more_laps():
             self.run()
@@ -153,8 +150,8 @@ class BenchmarkActor(actor.RallyActor):
             self.teardown()
 
     def receiveMsg_EngineStopped(self, msg, sender):
-        logger.info("Mechanic has stopped engine successfully.")
-        logger.info("Bulk adding system metrics to metrics store.")
+        self.logger.info("Mechanic has stopped engine successfully.")
+        self.logger.info("Bulk adding system metrics to metrics store.")
         self.metrics_store.bulk_add(msg.system_metrics)
         self.metrics_store.flush()
         if not self.cancelled and not self.error:
@@ -163,7 +160,7 @@ class BenchmarkActor(actor.RallyActor):
             reporter.summarize(self.race, self.cfg)
             self.race_store.store_race(self.race)
         else:
-            logger.info("Suppressing output of summary report. Cancelled = [%r], Error = [%r]." % (self.cancelled, self.error))
+            self.logger.info("Suppressing output of summary report. Cancelled = [%r], Error = [%r]." % (self.cancelled, self.error))
         self.metrics_store.close()
         self.send(self.start_sender, Success())
 
@@ -179,7 +176,7 @@ class BenchmarkActor(actor.RallyActor):
             distribution_version = mechanic.cluster_distribution_version(self.cfg)
             if not distribution_version:
                 raise exceptions.SystemSetupError("A distribution version is required. Please specify it with --distribution-version.")
-            logger.info("Automatically derived distribution version [%s]" % distribution_version)
+            self.logger.info("Automatically derived distribution version [%s]" % distribution_version)
             self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", distribution_version)
 
         t = track.load_track(self.cfg)
@@ -189,7 +186,7 @@ class BenchmarkActor(actor.RallyActor):
             raise exceptions.SystemSetupError("Track [%s] does not provide challenge [%s]. List the available tracks with %s list tracks."
                                               % (t.name, challenge_name, PROGRAM_NAME))
         if challenge.user_info:
-            console.info(challenge.user_info, logger=logger)
+            console.info(challenge.user_info)
         self.race = metrics.create_race(self.cfg, t, challenge)
 
         self.metrics_store = metrics.metrics_store(
@@ -200,7 +197,7 @@ class BenchmarkActor(actor.RallyActor):
         )
         self.lap_counter = LapCounter(self.race, self.metrics_store, self.cfg)
         self.race_store = metrics.race_store(self.cfg)
-        logger.info("Asking mechanic to start the engine.")
+        self.logger.info("Asking mechanic to start the engine.")
         cluster_settings = self.race.challenge.cluster_settings
         self.send(self.mechanic, mechanic.StartEngine(self.cfg, self.metrics_store.open_context, cluster_settings, msg.sources, msg.build,
                                                       msg.distribution, msg.external, msg.docker))
@@ -209,14 +206,14 @@ class BenchmarkActor(actor.RallyActor):
         self.lap_counter.before_lap()
         lap = self.lap_counter.current_lap
         self.metrics_store.lap = lap
-        logger.info("Telling mechanic of benchmark start.")
+        self.logger.info("Telling mechanic of benchmark start.")
         self.send(self.mechanic, mechanic.OnBenchmarkStart(lap))
         self.main_driver = self.createActor(driver.DriverActor, targetActorRequirements={"coordinator": True})
-        logger.info("Telling driver to start benchmark.")
+        self.logger.info("Telling driver to start benchmark.")
         self.send(self.main_driver, driver.StartBenchmark(self.cfg, self.race.track, self.metrics_store.meta_info, lap))
 
     def teardown(self):
-        logger.info("Asking mechanic to stop the engine.")
+        self.logger.info("Asking mechanic to stop the engine.")
         self.send(self.mechanic, mechanic.StopEngine())
 
 
@@ -229,20 +226,21 @@ class LapCounter:
         self.lap_timer.start()
         self.lap_times = 0
         self.current_lap = 0
+        self.logger = logging.getLogger(__name__)
 
     def has_more_laps(self):
         return self.current_lap < self.race.total_laps
 
     def before_lap(self):
         self.current_lap += 1
-        logger.info("Starting lap [%d/%d]" % (self.current_lap, self.race.total_laps))
+        self.logger.info("Starting lap [%d/%d]" % (self.current_lap, self.race.total_laps))
         if self.race.total_laps > 1:
             msg = "Lap [%d/%d]" % (self.current_lap, self.race.total_laps)
             console.println(console.format.bold(msg))
             console.println(console.format.underline_for(msg))
 
     def after_lap(self):
-        logger.info("Finished lap [%d/%d]" % (self.current_lap, self.race.total_laps))
+        self.logger.info("Finished lap [%d/%d]" % (self.current_lap, self.race.total_laps))
         if self.race.total_laps > 1:
             lap_time = self.lap_timer.split_time() - self.lap_times
             self.lap_times += lap_time
@@ -254,13 +252,14 @@ class LapCounter:
             if self.current_lap < self.race.total_laps:
                 remaining = (self.race.total_laps - self.current_lap) * self.lap_times / self.current_lap
                 hr, mr, sr = convert.seconds_to_hour_minute_seconds(remaining)
-                console.info("Lap time %02d:%02d:%02d (ETA: %02d:%02d:%02d)" % (hl, ml, sl, hr, mr, sr), logger=logger)
+                console.info("Lap time %02d:%02d:%02d (ETA: %02d:%02d:%02d)" % (hl, ml, sl, hr, mr, sr), logger=self.logger)
             else:
-                console.info("Lap time %02d:%02d:%02d" % (hl, ml, sl), logger=logger)
+                console.info("Lap time %02d:%02d:%02d" % (hl, ml, sl), logger=self.logger)
             console.println("")
 
 
 def race(cfg, sources=False, build=False, distribution=False, external=False, docker=False):
+    logger = logging.getLogger(__name__)
     # at this point an actor system has to run and we should only join
     actor_system = actor.bootstrap_actor_system(try_join=True)
     benchmark_actor = actor_system.createActor(BenchmarkActor, targetActorRequirements={"coordinator": True})
@@ -287,6 +286,7 @@ def race(cfg, sources=False, build=False, distribution=False, external=False, do
 
 
 def set_default_hosts(cfg, host="127.0.0.1", port=9200):
+    logger = logging.getLogger(__name__)
     configured_hosts = cfg.opts("client", "hosts")
     if len(configured_hosts.default) !=0 :
         logger.info("Using configured hosts %s", configured_hosts.default)
@@ -354,6 +354,7 @@ def list_pipelines():
 
 
 def run(cfg):
+    logger = logging.getLogger(__name__)
     name = cfg.opts("race", "pipeline")
     if len(name) == 0:
         if cfg.exists("mechanic", "distribution.version"):

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -90,12 +90,12 @@ class BenchmarkActor(actor.RallyActor):
         self.main_driver = None
 
     def receiveMsg_PoisonMessage(self, msg, sender):
-        self.logger.info("BenchmarkActor got notified of poison message [%s] (forwarding)." % (str(msg)))
+        self.logger.info("BenchmarkActor got notified of poison message [%s] (forwarding).", (str(msg)))
         self.error = True
         self.send(self.start_sender, msg)
 
     def receiveUnrecognizedMessage(self, msg, sender):
-        self.logger.info("BenchmarkActor received unknown message [%s] (ignoring)." % (str(msg)))
+        self.logger.info("BenchmarkActor received unknown message [%s] (ignoring).", (str(msg)))
 
     def receiveMsg_Setup(self, msg, sender):
         self.setup(msg, sender)
@@ -125,7 +125,7 @@ class BenchmarkActor(actor.RallyActor):
         self.send(self.start_sender, msg)
 
     def receiveMsg_BenchmarkFailure(self, msg, sender):
-        self.logger.info("Received a benchmark failure from [%s] and will forward it now." % sender)
+        self.logger.info("Received a benchmark failure from [%s] and will forward it now.", sender)
         self.error = True
         self.send(self.start_sender, msg)
 
@@ -160,7 +160,7 @@ class BenchmarkActor(actor.RallyActor):
             reporter.summarize(self.race, self.cfg)
             self.race_store.store_race(self.race)
         else:
-            self.logger.info("Suppressing output of summary report. Cancelled = [%r], Error = [%r]." % (self.cancelled, self.error))
+            self.logger.info("Suppressing output of summary report. Cancelled = [%r], Error = [%r].", self.cancelled, self.error)
         self.metrics_store.close()
         self.send(self.start_sender, Success())
 
@@ -176,7 +176,7 @@ class BenchmarkActor(actor.RallyActor):
             distribution_version = mechanic.cluster_distribution_version(self.cfg)
             if not distribution_version:
                 raise exceptions.SystemSetupError("A distribution version is required. Please specify it with --distribution-version.")
-            self.logger.info("Automatically derived distribution version [%s]" % distribution_version)
+            self.logger.info("Automatically derived distribution version [%s]", distribution_version)
             self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", distribution_version)
 
         t = track.load_track(self.cfg)
@@ -233,14 +233,14 @@ class LapCounter:
 
     def before_lap(self):
         self.current_lap += 1
-        self.logger.info("Starting lap [%d/%d]" % (self.current_lap, self.race.total_laps))
+        self.logger.info("Starting lap [%d/%d]", self.current_lap, self.race.total_laps)
         if self.race.total_laps > 1:
             msg = "Lap [%d/%d]" % (self.current_lap, self.race.total_laps)
             console.println(console.format.bold(msg))
             console.println(console.format.underline_for(msg))
 
     def after_lap(self):
-        self.logger.info("Finished lap [%d/%d]" % (self.current_lap, self.race.total_laps))
+        self.logger.info("Finished lap [%d/%d]", self.current_lap, self.race.total_laps)
         if self.race.total_laps > 1:
             lap_time = self.lap_timer.split_time() - self.lap_times
             self.lap_times += lap_time
@@ -361,10 +361,10 @@ def run(cfg):
             name = "from-distribution"
         else:
             name = "from-sources-complete"
-        logger.info("User specified no pipeline. Automatically derived pipeline [%s]." % name)
+        logger.info("User specified no pipeline. Automatically derived pipeline [%s].", name)
         cfg.add(config.Scope.applicationOverride, "race", "pipeline", name)
     else:
-        logger.info("User specified pipeline [%s]." % name)
+        logger.info("User specified pipeline [%s].", name)
 
     try:
         pipeline = pipelines[name]

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -1,97 +1,15 @@
 import argparse
 import datetime
 import logging
-import logging.handlers
 import os
 import sys
 import time
 import uuid
 
-from esrally import version, actor, config, paths, racecontrol, reporter, metrics, track, chart_generator, exceptions, time as rtime
+from esrally import version, actor, config, paths, racecontrol, reporter, metrics, track, chart_generator, exceptions, log
 from esrally import PROGRAM_NAME, DOC_LINK, BANNER, SKULL, check_python_version
 from esrally.mechanic import team, telemetry
 from esrally.utils import io, convert, process, console, net, opts
-
-logger = logging.getLogger("rally.main")
-
-
-# we want to use some basic logging even before the output to log file is configured
-def pre_configure_logging():
-    logging.basicConfig(level=logging.INFO)
-
-
-def application_log_dir_path():
-    return "%s/.rally/logs" % os.path.expanduser("~")
-
-
-def application_log_file_path(start_time):
-    return "%s/rally_out_%s.log" % (application_log_dir_path(), start_time)
-
-
-def configure_logging(cfg):
-    start_time = rtime.to_iso8601(cfg.opts("system", "time.start"))
-    logging_output = cfg.opts("system", "logging.output")
-    profiling_enabled = cfg.opts("driver", "profiling")
-
-    if logging_output == "file":
-        log_file = application_log_file_path(start_time)
-        log_dir = os.path.dirname(log_file)
-        io.ensure_dir(log_dir)
-        console.info("Writing logs to %s" % log_file)
-        # there is an old log file lying around -> backup
-        if os.path.exists(log_file):
-            os.rename(log_file, "%s-bak-%d.log" % (log_file, int(os.path.getctime(log_file))))
-        ch = logging.FileHandler(filename=log_file, mode="a")
-    else:
-        ch = logging.StreamHandler(stream=sys.stdout)
-
-    log_level = logging.INFO
-    ch.setLevel(log_level)
-    formatter = logging.Formatter("%(asctime)s,%(msecs)d PID:%(process)d %(name)s %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
-    formatter.converter = time.gmtime
-    ch.setFormatter(formatter)
-
-    # Remove all handlers associated with the root logger object so we can start over with an entirely fresh log configuration
-    for handler in logging.root.handlers[:]:
-        logging.root.removeHandler(handler)
-
-    logging.root.addHandler(ch)
-    logging.getLogger("elasticsearch").setLevel(logging.WARNING)
-
-    # Avoid failures such as the following (shortened a bit):
-    #
-    # ---------------------------------------------------------------------------------------------
-    # "esrally/driver/driver.py", line 220, in create_client
-    # "thespian-3.8.0-py3.5.egg/thespian/actors.py", line 187, in createActor
-    # [...]
-    # "thespian-3.8.0-py3.5.egg/thespian/system/multiprocCommon.py", line 348, in _startChildActor
-    # "python3.5/multiprocessing/process.py", line 105, in start
-    # "python3.5/multiprocessing/context.py", line 267, in _Popen
-    # "python3.5/multiprocessing/popen_fork.py", line 18, in __init__
-    # sys.stderr.flush()
-    #
-    # OSError: [Errno 5] Input/output error
-    # ---------------------------------------------------------------------------------------------
-    #
-    # This is caused by urllib3 wanting to send warnings about insecure SSL connections to stderr when we disable them (in client.py) with:
-    #
-    #   urllib3.disable_warnings()
-    #
-    # The filtering functionality of the warnings module causes the error above on some systems. If we instead redirect the warning output
-    # to our logs instead of stderr (which is the warnings module's default), we can disable warnings safely.
-    logging.captureWarnings(True)
-
-    if profiling_enabled:
-        profile_file = "%s/profile.log" % application_log_dir_path()
-        log_dir = os.path.dirname(profile_file)
-        io.ensure_dir(log_dir)
-        console.info("Writing driver profiling data to %s" % profile_file)
-        handler = logging.FileHandler(filename=profile_file, encoding="UTF-8")
-        handler.setFormatter(formatter)
-
-        profile_logger = logging.getLogger("rally.profile")
-        profile_logger.setLevel(logging.INFO)
-        profile_logger.addHandler(handler)
 
 
 def create_arg_parser():
@@ -393,12 +311,6 @@ def create_arg_parser():
             "--configuration-name",
             help=argparse.SUPPRESS,
             default=None)
-        p.add_argument(
-            "--logging",
-            choices=["file", "console"],
-            help=argparse.SUPPRESS,
-            default="file"
-        )
 
     return parser
 
@@ -453,11 +365,11 @@ def print_help_on_errors():
     heading = "Getting further help:"
     console.println(console.format.bold(heading))
     console.println(console.format.underline_for(heading))
-    console.println("* Check the log files in %s for errors." % application_log_dir_path())
-    console.println("* Read the documentation at %s" % console.format.link(DOC_LINK))
-    console.println("* Ask a question on the forum at %s" % console.format.link("https://discuss.elastic.co/c/elasticsearch/rally"))
-    console.println("* Raise an issue at %s and include the log files in %s." %
-                    (console.format.link("https://github.com/elastic/rally/issues"), application_log_dir_path()))
+    console.println("* Check the log files in {} for errors.".format(log.default_log_path()))
+    console.println("* Read the documentation at {}".format(console.format.link(DOC_LINK)))
+    console.println("* Ask a question on the forum at {}".format(console.format.link("https://discuss.elastic.co/c/elasticsearch/rally")))
+    console.println("* Raise an issue at {} and include the log files in {}."
+                    .format(console.format.link("https://github.com/elastic/rally/issues"), log.default_log_path()))
 
 
 def race(cfg):
@@ -472,6 +384,7 @@ def race(cfg):
 
 
 def with_actor_system(runnable, cfg):
+    logger = logging.getLogger(__name__)
     already_running = actor.actor_system_already_running()
     logger.info("Actor system already running locally? [%s]" % str(already_running))
     try:
@@ -570,13 +483,14 @@ def dispatch_sub_command(cfg, sub_command):
 
 def main():
     check_python_version()
-
+    log.install_default_log_config()
+    log.configure_logging()
+    logger = logging.getLogger(__name__)
     start = time.time()
 
     # Early init of console output so we start to show everything consistently.
     console.init(quiet=False)
 
-    pre_configure_logging()
     arg_parser = create_arg_parser()
     args = arg_parser.parse_args()
 
@@ -594,12 +508,9 @@ def main():
         cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.utcnow())
         cfg.add(config.Scope.application, "system", "time.start.user_provided", False)
 
-    cfg.add(config.Scope.applicationOverride, "system", "quiet.mode", args.quiet)
     cfg.add(config.Scope.applicationOverride, "system", "trial.id", str(uuid.uuid4()))
-
-    # per node?
+    cfg.add(config.Scope.applicationOverride, "system", "quiet.mode", args.quiet)
     cfg.add(config.Scope.applicationOverride, "system", "offline.mode", args.offline)
-    cfg.add(config.Scope.applicationOverride, "system", "logging.output", args.logging)
 
     # Local config per node
     cfg.add(config.Scope.application, "node", "rally.root", paths.rally_root())
@@ -692,7 +603,6 @@ def main():
         cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
         cfg.add(config.Scope.applicationOverride, "system", "list.races.max_results", args.limit)
 
-    configure_logging(cfg)
     logger.info("OS [%s]" % str(os.uname()))
     logger.info("Python [%s]" % str(sys.implementation))
     logger.info("Rally version [%s]" % version.version())

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -386,7 +386,7 @@ def race(cfg):
 def with_actor_system(runnable, cfg):
     logger = logging.getLogger(__name__)
     already_running = actor.actor_system_already_running()
-    logger.info("Actor system already running locally? [%s]" % str(already_running))
+    logger.info("Actor system already running locally? [%s]", str(already_running))
     try:
         actors = actor.bootstrap_actor_system(try_join=already_running, prefer_local_only=not already_running)
         # We can only support remote benchmarks if we have a dedicated daemon that is not only bound to 127.0.0.1
@@ -428,7 +428,7 @@ def with_actor_system(runnable, cfg):
                     logger.warning("User interrupted shutdown of internal actor system.")
                     console.info("Please wait a moment for Rally's internal components to shutdown.")
             if not shutdown_complete and times_interrupted > 0:
-                logger.warning("Terminating after user has interrupted actor system shutdown explicitly for [%d] times." % times_interrupted)
+                logger.warning("Terminating after user has interrupted actor system shutdown explicitly for [%d] times.", times_interrupted)
                 console.println("")
                 console.warn("Terminating now at the risk of leaving child processes behind.")
                 console.println("")
@@ -458,7 +458,7 @@ def dispatch_sub_command(cfg, sub_command):
             raise exceptions.SystemSetupError("Unknown subcommand [%s]" % sub_command)
         return True
     except exceptions.RallyError as e:
-        logging.exception("Cannot run subcommand [%s]." % sub_command)
+        logging.getLogger(__name__).exception("Cannot run subcommand [%s].", sub_command)
         msg = str(e.message)
         nesting = 0
         while hasattr(e, "cause") and e.cause:
@@ -474,7 +474,7 @@ def dispatch_sub_command(cfg, sub_command):
         print_help_on_errors()
         return False
     except BaseException as e:
-        logging.exception("A fatal error occurred while running subcommand [%s]." % sub_command)
+        logging.getLogger(__name__).exception("A fatal error occurred while running subcommand [%s].", sub_command)
         console.error("Cannot %s. %s." % (sub_command, e))
         console.println("")
         print_help_on_errors()
@@ -603,10 +603,10 @@ def main():
         cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
         cfg.add(config.Scope.applicationOverride, "system", "list.races.max_results", args.limit)
 
-    logger.info("OS [%s]" % str(os.uname()))
-    logger.info("Python [%s]" % str(sys.implementation))
-    logger.info("Rally version [%s]" % version.version())
-    logger.info("Command line arguments: %s" % args)
+    logger.info("OS [%s]", str(os.uname()))
+    logger.info("Python [%s]", str(sys.implementation))
+    logger.info("Rally version [%s]", version.version())
+    logger.info("Command line arguments: %s", args)
     # Configure networking
     net.init()
     if not args.offline:

--- a/esrally/rallyd.py
+++ b/esrally/rallyd.py
@@ -3,20 +3,13 @@ import time
 import logging
 import argparse
 
-from esrally import actor, version, exceptions, DOC_LINK, BANNER, PROGRAM_NAME, check_python_version
+from esrally import actor, version, exceptions, DOC_LINK, BANNER, PROGRAM_NAME, check_python_version, log
 from esrally.utils import console
 
 
 def start(args):
     if actor.actor_system_already_running():
         raise exceptions.RallyError("An actor system appears to be already running.")
-    # TheSpian writes the following warning upon start (at least) on Mac OS X:
-    #
-    # WARNING:root:Unable to get address info for address 103.1.168.192.in-addr.arpa (AddressFamily.AF_INET,\
-    # SocketKind.SOCK_DGRAM, 17, 0): <class 'socket.gaierror'> [Errno 8] nodename nor servname provided, or not known
-    #
-    # Therefore, we will not show warnings but only errors.
-    logging.basicConfig(level=logging.ERROR)
     actor.bootstrap_actor_system(local_ip=args.node_ip, coordinator_ip=args.coordinator_ip)
     console.info("Successfully started actor system on node [%s] with coordinator node IP [%s]." % (args.node_ip, args.coordinator_ip))
 
@@ -59,6 +52,8 @@ def status():
 
 def main():
     check_python_version()
+    log.install_default_log_config()
+    log.configure_logging()
     console.init()
 
     parser = argparse.ArgumentParser(prog=PROGRAM_NAME,

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -8,8 +8,6 @@ import tabulate
 from esrally import metrics, exceptions
 from esrally.utils import convert, io as rio, console
 
-logger = logging.getLogger("rally.reporting")
-
 
 def calculate_results(metrics_store, race, lap=None):
     calc = StatsCalculator(metrics_store, race.challenge, lap)
@@ -17,7 +15,6 @@ def calculate_results(metrics_store, race, lap=None):
 
 
 def summarize(race, cfg, lap=None):
-    logger.info("Summarizing results.")
     results = race.results_of_lap_number(lap) if lap else race.results
     SummaryReporter(results, cfg, race.revision, lap, race.total_laps).report()
 
@@ -35,7 +32,7 @@ def compare(cfg):
 
 
 def print_internal(message):
-    console.println(message, logger=logger.info)
+    console.println(message, logger=logging.getLogger(__name__).info)
 
 
 def print_header(message):
@@ -53,8 +50,6 @@ def write_single_report(report_file, report_format, cwd, headers, data_plain, da
     print_internal(formatter(headers, data_rich))
     if len(report_file) > 0:
         normalized_report_file = rio.normalize_path(report_file, cwd)
-        logger.info("Writing report to [%s] (user specified: [%s]) in format [%s]" %
-                    (normalized_report_file, report_file, report_format))
         # ensure that the parent folder already exists when we try to write the file...
         rio.ensure_dir(rio.dirname(normalized_report_file))
         with open(normalized_report_file, mode="a+", encoding="utf-8") as f:
@@ -109,6 +104,7 @@ class StatsCalculator:
         self.store = store
         self.challenge = challenge
         self.lap = lap
+        self.logger = logging.getLogger(__name__)
 
     def __call__(self):
         result = Stats()
@@ -117,7 +113,7 @@ class StatsCalculator:
             for task in tasks:
                 if task.operation.include_in_reporting:
                     t = task.name
-                    logger.debug("Gathering request metrics for [%s]." % t)
+                    self.logger.debug("Gathering request metrics for [%s]." % t)
                     result.add_op_metrics(
                         t,
                         task.operation.name,
@@ -126,15 +122,15 @@ class StatsCalculator:
                         self.single_latency(t, metric_name="service_time"),
                         self.error_rate(t)
                     )
-        logger.debug("Gathering node startup time metrics.")
+        self.logger.debug("Gathering node startup time metrics.")
         startup_times = self.store.get_raw("node_startup_time")
         for startup_time in startup_times:
             if "meta" in startup_time and "node_name" in startup_time["meta"]:
                 result.add_node_metrics(startup_time["meta"]["node_name"], startup_time["value"])
             else:
-                logger.debug("Skipping incomplete startup time record [%s]." % str(startup_time))
+                self.logger.debug("Skipping incomplete startup time record [%s]." % str(startup_time))
 
-        logger.debug("Gathering indexing metrics.")
+        self.logger.debug("Gathering indexing metrics.")
         result.total_time = self.sum("indexing_total_time")
         result.indexing_throttle_time = self.sum("indexing_throttle_time")
         result.merge_time = self.sum("merges_total_time")
@@ -142,7 +138,7 @@ class StatsCalculator:
         result.flush_time = self.sum("flush_total_time")
         result.merge_throttle_time = self.sum("merges_total_throttled_time")
 
-        logger.debug("Gathering merge part metrics.")
+        self.logger.debug("Gathering merge part metrics.")
         result.merge_part_time_postings = self.sum("merge_parts_total_time_postings")
         result.merge_part_time_stored_fields = self.sum("merge_parts_total_time_stored_fields")
         result.merge_part_time_doc_values = self.sum("merge_parts_total_time_doc_values")
@@ -150,17 +146,17 @@ class StatsCalculator:
         result.merge_part_time_vectors = self.sum("merge_parts_total_time_vectors")
         result.merge_part_time_points = self.sum("merge_parts_total_time_points")
 
-        logger.debug("Gathering ML max processing time.")
+        self.logger.debug("Gathering ML max processing time.")
         result.ml_max_processing_time = self.one("ml_max_processing_time_millis")
 
-        logger.debug("Gathering CPU usage metrics.")
+        self.logger.debug("Gathering CPU usage metrics.")
         result.median_cpu_usage = self.median("cpu_utilization_1s", sample_type=metrics.SampleType.Normal)
 
-        logger.debug("Gathering garbage collection metrics.")
+        self.logger.debug("Gathering garbage collection metrics.")
         result.young_gc_time = self.sum("node_total_young_gen_gc_time")
         result.old_gc_time = self.sum("node_total_old_gen_gc_time")
 
-        logger.debug("Gathering segment memory metrics.")
+        self.logger.debug("Gathering segment memory metrics.")
         result.memory_segments = self.median("segments_memory_in_bytes")
         result.memory_doc_values = self.median("segments_doc_values_memory_in_bytes")
         result.memory_terms = self.median("segments_terms_memory_in_bytes")
@@ -168,7 +164,7 @@ class StatsCalculator:
         result.memory_points = self.median("segments_points_memory_in_bytes")
         result.memory_stored_fields = self.median("segments_stored_fields_memory_in_bytes")
 
-        logger.debug("Gathering disk metrics.")
+        self.logger.debug("Gathering disk metrics.")
         # This metric will only be written for the last iteration (as it can only be determined after the cluster has been shut down)
         result.index_size = self.sum("final_index_size_bytes")
         # we need to use the median here because these two are captured with the indices stats API and thus once per lap. If we'd
@@ -415,7 +411,7 @@ class SummaryReporter:
 
         if warnings:
             for warning in warnings:
-                console.warn(warning, logger=logger)
+                console.warn(warning)
 
     def add_warnings(self, warnings, values, op):
         if values["throughput"]["median"] is None:
@@ -551,10 +547,6 @@ class ComparisonReporter:
         self.plain = False
 
     def report(self, r1, r2):
-        logger.info("Generating comparison report for baseline (trial timestamp=[%s], track=[%s], challenge=[%s], car=[%s]) and "
-                    "contender (trial timestamp=[%s], track=[%s], challenge=[%s], car=[%s])" %
-                    (r1.trial_timestamp, r1.track, r1.challenge, r1.car,
-                     r2.trial_timestamp, r2.track, r2.challenge, r2.car))
         # we don't verify anything about the races as it is possible that the user benchmarks two different tracks intentionally
         baseline_stats = Stats(r1.results)
         contender_stats = Stats(r2.results)

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -113,7 +113,7 @@ class StatsCalculator:
             for task in tasks:
                 if task.operation.include_in_reporting:
                     t = task.name
-                    self.logger.debug("Gathering request metrics for [%s]." % t)
+                    self.logger.debug("Gathering request metrics for [%s].", t)
                     result.add_op_metrics(
                         t,
                         task.operation.name,
@@ -128,7 +128,7 @@ class StatsCalculator:
             if "meta" in startup_time and "node_name" in startup_time["meta"]:
                 result.add_node_metrics(startup_time["meta"]["node_name"], startup_time["value"])
             else:
-                self.logger.debug("Skipping incomplete startup time record [%s]." % str(startup_time))
+                self.logger.debug("Skipping incomplete startup time record [%s].", str(startup_time))
 
         self.logger.debug("Gathering indexing metrics.")
         result.total_time = self.sum("indexing_total_time")

--- a/esrally/resources/logging.json
+++ b/esrally/resources/logging.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "formatters": {
+    "normal": {
+      "format": "%(asctime)s,%(msecs)d %(actorAddress)s/PID:%(process)d %(name)s %(levelname)s %(message)s",
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "()": "esrally.log.configure_utc_formatter"
+    },
+    "profile": {
+      "format": "%(asctime)s,%(msecs)d PID:%(process)d %(name)s %(levelname)s %(message)s",
+      "datefmt": "%Y-%m-%d %H:%M:%S",
+      "()": "esrally.log.configure_utc_formatter"
+    }
+  },
+  "filters": {
+    "isActorLog": {
+      "()": "thespian.director.ActorAddressLogFilter"
+    }
+  },
+  "handlers": {
+    "rally_log_handler": {
+      "class": "logging.handlers.TimedRotatingFileHandler",
+      "filename": "${LOG_PATH}/rally.log",
+      "utc": true,
+      "when": "midnight",
+      "backupCount": 14,
+      "encoding": "UTF-8",
+      "formatter": "normal",
+      "filters": ["isActorLog"]
+    },
+    "rally_profile_handler": {
+      "class": "logging.FileHandler",
+      "filename": "${LOG_PATH}/profile.log",
+      "delay": true,
+      "encoding": "UTF-8",
+      "formatter": "profile"
+    }
+  },
+  "root": {
+    "handlers": ["rally_log_handler"],
+    "level": "INFO"
+  },
+  "loggers": {
+    "elasticsearch": {
+      "handlers": ["rally_log_handler"],
+      "level": "WARNING",
+      "propagate": false
+    },
+    "rally.profile": {
+      "handlers": ["rally_profile_handler"],
+      "level": "INFO",
+      "propagate": false
+    }
+  }
+}

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -74,7 +74,7 @@ def load_track(cfg):
         else:
             return current_track
     except FileNotFoundError:
-        logging.getLogger(__name__).exception("Cannot load track [%s]" % track_name)
+        logging.getLogger(__name__).exception("Cannot load track [%s]", track_name)
         raise exceptions.SystemSetupError("Cannot load track %s. List the available tracks with %s list tracks." %
                                           (track_name, PROGRAM_NAME))
 
@@ -229,7 +229,7 @@ def prepare_track(t, cfg):
     test_mode = cfg.opts("track", "test.mode.enabled")
     for corpus in t.corpora:
         data_root = data_dir(cfg, t.name, corpus.name)
-        logger.info("Resolved data root directory for document corpus [%s] in track [%s] to %s." % (corpus.name, t.name, data_root))
+        logger.info("Resolved data root directory for document corpus [%s] in track [%s] to %s.", corpus.name, t.name, data_root)
         prep = DocumentSetPreparator(t.name, offline, test_mode)
 
         for document_set in corpus.documents:
@@ -288,15 +288,15 @@ class DocumentSetPreparator:
             io.ensure_dir(os.path.dirname(target_path))
             if size_in_bytes:
                 size_in_mb = round(convert.bytes_to_mb(size_in_bytes))
-                self.logger.info("Downloading data from [%s] (%s MB) to [%s]." % (data_url, size_in_mb, target_path))
+                self.logger.info("Downloading data from [%s] (%s MB) to [%s].", data_url, size_in_mb, target_path)
             else:
-                self.logger.info("Downloading data from [%s] to [%s]." % (data_url, target_path))
+                self.logger.info("Downloading data from [%s] to [%s].", data_url, target_path)
 
             # we want to have a bit more accurate download progress as these files are typically very large
             progress = net.Progress("[INFO] Downloading data for track %s" % self.track_name, accuracy=1)
             net.download(data_url, target_path, size_in_bytes, progress_indicator=progress)
             progress.finish()
-            self.logger.info("Downloaded data from [%s] to [%s]." % (data_url, target_path))
+            self.logger.info("Downloaded data from [%s] to [%s].", data_url, target_path)
         except urllib.error.HTTPError as e:
             if e.code == 404 and self.test_mode:
                 raise exceptions.DataError("Track [%s] does not support test mode. Please ask the track author to add it or "
@@ -309,7 +309,7 @@ class DocumentSetPreparator:
                     msg += " (HTTP status: %s)" % str(e.code)
                 raise exceptions.DataError(msg)
         except urllib.error.URLError:
-            self.logger.exception("Could not download [%s] to [%s]." % (data_url, target_path))
+            self.logger.exception("Could not download [%s] to [%s].", data_url, target_path)
             raise exceptions.DataError("Could not download [%s] to [%s]." % (data_url, target_path))
 
         if not os.path.isfile(target_path):
@@ -489,10 +489,10 @@ def filter_included_tasks(t, filters):
                         if not match(leaf_task, complete_filters):
                             leafs_to_remove.append(leaf_task)
                     for leaf_task in leafs_to_remove:
-                        logger.info("Removing sub-task [%s] from challenge [%s] due to task filter." % (leaf_task, challenge))
+                        logger.info("Removing sub-task [%s] from challenge [%s] due to task filter.", leaf_task, challenge)
                         task.remove_task(leaf_task)
             for task in tasks_to_remove:
-                logger.info("Removing task [%s] from challenge [%s] due to task filter." % (task, challenge))
+                logger.info("Removing task [%s] from challenge [%s] due to task filter.", task, challenge)
                 challenge.remove_task(task)
 
     return t
@@ -518,9 +518,9 @@ def filters_from_included_tasks(included_tasks):
 
 def post_process_for_test_mode(t):
     logger = logging.getLogger(__name__)
-    logger.info("Preparing track [%s] for test mode." % str(t))
+    logger.info("Preparing track [%s] for test mode.", str(t))
     for corpus in t.corpora:
-        logger.info("Reducing corpus size to 1000 documents for [%s]" % corpus.name)
+        logger.info("Reducing corpus size to 1000 documents for [%s]", corpus.name)
         for document_set in corpus.documents:
             # TODO #341: Should we allow this for snapshots too?
             if document_set.is_bulk:
@@ -550,18 +550,18 @@ def post_process_for_test_mode(t):
                 # iteration-based schedules are divided among all clients and we should provide at least one iteration for each client.
                 if leaf_task.warmup_iterations is not None and leaf_task.warmup_iterations > leaf_task.clients:
                     count = leaf_task.clients
-                    logger.info("Resetting warmup iterations to %d for [%s]" % (count, str(leaf_task)))
+                    logger.info("Resetting warmup iterations to %d for [%s]", count, str(leaf_task))
                     leaf_task.warmup_iterations = count
                 if leaf_task.iterations is not None and leaf_task.iterations > leaf_task.clients:
                     count = leaf_task.clients
-                    logger.info("Resetting measurement iterations to %d for [%s]" % (count, str(leaf_task)))
+                    logger.info("Resetting measurement iterations to %d for [%s]", count, str(leaf_task))
                     leaf_task.iterations = count
                 if leaf_task.warmup_time_period is not None and leaf_task.warmup_time_period > 0:
                     leaf_task.warmup_time_period = 0
-                    logger.info("Resetting warmup time period for [%s] to [%d] seconds." % (str(leaf_task), leaf_task.warmup_time_period))
+                    logger.info("Resetting warmup time period for [%s] to [%d] seconds.", str(leaf_task), leaf_task.warmup_time_period)
                 if leaf_task.time_period is not None and leaf_task.time_period > 10:
                     leaf_task.time_period = 10
-                    logger.info("Resetting measurement time period for [%s] to [%d] seconds." % (str(leaf_task), leaf_task.time_period))
+                    logger.info("Resetting measurement time period for [%s] to [%d] seconds.", str(leaf_task), leaf_task.time_period)
     return t
 
 
@@ -734,14 +734,14 @@ class TrackSpecificationReader:
         return track.IndexTemplate(name, index_pattern, template_content, delete_matching_indices)
 
     def _load_template(self, contents, description):
-        self.logger.info("Loading template [%s]." % description)
+        self.logger.info("Loading template [%s].", description)
         try:
             rendered = render_template(loader=jinja2.DictLoader({"default": contents}),
                                        template_name="default",
                                        template_vars=self.track_params)
             return json.loads(rendered)
         except (json.JSONDecodeError, jinja2.exceptions.TemplateError) as e:
-            self.logger.exception("Could not load file template for %s." % description)
+            self.logger.exception("Could not load file template for %s.", description)
             raise TrackSyntaxError("Could not load file template for '%s'" % description, str(e))
 
     def _create_corpora(self, corpora_specs, indices):
@@ -984,9 +984,9 @@ class TrackSpecificationReader:
             if "include-in-reporting" not in params:
                 params["include-in-reporting"] = not op.admin_op
             op_type = op.name
-            self.logger.debug("Using built-in operation type [%s] for operation [%s]." % (op_type, op_name))
+            self.logger.debug("Using built-in operation type [%s] for operation [%s].", op_type, op_name)
         except KeyError:
-            self.logger.info("Using user-provided operation type [%s] for operation [%s]." % (op_type_name, op_name))
+            self.logger.info("Using user-provided operation type [%s] for operation [%s].", op_type_name, op_name)
             op_type = op_type_name
 
         try:

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -12,10 +12,6 @@ from esrally import exceptions, time, PROGRAM_NAME
 from esrally.track import params, track
 from esrally.utils import io, convert, net, console, modules, repo
 
-logger = logging.getLogger("rally.track")
-
-DEFAULT_TRACKS = ["geonames", "geopoint", "noaa", "http_logs", "nyc_taxis", "pmc", "percolator", "nested"]
-
 
 class TrackSyntaxError(exceptions.InvalidSyntax):
     """
@@ -78,7 +74,7 @@ def load_track(cfg):
         else:
             return current_track
     except FileNotFoundError:
-        logger.exception("Cannot load track [%s]" % track_name)
+        logging.getLogger(__name__).exception("Cannot load track [%s]" % track_name)
         raise exceptions.SystemSetupError("Cannot load track %s. List the available tracks with %s list tracks." %
                                           (track_name, PROGRAM_NAME))
 
@@ -92,8 +88,6 @@ def load_track_plugins(cfg, register_runner, register_scheduler):
 
     if plugin_reader.can_load():
         plugin_reader.load()
-    else:
-        logger.debug("Track [%s] in path [%s] does not define any track plugins." % (track_name, track_plugin_path))
 
 
 def set_absolute_data_path(cfg, t):
@@ -218,10 +212,8 @@ class SimpleTrackRepository:
 
 def operation_parameters(t, op):
     if op.param_source:
-        logger.debug("Creating parameter source with name [%s]" % op.param_source)
         return params.param_source_for_name(op.param_source, t, op.params)
     else:
-        logger.debug("Creating parameter source for operation type [%s]" % op.type)
         return params.param_source_for_operation(op.type, t, op.params)
 
 
@@ -232,6 +224,7 @@ def prepare_track(t, cfg):
     :param t: A track that is about to be run.
     :param cfg: The config object.
     """
+    logger = logging.getLogger(__name__)
     offline = cfg.opts("system", "offline.mode")
     test_mode = cfg.opts("track", "test.mode.enabled")
     for corpus in t.corpora:
@@ -253,6 +246,7 @@ class DocumentSetPreparator:
         self.track_name = track_name
         self.offline = offline
         self.test_mode = test_mode
+        self.logger = logging.getLogger(__name__)
 
     def is_locally_available(self, file_name):
         return os.path.isfile(file_name)
@@ -264,10 +258,10 @@ class DocumentSetPreparator:
         if uncompressed_size:
             console.info("Decompressing track data from [%s] to [%s] (resulting size: %.2f GB) ... " %
                          (archive_path, documents_path, convert.bytes_to_gb(uncompressed_size)),
-                         end='', flush=True, logger=logger)
+                         end='', flush=True, logger=self.logger)
         else:
             console.info("Decompressing track data from [%s] to [%s] ... " % (archive_path, documents_path), end='',
-                         flush=True, logger=logger)
+                         flush=True, logger=self.logger)
 
         io.decompress(archive_path, io.dirname(archive_path))
         console.println("[OK]")
@@ -294,15 +288,15 @@ class DocumentSetPreparator:
             io.ensure_dir(os.path.dirname(target_path))
             if size_in_bytes:
                 size_in_mb = round(convert.bytes_to_mb(size_in_bytes))
-                logger.info("Downloading data from [%s] (%s MB) to [%s]." % (data_url, size_in_mb, target_path))
+                self.logger.info("Downloading data from [%s] (%s MB) to [%s]." % (data_url, size_in_mb, target_path))
             else:
-                logger.info("Downloading data from [%s] to [%s]." % (data_url, target_path))
+                self.logger.info("Downloading data from [%s] to [%s]." % (data_url, target_path))
 
             # we want to have a bit more accurate download progress as these files are typically very large
             progress = net.Progress("[INFO] Downloading data for track %s" % self.track_name, accuracy=1)
             net.download(data_url, target_path, size_in_bytes, progress_indicator=progress)
             progress.finish()
-            logger.info("Downloaded data from [%s] to [%s]." % (data_url, target_path))
+            self.logger.info("Downloaded data from [%s] to [%s]." % (data_url, target_path))
         except urllib.error.HTTPError as e:
             if e.code == 404 and self.test_mode:
                 raise exceptions.DataError("Track [%s] does not support test mode. Please ask the track author to add it or "
@@ -315,7 +309,7 @@ class DocumentSetPreparator:
                     msg += " (HTTP status: %s)" % str(e.code)
                 raise exceptions.DataError(msg)
         except urllib.error.URLError:
-            logger.exception("Could not download [%s] to [%s]." % (data_url, target_path))
+            self.logger.exception("Could not download [%s] to [%s]." % (data_url, target_path))
             raise exceptions.DataError("Could not download [%s] to [%s]." % (data_url, target_path))
 
         if not os.path.isfile(target_path):
@@ -469,6 +463,8 @@ def render_template_from_file(template_file_name, template_vars):
 
 
 def filter_included_tasks(t, filters):
+    logger = logging.getLogger(__name__)
+
     def match(task, filters):
         for f in filters:
             if task.matches(f):
@@ -521,6 +517,7 @@ def filters_from_included_tasks(included_tasks):
 
 
 def post_process_for_test_mode(t):
+    logger = logging.getLogger(__name__)
     logger.info("Preparing track [%s] for test mode." % str(t))
     for corpus in t.corpora:
         logger.info("Reducing corpus size to 1000 documents for [%s]" % corpus.name)
@@ -581,6 +578,7 @@ class TrackFileReader:
             self.track_schema = json.loads(f.read())
         self.track_params = cfg.opts("track", "params")
         self.read_track = TrackSpecificationReader(self.track_params)
+        self.logger = logging.getLogger(__name__)
 
     def read(self, track_name, track_spec_file, mapping_dir):
         """
@@ -592,16 +590,16 @@ class TrackFileReader:
         :return: A corresponding track instance if the track file is valid.
         """
 
-        logger.info("Reading track specification file [{}].".format(track_spec_file))
+        self.logger.info("Reading track specification file [%s].", track_spec_file)
         try:
             rendered = render_template_from_file(track_spec_file, self.track_params)
-            logger.info("Final rendered track for '{}': {}".format(track_spec_file, rendered))
+            self.logger.info("Final rendered track for '%s': %s", track_spec_file, rendered)
             track_spec = json.loads(rendered)
         except jinja2.exceptions.TemplateNotFound:
-            logger.exception("Could not load [{}]".format(track_spec_file))
+            self.logger.exception("Could not load [%s]", track_spec_file)
             raise exceptions.SystemSetupError("Track {} does not exist".format(track_name))
         except (json.JSONDecodeError, jinja2.exceptions.TemplateError) as e:
-            logger.exception("Could not load [{}].".format(track_spec_file))
+            self.logger.exception("Could not load [%s].", track_spec_file)
             # Convert to string early on to avoid serialization errors with Jinja exceptions.
             raise TrackSyntaxError("Could not load '{}'".format(track_spec_file), str(e))
         # check the track version before even attempting to validate the JSON format to avoid bogus errors.
@@ -647,7 +645,7 @@ class TrackPluginReader:
             root_module.register(self)
         except BaseException:
             msg = "Could not register track plugin at [%s]" % self.loader.root_path
-            logger.exception(msg)
+            logging.getLogger(__name__).exception(msg)
             raise exceptions.SystemSetupError(msg)
 
     def register_param_source(self, name, param_source):
@@ -677,6 +675,7 @@ class TrackSpecificationReader:
         self.name = None
         self.track_params = track_params if track_params else {}
         self.source = source
+        self.logger = logging.getLogger(__name__)
 
     def __call__(self, track_name, track_specification, mapping_dir):
         self.name = track_name
@@ -735,14 +734,14 @@ class TrackSpecificationReader:
         return track.IndexTemplate(name, index_pattern, template_content, delete_matching_indices)
 
     def _load_template(self, contents, description):
-        logger.info("Loading template [%s]." % description)
+        self.logger.info("Loading template [%s]." % description)
         try:
             rendered = render_template(loader=jinja2.DictLoader({"default": contents}),
                                        template_name="default",
                                        template_vars=self.track_params)
             return json.loads(rendered)
         except (json.JSONDecodeError, jinja2.exceptions.TemplateError) as e:
-            logger.exception("Could not load file template for %s." % description)
+            self.logger.exception("Could not load file template for %s." % description)
             raise TrackSyntaxError("Could not load file template for '%s'" % description, str(e))
 
     def _create_corpora(self, corpora_specs, indices):
@@ -985,9 +984,9 @@ class TrackSpecificationReader:
             if "include-in-reporting" not in params:
                 params["include-in-reporting"] = not op.admin_op
             op_type = op.name
-            logger.debug("Using built-in operation type [%s] for operation [%s]." % (op_type, op_name))
+            self.logger.debug("Using built-in operation type [%s] for operation [%s]." % (op_type, op_name))
         except KeyError:
-            logger.info("Using user-provided operation type [%s] for operation [%s]." % (op_type_name, op_name))
+            self.logger.info("Using user-provided operation type [%s] for operation [%s]." % (op_type_name, op_name))
             op_type = op_type_name
 
         try:

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -630,7 +630,7 @@ def create_readers(num_clients, client_index, corpora, batch_size, bulk_size, id
                 readers.append(create_reader(docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability,
                                              on_conflict))
             else:
-                logger.info("Task-relative client at index [%d] skips [%s] (no documents to read)." % (client_index, corpus.name))
+                logger.info("Task-relative client at index [%d] skips [%s] (no documents to read).", client_index, corpus.name)
     return readers
 
 
@@ -772,11 +772,11 @@ class Slice:
         logger = logging.getLogger(__name__)
         self.source = self.source_class(file_name, mode).open()
         # skip offset number of lines
-        logger.info("Skipping %d lines in [%s]." % (self.offset, file_name))
+        logger.info("Skipping %d lines in [%s].", self.offset, file_name)
         start = time.perf_counter()
         io.skip_lines(file_name, self.source, self.offset)
         end = time.perf_counter()
-        logger.info("Skipping %d lines took %f s." % (self.offset, end - start))
+        logger.info("Skipping %d lines took %f s.", self.offset, end - start)
         return self
 
     def close(self):
@@ -841,7 +841,7 @@ class IndexDataReader:
                 raise StopIteration()
             return self.index_name, self.type_name, batch
         except IOError:
-            logging.getLogger(__name__).exception("Could not read [%s]" % self.data_file)
+            logging.getLogger(__name__).exception("Could not read [%s]", self.data_file)
 
     def read_bulk(self):
         docs_in_bulk = 0

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -1,9 +1,6 @@
-import logging
 from enum import Enum, unique
 
 from esrally import exceptions
-
-logger = logging.getLogger("rally.track")
 
 
 class Index:

--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -6,11 +6,8 @@ import bz2
 import gzip
 import zipfile
 import tarfile
-import logging
 
 from esrally.utils import console
-
-logger = logging.getLogger("rally.utils.io")
 
 
 class FileSource:
@@ -278,7 +275,7 @@ def prepare_file_offset_table(data_file_path):
     offset_file_path = "%s.offset" % data_file_path
     # recreate only if necessary as this can be time-consuming
     if not os.path.exists(offset_file_path) or os.path.getmtime(offset_file_path) < os.path.getmtime(data_file_path):
-        console.info("Preparing file offset table for [%s] ... " % data_file_path, end="", flush=True, logger=logger)
+        console.info("Preparing file offset table for [%s] ... " % data_file_path, end="", flush=True)
         line_number = 0
         with open(offset_file_path, mode="wt", encoding="utf-8") as offset_file:
             with open(data_file_path, mode="rt", encoding="utf-8") as data_file:
@@ -292,7 +289,6 @@ def prepare_file_offset_table(data_file_path):
         console.println("[OK]")
         return line_number
     else:
-        logger.info("Skipping creation of file offset table at [%s] as it is still valid." % offset_file_path)
         return None
 
 
@@ -304,10 +300,7 @@ def remove_file_offset_table(data_file_path):
     :param data_file_path: The path to a text file that is readable by this process.
     """
     offset_file_path = "%s.offset" % data_file_path
-    try:
-        os.remove(offset_file_path)
-    except OSError as e:
-        logger.debug("Error while attempting to delete [%s]: [%s]" % (offset_file_path, e))
+    os.remove(offset_file_path)
 
 
 def skip_lines(data_file_path, data_file, number_of_lines_to_skip):

--- a/esrally/utils/modules.py
+++ b/esrally/utils/modules.py
@@ -6,8 +6,6 @@ import importlib.machinery
 from esrally import exceptions
 from esrally.utils import io
 
-logger = logging.getLogger("rally.modules")
-
 
 class ComponentLoader:
     """
@@ -30,6 +28,7 @@ class ComponentLoader:
         self.root_path = root_path
         self.component_entry_point = component_entry_point
         self.recurse = recurse
+        self.logger = logging.getLogger(__name__)
 
     def _modules(self, module_paths, component_name):
         for path in module_paths:
@@ -45,7 +44,7 @@ class ComponentLoader:
         root_module_name = "%s.%s" % (component_name, self.component_entry_point)
 
         for p in self._modules(module_dirs, component_name):
-            logger.debug("Loading module [%s]" % p)
+            self.logger.debug("Loading module [%s]", p)
             m = importlib.import_module(p)
             importlib.reload(m)
             if p == root_module_name:
@@ -67,7 +66,7 @@ class ComponentLoader:
         :return: The root module.
         """
         component_name = io.basename(self.root_path)
-        logger.info("Loading component [%s] from [%s]" % (component_name, self.root_path))
+        self.logger.info("Loading component [%s] from [%s]", component_name, self.root_path)
         module_dirs = []
         # search all paths within this directory for modules but exclude all directories starting with "_"
         if self.recurse:
@@ -76,7 +75,7 @@ class ComponentLoader:
                 ignore = []
                 for d in dirs:
                     if d.startswith("_"):
-                        logger.debug("Removing [%s] from load path." % d)
+                        self.logger.debug("Removing [%s] from load path.", d)
                         ignore.append(d)
                 for d in ignore:
                     dirs.remove(d)
@@ -84,13 +83,13 @@ class ComponentLoader:
             module_dirs.append(self.root_path)
         # load path is only the root of the package hierarchy
         component_root_path = os.path.abspath(os.path.join(self.root_path, os.pardir))
-        logger.debug("Adding [%s] to Python load path." % component_root_path)
+        self.logger.debug("Adding [%s] to Python load path.", component_root_path)
         # needs to be at the beginning of the system path, otherwise import machinery tries to load application-internal modules
         sys.path.insert(0, component_root_path)
         try:
             root_module = self._load_component(component_name, module_dirs)
             return root_module
         except BaseException:
-            msg = "Could not load component [%s]" % component_name
-            logger.exception(msg)
+            msg = "Could not load component [{}]".format(component_name)
+            self.logger.exception(msg)
             raise exceptions.SystemSetupError(msg)

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -8,14 +8,13 @@ from esrally import exceptions
 
 __HTTP = None
 
-logger = logging.getLogger("rally.net")
-
 
 def init():
+    logger = logging.getLogger(__name__)
     global __HTTP
     proxy_url = os.getenv("http_proxy")
     if proxy_url and len(proxy_url) > 0:
-        logger.info("Rally connects via proxy URL [%s] to the Internet (picked up from the environment variable [http_proxy])." % proxy_url)
+        logger.info("Rally connects via proxy URL [%s] to the Internet (picked up from the environment variable [http_proxy]).",  proxy_url)
         __HTTP = urllib3.ProxyManager(proxy_url, cert_reqs='CERT_REQUIRED', ca_certs=certifi.where())
     else:
         logger.info("Rally connects directly to the Internet (no proxy support).")
@@ -96,15 +95,16 @@ def retrieve_content_as_string(url):
 
 
 def has_internet_connection():
+    logger = logging.getLogger(__name__)
     try:
         # We connect to Github anyway later on so we use that to avoid touching too much different remote endpoints.
         probing_url = "https://github.com/"
-        logger.debug("Checking for internet connection against [%s]" % probing_url)
+        logger.debug("Checking for internet connection against [%s]", probing_url)
         # We do a HTTP request here to respect the HTTP proxy setting. If we'd open a plain socket connection we circumvent the
         # proxy and erroneously conclude we don't have an Internet connection.
         response = __http().request("GET", probing_url, timeout=2.0)
         status = response.status
-        logger.debug("Probing result is HTTP status [%s]" % str(status))
+        logger.debug("Probing result is HTTP status [%s]", str(status))
         return status == 200
     except BaseException:
         return False

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -51,11 +51,11 @@ def run_subprocess_with_logging(command_line, header=None, level=logging.INFO, e
     :return: The process exit code as an int.
     """
     logger = logging.getLogger(__name__)
-    logger.debug("Running subprocess [%s] with logging." % command_line)
+    logger.debug("Running subprocess [%s] with logging.", command_line)
     command_line_args = shlex.split(command_line)
     if header is not None:
         logger.info(header)
-    logger.debug("Invoking subprocess '%s'" % command_line)
+    logger.debug("Invoking subprocess '%s'", command_line)
     with subprocess.Popen(command_line_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env) as command_line_process:
         has_output = True
         while has_output:
@@ -64,7 +64,7 @@ def run_subprocess_with_logging(command_line, header=None, level=logging.INFO, e
                 logger.log(level=level, msg=line)
             else:
                 has_output = False
-    logger.debug("Subprocess [%s] finished with return code [%s]." % (command_line, str(command_line_process.returncode)))
+    logger.debug("Subprocess [%s] finished with return code [%s].", command_line, str(command_line_process.returncode))
     return command_line_process.returncode
 
 
@@ -78,7 +78,7 @@ def kill_running_es_instances(trait):
     def elasticsearch_process(p):
         return p.name() == "java" and any("elasticsearch" in e for e in p.cmdline()) and any(trait in e for e in p.cmdline())
 
-    logging.getLogger(__name__).info("Killing all processes which match [java], [elasticsearch] and [%s]" % trait)
+    logging.getLogger(__name__).info("Killing all processes which match [java], [elasticsearch] and [%s]", trait)
     kill_all(elasticsearch_process)
 
 
@@ -98,7 +98,7 @@ def find_all_other_rally_processes():
 
 def kill_all(predicate):
     def kill(p):
-        logging.getLogger(__name__).info("Killing lingering process with PID [%s] and command line [%s]." % (p.pid, p.cmdline()))
+        logging.getLogger(__name__).info("Killing lingering process with PID [%s] and command line [%s].", p.pid, p.cmdline())
         p.kill()
         # wait until process has terminated, at most 3 seconds. Otherwise we might run into race conditions with actor system
         # sockets that are still open.

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -5,8 +5,6 @@ import logging
 from esrally import exceptions
 from esrally.utils import git, console, versions
 
-logger = logging.getLogger("rally.repo")
-
 
 class RallyRepository:
     """
@@ -20,6 +18,7 @@ class RallyRepository:
         self.repo_dir = os.path.join(root_dir, repo_name)
         self.resource_name = resource_name
         self.offline = offline
+        self.logger = logging.getLogger(__name__)
         if self.remote and not self.offline and fetch:
             # a normal git repo with a remote
             if not git.is_working_copy(self.repo_dir):
@@ -28,7 +27,7 @@ class RallyRepository:
                 try:
                     git.fetch(src=self.repo_dir)
                 except exceptions.SupplyError:
-                    console.warn("Could not update %s. Continuing with your locally available state." % self.resource_name, logger=logger)
+                    console.warn("Could not update %s. Continuing with your locally available state." % self.resource_name)
         else:
             if not git.is_working_copy(self.repo_dir):
                 raise exceptions.SystemSetupError("[{src}] must be a git repository.\n\nPlease run:\ngit -C {src} init"
@@ -40,14 +39,14 @@ class RallyRepository:
                 branch = versions.best_match(git.branches(self.repo_dir, remote=self.remote), distribution_version)
                 if branch:
                     # Allow uncommitted changes iff we do not have to change the branch
-                    logger.info(
-                        "Checking out [%s] in [%s] for distribution version [%s]." % (branch, self.repo_dir, distribution_version))
+                    self.logger.info(
+                        "Checking out [%s] in [%s] for distribution version [%s].", branch, self.repo_dir, distribution_version)
                     git.checkout(self.repo_dir, branch=branch)
-                    logger.info("Rebasing on [%s] in [%s] for distribution version [%s]." % (branch, self.repo_dir, distribution_version))
+                    self.logger.info("Rebasing on [%s] in [%s] for distribution version [%s].", branch, self.repo_dir, distribution_version)
                     try:
                         git.rebase(self.repo_dir, branch=branch)
                     except exceptions.SupplyError:
-                        logger.exception("Cannot rebase due to local changes in [%s]" % self.repo_dir)
+                        self.logger.exception("Cannot rebase due to local changes in [%s]" % self.repo_dir)
                         console.warn(
                             "Local changes in [%s] prevent %s update from remote. Please commit your changes." %
                             (self.repo_dir, self.resource_name))
@@ -55,10 +54,10 @@ class RallyRepository:
                 else:
                     msg = "Could not find %s remotely for distribution version [%s]. Trying to find %s locally." % \
                           (self.resource_name, distribution_version, self.resource_name)
-                    logger.warning(msg)
+                    self.logger.warning(msg)
             branch = versions.best_match(git.branches(self.repo_dir, remote=False), distribution_version)
             if branch:
-                logger.info("Checking out [%s] in [%s] for distribution version [%s]." % (branch, self.repo_dir, distribution_version))
+                self.logger.info("Checking out [%s] in [%s] for distribution version [%s]." % (branch, self.repo_dir, distribution_version))
                 git.checkout(self.repo_dir, branch=branch)
             else:
                 raise exceptions.SystemSetupError("Cannot find %s for distribution version %s" % (self.resource_name, distribution_version))

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -46,7 +46,7 @@ class RallyRepository:
                     try:
                         git.rebase(self.repo_dir, branch=branch)
                     except exceptions.SupplyError:
-                        self.logger.exception("Cannot rebase due to local changes in [%s]" % self.repo_dir)
+                        self.logger.exception("Cannot rebase due to local changes in [%s]", self.repo_dir)
                         console.warn(
                             "Local changes in [%s] prevent %s update from remote. Please commit your changes." %
                             (self.repo_dir, self.resource_name))
@@ -57,7 +57,7 @@ class RallyRepository:
                     self.logger.warning(msg)
             branch = versions.best_match(git.branches(self.repo_dir, remote=False), distribution_version)
             if branch:
-                self.logger.info("Checking out [%s] in [%s] for distribution version [%s]." % (branch, self.repo_dir, distribution_version))
+                self.logger.info("Checking out [%s] in [%s] for distribution version [%s].", branch, self.repo_dir, distribution_version)
                 git.checkout(self.repo_dir, branch=branch)
             else:
                 raise exceptions.SystemSetupError("Cannot find %s for distribution version %s" % (self.resource_name, distribution_version))

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -159,10 +159,10 @@ function test_sources {
     # build Elasticsearch and a core plugin
     info "test sources [--configuration-name=${cfg}], [--revision=latest], [--track=geonames], [--challenge=append-no-conflicts], [--car=4gheap] [--elasticsearch-plugins=analysis-icu]"
     kill_rally_processes
-    esrally --logging=console --configuration-name="${cfg}" --revision=latest --track=geonames --test-mode --challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu
+    esrally --configuration-name="${cfg}" --revision=latest --track=geonames --test-mode --challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu
     info "test sources [--configuration-name=${cfg}], [--pipeline=from-sources-skip-build], [--track=geonames], [--challenge=append-no-conflicts-index-only], [--car=4gheap,ea] [--laps=2]"
     kill_rally_processes
-    esrally --logging=console --configuration-name="${cfg}" --pipeline=from-sources-skip-build --track=geonames --test-mode --challenge=append-no-conflicts-index-only --car="4gheap,ea" --laps=2
+    esrally --configuration-name="${cfg}" --pipeline=from-sources-skip-build --track=geonames --test-mode --challenge=append-no-conflicts-index-only --car="4gheap,ea" --laps=2
 }
 
 function test_distributions {
@@ -175,7 +175,7 @@ function test_distributions {
             random_configuration cfg
             info "test distributions [--configuration-name=${cfg}], [--distribution-version=${dist}], [--track=${track}], [--car=4gheap]"
             kill_rally_processes
-            esrally --logging=console --configuration-name="${cfg}" --distribution-version="${dist}" --track="${track}" --test-mode --car=4gheap
+            esrally --configuration-name="${cfg}" --distribution-version="${dist}" --track="${track}" --test-mode --car=4gheap
         done
     done
 }
@@ -188,7 +188,7 @@ function test_benchmark_only {
 
     info "test benchmark-only [--configuration-name=${cfg}]"
     kill_rally_processes
-    esrally --logging=console --configuration-name="${cfg}" --pipeline=benchmark-only --track=geonames --test-mode --challenge=append-no-conflicts-index-only --track-params="cluster_health:'yellow'"
+    esrally --configuration-name="${cfg}" --pipeline=benchmark-only --track=geonames --test-mode --challenge=append-no-conflicts-index-only --track-params="cluster_health:'yellow'"
 }
 
 function run_test {

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from datetime import datetime
 
 from esrally import metrics, track, exceptions, config
-from esrally.driver import driver
+from esrally.driver import driver, runner
 from esrally.track import params
 
 
@@ -418,6 +418,7 @@ class SchedulerTests(ScheduleTestCase):
     def setUp(self):
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
         params.register_param_source_for_name("driver-test-param-source-with-progress", DriverTestParamSourceWithProgress)
+        runner.register_default_runners()
         self.test_track = track.Track(name="unittest")
 
     def test_search_task_one_client(self):
@@ -589,6 +590,9 @@ class ExecutorTests(TestCase):
 
     def context_managed(self, mock):
         return ExecutorTests.NoopContextManager(mock)
+
+    def setUp(self):
+        runner.register_default_runners()
 
     @mock.patch("elasticsearch.Elasticsearch")
     def test_execute_schedule_in_throughput_mode(self, es):

--- a/tests/utils/repo_test.py
+++ b/tests/utils/repo_test.py
@@ -5,7 +5,7 @@ from esrally import exceptions
 from esrally.utils import repo
 
 
-class RallyRepository(TestCase):
+class RallyRepositoryTests(TestCase):
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
     def test_fails_in_offline_mode_if_not_a_git_repo(self, is_working_copy):
         is_working_copy.return_value = False


### PR DESCRIPTION
With this commit, Rally's logging configuration is read from a JSON
configuration file. To make this work reliably, we remove all
module-level loggers and have them either scoped to a function or class.
This ensures that Python does not implicitly initialize logging before
it is actually configured.

We also ensure that a default logging configuration file is present in
`~/.rally/logging.json` and that the default log directory
`~/.rally/logs` is present as well.

We lazy-format all logging statements, i.e. we switch from the  form 
`logger.level("str" % param)` to `logger.level("str", param)`. In a few
cases we also change the logging level or reword the message slightly.

Finally, we remove the undocumented command line parameter `--logging`
which allowed to log either to console or a file as this can now be
achieved instead within the configuration file.

Closes #230