### PR TITLE
Derive JDK version at runtime

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -284,6 +284,20 @@ Example::
 
 This enables the Java flight recorder telemetry device and sets the ``recording-template`` parameter to "profile".
 
+``runtime-jdk``
+~~~~~~~~~~~~~~~
+
+By default, Rally will derive the appropriate runtime JDK versions automatically per version of Elasticsearch. For example, it will choose JDK 8 or 7 for Elasticsearch 2.x but only JDK 8 for Elasticsearch 5.0.0. It will choose the highest available version.
+
+This command line parameter sets the major version of the JDK that Rally should use to run Elasticsearch. It is required that either ``JAVA_HOME`` or ``JAVAx_HOME`` (where ``x`` is the major version, e.g. ``JAVA8_HOME`` for a JDK 8) points to the appropriate JDK.
+
+Example::
+
+   # Run a benchmark with defaults (i.e. JDK 8)
+   esrally --distribution-version=2.4.0
+   # Force to run with JDK 7
+   esrally --distribution-version=2.4.0 --runtime-jdk=7
+
 .. _clr_revision:
 
 ``revision``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -26,10 +26,10 @@ Let's go through an example step by step: First run ``esrally``::
 
       esrally configure --advanced-config
 
-    * Setting up benchmark data directory in /Users/daniel/.rally/benchmarks
-    * Setting up benchmark source directory in /Users/daniel/.rally/benchmarks/src/elasticsearch
+    * Setting up benchmark data directory in /Users/dm/.rally/benchmarks
+    * Setting up benchmark source directory in /Users/dm/.rally/benchmarks/src/elasticsearch
 
-    Configuration successfully written to /Users/daniel/.rally/rally.ini. Happy benchmarking!
+    Configuration successfully written to /Users/dm/.rally/rally.ini. Happy benchmarking!
 
     More info about Rally:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,7 +15,6 @@ Rally can build Elasticsearch either from sources or use an `official binary dis
 Let's go through an example step by step: First run ``esrally``::
 
     dm@io:~ $ esrally
-
         ____        ____
        / __ \____ _/ / /_  __
       / /_/ / __ `/ / / / / /
@@ -27,41 +26,10 @@ Let's go through an example step by step: First run ``esrally``::
 
       esrally configure --advanced-config
 
-    * Autodetecting available third-party software
-      git    : [OK]
-      JDK    : [OK]
+    * Setting up benchmark data directory in /Users/daniel/.rally/benchmarks
+    * Setting up benchmark source directory in /Users/daniel/.rally/benchmarks/src/elasticsearch
 
-    * Setting up benchmark data directory in /Users/dm/.rally/benchmarks
-    Enter the JDK 10 root directory (Press Enter to skip):
-
-As you can see above, Rally autodetects if git and a JDK are installed. It also searches for a JDK 10; if you don't have it, that's no problem, you are just not able to build Elasticsearch from sources. Let's assume you press Enter and don't specify a path for JDK 10::
-
-    ********************************************************************************
-    You don't have a valid JDK 10 installation and cannot benchmark source builds.
-
-    You can still benchmark binary distributions with e.g.:
-
-      esrally --distribution-version=6.0.0
-    ********************************************************************************
-
-As you can see, Rally tells you that you cannot build Elasticsearch from sources but you can still benchmark official binary distributions.
-
-It's also possible that Rally cannot automatically your JDK home directory. In that case, it will ask you later in the configuration process. If you do not provide a JDK home directory, Rally cannot start Elasticsearch on this machine but you can still use it as a load generator to :doc:`benchmark remote clusters </recipes>`.
-
-If you specify a valid path for JDK 10, Rally will try to autodetect your Elasticsearch project directory (either in the current directory or in ``../elasticsearch``) or will choose a default directory::
-
-    * Setting up benchmark data directory in /Users/dm/.rally/benchmarks
-    * Setting up benchmark source directory in /Users/dm/.rally/benchmarks/src/elasticsearch
-
-If a valid path for JDK 10 was not found (or entered), it will not ask you for a source directory and just go on.
-
-Now Rally is done::
-
-    Configuration successfully written to /Users/dm/.rally/rally.ini. Happy benchmarking!
-
-    To benchmark Elasticsearch 6.0.0 with the default benchmark, run:
-
-      esrally --distribution-version=6.0.0
+    Configuration successfully written to /Users/daniel/.rally/rally.ini. Happy benchmarking!
 
     More info about Rally:
 
@@ -102,7 +70,6 @@ Rally will ask you a few more things in the advanced setup:
 
 * **Benchmark data directory**: Rally stores all benchmark related data in this directory which can take up to several tens of GB. If you want to use a dedicated partition, you can specify a different data directory here.
 * **Elasticsearch project directory**: This is the directory where the Elasticsearch sources are located. If you don't actively develop on Elasticsearch you can just leave the default but if you want to benchmark local changes you should point Rally to your project directory. Note that Rally will run builds with the Gradle Wrapper in this directory (it runs ``./gradlew clean`` and ``./gradlew :distribution:tar:assemble``).
-* **JDK root directory**: Rally will only ask this if it could not autodetect the JDK home by itself. Just enter the root directory of the JDK you want to use. By default, Rally will choose Java 8 if available and fallback to Java 10.
 * **Metrics store type**: You can choose between ``in-memory`` which requires no additional setup or ``elasticsearch`` which requires that you start a dedicated Elasticsearch instance to store metrics but gives you much more flexibility to analyse results.
 * **Metrics store settings** (only for metrics store type ``elasticsearch``): Provide the connection details to the Elasticsearch metrics store. This should be an instance that you use just for Rally but it can be a rather small one. A single node cluster with default setting should do it. When using self-signed certificates on the Elasticsearch metrics store, certificate verification can be turned off by setting the ``datastore.ssl.verification_mode`` setting to ``none``. Alternatively you can enter the path to the certificate authority's signing certificate in ``datastore.ssl.certificate_authorities``. Both settings are optional.
 * **Name for this benchmark environment** (only for metrics store type ``elasticsearch``): You can use the same metrics store for multiple environments (e.g. local, continuous integration etc.) so you can separate metrics from different environments by choosing a different name.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -101,9 +101,11 @@ In all other cases, Rally requires ``git 1.9`` or better. Verify with ``git --ve
 JDK
 ~~~
 
-A JDK is required on all machines where you want to launch Elasticsearch. If you use Rally just as a load generator, no JDK is required.
+A JDK is required on all machines where you want to launch Elasticsearch. If you use Rally just as a load generator to :doc:`benchmark remote clusters </recipes>`, no JDK is required.
 
 We recommend to use Oracle JDK but you are free to use OpenJDK as well. For details on how to install a JDK check your operating system's documentation pages.
+
+To find the JDK, Rally expects the environment variable ``JAVA_HOME`` to be set on all targeted machines. To have more specific control, for example when you want to benchmark across a wide range of Elasticsearch releases, you can also set ``JAVAx_HOME`` where ``x``  is the major version of a JDK (e.g. ``JAVA8_HOME`` would point to a JDK 8 installation). Rally will then choose the highest supported JDK per version of Elasticsearch that is available.
 
 
 .. note::

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,23 @@
 Migration Guide
 ===============
 
+Migrating to Rally 1.0.0
+------------------------
+
+Handling of JDK versions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Previously the path to the JDK needed to be configured in Rally's configuration file (``~/.rally/rally.ini``) but this is too inflexible given the increased JDK release cadence. In order to keep up, we define now the allowed runtime JDKs in `rally-teams <https://github.com/elastic/rally-teams/blob/master/cars/v1/vanilla/config.ini>`_ per Elasticsearch version.
+
+To resolve the path to the appropriate JDK you need to define the environment variable ``JAVA_HOME`` on each targeted machine.
+
+You can also set version-specific environment variables, e.g. ``JAVA7_HOME``, ``JAVA8_HOME`` or ``JAVA10_HOME`` which will take precedence over ``JAVA_HOME``.
+
+.. note::
+
+    Rally will choose the highest appropriate JDK per Elasticsearch version. You can use ``--runtime-jdk`` to force a specific JDK version but the path will still be resolved according to the logic above.
+
+
 Migrating to Rally 0.11.0
 -------------------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,7 +4,7 @@ Quickstart
 Install
 -------
 
-Install Python 3.4+ including ``pip3``, git 1.9+ and an appropriate JDK to run Elasticsearch Be sure that ``JAVA_HOME`` points to that JDK. Then run the following command, optionally prefixed by ``sudo`` if necessary::
+Install Python 3.4+ including ``pip3``, git 1.9+ and an `appropriate JDK to run Elasticsearch <https://www.elastic.co/support/matrix#matrix_jvm>`_ Be sure that ``JAVA_HOME`` points to that JDK. Then run the following command, optionally prefixed by ``sudo`` if necessary::
 
     pip3 install esrally
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,7 +4,7 @@ Quickstart
 Install
 -------
 
-Install Python 3.4+ including ``pip3``, git 1.9+ and at least JDK 8. If you want to benchmark source builds of Elasticsearch you also need JDK 10. Then run the following command, optionally prefixed by ``sudo`` if necessary::
+Install Python 3.4+ including ``pip3``, git 1.9+ and an appropriate JDK to run Elasticsearch Be sure that ``JAVA_HOME`` points to that JDK. Then run the following command, optionally prefixed by ``sudo`` if necessary::
 
     pip3 install esrally
 

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -231,8 +231,8 @@ class InProcessLauncher:
         self.metrics_store = metrics_store
         self._clock = clock
         self.races_root_dir = races_root_dir
-        self.java_home = self.cfg.opts("runtime", "java.home")
         self.keep_running = self.cfg.opts("mechanic", "keep.running")
+        self.override_runtime_jdk = self.cfg.opts("mechanic", "runtime.jdk")
         self.logger = logging.getLogger(__name__)
 
     def start(self, node_configurations):
@@ -241,19 +241,17 @@ class InProcessLauncher:
         #
         # We also do this only once per host otherwise we would kill instances that we've just launched.
         process.kill_running_es_instances(self.races_root_dir)
-        java_major_version = jvm.major_version(self.java_home)
-        self.logger.info("Detected Java major version [%s].", java_major_version)
-
         node_count_on_host = len(node_configurations)
-        return [self._start_node(node_configuration, node_count_on_host, java_major_version) for node_configuration in node_configurations]
+        return [self._start_node(node_configuration, node_count_on_host) for node_configuration in node_configurations]
 
-    def _start_node(self, node_configuration, node_count_on_host, java_major_version):
+    def _start_node(self, node_configuration, node_count_on_host):
         host_name = node_configuration.ip
         node_name = node_configuration.node_name
         car = node_configuration.car
         binary_path = node_configuration.binary_path
         data_paths = node_configuration.data_paths
         node_telemetry_dir = "%s/telemetry" % node_configuration.node_root_path
+        java_major_version, java_home = self._resolve_java_home(car)
 
         self.logger.info("Starting node [%s] based on car [%s].", node_name, car)
 
@@ -273,7 +271,7 @@ class InProcessLauncher:
         ]
 
         t = telemetry.Telemetry(enabled_devices, devices=node_telemetry)
-        env = self._prepare_env(car, node_name, t)
+        env = self._prepare_env(car, node_name, java_home, t)
         t.on_pre_node_start(node_name)
         node_process = self._start_process(env, node_name, binary_path)
         node = cluster.Node(node_process, host_name, node_name, t)
@@ -283,21 +281,38 @@ class InProcessLauncher:
 
         return node
 
-    def _prepare_env(self, car, node_name, t):
+    def _resolve_java_home(self, car):
+        runtime_jdk_versions = self._determine_runtime_jdks(car)
+        self.logger.info("Allowed JDK versions are %s.", runtime_jdk_versions)
+        major, java_home = jvm.resolve_path(runtime_jdk_versions)
+        self.logger.info("Detected JDK with major version [%s] in [%s].", major, java_home)
+        return major, java_home
+
+    def _determine_runtime_jdks(self, car):
+        if self.override_runtime_jdk:
+            return [self.override_runtime_jdk]
+        else:
+            runtime_jdks = car.mandatory_var("runtime.jdk")
+            try:
+                return [int(v) for v in runtime_jdks.split(",")]
+            except ValueError:
+                raise exceptions.SystemSetupError("Car config key \"runtime.jdk\" is invalid: \"{}\" (must be int)".format(runtime_jdks))
+
+    def _prepare_env(self, car, node_name, java_home, t):
         env = {}
         env.update(os.environ)
         env.update(car.env)
         # Unix specific!:
-        self._set_env(env, "PATH", "%s/bin" % self.java_home, separator=":")
+        self._set_env(env, "PATH", "%s/bin" % java_home, separator=":")
         # Don't merge here!
-        env["JAVA_HOME"] = self.java_home
+        env["JAVA_HOME"] = java_home
 
         # we just blindly trust telemetry here...
         for k, v in t.instrument_candidate_env(car, node_name).items():
             self._set_env(env, k, v)
 
         exit_on_oome_flag = "-XX:+ExitOnOutOfMemoryError"
-        if jvm.supports_option(self.java_home, exit_on_oome_flag):
+        if jvm.supports_option(java_home, exit_on_oome_flag):
             self.logger.info("Setting [%s] to detect out of memory errors during the benchmark.", exit_on_oome_flag)
             self._set_env(env, "ES_JAVA_OPTS", exit_on_oome_flag)
         else:

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -302,8 +302,7 @@ class InProcessLauncher:
         env = {}
         env.update(os.environ)
         env.update(car.env)
-        # Unix specific!:
-        self._set_env(env, "PATH", "%s/bin" % java_home, separator=":")
+        self._set_env(env, "PATH", os.path.join(java_home, "bin"), separator=os.pathsep)
         # Don't merge here!
         env["JAVA_HOME"] = java_home
 

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -245,6 +245,12 @@ class Car:
         self.variables = variables
         self.env = env
 
+    def mandatory_var(self, name):
+        try:
+            return self.variables[name]
+        except KeyError:
+            raise exceptions.SystemSetupError("Car \"{}\" misses mandatory config key \"{}\"".format(self.name, name))
+
     @property
     def name(self):
         return "+".join(self.names)

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -249,7 +249,7 @@ class Car:
         try:
             return self.variables[name]
         except KeyError:
-            raise exceptions.SystemSetupError("Car \"{}\" misses mandatory config key \"{}\"".format(self.name, name))
+            raise exceptions.SystemSetupError("Car \"{}\" requires config key \"{}\"".format(self.name, name))
 
     @property
     def name(self):

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -127,9 +127,6 @@ def create_arg_parser():
             help="Automatically accept all options with default values (default: false)",
             default=False,
             action="store_true")
-        # undocumented - only as a workaround for integration tests
-        p.add_argument("--java-home", default=None)
-        p.add_argument("--runtime-java-home", default=None)
 
     for p in [parser, list_parser, race_parser, generate_parser]:
         p.add_argument(
@@ -137,6 +134,11 @@ def create_arg_parser():
             help="define the version of the Elasticsearch distribution to download. "
                  "Check https://www.elastic.co/downloads/elasticsearch for released versions.",
             default="")
+        p.add_argument(
+            "--runtime-jdk",
+            type=positive_number,
+            help="The major version of the runtime JDK to use.",
+            default=None)
 
         track_source_group = p.add_mutually_exclusive_group()
         track_source_group.add_argument(
@@ -331,9 +333,7 @@ def ensure_configuration_present(cfg, args, sub_command):
     if sub_command == "configure":
         config.ConfigFactory().create_config(cfg.config_file,
                                              advanced_config=args.advanced_config,
-                                             assume_defaults=args.assume_defaults,
-                                             java_home=args.java_home,
-                                             runtime_java_home=args.runtime_java_home)
+                                             assume_defaults=args.assume_defaults)
         exit(0)
     else:
         if cfg.config_present():
@@ -536,6 +536,7 @@ def main():
     else:
         cfg.add(config.Scope.applicationOverride, "mechanic", "keep.running", False)
         cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
+    cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
     cfg.add(config.Scope.applicationOverride, "mechanic", "telemetry.devices", opts.csv_to_list(args.telemetry))
     cfg.add(config.Scope.applicationOverride, "mechanic", "telemetry.params", opts.to_dict(args.telemetry_params))
 

--- a/esrally/utils/jvm.py
+++ b/esrally/utils/jvm.py
@@ -1,5 +1,7 @@
 import re
+import os
 
+from esrally import exceptions
 from esrally.utils import process
 
 
@@ -74,3 +76,78 @@ def is_early_access_release(java_home, sysprop_reader=system_property):
     :return: True iff the JVM available at ``java_home`` is classified as an early access release.
     """
     return vendor(java_home, sysprop_reader) == "Oracle Corporation" and version(java_home, sysprop_reader).endswith("-ea")
+
+
+def resolve_path(majors, sysprop_reader=system_property):
+    """
+    Resolves the path to the JDK with the provided major version(s). It checks the provided versions in order and will return the first
+    match. For that it checks first the environment variable ``JAVAx_HOME`` where ``x`` is the checked major version and will fall back
+    to ``JAVA_HOME``. It also ensures that the environment variable points to the right JDK version.
+
+    If no appropriate version is found, a ``SystemSetupError`` is raised.
+
+    :param majors: Either a list of major versions to check or a single version as an ``int``.
+    :param sysprop_reader: (Optional) only relevant for testing.
+    :return: A tuple of (major version, path to Java home directory).
+    """
+    if isinstance(majors, int):
+        return majors, _resolve_single_path(majors, sysprop_reader=sysprop_reader)
+    else:
+        for major in majors:
+            java_home = _resolve_single_path(major, mandatory=False, sysprop_reader=sysprop_reader)
+            if java_home:
+                return major, java_home
+        raise exceptions.SystemSetupError("Install a JDK with one of the versions {} and point to it with one of {}."
+                                          .format(majors, _checked_env_vars(majors)))
+
+
+def _resolve_single_path(major, mandatory=True, sysprop_reader=system_property):
+    """
+
+    Resolves the path to a JDK with the provided major version.
+
+    :param major: The major version to check.
+    :param mandatory: Determines if we expect to find a matching JDK.
+    :param sysprop_reader: (Optional) only relevant for testing.
+    :return: The resolved path to the JDK or ``None`` if ``mandatory`` is ``False`` and no appropriate JDK has been found.
+    """
+    def do_resolve(env_var, major):
+        java_v_home = os.getenv(env_var)
+        if java_v_home:
+            actual_major = major_version(java_v_home, sysprop_reader)
+            if actual_major == major:
+                return java_v_home
+            elif mandatory:
+                raise exceptions.SystemSetupError("{} points to JDK {} but it should point to JDK {}.".format(env_var, actual_major, major))
+            else:
+                return None
+        else:
+            return None
+
+    # this has to be consistent with _checked_env_vars()
+    specific_env_var = "JAVA{}_HOME".format(major)
+    generic_env_var = "JAVA_HOME"
+    java_home = do_resolve(specific_env_var, major)
+    if java_home:
+        return java_home
+    else:
+        java_home = do_resolve(generic_env_var, major)
+        if java_home:
+            return java_home
+        elif mandatory:
+            raise exceptions.SystemSetupError("Neither {} nor {} point to a JDK {} installation.".
+                                              format(specific_env_var, generic_env_var, major))
+        else:
+            return None
+
+
+def _checked_env_vars(majors):
+    """
+    Provides a list of environment variables that are checked for the given list of major versions.
+
+    :param majors: A list of major versions.
+    :return: A list of checked environment variables.
+    """
+    checked = ["JAVA{}_HOME".format(major) for major in majors]
+    checked.append("JAVA_HOME")
+    return checked

--- a/esrally/utils/jvm.py
+++ b/esrally/utils/jvm.py
@@ -80,9 +80,9 @@ def is_early_access_release(java_home, sysprop_reader=system_property):
 
 def resolve_path(majors, sysprop_reader=system_property):
     """
-    Resolves the path to the JDK with the provided major version(s). It checks the provided versions in order and will return the first
-    match. For that it checks first the environment variable ``JAVAx_HOME`` where ``x`` is the checked major version and will fall back
-    to ``JAVA_HOME``. It also ensures that the environment variable points to the right JDK version.
+    Resolves the path to the JDK with the provided major version(s). It checks the versions in the same order specified in ``majors``
+    and will return the first match. To achieve this, it first checks the major version x in the environment variable ``JAVAx_HOME``
+    and falls back to ``JAVA_HOME``. It also ensures that the environment variable points to the right JDK version.
 
     If no appropriate version is found, a ``SystemSetupError`` is raised.
 

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -4,16 +4,10 @@ set -e
 
 readonly CONFIGURATIONS=(integration-test es-integration-test)
 
-# we will not test ES 1.x anymore because it does not work with (out of the box) with Java 9 anymore (Java 8 is still fine). On startup it
-# fails with:
-#
-#       java.lang.UnsupportedOperationException: Boot class path mechanism is not supported
-#
-# Temporarily disable testing ES 2.x because it does not start with JDK 10 (sets unrecognized JVM options)
-# readonly DISTRIBUTIONS=(2.4.6 5.6.7)
-readonly DISTRIBUTIONS=(5.6.7)
+readonly DISTRIBUTIONS=(1.7.6 2.4.6 5.6.9)
 readonly TRACKS=(geonames nyc_taxis http_logs nested)
 
+readonly ES_METRICS_STORE_JAVA_HOME="${JAVA8_HOME}"
 readonly ES_METRICS_STORE_VERSION="6.2.1"
 readonly ES_ARTIFACT_PATH="elasticsearch-${ES_METRICS_STORE_VERSION}"
 readonly ES_ARTIFACT="${ES_ARTIFACT_PATH}.tar.gz"
@@ -71,19 +65,10 @@ function set_up {
     local in_memory_config_file_path="${HOME}/.rally/rally-integration-test.ini"
     local es_config_file_path="${HOME}/.rally/rally-es-integration-test.ini"
 
-    # if the build defines these variables we'll explicitly use them instead of auto-detection
-    if [ -n "${JAVA_HOME}" ] && [ -n "${RUNTIME_JAVA_HOME}" ]; then
-        # configure for tests with an in-memory metrics store
-        esrally configure --java-home="${JAVA_HOME}" --runtime-java-home="${RUNTIME_JAVA_HOME}" --assume-defaults --configuration-name="integration-test"
-        # configure for tests with an Elasticsearch metrics store
-        esrally configure --java-home="${JAVA_HOME}" --runtime-java-home="${RUNTIME_JAVA_HOME}" --assume-defaults --configuration-name="es-integration-test"
-    else
-        # configure for tests with an in-memory metrics store
-        esrally configure --assume-defaults --configuration-name="integration-test"
-        # configure for tests with an Elasticsearch metrics store
-        esrally configure --assume-defaults --configuration-name="es-integration-test"
-
-    fi
+    # configure for tests with an in-memory metrics store
+    esrally configure --assume-defaults --configuration-name="integration-test"
+    # configure for tests with an Elasticsearch metrics store
+    esrally configure --assume-defaults --configuration-name="es-integration-test"
 
     # configure Elasticsearch instead of in-memory after the fact
     # this is more portable than using sed's in-place editing which requires "-i" on GNU and "-i ''" elsewhere.
@@ -109,6 +94,7 @@ function set_up {
     # Delete and exit if archive is somehow corrupted, despite getting downloaded correctly.
     tar -xzf "${ES_ARTIFACT}" || { rm -f "${ES_ARTIFACT}"; exit 1; }
     cd "${ES_ARTIFACT_PATH}"
+    export JAVA_HOME=${ES_METRICS_STORE_JAVA_HOME}
     bin/elasticsearch &
     # store PID so we can kill ES later
     ES_PID=$!
@@ -159,10 +145,10 @@ function test_sources {
     # build Elasticsearch and a core plugin
     info "test sources [--configuration-name=${cfg}], [--revision=latest], [--track=geonames], [--challenge=append-no-conflicts], [--car=4gheap] [--elasticsearch-plugins=analysis-icu]"
     kill_rally_processes
-    esrally --configuration-name="${cfg}" --revision=latest --track=geonames --test-mode --challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu
+    esrally --configuration-name="${cfg}" --on-error=abort --revision=latest --track=geonames --test-mode --challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu
     info "test sources [--configuration-name=${cfg}], [--pipeline=from-sources-skip-build], [--track=geonames], [--challenge=append-no-conflicts-index-only], [--car=4gheap,ea] [--laps=2]"
     kill_rally_processes
-    esrally --configuration-name="${cfg}" --pipeline=from-sources-skip-build --track=geonames --test-mode --challenge=append-no-conflicts-index-only --car="4gheap,ea" --laps=2
+    esrally --configuration-name="${cfg}" --on-error=abort --pipeline=from-sources-skip-build --track=geonames --test-mode --challenge=append-no-conflicts-index-only --car="4gheap,ea" --laps=2
 }
 
 function test_distributions {
@@ -175,7 +161,7 @@ function test_distributions {
             random_configuration cfg
             info "test distributions [--configuration-name=${cfg}], [--distribution-version=${dist}], [--track=${track}], [--car=4gheap]"
             kill_rally_processes
-            esrally --configuration-name="${cfg}" --distribution-version="${dist}" --track="${track}" --test-mode --car=4gheap
+            esrally --configuration-name="${cfg}" --on-error=abort --distribution-version="${dist}" --track="${track}" --test-mode --car=4gheap
         done
     done
 }
@@ -188,7 +174,7 @@ function test_benchmark_only {
 
     info "test benchmark-only [--configuration-name=${cfg}]"
     kill_rally_processes
-    esrally --configuration-name="${cfg}" --pipeline=benchmark-only --track=geonames --test-mode --challenge=append-no-conflicts-index-only --track-params="cluster_health:'yellow'"
+    esrally --configuration-name="${cfg}" --on-error=abort --pipeline=benchmark-only --track=geonames --test-mode --challenge=append-no-conflicts-index-only --track-params="cluster_health:'yellow'"
 }
 
 function run_test {

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -180,7 +180,7 @@ class ElasticsearchSourceSupplierTests(TestCase):
         builder = mock.create_autospec(supplier.Builder)
         es = supplier.ElasticsearchSourceSupplier(revision="abc", es_src_dir="/src", remote_url="", car=car, builder=builder)
         with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    "Car \"default\" misses mandatory config key \"build_command\"."):
+                                    "Car \"default\" requires config key \"build_command\"."):
             es.prepare()
 
         self.assertEqual(0, builder.build.call_count)

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,11 @@ deps =
     pytest-benchmark
 passenv =
     HOME
-    JAVA_HOME
-    RUNTIME_JAVA_HOME
+    JAVA7_HOME
+    JAVA8_HOME
+    JAVA9_HOME
+    JAVA10_HOME
+    JAVA11_HOME
     SSH_AUTH_SOCK
 # we do not pass LANG and LC_ALL anymore in order to isolate integration tests
 # from the test environment. Rally needs to enforce UTF-8 encoding in every


### PR DESCRIPTION
With this commit we derive the appropriate JDK version at benchmark
runtime instead of requiring that it is preconfigured. This requires two
new variables in the rally-teams repo: `build.jdk` and `runtime.jdk` to
resolve the appropriate (major) JDK version depending on the
Elasticsearch version.

When we know the required JDK version, we check the environment
variables `JAVAx_HOME` (where `x` is the JDK version) and `JAVA_HOME` to
find the correct JAVA_HOME path. We also allow the user to override the
runtime JDK with a new command line parameter `--runtime-jdk` as Rally
will default to the highest available and supported JDK version on the
target system.

Closes #452