### PR TITLE
Fold node-stats telemetry device fields in one doc per sample

### DIFF
--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -418,6 +418,238 @@ class CcrStatsRecorderTests(TestCase):
 
 
 class NodeStatsRecorderTests(TestCase):
+    node_stats_response = {
+        "cluster_name" : "elasticsearch",
+        "nodes" : {
+            "Zbl_e8EyRXmiR47gbHgPfg" : {
+                "timestamp" : 1524379617017,
+                "name" : "rally0",
+                "transport_address" : "127.0.0.1:9300",
+                "host" : "127.0.0.1",
+                "ip" : "127.0.0.1:9300",
+                "roles" : [
+                    "master",
+                    "data",
+                    "ingest"
+                ],
+                "indices" : {
+                    "docs" : {
+                        "count" : 0,
+                        "deleted" : 0
+                    },
+                    "store" : {
+                        "size_in_bytes" : 0
+                    },
+                    "indexing" : {
+                        "is_throttled" : False,
+                        "throttle_time_in_millis" : 0
+                    },
+                    "search" : {
+                        "open_contexts" : 0,
+                        "query_total" : 0,
+                        "query_time_in_millis" : 0
+                    },
+                    "merges" : {
+                        "current" : 0,
+                        "current_docs" : 0,
+                        "current_size_in_bytes" : 0
+                    },
+                    "query_cache" : {
+                        "memory_size_in_bytes" : 0,
+                        "total_count" : 0,
+                        "hit_count" : 0,
+                        "miss_count" : 0,
+                        "cache_size" : 0,
+                        "cache_count" : 0,
+                        "evictions" : 0
+                    },
+                    "completion" : {
+                        "size_in_bytes" : 0
+                    },
+                    "segments" : {
+                        "count" : 0,
+                        "memory_in_bytes" : 0,
+                        "max_unsafe_auto_id_timestamp" : -9223372036854775808,
+                        "file_sizes" : { }
+                    },
+                    "translog" : {
+                        "operations" : 0,
+                        "size_in_bytes" : 0,
+                        "uncommitted_operations" : 0,
+                        "uncommitted_size_in_bytes" : 0
+                    },
+                    "request_cache" : {
+                        "memory_size_in_bytes" : 0,
+                        "evictions" : 0,
+                        "hit_count" : 0,
+                        "miss_count" : 0
+                    },
+                    "recovery" : {
+                        "current_as_source" : 0,
+                        "current_as_target" : 0,
+                        "throttle_time_in_millis" : 0
+                    }
+                },
+                "jvm" : {
+                    "buffer_pools" : {
+                        "mapped" : {
+                            "count" : 7,
+                            "used_in_bytes" : 3120,
+                            "total_capacity_in_bytes" : 9999
+                        },
+                        "direct" : {
+                            "count" : 6,
+                            "used_in_bytes" : 73868,
+                            "total_capacity_in_bytes" : 73867
+                        }
+                    },
+                    "classes" : {
+                        "current_loaded_count" : 9992,
+                        "total_loaded_count" : 9992,
+                        "total_unloaded_count" : 0
+                    },
+                    "mem": {
+                        "heap_used_in_bytes": 119073552,
+                        "heap_used_percent": 19,
+                        "heap_committed_in_bytes": 626393088,
+                        "heap_max_in_bytes": 626393088,
+                        "non_heap_used_in_bytes": 110250424,
+                        "non_heap_committed_in_bytes": 118108160,
+                        "pools": {
+                            "young": {
+                                "used_in_bytes": 66378576,
+                                "max_in_bytes": 139591680,
+                                "peak_used_in_bytes": 139591680,
+                                "peak_max_in_bytes": 139591680
+                            },
+                            "survivor": {
+                                "used_in_bytes": 358496,
+                                "max_in_bytes": 17432576,
+                                "peak_used_in_bytes": 17432576,
+                                "peak_max_in_bytes": 17432576
+                            },
+                            "old": {
+                                "used_in_bytes": 52336480,
+                                "max_in_bytes": 469368832,
+                                "peak_used_in_bytes": 52336480,
+                                "peak_max_in_bytes": 469368832
+                            }
+                        }
+                    }
+                },
+                "process": {
+                    "timestamp": 1526045135857,
+                    "open_file_descriptors": 312,
+                    "max_file_descriptors": 1048576,
+                    "cpu": {
+                        "percent": 10,
+                        "total_in_millis": 56520
+                    },
+                    "mem": {
+                        "total_virtual_in_bytes": 2472173568
+                    }
+                },
+                "thread_pool" : {
+                    "generic" : {
+                        "threads" : 4,
+                        "queue" : 0,
+                        "active" : 0,
+                        "rejected" : 0,
+                        "largest" : 4,
+                        "completed" : 8
+                    }
+                },
+                "breakers" : {
+                    "parent" : {
+                        "limit_size_in_bytes" : 726571417,
+                        "limit_size" : "692.9mb",
+                        "estimated_size_in_bytes" : 0,
+                        "estimated_size" : "0b",
+                        "overhead" : 1.0,
+                        "tripped" : 0
+                    }
+                }
+            }
+        }
+    }
+
+    indices_stats_response_flattened = {
+        "indices_docs_count": 0,
+        "indices_docs_deleted": 0,
+        "indices_store_size_in_bytes": 0,
+        "indices_indexing_is_throttled": False,
+        "indices_indexing_throttle_time_in_millis": 0,
+        "indices_search_open_contexts": 0,
+        "indices_search_query_total": 0,
+        "indices_search_query_time_in_millis": 0,
+        "indices_merges_current": 0,
+        "indices_merges_current_docs": 0,
+        "indices_merges_current_size_in_bytes": 0,
+        "indices_query_cache_memory_size_in_bytes": 0,
+        "indices_query_cache_total_count": 0,
+        "indices_query_cache_hit_count": 0,
+        "indices_query_cache_miss_count": 0,
+        "indices_query_cache_cache_size": 0,
+        "indices_query_cache_cache_count": 0,
+        "indices_query_cache_evictions": 0,
+        "indices_completion_size_in_bytes": 0,
+        "indices_segments_count": 0,
+        "indices_segments_memory_in_bytes": 0,
+        "indices_segments_max_unsafe_auto_id_timestamp": -9223372036854775808,
+        "indices_translog_operations": 0,
+        "indices_translog_size_in_bytes": 0,
+        "indices_translog_uncommitted_operations": 0,
+        "indices_translog_uncommitted_size_in_bytes": 0,
+        "indices_request_cache_memory_size_in_bytes": 0,
+        "indices_request_cache_evictions": 0,
+        "indices_request_cache_hit_count": 0,
+        "indices_request_cache_miss_count": 0,
+        "indices_recovery_current_as_source": 0,
+        "indices_recovery_current_as_target": 0,
+        "indices_recovery_throttle_time_in_millis": 0
+    }
+
+    default_stats_response_flattened = {
+        "jvm_buffer_pools_mapped_count": 7,
+        "jvm_buffer_pools_mapped_used_in_bytes": 3120,
+        "jvm_buffer_pools_mapped_total_capacity_in_bytes": 9999,
+        "jvm_buffer_pools_direct_count": 6,
+        "jvm_buffer_pools_direct_used_in_bytes": 73868,
+        "jvm_buffer_pools_direct_total_capacity_in_bytes": 73867,
+        "jvm_mem_heap_used_in_bytes": 119073552,
+        "jvm_mem_heap_used_percent": 19,
+        "jvm_mem_heap_committed_in_bytes": 626393088,
+        "jvm_mem_heap_max_in_bytes": 626393088,
+        "jvm_mem_non_heap_used_in_bytes": 110250424,
+        "jvm_mem_non_heap_committed_in_bytes": 118108160,
+        "jvm_mem_pools_young_used_in_bytes": 66378576,
+        "jvm_mem_pools_young_max_in_bytes": 139591680,
+        "jvm_mem_pools_young_peak_used_in_bytes": 139591680,
+        "jvm_mem_pools_young_peak_max_in_bytes": 139591680,
+        "jvm_mem_pools_survivor_used_in_bytes": 358496,
+        "jvm_mem_pools_survivor_max_in_bytes": 17432576,
+        "jvm_mem_pools_survivor_peak_used_in_bytes": 17432576,
+        "jvm_mem_pools_survivor_peak_max_in_bytes": 17432576,
+        "jvm_mem_pools_old_used_in_bytes": 52336480,
+        "jvm_mem_pools_old_max_in_bytes": 469368832,
+        "jvm_mem_pools_old_peak_used_in_bytes": 52336480,
+        "jvm_mem_pools_old_peak_max_in_bytes": 469368832,
+        "process_cpu_percent": 10,
+        "process_cpu_total_in_millis": 56520,
+        "breakers_parent_limit_size_in_bytes": 726571417,
+        "breakers_parent_limit_size": "692.9mb",
+        "breakers_parent_estimated_size_in_bytes": 0,
+        "breakers_parent_estimated_size": "0b",
+        "breakers_parent_overhead": 1.0,
+        "breakers_parent_tripped": 0,
+        "thread_pool_generic_threads": 4,
+        "thread_pool_generic_queue": 0,
+        "thread_pool_generic_active": 0,
+        "thread_pool_generic_rejected": 0,
+        "thread_pool_generic_largest": 4,
+        "thread_pool_generic_completed": 8
+    }
+
     def test_negative_sample_interval_forbidden(self):
         client = Client()
         cfg = create_config()
@@ -429,165 +661,63 @@ class NodeStatsRecorderTests(TestCase):
                                     "The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was .*\."):
             telemetry.NodeStatsRecorder(telemetry_params, cluster_name="default", client=client, metrics_store=metrics_store)
 
-    @mock.patch("esrally.metrics.EsMetricsStore.put_count_node_level")
-    @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
-    def test_stores_default_nodes_stats(self, metrics_store_put_value, metrics_store_put_count):
-        node_stats_response = {
-            "cluster_name" : "elasticsearch",
-            "nodes" : {
-                "Zbl_e8EyRXmiR47gbHgPfg" : {
-                    "timestamp" : 1524379617017,
-                    "name" : "rally0",
-                    "transport_address" : "127.0.0.1:9300",
-                    "host" : "127.0.0.1",
-                    "ip" : "127.0.0.1:9300",
-                    "roles" : [
-                        "master",
-                        "data",
-                        "ingest"
-                    ],
-                    "indices" : {
-                        "docs" : {
-                            "count" : 0,
-                            "deleted" : 0
-                        },
-                        "store" : {
-                            "size_in_bytes" : 0
-                        },
-                        "indexing" : {
-                            "is_throttled" : False,
-                            "throttle_time_in_millis" : 0
-                        },
-                        "search" : {
-                            "open_contexts" : 0,
-                            "query_total" : 0,
-                            "query_time_in_millis" : 0
-                        },
-                        "merges" : {
-                            "current" : 0,
-                            "current_docs" : 0,
-                            "current_size_in_bytes" : 0
-                        },
-                        "query_cache" : {
-                            "memory_size_in_bytes" : 0,
-                            "total_count" : 0,
-                            "hit_count" : 0,
-                            "miss_count" : 0,
-                            "cache_size" : 0,
-                            "cache_count" : 0,
-                            "evictions" : 0
-                        },
-                        "completion" : {
-                            "size_in_bytes" : 0
-                        },
-                        "segments" : {
-                            "count" : 0,
-                            "memory_in_bytes" : 0,
-                            "max_unsafe_auto_id_timestamp" : -9223372036854775808,
-                            "file_sizes" : { }
-                        },
-                        "translog" : {
-                            "operations" : 0,
-                            "size_in_bytes" : 0,
-                            "uncommitted_operations" : 0,
-                            "uncommitted_size_in_bytes" : 0
-                        },
-                        "request_cache" : {
-                            "memory_size_in_bytes" : 0,
-                            "evictions" : 0,
-                            "hit_count" : 0,
-                            "miss_count" : 0
-                        },
-                        "recovery" : {
-                            "current_as_source" : 0,
-                            "current_as_target" : 0,
-                            "throttle_time_in_millis" : 0
-                        }
-                    },
-                    "jvm" : {
-                        "buffer_pools" : {
-                            "mapped" : {
-                                "count" : 7,
-                                "used_in_bytes" : 3120,
-                                "total_capacity_in_bytes" : 9999
-                            },
-                            "direct" : {
-                                "count" : 6,
-                                "used_in_bytes" : 73868,
-                                "total_capacity_in_bytes" : 73867
-                            }
-                        },
-                        "classes" : {
-                            "current_loaded_count" : 9992,
-                            "total_loaded_count" : 9992,
-                            "total_unloaded_count" : 0
-                        },
-                        "mem": {
-                            "heap_used_in_bytes": 119073552,
-                            "heap_used_percent": 19,
-                            "heap_committed_in_bytes": 626393088,
-                            "heap_max_in_bytes": 626393088,
-                            "non_heap_used_in_bytes": 110250424,
-                            "non_heap_committed_in_bytes": 118108160,
-                            "pools": {
-                                "young": {
-                                    "used_in_bytes": 66378576,
-                                    "max_in_bytes": 139591680,
-                                    "peak_used_in_bytes": 139591680,
-                                    "peak_max_in_bytes": 139591680
-                                },
-                                "survivor": {
-                                    "used_in_bytes": 358496,
-                                    "max_in_bytes": 17432576,
-                                    "peak_used_in_bytes": 17432576,
-                                    "peak_max_in_bytes": 17432576
-                                },
-                                "old": {
-                                    "used_in_bytes": 52336480,
-                                    "max_in_bytes": 469368832,
-                                    "peak_used_in_bytes": 52336480,
-                                    "peak_max_in_bytes": 469368832
-                                }
-                            }
-                        }
-                    },
-                    "process": {
-                        "timestamp": 1526045135857,
-                        "open_file_descriptors": 312,
-                        "max_file_descriptors": 1048576,
-                        "cpu": {
-                            "percent": 10,
-                            "total_in_millis": 56520
-                        },
-                        "mem": {
-                            "total_virtual_in_bytes": 2472173568
-                        }
-                    },
-                    "thread_pool" : {
-                        "generic" : {
-                            "threads" : 4,
-                            "queue" : 0,
-                            "active" : 0,
-                            "rejected" : 0,
-                            "largest" : 4,
-                            "completed" : 8
-                        }
-                    },
-                    "breakers" : {
-                        "parent" : {
-                            "limit_size_in_bytes" : 726571417,
-                            "limit_size" : "692.9mb",
-                            "estimated_size_in_bytes" : 0,
-                            "estimated_size" : "0b",
-                            "overhead" : 1.0,
-                            "tripped" : 0
-                        }
-                    }
-                }
-            }
-        }
+    def test_flatten_indices_fields(self):
+        client = Client(nodes=SubClient(stats=NodeStatsRecorderTests.node_stats_response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        telemetry_params = {}
+        recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
+        flattened_fields = recorder.flatten_stats_fields(prefix="indices", stats=NodeStatsRecorderTests.node_stats_response["nodes"]["Zbl_e8EyRXmiR47gbHgPfg"]["indices"])
 
-        client = Client(nodes=SubClient(stats=node_stats_response))
+        self.assertDictEqual(NodeStatsRecorderTests.indices_stats_response_flattened, flattened_fields)
+
+    def test_flatten_filtered_indices_fields(self):
+        client = Client(nodes=SubClient(stats=NodeStatsRecorderTests.node_stats_response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        telemetry_params = {}
+        recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
+
+        flattened_fields = recorder.flatten_stats_fields(prefix="indices", stats=NodeStatsRecorderTests.node_stats_response["nodes"]["Zbl_e8EyRXmiR47gbHgPfg"]["indices"], include=["translog"])
+        self.assertDictEqual({
+            "indices_translog_operations": 0,
+            "indices_translog_size_in_bytes": 0,
+            "indices_translog_uncommitted_operations": 0,
+            "indices_translog_uncommitted_size_in_bytes": 0
+        }, flattened_fields)
+
+    def test_flatten_jvm_mem_fields(self):
+        client = Client(nodes=SubClient(stats=NodeStatsRecorderTests.node_stats_response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        telemetry_params = {}
+        recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
+
+        flattened_fields = recorder.flatten_stats_fields(prefix="jvm_mem", stats=NodeStatsRecorderTests.node_stats_response["nodes"]["Zbl_e8EyRXmiR47gbHgPfg"]["jvm"]["mem"])
+        self.assertDictEqual({
+            "jvm_mem_heap_used_in_bytes": 119073552,
+            "jvm_mem_heap_used_percent": 19,
+            "jvm_mem_heap_committed_in_bytes": 626393088,
+            "jvm_mem_heap_max_in_bytes": 626393088,
+            "jvm_mem_non_heap_used_in_bytes": 110250424,
+            "jvm_mem_non_heap_committed_in_bytes": 118108160,
+            "jvm_mem_pools_young_used_in_bytes": 66378576,
+            "jvm_mem_pools_young_max_in_bytes": 139591680,
+            "jvm_mem_pools_young_peak_used_in_bytes": 139591680,
+            "jvm_mem_pools_young_peak_max_in_bytes": 139591680,
+            "jvm_mem_pools_survivor_used_in_bytes": 358496,
+            "jvm_mem_pools_survivor_max_in_bytes": 17432576,
+            "jvm_mem_pools_survivor_peak_used_in_bytes": 17432576,
+            "jvm_mem_pools_survivor_peak_max_in_bytes": 17432576,
+            "jvm_mem_pools_old_used_in_bytes": 52336480,
+            "jvm_mem_pools_old_max_in_bytes": 469368832,
+            "jvm_mem_pools_old_peak_used_in_bytes": 52336480,
+            "jvm_mem_pools_old_peak_max_in_bytes": 469368832
+        }, flattened_fields)
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    def test_stores_default_nodes_stats(self, metrics_store_put_doc):
+        client = Client(nodes=SubClient(stats=NodeStatsRecorderTests.node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         metrics_store_meta_data = {"cluster": "remote"}
@@ -595,36 +725,21 @@ class NodeStatsRecorderTests(TestCase):
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         recorder.record()
 
-        metrics_store_put_count.assert_has_calls([
-            mock.call(node_name="rally0", name="thread_pool_generic_threads", count=4, meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_queue", count=0, meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_active", count=0, meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_rejected", count=0, meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_largest", count=4, meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_completed", count=8, meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="breaker_parent_overhead", count=1.0, meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="breaker_parent_tripped", count=0, meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_mapped_count", count=7, meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_direct_count", count=6, meta_data=metrics_store_meta_data),
-        ], any_order=True)
+        # Extract mock call args, needed to perform dict comparison of first param of mocked method
+        # https://stackoverflow.com/a/28418085/108668
+        call = metrics_store_put_doc.call_args
+        call_args, _ = call
+        self.maxDiff = None
+        self.assertDictEqual(call_args[0], NodeStatsRecorderTests.default_stats_response_flattened)
 
-        metrics_store_put_value.assert_has_calls([
-            mock.call(node_name="rally0", name="breaker_parent_limit_size_in_bytes", value=726571417, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="breaker_parent_estimated_size_in_bytes", value=0, unit="byte", meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_mapped_used_in_bytes", value=3120, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_mapped_total_capacity_in_bytes", value=9999, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_direct_used_in_bytes", value=73868, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_direct_total_capacity_in_bytes", value=73867, unit="byte",
-                      meta_data=metrics_store_meta_data),
-        ], any_order=True)
+        # Now that we've ensured first param is correct, also ensure method gets called with correct remaining params
+        metrics_store_put_doc.assert_called_once_with(mock.ANY,
+                                                      level=MetaInfoScope.node,
+                                                      node_name="rally0",
+                                                      meta_data=metrics_store_meta_data)
 
-    @mock.patch("esrally.metrics.EsMetricsStore.put_count_node_level")
-    @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
-    def test_stores_all_nodes_stats(self, metrics_store_put_value, metrics_store_put_count):
+    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    def test_stores_all_nodes_stats(self, metrics_store_put_doc):
         node_stats_response = {
             "cluster_name" : "elasticsearch",
             "nodes" : {
@@ -801,129 +916,92 @@ class NodeStatsRecorderTests(TestCase):
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         recorder.record()
 
-        metrics_store_put_count.assert_has_calls([
-            mock.call(node_name="rally0", name="indices_docs_count", count=76892364,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_docs_deleted", count=324530,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_search_open_contexts", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_search_query_total", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_merges_current", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_merges_current_docs", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_query_cache_total_count", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_query_cache_hit_count", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_query_cache_miss_count", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_query_cache_cache_size", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_query_cache_cache_count", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_query_cache_evictions", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_fielddata_evictions", count=17,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_segments_count", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_segments_max_unsafe_auto_id_timestamp", count=-9223372036854775808,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_translog_operations", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_translog_uncommitted_operations", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_request_cache_evictions", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_request_cache_hit_count", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_request_cache_miss_count", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_threads", count=4,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_queue", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_active", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_rejected", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_largest", count=4,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="thread_pool_generic_completed", count=8,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="transport_server_open", count=12,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="transport_rx_count", count=77,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="transport_tx_count", count=88,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="process_cpu_percent", count=10,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="breaker_parent_overhead", count=1.0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="breaker_parent_tripped", count=0,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_mapped_count", count=7,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_direct_count", count=6,
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_mem_heap_used_percent", count=19,
-                      meta_data=metrics_store_meta_data),
-        ], any_order=True)
+        call = metrics_store_put_doc.call_args
+        call_args, _ = call
 
-        metrics_store_put_value.assert_has_calls([
-            mock.call(node_name="rally0", name="indices_store_size_in_bytes", value=983409834, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_indexing_throttle_time_in_millis", value=0, unit="ms",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_search_query_time_in_millis", value=0, unit="ms",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_merges_current_size_in_bytes", value=0, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_query_cache_memory_size_in_bytes", value=0, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_fielddata_memory_size_in_bytes", value=6936, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_segments_memory_in_bytes", value=0, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_translog_size_in_bytes", value=0, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_translog_uncommitted_size_in_bytes", value=0, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="indices_request_cache_memory_size_in_bytes", value=0, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="transport_rx_size_in_bytes", value=98723498, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="transport_tx_size_in_bytes", value=23879803, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="process_cpu_total_in_millis", value=56520, unit="ms",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="breaker_parent_limit_size_in_bytes", value=726571417, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="breaker_parent_estimated_size_in_bytes", value=0, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_mapped_used_in_bytes", value=3120, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_mapped_total_capacity_in_bytes", value=9999, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_direct_used_in_bytes", value=73868, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_buffer_pool_direct_total_capacity_in_bytes", value=73867, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_mem_heap_used_in_bytes", value=119073552, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_mem_heap_committed_in_bytes", value=626393088, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_mem_heap_max_in_bytes", value=626393088, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_mem_non_heap_used_in_bytes", value=110250424, unit="byte",
-                      meta_data=metrics_store_meta_data),
-            mock.call(node_name="rally0", name="jvm_mem_non_heap_committed_in_bytes", value=118108160, unit="byte",
-                      meta_data=metrics_store_meta_data),
-        ], any_order=True)
+        self.maxDiff = None
+        self.assertDictEqual(
+            call_args[0],
+            {"indices_docs_count": 76892364,
+             "indices_docs_deleted": 324530,
+             "indices_fielddata_evictions": 17,
+             "indices_fielddata_memory_size_in_bytes": 6936,
+             "indices_indexing_is_throttled": False,
+             "indices_indexing_throttle_time_in_millis": 0,
+             "indices_merges_current": 0,
+             "indices_merges_current_docs": 0,
+             "indices_merges_current_size_in_bytes": 0,
+             "indices_query_cache_cache_count": 0,
+             "indices_query_cache_cache_size": 0,
+             "indices_query_cache_evictions": 0,
+             "indices_query_cache_hit_count": 0,
+             "indices_query_cache_memory_size_in_bytes": 0,
+             "indices_query_cache_miss_count": 0,
+             "indices_query_cache_total_count": 0,
+             "indices_request_cache_evictions": 0,
+             "indices_request_cache_hit_count": 0,
+             "indices_request_cache_memory_size_in_bytes": 0,
+             "indices_request_cache_miss_count": 0,
+             "indices_search_open_contexts": 0,
+             "indices_search_query_time_in_millis": 0,
+             "indices_search_query_total": 0,
+             "indices_segments_count": 0,
+             "indices_segments_max_unsafe_auto_id_timestamp": -9223372036854775808,
+             "indices_segments_memory_in_bytes": 0,
+             "indices_store_size_in_bytes": 983409834,
+             "indices_translog_operations": 0,
+             "indices_translog_size_in_bytes": 0,
+             "indices_translog_uncommitted_operations": 0,
+             "indices_translog_uncommitted_size_in_bytes": 0,
+             "thread_pool_generic_active": 0,
+             "thread_pool_generic_completed": 8,
+             "thread_pool_generic_largest": 4,
+             "thread_pool_generic_queue": 0,
+             "thread_pool_generic_rejected": 0,
+             "thread_pool_generic_threads": 4,
+             "breakers_parent_estimated_size": "0b",
+             "breakers_parent_estimated_size_in_bytes": 0,
+             "breakers_parent_limit_size": "692.9mb",
+             "breakers_parent_limit_size_in_bytes": 726571417,
+             "breakers_parent_overhead": 1.0,
+             "breakers_parent_tripped": 0,
+             "jvm_buffer_pools_direct_count": 6,
+             "jvm_buffer_pools_direct_total_capacity_in_bytes": 73867,
+             "jvm_buffer_pools_direct_used_in_bytes": 73868,
+             "jvm_buffer_pools_mapped_count": 7,
+             "jvm_buffer_pools_mapped_total_capacity_in_bytes": 9999,
+             "jvm_buffer_pools_mapped_used_in_bytes": 3120,
+             "jvm_mem_heap_committed_in_bytes": 626393088,
+             "jvm_mem_heap_max_in_bytes": 626393088,
+             "jvm_mem_heap_used_in_bytes": 119073552,
+             "jvm_mem_heap_used_percent": 19,
+             "jvm_mem_non_heap_committed_in_bytes": 118108160,
+             "jvm_mem_non_heap_used_in_bytes": 110250424,
+             "jvm_mem_pools_old_max_in_bytes": 469368832,
+             "jvm_mem_pools_old_peak_max_in_bytes": 469368832,
+             "jvm_mem_pools_old_peak_used_in_bytes": 52336480,
+             "jvm_mem_pools_old_used_in_bytes": 52336480,
+             "jvm_mem_pools_survivor_max_in_bytes": 17432576,
+             "jvm_mem_pools_survivor_peak_max_in_bytes": 17432576,
+             "jvm_mem_pools_survivor_peak_used_in_bytes": 17432576,
+             "jvm_mem_pools_survivor_used_in_bytes": 358496,
+             "jvm_mem_pools_young_max_in_bytes": 139591680,
+             "jvm_mem_pools_young_peak_max_in_bytes": 139591680,
+             "jvm_mem_pools_young_peak_used_in_bytes": 139591680,
+             "jvm_mem_pools_young_used_in_bytes": 66378576,
+             "transport_rx_count": 77,
+             "transport_rx_size_in_bytes": 98723498,
+             "transport_server_open": 12,
+             "transport_tx_count": 88,
+             "transport_tx_size_in_bytes": 23879803,
+             "process_cpu_percent": 10,
+             "process_cpu_total_in_millis": 56520}
+        )
+
+        metrics_store_put_doc.assert_called_once_with(mock.ANY,
+                                                      level=MetaInfoScope.node,
+                                                      node_name="rally0",
+                                                      meta_data=metrics_store_meta_data)
 
 
 class ClusterEnvironmentInfoTests(TestCase):


### PR DESCRIPTION
This is similar to the work done earlier for the ccr-stats telemetry
device in 198ceefc93d223cdb292fb15b1373b64058f28cb