### PR TITLE
Commit ccr-stats telemetry device and tests

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -80,7 +80,7 @@ class ClusterLauncher:
             telemetry.GcTimesSummary(es_default, self.metrics_store),
             telemetry.IndexStats(es_default, self.metrics_store),
             telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
-            telemetry.CCRStats(telemetry_params, es, self.metrics_store)
+            telemetry.CcrStats(telemetry_params, es, self.metrics_store)
         ])
 
         # The list of nodes will be populated by ClusterMetaDataInfo, so no need to do it here

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -79,7 +79,8 @@ class ClusterLauncher:
             telemetry.ClusterEnvironmentInfo(es_default, self.metrics_store),
             telemetry.GcTimesSummary(es_default, self.metrics_store),
             telemetry.IndexStats(es_default, self.metrics_store),
-            telemetry.MlBucketProcessingTime(es_default, self.metrics_store)
+            telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
+            telemetry.CCRStats(telemetry_params, es, self.metrics_store)
         ])
 
         # The list of nodes will be populated by ClusterMetaDataInfo, so no need to do it here

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -3,9 +3,9 @@ import os
 import re
 import signal
 import subprocess
+import tabulate
 import threading
 
-import tabulate
 from esrally import metrics, time, exceptions
 from esrally.utils import io, sysstats, process, console, versions
 
@@ -274,6 +274,159 @@ class PerfStat(TelemetryDevice):
                 logger.warning("perf stat did not terminate")
             self.log.close()
             self.attached = False
+
+
+class CCRStats(TelemetryDevice):
+    internal = False
+    command = "ccr-stats"
+    human_name = "CCR Stats"
+    help = "Regularly samples CCR related stats"
+
+    """
+    Gathers CCR stats on a cluster level
+    """
+
+    def __init__(self, telemetry_params, clients, metrics_store):
+        """
+        :param telemetry_params: The configuration object for telemetry_params.
+            May optionally specify:
+            ``ccr-stats-indices``: JSON object specifying the indices per cluster to pushish statistics from.
+            Not all clusters need to be specified, but any name used must be be present in target.hosts.
+            Example:
+            {"ccr-stats-indices": {"cluster_a": ["follower"],"default": ["leader"]}
+            ``ccr-stats-sample-interval``: integer controlling the interval, in seconds, between collecting samples.
+        :param clients: A dict of client connections to all clusters.
+        :param metrics_store: The configured metrics store we write to.
+        """
+        super().__init__()
+
+        self.telemetry_params = telemetry_params
+        self.clients = clients
+        self.sample_interval = telemetry_params.get("ccr-stats-sample-interval", 1)
+        if self.sample_interval <= 0:
+            raise exceptions.SystemSetupError(
+                "The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was {}.".format(self.sample_interval))
+        self.specified_cluster_names = self.clients.keys()
+        self.indices_per_cluster = self.telemetry_params.get("ccr-stats-indices", False)
+        if self.indices_per_cluster:
+            for cluster_name in self.indices_per_cluster.keys():
+                if cluster_name not in clients.keys():
+                    raise exceptions.SystemSetupError(
+                        "The telemetry parameter 'ccr-stats-indices' must be a JSON Object with keys matching the cluster names "
+                        "specified in --target-hosts but it had [{}].".format(cluster_name))
+            self.specified_cluster_names = self.indices_per_cluster.keys()
+
+        self.metrics_store = metrics_store
+        self.samplers = []
+
+    def attach_to_cluster(self, cluster):
+        # This cluster parameter does not correspond to the cluster names passed in target.hosts, see on_benchmark_start()
+        super().attach_to_cluster(cluster)
+
+    def on_benchmark_start(self):
+        recorder = []
+        for cluster_name in self.specified_cluster_names:
+            recorder = CCRStatsRecorder(cluster_name, self.clients[cluster_name], self.metrics_store, self.sample_interval,
+                                        self.indices_per_cluster[cluster_name] if self.indices_per_cluster else None)
+            sampler = SamplerThread(recorder)
+            self.samplers.append(sampler)
+            sampler.setDaemon(True)
+            # we don't require starting recorders precisely at the same time
+            sampler.start()
+
+    def on_benchmark_stop(self):
+        if self.samplers:
+            for sampler in self.samplers:
+                sampler.finish()
+
+
+class CCRStatsRecorder:
+    """
+    Collects and pushes CCR stats for the specified cluster to the metric store.
+    """
+
+    def __init__(self, cluster_name, client, metrics_store, sample_interval, indices=None):
+        """
+        :param cluster_name: The cluster_name that the client connects to, as specified in target.hosts.
+        :param client: The Elasticsearch client connection to the cluster.
+        :param metrics_store: The configured metrics store we write to.
+        :param sample_interval: integer controlling the interval, in seconds, between collecting samples.
+        :param indices: optional list of indices to filter results from.
+        """
+
+        self.cluster_name = cluster_name
+        self.client = client
+        self.metrics_store = metrics_store
+        self.sample_interval= sample_interval
+        self.indices = indices
+
+    def __str__(self):
+        return "ccr stats"
+
+    def record(self):
+        """
+        Collect CCR stats for indexes (optionally) specified in telemetry parameters and push to metrics store.
+        """
+
+        # ES returns all stats values in bytes or ms via "human: false"
+        stats = self.client.transport.perform_request('GET', '/_xpack/ccr/_stats', params={"human": "false"})
+        if self.indices:
+            # Record metrics only for indices specified with telemetry-params.
+            for index in self.indices:
+                try:
+                    if stats[index] == {}:
+                        continue
+                    self.record_all_index_stats(index, stats[index])
+                except KeyError:
+                    logger.warning("The telemetry parameter 'ccr-stats-indices' specified the index [%s] for cluster [%s] but there are "
+                                   "no stats available. Maybe the index hasn't been created yet, ignoring.",
+                                   index,
+                                   self.cluster_name)
+        else:
+            # Record metrics for every index returned by the CCR stats API.
+            if stats != {}:
+                for index, stats in stats.items():
+                    self.record_all_index_stats(index, stats)
+            pass
+        time.sleep(self.sample_interval)
+
+    def record_all_index_stats(self, name, stats):
+        """
+        Push metric fields per shard to separate docs in metrics store.
+
+        :param name: The index name.
+        :param stats: A dict with returned CCR stats for the index.
+        """
+
+        shard_metadata = {}
+
+        for shard_num, shard_stats in stats.items():
+            shard_metadata = {
+                "cluster": self.cluster_name,
+                "index": name,
+                "shard": shard_num
+            }
+
+            for metric_name, metric_value in shard_stats.items():
+                self.put_value(metric_name, metric_value, shard_metadata)
+
+    def put_value(self, metric_name, metric_value, shard_metadata):
+        if isinstance(metric_value, (int, float)) and not isinstance(metric_value, bool):
+            # auto-recognize metric keys containing well-known keywords
+            if "_bytes" in metric_name:
+                self.metrics_store.put_count_cluster_level(name=metric_name,
+                                                           count=metric_value,
+                                                           unit="byte",
+                                                           meta_data=shard_metadata)
+            elif "_millis" in metric_name:
+                self.metrics_store.put_count_cluster_level(name=metric_name,
+                                                           count=metric_value,
+                                                           unit="millis",
+                                                           meta_data=shard_metadata)
+            else:
+                self.metrics_store.put_count_cluster_level(name=metric_name,
+                                                           count=metric_value,
+                                                           meta_data=shard_metadata)
 
 
 class NodeStats(TelemetryDevice):

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -310,7 +310,7 @@ class CcrStats(TelemetryDevice):
         self.indices_per_cluster = self.telemetry_params.get("ccr-stats-indices", False)
         if self.indices_per_cluster:
             for cluster_name in self.indices_per_cluster.keys():
-                if cluster_name not in clients.keys():
+                if cluster_name not in clients:
                     raise exceptions.SystemSetupError(
                         "The telemetry parameter 'ccr-stats-indices' must be a JSON Object with keys matching "
                         "the cluster names [{}] specified in --target-hosts but it had [{}].".format(",".join(clients.keys()), cluster_name))

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -125,10 +125,12 @@ class MergePartsDeviceTests(TestCase):
 
 
 class Client:
-    def __init__(self, nodes=None, info=None, indices=None):
+    def __init__(self, nodes=None, info=None, indices=None, transport_client=None):
         self.nodes = nodes
         self._info = info
         self.indices = indices
+        if transport_client:
+            self.transport = transport_client
 
     def info(self):
         return self._info
@@ -144,6 +146,14 @@ class SubClient:
 
     def info(self, *args, **kwargs):
         return self._info
+
+
+class TransportClient:
+    def __init__(self, stats=None):
+        self._stats = stats
+
+    def perform_request(self, *args, **kwargs):
+        return self._stats
 
 
 class JfrTests(TestCase):
@@ -198,6 +208,214 @@ class GcTests(TestCase):
         self.assertEqual(
             "-Xlog:gc*=info,safepoint=info,age*=trace:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0",
             env["ES_JAVA_OPTS"])
+
+
+class CCRStatsTests(TestCase):
+    def test_negative_sample_interval_forbidden(self):
+        clients = { "default": Client(), "cluster_b": Client() }
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        telemetry_params = {
+            "ccr-stats-sample-interval": -1 * random.random()
+        }
+        with self.assertRaisesRegex(exceptions.SystemSetupError,
+                                    "The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was .*\."):
+            telemetry.CCRStats(telemetry_params, clients, metrics_store)
+
+    def test_wrong_cluster_name_in_ccr_stats_indices_forbidden(self):
+        clients = { "default": Client(), "cluster_b": Client() }
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        telemetry_params = {
+            "ccr-stats-indices":{
+                "default": ["leader"],
+                "wrong_cluster_name": ["follower"]
+            }
+        }
+        with self.assertRaisesRegex(exceptions.SystemSetupError,
+                                    "The telemetry parameter 'ccr-stats-indices' must be a JSON Object with keys matching the cluster names "
+                                    "specified in --target-hosts but it had \[wrong_cluster_name\]."):
+            telemetry.CCRStats(telemetry_params, clients, metrics_store)
+
+
+class CCRStatsRecorderTests(TestCase):
+    @mock.patch("esrally.metrics.EsMetricsStore.put_count_cluster_level")
+    def test_stores_default_ccr_stats(self, metrics_store_put_count):
+        total_fetch_time_millis = random.randint(0,9999999)
+        total_index_time_millis = random.randint(0,9999999)
+        operations_received_field = random.randint(0,9999999)
+        number_of_batches_field = random.randint(0,9999999)
+        total_transferred_bytes = random.randint(0,999999999)
+        current_idle_time_millis = random.randint(0,9999999)
+        leader_max_seq_no = random.randint(0,9999999)
+        follower_primary_max_seq_no = random.randint(0,9999999)
+        processed_global_checkpoint = random.randint(0,9999999)
+
+        ccr_stats_follower_response = {
+            "follower": {
+                "0": {
+                    "total_fetch_time_millis": total_fetch_time_millis,
+                    "total_index_time_millis": total_index_time_millis,
+                    "operations_received_field": operations_received_field,
+                    "number_of_batches_field": number_of_batches_field,
+                    "total_transferred_bytes": total_transferred_bytes,
+                    "current_idle_time_millis": current_idle_time_millis,
+                    "leader_max_seq_no": leader_max_seq_no,
+                    "follower_primary_max_seq_no": follower_primary_max_seq_no,
+                    "processed_global_checkpoint": processed_global_checkpoint
+                }
+            }
+        }
+
+        client = Client(transport_client=TransportClient(stats=ccr_stats_follower_response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        recorder = telemetry.CCRStatsRecorder("remote", client, metrics_store, 1)
+        recorder.record()
+
+        shard_metadata = {
+            "cluster": "remote",
+            "index": "follower",
+            "shard": '0'
+        }
+
+        metrics_store_put_count.assert_has_calls([
+            mock.call(name="total_fetch_time_millis", count=total_fetch_time_millis, unit="millis", meta_data=shard_metadata),
+            mock.call(name="total_index_time_millis", count=total_index_time_millis, unit="millis", meta_data=shard_metadata),
+            mock.call(name="operations_received_field", count=operations_received_field, meta_data=shard_metadata),
+            mock.call(name="number_of_batches_field", count=number_of_batches_field, meta_data=shard_metadata),
+            mock.call(name="total_transferred_bytes", count=total_transferred_bytes, unit="byte", meta_data=shard_metadata),
+            mock.call(name="current_idle_time_millis", count=current_idle_time_millis, unit="millis", meta_data=shard_metadata),
+            mock.call(name="leader_max_seq_no", count=leader_max_seq_no, meta_data=shard_metadata),
+            mock.call(name="follower_primary_max_seq_no", count=follower_primary_max_seq_no, meta_data=shard_metadata),
+            mock.call(name="processed_global_checkpoint", count=processed_global_checkpoint, meta_data=shard_metadata),
+        ], any_order=True)
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_count_cluster_level")
+    def test_stores_default_ccr_stats_many_shards(self, metrics_store_put_count):
+        shard_range = range(2)
+        total_fetch_time_millis = [random.randint(0,9999999) for i in shard_range]
+        total_index_time_millis = [random.randint(0,9999999) for i in shard_range]
+        operations_received_field = [random.randint(0,9999999) for i in shard_range]
+        number_of_batches_field = [random.randint(0,9999999) for i in shard_range]
+        total_transferred_bytes = [random.randint(0,999999999) for i in shard_range]
+        current_idle_time_millis = [random.randint(0,9999999) for i in shard_range]
+        leader_max_seq_no = [random.randint(0,9999999) for i in shard_range]
+        follower_primary_max_seq_no = [random.randint(0,9999999) for i in shard_range]
+        processed_global_checkpoint = [random.randint(0,9999999) for i in shard_range]
+
+        ccr_stats_follower_response = {
+            "follower": {
+                str(shard_num): {
+                    "total_fetch_time_millis": total_fetch_time_millis[shard_num],
+                    "total_index_time_millis": total_index_time_millis[shard_num],
+                    "operations_received_field": operations_received_field[shard_num],
+                    "number_of_batches_field": number_of_batches_field[shard_num],
+                    "total_transferred_bytes": total_transferred_bytes[shard_num],
+                    "current_idle_time_millis": current_idle_time_millis[shard_num],
+                    "leader_max_seq_no": leader_max_seq_no[shard_num],
+                    "follower_primary_max_seq_no": follower_primary_max_seq_no[shard_num],
+                    "processed_global_checkpoint": processed_global_checkpoint[shard_num]
+                } for shard_num in shard_range
+            }
+        }
+
+        client = Client(transport_client=TransportClient(stats=ccr_stats_follower_response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        recorder = telemetry.CCRStatsRecorder("remote", client, metrics_store, 1)
+        recorder.record()
+
+        shard_metadata = [
+            {
+                "cluster": "remote",
+                "index": "follower",
+                "shard": '0'
+            },
+            {
+                "cluster": "remote",
+                "index": "follower",
+                "shard": '1'
+            }
+        ]
+
+        for shard_num in shard_range:
+            metrics_store_put_count.assert_has_calls([
+                mock.call(name="total_fetch_time_millis", count=total_fetch_time_millis[shard_num], unit="millis", meta_data=shard_metadata[shard_num]),
+                mock.call(name="total_index_time_millis", count=total_index_time_millis[shard_num], unit="millis", meta_data=shard_metadata[shard_num]),
+                mock.call(name="operations_received_field", count=operations_received_field[shard_num], meta_data=shard_metadata[shard_num]),
+                mock.call(name="number_of_batches_field", count=number_of_batches_field[shard_num], meta_data=shard_metadata[shard_num]),
+                mock.call(name="total_transferred_bytes", count=total_transferred_bytes[shard_num], unit="byte", meta_data=shard_metadata[shard_num]),
+                mock.call(name="current_idle_time_millis", count=current_idle_time_millis[shard_num], unit="millis", meta_data=shard_metadata[shard_num]),
+                mock.call(name="leader_max_seq_no", count=leader_max_seq_no[shard_num], meta_data=shard_metadata[shard_num]),
+                mock.call(name="follower_primary_max_seq_no", count=follower_primary_max_seq_no[shard_num], meta_data=shard_metadata[shard_num]),
+                mock.call(name="processed_global_checkpoint", count=processed_global_checkpoint[shard_num], meta_data=shard_metadata[shard_num]),
+            ], any_order=True)
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_count_cluster_level")
+    def test_stores_filtered_ccr_stats(self, metrics_store_put_count):
+        total_fetch_time_millis = random.randint(0,9999999)
+        total_index_time_millis = random.randint(0,9999999)
+        operations_received_field = random.randint(0,9999999)
+        number_of_batches_field = random.randint(0,9999999)
+        total_transferred_bytes = random.randint(0,999999999)
+        current_idle_time_millis = random.randint(0,9999999)
+        leader_max_seq_no = random.randint(0,9999999)
+        follower_primary_max_seq_no = random.randint(0,9999999)
+        processed_global_checkpoint = random.randint(0,9999999)
+
+        ccr_stats_follower_response = {
+            "follower1": {
+                "0": {
+                    "total_fetch_time_millis": total_fetch_time_millis,
+                    "total_index_time_millis": total_index_time_millis,
+                    "operations_received_field": operations_received_field,
+                    "number_of_batches_field": number_of_batches_field,
+                    "total_transferred_bytes": total_transferred_bytes,
+                    "current_idle_time_millis": current_idle_time_millis,
+                    "leader_max_seq_no": leader_max_seq_no,
+                    "follower_primary_max_seq_no": follower_primary_max_seq_no,
+                    "processed_global_checkpoint": processed_global_checkpoint
+                }
+            },
+            "follower2": {
+                "0": {
+                    "total_fetch_time_millis": random.randint(0,9999999),
+                    "total_index_time_millis": random.randint(0,9999999),
+                    "operations_received_field": random.randint(0,9999999),
+                    "number_of_batches_field": random.randint(0,9999999),
+                    "total_transferred_bytes": random.randint(0,999999999),
+                    "current_idle_time_millis": random.randint(0,9999999),
+                    "leader_max_seq_no": random.randint(0,9999999),
+                    "follower_primary_max_seq_no": random.randint(0,9999999),
+                    "processed_global_checkpoint": random.randint(0,9999999)
+                }
+            }
+        }
+
+        client = Client(transport_client=TransportClient(stats=ccr_stats_follower_response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        recorder = telemetry.CCRStatsRecorder("remote", client, metrics_store, 1, indices=["follower1"])
+        recorder.record()
+
+        shard_metadata = {
+            "cluster": "remote",
+            "index": "follower1",
+            "shard": '0'
+        }
+
+        metrics_store_put_count.assert_has_calls([
+            mock.call(name="total_fetch_time_millis", count=total_fetch_time_millis, unit="millis", meta_data=shard_metadata),
+            mock.call(name="total_index_time_millis", count=total_index_time_millis, unit="millis", meta_data=shard_metadata),
+            mock.call(name="operations_received_field", count=operations_received_field, meta_data=shard_metadata),
+            mock.call(name="number_of_batches_field", count=number_of_batches_field, meta_data=shard_metadata),
+            mock.call(name="total_transferred_bytes", count=total_transferred_bytes, unit="byte", meta_data=shard_metadata),
+            mock.call(name="current_idle_time_millis", count=current_idle_time_millis, unit="millis", meta_data=shard_metadata),
+            mock.call(name="leader_max_seq_no", count=leader_max_seq_no, meta_data=shard_metadata),
+            mock.call(name="follower_primary_max_seq_no", count=follower_primary_max_seq_no, meta_data=shard_metadata),
+            mock.call(name="processed_global_checkpoint", count=processed_global_checkpoint, meta_data=shard_metadata),
+        ], any_order=True)
 
 
 class NodeStatsRecorderTests(TestCase):

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -245,8 +245,7 @@ class CcrStatsTests(TestCase):
 
 
 class CcrStatsRecorderTests(TestCase):
-    @mock.patch("esrally.metrics.EsMetricsStore.put_count_cluster_level")
-    def test_raises_exception_on_transport_error(self, metrics_store_put_count):
+    def test_raises_exception_on_transport_error(self):
         client = Client(transport_client=TransportClient(response={}, force_error=True))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)


### PR DESCRIPTION
This PR adds a telemetry device called `ccr-stats`.

As this is meant to be used mostly internally no accompanying documentation is available yet, but I put some effort to document the Classes/Methods.