### PR TITLE
Add node-stats-include-mem option to record jvm heap stats

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -93,5 +93,6 @@ Supported telemetry parameters:
 * ``node-stats-include-thread-pools`` (default: ``true``): A boolean indicating whether thread pool stats should be included.
 * ``node-stats-include-buffer-pools`` (default: ``true``): A boolean indicating whether buffer pool stats should be included.
 * ``node-stats-include-breakers`` (default: ``true``): A boolean indicating whether circuit breaker stats should be included.
+* ``node-stats-include-mem`` (default: ``true``): A boolean indicating whether JVM heap stats should be included.
 * ``node-stats-include-network`` (default: ``true``): A boolean indicating whether network-related stats should be included.
 * ``node-stats-include-process`` (default: ``true``): A boolean indicating whether process cpu stats should be included.

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -319,6 +319,7 @@ class NodeStatsRecorder:
         self.include_breakers = telemetry_params.get("node-stats-include-breakers", True)
         self.include_network = telemetry_params.get("node-stats-include-network", True)
         self.include_process = telemetry_params.get("node-stats-include-process", True)
+        self.include_mem_stats = telemetry_params.get("node-stats-include-mem", True)
         self.client = client
         self.metrics_store = metrics_store
 
@@ -339,6 +340,8 @@ class NodeStatsRecorder:
                 self.record_circuit_breaker_stats(node_name, node_stats)
             if self.include_buffer_pools:
                 self.record_jvm_buffer_pool_stats(node_name, node_stats)
+            if self.include_mem_stats:
+                self.record_jvm_mem_stats(node_name, node_stats)
             if self.include_network:
                 self.record_network_stats(node_name, node_stats)
             if self.include_process:
@@ -380,6 +383,15 @@ class NodeStatsRecorder:
             for metric_name, metric_value in pool_metrics.items():
                 self.put_value(node_name,
                                metric_name="jvm_buffer_pool_{}_{}".format(pool_name, metric_name),
+                               node_stats_metric_name=metric_name,
+                               metric_value=metric_value)
+
+    def record_jvm_mem_stats(self, node_name, node_stats):
+        mem_stats = node_stats["jvm"]["mem"]
+        if mem_stats:
+            for metric_name, metric_value in mem_stats.items():
+                self.put_value(node_name,
+                               metric_name="jvm_mem_{}".format(metric_name),
                                node_stats_metric_name=metric_name,
                                metric_value=metric_value)
 

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -304,6 +304,34 @@ class NodeStatsRecorderTests(TestCase):
                             "current_loaded_count" : 9992,
                             "total_loaded_count" : 9992,
                             "total_unloaded_count" : 0
+                        },
+                        "mem": {
+                            "heap_used_in_bytes": 119073552,
+                            "heap_used_percent": 19,
+                            "heap_committed_in_bytes": 626393088,
+                            "heap_max_in_bytes": 626393088,
+                            "non_heap_used_in_bytes": 110250424,
+                            "non_heap_committed_in_bytes": 118108160,
+                            "pools": {
+                                "young": {
+                                    "used_in_bytes": 66378576,
+                                    "max_in_bytes": 139591680,
+                                    "peak_used_in_bytes": 139591680,
+                                    "peak_max_in_bytes": 139591680
+                                },
+                                "survivor": {
+                                    "used_in_bytes": 358496,
+                                    "max_in_bytes": 17432576,
+                                    "peak_used_in_bytes": 17432576,
+                                    "peak_max_in_bytes": 17432576
+                                },
+                                "old": {
+                                    "used_in_bytes": 52336480,
+                                    "max_in_bytes": 469368832,
+                                    "peak_used_in_bytes": 52336480,
+                                    "peak_max_in_bytes": 469368832
+                                }
+                            }
                         }
                     },
                     "process": {
@@ -467,6 +495,34 @@ class NodeStatsRecorderTests(TestCase):
                             "current_loaded_count" : 9992,
                             "total_loaded_count" : 9992,
                             "total_unloaded_count" : 0
+                        },
+                        "mem": {
+                            "heap_used_in_bytes": 119073552,
+                            "heap_used_percent": 19,
+                            "heap_committed_in_bytes": 626393088,
+                            "heap_max_in_bytes": 626393088,
+                            "non_heap_used_in_bytes": 110250424,
+                            "non_heap_committed_in_bytes": 118108160,
+                            "pools": {
+                                "young": {
+                                    "used_in_bytes": 66378576,
+                                    "max_in_bytes": 139591680,
+                                    "peak_used_in_bytes": 139591680,
+                                    "peak_max_in_bytes": 139591680
+                                },
+                                "survivor": {
+                                    "used_in_bytes": 358496,
+                                    "max_in_bytes": 17432576,
+                                    "peak_used_in_bytes": 17432576,
+                                    "peak_max_in_bytes": 17432576
+                                },
+                                "old": {
+                                    "used_in_bytes": 52336480,
+                                    "max_in_bytes": 469368832,
+                                    "peak_used_in_bytes": 52336480,
+                                    "peak_max_in_bytes": 469368832
+                                }
+                            }
                         }
                     },
                     "process": {
@@ -556,6 +612,7 @@ class NodeStatsRecorderTests(TestCase):
             mock.call(node_name="rally0", name="breaker_parent_tripped", count=0),
             mock.call(node_name="rally0", name="jvm_buffer_pool_mapped_count", count=7),
             mock.call(node_name="rally0", name="jvm_buffer_pool_direct_count", count=6),
+            mock.call(node_name="rally0", name="jvm_mem_heap_used_percent", count=19),
         ], any_order=True)
 
         metrics_store_put_value.assert_has_calls([
@@ -578,6 +635,11 @@ class NodeStatsRecorderTests(TestCase):
             mock.call(node_name="rally0", name="jvm_buffer_pool_mapped_total_capacity_in_bytes", value=9999, unit="byte"),
             mock.call(node_name="rally0", name="jvm_buffer_pool_direct_used_in_bytes", value=73868, unit="byte"),
             mock.call(node_name="rally0", name="jvm_buffer_pool_direct_total_capacity_in_bytes", value=73867, unit="byte"),
+            mock.call(node_name="rally0", name="jvm_mem_heap_used_in_bytes", value=119073552, unit="byte"),
+            mock.call(node_name="rally0", name="jvm_mem_heap_committed_in_bytes", value=626393088, unit="byte"),
+            mock.call(node_name="rally0", name="jvm_mem_heap_max_in_bytes", value=626393088, unit="byte"),
+            mock.call(node_name="rally0", name="jvm_mem_non_heap_used_in_bytes", value=110250424, unit="byte"),
+            mock.call(node_name="rally0", name="jvm_mem_non_heap_committed_in_bytes", value=118108160, unit="byte"),
         ], any_order=True)
 
 


### PR DESCRIPTION
Similar to https://github.com/elastic/rally/pull/497, this PR adds recording of JVM heap stats (https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html) for recording CPU metric in `pipeline=benchmark-only` mode.

Correspondingly, there is a `node-stats-include-mem`  telemetry parameter flag to enable/disable collection (defaulting to `true`).