### PR TITLE
Set retry-on-timeout=true for ES clients used by Telemetry devices

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -69,6 +69,8 @@ class ClusterLauncher:
         for cluster_name, cluster_hosts in all_hosts.items():
             all_client_options = self.cfg.opts("client", "options").all_client_options
             cluster_client_options = all_client_options[cluster_name]
+            # Use retries for telemetry connections: http://elasticsearch-py.readthedocs.io/en/latest/index.html#automatic-retries
+            cluster_client_options.update({"retry-on-timeout": True})
             es[cluster_name] = self.client_factory(cluster_hosts, cluster_client_options).create()
 
         es_default = es["default"]

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -68,9 +68,9 @@ class ClusterLauncher:
         es = {}
         for cluster_name, cluster_hosts in all_hosts.items():
             all_client_options = self.cfg.opts("client", "options").all_client_options
-            cluster_client_options = all_client_options[cluster_name]
-            # Use retries for telemetry connections: http://elasticsearch-py.readthedocs.io/en/latest/index.html#automatic-retries
-            cluster_client_options.update({"retry-on-timeout": True})
+            cluster_client_options = dict(all_client_options[cluster_name])
+            # Use retries to avoid aborts on long living connections for telemetry devices
+            cluster_client_options["retry-on-timeout"] = True
             es[cluster_name] = self.client_factory(cluster_hosts, cluster_client_options).create()
 
         es_default = es["default"]

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -151,10 +151,8 @@ class ClusterLauncherTests(TestCase):
         cluster_launcher = launcher.ClusterLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
         cluster = cluster_launcher.start()
 
-        retry_timeout_setting = {"retry-on-timeout": True}
-
         for telemetry_device in cluster.telemetry.devices:
-            self.assertLessEqual(retry_timeout_setting.items(),telemetry_device.client.client_options.items())
+            self.assertDictEqual({"retry-on-timeout": True, "timeout": 60}, telemetry_device.client.client_options)
 
     @mock.patch("time.sleep")
     def test_error_on_cluster_launch(self, sleep):

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -141,6 +141,21 @@ class ClusterLauncherTests(TestCase):
         self.assertEqual([{"host": "10.0.0.10", "port":9200}, {"host": "10.0.0.11", "port":9200}], cluster.hosts)
         self.assertIsNotNone(cluster.telemetry)
 
+    def test_launches_cluster_with_telemetry_client_timeout_enabled(self):
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "client", "hosts", self.test_host)
+        cfg.add(config.Scope.application, "client", "options", self.client_options)
+        cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
+        cfg.add(config.Scope.application, "mechanic", "telemetry.params", {})
+
+        cluster_launcher = launcher.ClusterLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
+        cluster = cluster_launcher.start()
+
+        retry_timeout_setting = {"retry-on-timeout": True}
+
+        for telemetry_device in cluster.telemetry.devices:
+            self.assertLessEqual(retry_timeout_setting.items(),telemetry_device.client.client_options.items())
+
     @mock.patch("time.sleep")
     def test_error_on_cluster_launch(self, sleep):
         on_post_launch = mock.Mock()


### PR DESCRIPTION
Closes #502