### PR TITLE
Remove post_launch bootstrap phase

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -35,20 +35,17 @@ class ClusterLauncher:
     The cluster launcher performs cluster-wide tasks that need to be done in the startup / shutdown phase.
 
     """
-    def __init__(self, cfg, metrics_store, on_post_launch=None, client_factory_class=client.EsClientFactory):
+    def __init__(self, cfg, metrics_store, client_factory_class=client.EsClientFactory):
         """
 
         Creates a new ClusterLauncher.
 
         :param cfg: The config object.
         :param metrics_store: A metrics store that is configured to receive system metrics.
-        :param on_post_launch: An optional function that takes the Elasticsearch client as a parameter. It is invoked after the
-                               REST API is available.
         :param client_factory_class: A factory class that can create an Elasticsearch client.
         """
         self.cfg = cfg
         self.metrics_store = metrics_store
-        self.on_post_launch = on_post_launch
         self.client_factory = client_factory_class
 
     def start(self):
@@ -98,8 +95,6 @@ class ClusterLauncher:
             logger.error("REST API layer is not yet available. Forcefully terminating cluster.")
             self.stop(c)
             raise exceptions.LaunchError("Elasticsearch REST API layer is not available. Forcefully terminated cluster.")
-        if self.on_post_launch:
-            self.on_post_launch(es_default)
         return c
 
     def stop(self, c):

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -360,9 +360,7 @@ class MechanicActor(actor.RallyActor):
         self.transition_when_all_children_responded(sender, msg, "cluster_stopping", "cluster_stopped", self.on_all_nodes_stopped)
 
     def on_all_nodes_started(self):
-        # we might not have a car if we benchmark external clusters
-        post_launch_handler = PostLaunchHandler([self.car]) if self.car else None
-        self.cluster_launcher = launcher.ClusterLauncher(self.cfg, self.metrics_store, on_post_launch=post_launch_handler)
+        self.cluster_launcher = launcher.ClusterLauncher(self.cfg, self.metrics_store)
         # Workaround because we could raise a LaunchError here and thespian will attempt to retry a failed message.
         # In that case, we will get a followup RallyAssertionError because on the second attempt, Rally will check
         # the status which is now "nodes_started" but we expected the status to be "nodes_starting" previously.
@@ -408,21 +406,6 @@ class MechanicActor(actor.RallyActor):
             self.send(m, thespian.actors.ActorExitRequest())
         self.children = []
         # do not self-terminate, let the parent actor handle this
-
-
-class PostLaunchHandler:
-    def __init__(self, components, hook_handler_class=team.BootstrapHookHandler):
-        self.handlers = []
-        if components:
-            for component in components:
-                handler = hook_handler_class(component)
-                if handler.can_load():
-                    handler.load()
-                    self.handlers.append(handler)
-
-    def __call__(self, client):
-        for handler in self.handlers:
-            handler.invoke(team.BootstrapPhase.post_launch.name, client=client)
 
 
 @thespian.actors.requireCapability('coordinator')

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -416,7 +416,6 @@ class PluginDescriptor:
 
 class BootstrapPhase(Enum):
     post_install = 10
-    post_launch = 20
 
     @classmethod
     def valid(cls, name):

--- a/tests/mechanic/team_test.py
+++ b/tests/mechanic/team_test.py
@@ -223,5 +223,5 @@ class BootstrapHookHandlerTests(TestCase):
         handler.loader.registration_function = hook
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             handler.load()
-        self.assertEqual("Unknown bootstrap phase [this_is_an_unknown_install_phase]. Valid phases are: ['post_install', 'post_launch'].",
+        self.assertEqual("Unknown bootstrap phase [this_is_an_unknown_install_phase]. Valid phases are: ['post_install'].",
                          ctx.exception.args[0])


### PR DESCRIPTION
With this commit we remove the unused bootstrap phase `post_launch`
which was intended to provide a car/plugin bootstrap phase after
Elasticsearch has been launched.

Relates #481