### PR TITLE
Make challenges optional

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -69,6 +69,8 @@ Selects the track repository that Rally should use to resolve tracks. By default
 
 Selects the track that Rally should run. By default the ``geonames`` track is run. For more details on how tracks work, see :doc:`adding tracks </adding_tracks>` or the :doc:`track reference </track>`. ``--track-path`` and ``--track-repository`` as well as ``--track`` are mutually exclusive.
 
+.. _clr_track_params:
+
 ``track-params``
 ~~~~~~~~~~~~~~~~
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -816,7 +816,7 @@ Each challenge consists of the following properties:
 
 * ``name`` (mandatory): A descriptive name of the challenge. Should not contain spaces in order to simplify handling on the command line for users.
 * ``description`` (optional): A human readable description of the challenge.
-* ``default`` (optional): If true, Rally selects this challenge by default if the user did not specify a challenge on the command line. If your track only defines one challenge, it is implicitly selected as default, otherwise you need define ``"default": true`` on exactly one challenge.
+* ``default`` (optional): If true, Rally selects this challenge by default if the user did not specify a challenge on the command line. If your track only defines one challenge, it is implicitly selected as default, otherwise you need to define ``"default": true`` on exactly one challenge.
 * ``schedule`` (mandatory): Defines the workload. It is described in more detail above.
 
 .. note::

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -112,7 +112,7 @@ A track JSON file consists of the following sections:
 * templates
 * corpora
 * operations
-* challenges
+* schedule
 
 In the ``indices`` and ``templates`` sections you define the relevant indices and index templates. These sections are optional but recommended if you want to create indices and index templates with the help of Rally.
 
@@ -120,7 +120,7 @@ In the ``corpora`` section you define all document corpora (i.e. data files) tha
 
 In the ``operations`` section you describe which operations are available for this track and how they are parametrized. This section is optional and you can also define any operations directly per challenge. You can use it, if you want to share operation definitions between challenges.
 
-In the ``challenge`` or ``challenges`` section you describe one or more execution schedules respectively. Each schedule either uses the operations defined in the ``operations`` block or defines the operations to execute inline. Think of a challenge as a scenario that you want to test for your data. An example challenge is to index with two clients at maximum throughput while searching with another two clients with ten operations per second.
+In the ``schedule`` section you describe the workload for the benchmark, for example index with two clients at maximum throughput while searching with another two clients with ten operations per second. The schedule either uses the operations defined in the ``operations`` block or defines the operations to execute inline.
 
 Track elements
 ==============
@@ -293,7 +293,7 @@ We can also define default values on document corpus level but override some of 
 operations
 ..........
 
-The ``operations`` section contains a list of all operations that are available later when specifying challenges. Operations define the static properties of a request against Elasticsearch whereas the ``schedule`` element defines the dynamic properties (such as the target throughput).
+The ``operations`` section contains a list of all operations that are available later when specifying a schedule. Operations define the static properties of a request against Elasticsearch whereas the ``schedule`` element defines the dynamic properties (such as the target throughput).
 
 Each operation consists of the following properties:
 
@@ -658,27 +658,10 @@ With the operation ``raw-request`` you can execute arbitrary HTTP requests again
 * ``request-params`` (optional): A structure containing HTTP request parameters.
 * ``ignore`` (optional): An array of HTTP response status codes to ignore (i.e. consider as successful).
 
-challenge
-.........
-
-If you track has only one challenge, you can use the ``challenge`` element. If you have multiple challenges, you can define an array of ``challenges``.
-
-This section contains one or more challenges which describe the benchmark scenarios for this data set. A challenge can reference all operations that are defined in the ``operations`` section.
-
-Each challenge consists of the following properties:
-
-* ``name`` (mandatory): A descriptive name of the challenge. Should not contain spaces in order to simplify handling on the command line for users.
-* ``description`` (optional): A human readable description of the challenge.
-* ``default`` (optional): If true, Rally selects this challenge by default if the user did not specify a challenge on the command line. If your track only defines one challenge, it is implicitly selected as default, otherwise you need define ``"default": true`` on exactly one challenge.
-* ``schedule`` (mandatory): Defines the concrete execution order of operations. It is described in more detail below.
-
-.. note::
-   You should strive to minimize the number of challenges. If you just want to run a subset of the tasks in a challenge, use :ref:`task filtering <clr_include_tasks>`.
-
 schedule
 ~~~~~~~~
 
-The ``schedule`` element contains a list of tasks that are executed by Rally. Each task consists of the following properties:
+The ``schedule`` element contains a list of tasks that are executed by Rally, i.e. it describes the workload. Each task consists of the following properties:
 
 * ``name`` (optional): This property defines an explicit name for the given task. By default the operation's name is implicitly used as the task name but if the same operation is run multiple times, a unique task name must be specified using this property.
 * ``operation`` (mandatory): This property refers either to the name of an operation that has been defined in the ``operations`` section or directly defines an operation inline.
@@ -696,100 +679,91 @@ Defining operations
 
 In the following snippet we define two operations ``force-merge`` and a ``match-all`` query separately in an operations block::
 
-   {
-     "operations": [
-       {
-         "name": "force-merge",
-         "operation-type": "force-merge"
-       },
-       {
-         "name": "match-all-query",
-         "operation-type": "search",
-         "body": {
-           "query": {
-             "match_all": {}
-           }
-         }
-       }
-     ],
-     "challenge": {
-       "name": "just-query",
-       "schedule": [
-         {
-           "operation": "force-merge",
-           "clients": 1
-         },
-         {
-           "operation": "match-all-query",
-           "clients": 4,
-           "warmup-iterations": 1000,
-           "iterations": 1000,
-           "target-throughput": 100
-         }
-       ]
-     }
-   }
+    {
+      "operations": [
+        {
+          "name": "force-merge",
+          "operation-type": "force-merge"
+        },
+        {
+          "name": "match-all-query",
+          "operation-type": "search",
+          "body": {
+            "query": {
+              "match_all": {}
+            }
+          }
+        }
+      ],
+      "schedule": [
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "operation": "match-all-query",
+          "clients": 4,
+          "warmup-iterations": 1000,
+          "iterations": 1000,
+          "target-throughput": 100
+        }
+      ]
+    }
 
 If we do not want to reuse these operations, we can also define them inline. Note that the ``operations`` section is gone::
 
-   {
-     "challenge": {
-       "name": "just-query",
-       "schedule": [
-         {
-           "operation": {
-             "name": "force-merge",
-             "operation-type": "force-merge"
-           },
-           "clients": 1
-         },
-         {
-           "operation": {
-             "name": "match-all-query",
-             "operation-type": "search",
-             "body": {
-               "query": {
-                 "match_all": {}
-               }
-             }
-           },
-           "clients": 4,
-           "warmup-iterations": 1000,
-           "iterations": 1000,
-           "target-throughput": 100
-         }
-       ]
-     }
-   }
+    {
+      "schedule": [
+        {
+          "operation": {
+            "name": "force-merge",
+            "operation-type": "force-merge"
+          },
+          "clients": 1
+        },
+        {
+          "operation": {
+            "name": "match-all-query",
+            "operation-type": "search",
+            "body": {
+              "query": {
+                "match_all": {}
+              }
+            }
+          },
+          "clients": 4,
+          "warmup-iterations": 1000,
+          "iterations": 1000,
+          "target-throughput": 100
+        }
+      ]
+    }
 
 Contrary to the ``query``, the ``force-merge`` operation does not take any parameters, so Rally allows us to just specify the ``operation-type`` for this operation. It's name will be the same as the operation's type::
 
-   {
-     "challenge": {
-       "name": "just-query",
-       "schedule": [
-         {
-           "operation": "force-merge",
-           "clients": 1
-         },
-         {
-           "operation": {
-             "name": "match-all-query",
-             "operation-type": "search",
-             "body": {
-               "query": {
-                 "match_all": {}
-               }
-             }
-           },
-           "clients": 4,
-           "warmup-iterations": 1000,
-           "iterations": 1000,
-           "target-throughput": 100
-         }
-       ]
-     }
-   }
+    {
+      "schedule": [
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "operation": {
+            "name": "match-all-query",
+            "operation-type": "search",
+            "body": {
+              "query": {
+                "match_all": {}
+              }
+            }
+          },
+          "clients": 4,
+          "warmup-iterations": 1000,
+          "iterations": 1000,
+          "target-throughput": 100
+        }
+      ]
+    }
 
 Choosing a schedule
 ...................
@@ -831,6 +805,23 @@ All tasks in the ``schedule`` list are executed sequentially in the order in whi
 
     Specify the number of clients on each task separately. If you specify this number on the ``parallel`` element instead, Rally will only use that many clients in total and you will only want to use this behavior in very rare cases (see examples)!
 
+challenge
+.........
+
+If your track defines only one benchmarking scenario specify the ``schedule`` on top-level. Use the ``challenge`` element if you want to specify additional properties like a name or a description. You can think of a challenge as a benchmarking scenario. If you have multiple challenges, you can define an array of ``challenges``.
+
+This section contains one or more challenges which describe the benchmark scenarios for this data set. A challenge can reference all operations that are defined in the ``operations`` section.
+
+Each challenge consists of the following properties:
+
+* ``name`` (mandatory): A descriptive name of the challenge. Should not contain spaces in order to simplify handling on the command line for users.
+* ``description`` (optional): A human readable description of the challenge.
+* ``default`` (optional): If true, Rally selects this challenge by default if the user did not specify a challenge on the command line. If your track only defines one challenge, it is implicitly selected as default, otherwise you need define ``"default": true`` on exactly one challenge.
+* ``schedule`` (mandatory): Defines the workload. It is described in more detail above.
+
+.. note::
+
+    You should strive to minimize the number of challenges. If you just want to run a subset of the tasks in a challenge, use :ref:`task filtering <clr_include_tasks>`.
 
 Examples
 ========
@@ -841,29 +832,26 @@ A track with a single task
 To get started with custom tracks, you can benchmark a single task, e.g. a match_all query::
 
     {
-      "challenge": {
-        "name": "just-search",
-        "schedule": [
-          {
-            "operation": {
-              "operation-type": "search",
-              "index": "_all",
-              "body": {
-                "query": {
-                  "match_all": {}
-                }
+      "schedule": [
+        {
+          "operation": {
+            "operation-type": "search",
+            "index": "_all",
+            "body": {
+              "query": {
+                "match_all": {}
               }
-            },
-            "warmup-iterations": 100,
-            "iterations": 100,
-            "target-throughput": 10
-          }
-        ]
-      }
+            }
+          },
+          "warmup-iterations": 100,
+          "iterations": 100,
+          "target-throughput": 10
+        }
+      ]
     }
 
 
-This track assumes that you have an existing cluster with pre-populated data. It will run the provided match_all query at 10 operations per second with one client and use 100 iterations as warmup and the next 100 iterations to measure.
+This track assumes that you have an existing cluster with pre-populated data. It will run the provided ``match_all`` query at 10 operations per second with one client and use 100 iterations as warmup and the next 100 iterations to measure.
 
 For the examples below, note that we do not show the operation definition but you should be able to infer from the operation name what it is doing.
 

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -105,8 +105,12 @@ class BenchmarkActor(actor.RallyActor):
         self.metrics_store.meta_info = msg.system_meta_info
         cluster = msg.cluster_meta_info
         self.race.cluster = cluster
-        console.info("Racing on track [%s], challenge [%s] and car %s with version [%s].\n"
-                     % (self.race.track_name, self.race.challenge_name, self.race.car, self.race.cluster.distribution_version))
+        if self.race.challenge.auto_generated:
+            console.info("Racing on track [{}] and car {} with version [{}].\n"
+                         .format(self.race.track_name, self.race.car, self.race.cluster.distribution_version))
+        else:
+            console.info("Racing on track [{}], challenge [{}] and car {} with version [{}].\n"
+                         .format(self.race.track_name, self.race.challenge_name, self.race.car, self.race.cluster.distribution_version))
         # start running we assume that each race has at least one lap
         self.run()
 
@@ -198,7 +202,7 @@ class BenchmarkActor(actor.RallyActor):
         self.lap_counter = LapCounter(self.race, self.metrics_store, self.cfg)
         self.race_store = metrics.race_store(self.cfg)
         self.logger.info("Asking mechanic to start the engine.")
-        cluster_settings = self.race.challenge.cluster_settings
+        cluster_settings = challenge.cluster_settings
         self.send(self.mechanic, mechanic.StartEngine(self.cfg, self.metrics_store.open_context, cluster_settings, msg.sources, msg.build,
                                                       msg.distribution, msg.external, msg.docker))
 

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -554,12 +554,14 @@ class ComparisonReporter:
         print_internal("")
         print_internal("Comparing baseline")
         print_internal("  Race timestamp: %s" % r1.trial_timestamp)
-        print_internal("  Challenge: %s" % r1.challenge_name)
+        if r1.challenge_name:
+            print_internal("  Challenge: %s" % r1.challenge_name)
         print_internal("  Car: %s" % r1.car_name)
         print_internal("")
         print_internal("with contender")
         print_internal("  Race timestamp: %s" % r2.trial_timestamp)
-        print_internal("  Challenge: %s" % r2.challenge_name)
+        if r2.challenge_name:
+            print_internal("  Challenge: %s" % r2.challenge_name)
         print_internal("  Car: %s" % r2.car_name)
         print_internal("")
         print_header("------------------------------------------------------")

--- a/esrally/resources/track-schema.json
+++ b/esrally/resources/track-schema.json
@@ -4,6 +4,160 @@
   "description": "Specification of tracks for Rally",
   "type": "object",
   "definitions": {
+    "schedule": {
+      "title": "Schedule",
+      "type": "array",
+      "minItems": 1,
+      "description": "Defines the concrete execution order of operations.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "parallel": {
+            "type": "object",
+            "description": "This element allows to define tasks that should be run in parallel. We do not support nested parallel tasks.",
+            "properties": {
+              "clients": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "warmup-iterations": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "iterations": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "warmup-time-period": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Defines the time period in seconds to run the operation in order to warmup the benchmark candidate. The warmup time period will not be considered in the benchmark result."
+              },
+              "time-period": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Defines the time period in seconds to run the operation. Note that the parameter source may be exhausted before the specified time period has elapsed."
+              },
+              "completed-by": {
+                "type": "string",
+                "description": "The name of an operation in the 'tasks' block. When this operation is completed, the whole parallel element is considered to be completed."
+              },
+              "tasks": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Defines the operations that will be run in parallel",
+                "items": {
+                  "type": "object",
+                  "description": "Defines an individual operation that is executed",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Explicit name of the task. By default the operation's name is implicitly used as the task's name but if the same operation is run multiple times, a unique task name must be specified."
+                    },
+                    "operation": {
+                      "description": "The name of an operation that should be executed. This name must match the operation name in the 'operations' block."
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Meta-information which will be added to each metrics-record of this task."
+                    },
+                    "clients": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "warmup-iterations": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "description": "Defines the number of times to run the operation in order to warmup the benchmark candidate. Warmup iterations will not be considered in the benchmark result."
+                    },
+                    "iterations": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "description": "Defines the number of times to run the operation."
+                    },
+                    "warmup-time-period": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "description": "Defines the time period in seconds to run the operation in order to warmup the benchmark candidate. The warmup time period will not be considered in the benchmark result."
+                    },
+                    "time-period": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "description": "Defines the time period in seconds to run the operation. Note that the parameter source may be exhausted before the specified time period has elapsed."
+                    },
+                    "schedule": {
+                      "type": "string",
+                      "description": "Defines the scheduling strategy that is used for throughput throttled operations. Out of the box, Rally supports 'deterministic' (default) and 'poisson' but you can implement your own schedules."
+                    },
+                    "target-throughput": {
+                      "type": "number",
+                      "minimum": 0,
+                      "description": "Defines the number of operations per second that Rally should attempt to run."
+                    },
+                    "target-interval": {
+                      "type": "number",
+                      "minimum": 0,
+                      "description": "Defines the number of seconds to wait between operations (inverse of target-throughput). Only one of 'target-throughput' or 'target-interval' may be defined."
+                    }
+                  },
+                  "required": [
+                    "operation"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "tasks"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Explicit name of the task. By default the operation's name is implicitly used as the task's name but if the same operation is run multiple times, a unique task name must be specified."
+          },
+          "operation": {
+            "description": "The name of an operation that should be executed. This name must match the operation name in the 'operations' block."
+          },
+          "meta": {
+            "type": "object",
+            "description": "Meta-information which will be added to each metrics-record of this task."
+          },
+          "clients": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "warmup-iterations": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Defines the number of times to run the operation in order to warmup the benchmark candidate. Warmup iterations will not be considered in the benchmark result."
+          },
+          "iterations": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Defines the number of times to run the operation."
+          },
+          "warmup-time-period": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Defines the time period in seconds to run the operation in order to warmup the benchmark candidate. The warmup time period will not be considered in the benchmark result."
+          },
+          "time-period": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Defines the time period in seconds to run the operation. Note that the parameter source may be exhausted before the specified time period has elapsed."
+          },
+          "target-throughput": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Defines the number of operations per second that Rally should attempt to run."
+          },
+          "target-interval": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Defines the number of seconds to wait between operations (inverse of target-throughput). Only one of 'target-throughput' or 'target-interval' may be defined."
+          }
+        }
+      }
+    },
     "challenge": {
       "title": "Challenge",
       "type": "object",
@@ -30,157 +184,7 @@
           "description": "Defines the cluster settings of the benchmark candidate."
         },
         "schedule": {
-          "type": "array",
-          "minItems": 1,
-          "description": "Defines the concrete execution order of operations.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "parallel": {
-                "type": "object",
-                "description": "This element allows to define tasks that should be run in parallel. We do not support nested parallel tasks.",
-                "properties": {
-                  "clients": {
-                    "type": "integer",
-                    "minimum": 1
-                  },
-                  "warmup-iterations": {
-                    "type": "integer",
-                    "minimum": 0
-                  },
-                  "iterations": {
-                    "type": "integer",
-                    "minimum": 1
-                  },
-                  "warmup-time-period": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "description": "Defines the time period in seconds to run the operation in order to warmup the benchmark candidate. The warmup time period will not be considered in the benchmark result."
-                  },
-                  "time-period": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "description": "Defines the time period in seconds to run the operation. Note that the parameter source may be exhausted before the specified time period has elapsed."
-                  },
-                  "completed-by": {
-                    "type": "string",
-                    "description": "The name of an operation in the 'tasks' block. When this operation is completed, the whole parallel element is considered to be completed."
-                  },
-                  "tasks": {
-                    "type": "array",
-                    "minItems": 1,
-                    "description": "Defines the operations that will be run in parallel",
-                    "items": {
-                      "type": "object",
-                      "description": "Defines an individual operation that is executed",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "description": "Explicit name of the task. By default the operation's name is implicitly used as the task's name but if the same operation is run multiple times, a unique task name must be specified."
-                        },
-                        "operation": {
-                          "description": "The name of an operation that should be executed. This name must match the operation name in the 'operations' block."
-                        },
-                        "meta": {
-                          "type": "object",
-                          "description": "Meta-information which will be added to each metrics-record of this task."
-                        },
-                        "clients": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "warmup-iterations": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "description": "Defines the number of times to run the operation in order to warmup the benchmark candidate. Warmup iterations will not be considered in the benchmark result."
-                        },
-                        "iterations": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "description": "Defines the number of times to run the operation."
-                        },
-                        "warmup-time-period": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "description": "Defines the time period in seconds to run the operation in order to warmup the benchmark candidate. The warmup time period will not be considered in the benchmark result."
-                        },
-                        "time-period": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "description": "Defines the time period in seconds to run the operation. Note that the parameter source may be exhausted before the specified time period has elapsed."
-                        },
-                        "schedule": {
-                          "type": "string",
-                          "description": "Defines the scheduling strategy that is used for throughput throttled operations. Out of the box, Rally supports 'deterministic' (default) and 'poisson' but you can implement your own schedules."
-                        },
-                        "target-throughput": {
-                          "type": "number",
-                          "minimum": 0,
-                          "description": "Defines the number of operations per second that Rally should attempt to run."
-                        },
-                        "target-interval": {
-                          "type": "number",
-                          "minimum": 0,
-                          "description": "Defines the number of seconds to wait between operations (inverse of target-throughput). Only one of 'target-throughput' or 'target-interval' may be defined."
-                        }
-                      },
-                      "required": [
-                        "operation"
-                      ]
-                    }
-                  }
-                },
-                "required": [
-                  "tasks"
-                ]
-              },
-              "name": {
-                "type": "string",
-                "description": "Explicit name of the task. By default the operation's name is implicitly used as the task's name but if the same operation is run multiple times, a unique task name must be specified."
-              },
-              "operation": {
-                "description": "The name of an operation that should be executed. This name must match the operation name in the 'operations' block."
-              },
-              "meta": {
-                "type": "object",
-                "description": "Meta-information which will be added to each metrics-record of this task."
-              },
-              "clients": {
-                "type": "integer",
-                "minimum": 1
-              },
-              "warmup-iterations": {
-                "type": "integer",
-                "minimum": 0,
-                "description": "Defines the number of times to run the operation in order to warmup the benchmark candidate. Warmup iterations will not be considered in the benchmark result."
-              },
-              "iterations": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "Defines the number of times to run the operation."
-              },
-              "warmup-time-period": {
-                "type": "integer",
-                "minimum": 0,
-                "description": "Defines the time period in seconds to run the operation in order to warmup the benchmark candidate. The warmup time period will not be considered in the benchmark result."
-              },
-              "time-period": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "Defines the time period in seconds to run the operation. Note that the parameter source may be exhausted before the specified time period has elapsed."
-              },
-              "target-throughput": {
-                "type": "number",
-                "minimum": 0,
-                "description": "Defines the number of operations per second that Rally should attempt to run."
-              },
-              "target-interval": {
-                "type": "number",
-                "minimum": 0,
-                "description": "Defines the number of seconds to wait between operations (inverse of target-throughput). Only one of 'target-throughput' or 'target-interval' may be defined."
-              }
-            }
-          }
+          "$ref": "#/definitions/schedule"
         }
       },
       "required": [
@@ -450,6 +454,9 @@
     },
     "challenge": {
       "$ref": "#/definitions/challenge"
+    },
+    "schedule": {
+      "$ref": "#/definitions/schedule"
     }
   }
 }

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -348,6 +348,7 @@ class Challenge:
                  user_info=None,
                  cluster_settings=None,
                  default=False,
+                 auto_generated=False,
                  meta_data=None,
                  schedule=None):
         self.name = name
@@ -356,6 +357,7 @@ class Challenge:
         self.user_info = user_info
         self.cluster_settings = cluster_settings if cluster_settings else {}
         self.default = default
+        self.auto_generated = auto_generated
         self.schedule = schedule if schedule else []
 
     def prepend_tasks(self, tasks):
@@ -375,12 +377,12 @@ class Challenge:
 
     def __hash__(self):
         return hash(self.name) ^ hash(self.description) ^ hash(self.cluster_settings) ^ hash(self.default) ^ \
-               hash(self.meta_data) ^ hash(self.schedule)
+               hash(self.auto_generated) ^ hash(self.meta_data) ^ hash(self.schedule)
 
     def __eq__(self, othr):
         return (isinstance(othr, type(self)) and
-                (self.name, self.description, self.cluster_settings, self.default, self.meta_data, self.schedule) ==
-                (othr.name, othr.description, othr.cluster_settings, othr.default, othr.meta_data, othr.schedule))
+                (self.name, self.description, self.cluster_settings, self.default, self.auto_generated, self.meta_data, self.schedule) ==
+                (othr.name, othr.description, othr.cluster_settings, othr.default, othr.auto_generated, othr.meta_data, othr.schedule))
 
 
 @unique

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -1074,7 +1074,7 @@ class TrackSpecificationReaderTests(TestCase):
         }))
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. You must define either 'challenge' or 'challenges' but none is specified.",
+        self.assertEqual("Track 'unittest' is invalid. You must define 'challenge', 'challenges' or 'schedule' but none is specified.",
                          ctx.exception.args[0])
 
     def test_parse_challenge_and_challenges_are_defined(self):
@@ -1109,8 +1109,8 @@ class TrackSpecificationReaderTests(TestCase):
         }))
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. 'challenge' and 'challenges' are defined but only one of them is allowed.",
-                         ctx.exception.args[0])
+        self.assertEqual("Track 'unittest' is invalid. Multiple out of 'challenge', 'challenges' or 'schedule' are defined but only "
+                         "one of them is allowed.", ctx.exception.args[0])
 
     def test_parse_with_mixed_warmup_time_period_and_iterations(self):
         track_specification = {
@@ -1627,6 +1627,28 @@ class TrackSpecificationReaderTests(TestCase):
         resulting_track = reader("unittest", track_specification, "/mappings")
         self.assertEqual(1, len(resulting_track.challenges))
         self.assertEqual("challenge", resulting_track.challenges[0].name)
+        self.assertTrue(resulting_track.challenges[0].default)
+
+    def test_auto_generates_challenge_from_schedule(self):
+        track_specification = {
+            "description": "description for unit test",
+            "indices": [{"name": "test-index"}],
+            "operations": [
+                {
+                    "name": "index-append",
+                    "operation-type": "bulk"
+                }
+            ],
+            "schedule": [
+                {
+                    "operation": "index-append"
+                }
+            ]
+        }
+        reader = loader.TrackSpecificationReader()
+        resulting_track = reader("unittest", track_specification, "/mappings")
+        self.assertEqual(1, len(resulting_track.challenges))
+        self.assertTrue(resulting_track.challenges[0].auto_generated)
         self.assertTrue(resulting_track.challenges[0].default)
 
     def test_inline_operations(self):


### PR DESCRIPTION
With this commit we make challenges an optional concept in Rally. We
modify the track syntax so it also allows to specify the `schedule`
property on top-level. We also hide the notion of a challenge from
console messages if possible.

Closes #474