### PR TITLE
Report indexing times per shard

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -143,12 +143,12 @@ Rally stores the following metrics:
 * ``segments_terms_memory_in_bytes``: Number of bytes used for terms as reported by the indices stats API.
 * ``segments_norms_memory_in_bytes``: Number of bytes used for norms as reported by the indices stats API.
 * ``segments_points_memory_in_bytes``: Number of bytes used for points as reported by the indices stats API.
-* ``merges_total_time``: Total runtime of merges as reported by the indices stats API. Note that this is not Wall clock time (i.e. if M merge threads ran for N minutes, we will report M * N minutes, not N minutes).
-* ``merges_total_throttled_time``: Total time within merges have been throttled as reported by the indices stats API. Note that this is not Wall clock time.
-* ``indexing_total_time``: Total time used for indexing as reported by the indices stats API. Note that this is not Wall clock time.
-* ``indexing_throttle_time``: Total time that indexing has been throttled as reported by the indices stats API. Note that this is not Wall clock time.
-* ``refresh_total_time``: Total time used for index refresh as reported by the indices stats API. Note that this is not Wall clock time.
-* ``flush_total_time``: Total time used for index flush as reported by the indices stats API. Note that this is not Wall clock time.
+* ``merges_total_time``: Total runtime of merges as reported by the indices stats API. Note that this is not Wall clock time (i.e. if M merge threads ran for N minutes, we will report M * N minutes, not N minutes). These metrics records also have a ``per-shard`` property that contains the times per primary shard in an array.
+* ``merges_total_throttled_time``: Total time within merges have been throttled as reported by the indices stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times per primary shard in an array.
+* ``indexing_total_time``: Total time used for indexing as reported by the indices stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times per primary shard in an array.
+* ``indexing_throttle_time``: Total time that indexing has been throttled as reported by the indices stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times per primary shard in an array.
+* ``refresh_total_time``: Total time used for index refresh as reported by the indices stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times per primary shard in an array.
+* ``flush_total_time``: Total time used for index flush as reported by the indices stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times per primary shard in an array.
 * ``final_index_size_bytes``: Final resulting index size on the file system after all nodes have been shutdown at the end of the benchmark. It includes all files in the nodes' data directories (actual index files and translog).
 * ``store_size_in_bytes``: The size in bytes of the index (excluding the translog) as reported by the indices stats API.
 * ``translog_size_in_bytes``: The size in bytes of the translog as reported by the indices stats API.

--- a/docs/summary_report.rst
+++ b/docs/summary_report.rst
@@ -9,11 +9,23 @@ Total indexing time
 * **Definition**: Total time used for indexing as reported by the indices stats API. Note that this is not Wall clock time (i.e. if M indexing threads ran for N minutes, we will report M * N minutes, not N minutes).
 * **Corresponding metrics key**: ``indexing_total_time``
 
+Indexing time per shard
+-----------------------
+
+* **Definition**: Minimum, median and maximum time used for indexing per primary shard as reported by the indices stats API.
+* **Corresponding metrics key**: ``indexing_total_time`` (property: ``per-shard``)
+
 Total indexing throttle time
 ----------------------------
 
 * **Definition**: Total time that indexing has been throttled as reported by the indices stats API. Note that this is not Wall clock time (i.e. if M indexing threads ran for N minutes, we will report M * N minutes, not N minutes).
 * **Corresponding metrics key**: ``indexing_throttle_time``
+
+Indexing throttle time per shard
+--------------------------------
+
+* **Definition**: Minimum, median and maximum time used that indexing has been throttled per primary shard as reported by the indices stats API.
+* **Corresponding metrics key**: ``indexing_throttle_time`` (property: ``per-shard``)
 
 Total merge time
 ----------------
@@ -21,11 +33,23 @@ Total merge time
 * **Definition**: Total runtime of merges as reported by the indices stats API. Note that this is not Wall clock time.
 * **Corresponding metrics key**: ``merges_total_time``
 
+Merge time per shard
+--------------------
+
+* **Definition**: Minimum, median and maximum time of merges per primary shard as reported by the indices stats API.
+* **Corresponding metrics key**: ``merges_total_time`` (property: ``per-shard``)
+
 Total refresh time
 ------------------
 
 * **Definition**: Total time used for index refresh as reported by the indices stats API. Note that this is not Wall clock time.
 * **Corresponding metrics key**: ``refresh_total_time``
+
+Refresh time per shard
+----------------------
+
+* **Definition**: Minimum, median and maximum time for index refresh per primary shard as reported by the indices stats API.
+* **Corresponding metrics key**: ``refresh_total_time`` (property: ``per-shard``)
 
 Total flush time
 ----------------
@@ -33,12 +57,23 @@ Total flush time
 * **Definition**: Total time used for index flush as reported by the indices stats API. Note that this is not Wall clock time.
 * **Corresponding metrics key**: ``flush_total_time``
 
+Flush time per shard
+--------------------
+
+* **Definition**: Minimum, median and maximum time for index flush per primary shard as reported by the indices stats API.
+* **Corresponding metrics key**: ``flush_total_time`` (property: ``per-shard``)
+
 Total merge throttle time
 -------------------------
 
 * **Definition**: Total time within merges have been throttled as reported by the indices stats API. Note that this is not Wall clock time.
 * **Corresponding metrics key**: ``merges_total_throttled_time``
 
+Merge throttle time per shard
+-----------------------------
+
+* **Definition**: Minimum, median and maximum time that merges have been throttled per primary shard as reported by the indices stats API.
+* **Corresponding metrics key**: ``merges_total_throttled_time`` (property: ``per-shard``)
 
 Merge time (``X``)
 ------------------
@@ -54,7 +89,7 @@ Where ``X`` is one of:
 
 ..
 
-* **Definition**: Different merge times as reported by Lucene. Only available if Lucene index writer trace logging is enabled (use `--car-params="verbose_iw_logging_enabled:true"` for that).
+* **Definition**: Different merge times as reported by Lucene. Only available if Lucene index writer trace logging is enabled (use ``--car-params="verbose_iw_logging_enabled:true"`` for that).
 * **Corresponding metrics keys**: ``merge_parts_total_time_*``
 
 


### PR DESCRIPTION
With this commit we do not only show the total indexing times (across
all shards) but also report the indexing times per (primary) shard.

Closes #374