### PR TITLE
Specify 1 for number of shards for metrics store indices

### DIFF
--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -2,6 +2,7 @@
   "template": "rally-metrics-*",
   "settings": {
     "index": {
+      "number_of_shards": 1,
       "refresh_interval": "5s"
     }
   },


### PR DESCRIPTION
Align with the new Elasticsearch defaults[1] for number of shards for
the indices used in the metrics store.

[1] https://github.com/elastic/elasticsearch/pull/30539