### PR TITLE
Remove deprecated usage of parameter source

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,47 @@
 Migration Guide
 ===============
 
+Migrating to Rally 1.0.0
+------------------------
+
+Custom Parameter Sources
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+In Rally 0.10.0 we have deprecated some parameter names in custom parameter sources. In Rally 1.0.0, these deprecated names have been removed. Therefore you need to replace the following parameter names if you use them in custom parameter sources:
+
+============== ======================= =======================
+Operation type Old name                New name
+============== ======================= =======================
+search         use_request_cache       cache
+search         request_params          request-params
+search         items_per_page          results-per-page
+bulk           action_metadata_present action-metadata-present
+force-merge    max_num_segments        max-num-segments
+============== ======================= =======================
+
+In Rally 0.9.0 the signature of custom parameter sources has also changed. In Rally 1.0.0 we have removed the backwards compatibility layer so you need to change the signatures.
+
+Old::
+
+    # for parameter sources implemented as functions
+    def custom_param_source(indices, params):
+
+    # for parameter sources implemented as classes
+    class CustomParamSource:
+        def __init__(self, indices, params):
+
+
+New::
+
+    # for parameter sources implemented as functions
+    def custom_param_source(track, params, **kwargs):
+
+    # for parameter sources implemented as classes
+    class CustomParamSource:
+        def __init__(self, track, params, **kwargs):
+
+You can use the property ``track.indices`` to access indices.
+
 Migrating to Rally 0.11.0
 -------------------------
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -334,16 +334,7 @@ class BulkIndex(Runner):
         if "pipeline" in params:
             bulk_params["pipeline"] = params["pipeline"]
 
-        # TODO: Remove this fallback logic with Rally 1.0
-        if "action-metadata-present" in params:
-            action_meta_data_key = "action-metadata-present"
-        else:
-            if "action_metadata_present" in params:
-                self.logger.warning("Your parameter source uses the deprecated name [action_metadata_present]. Please change it to "
-                               "[action-metadata-present].")
-            action_meta_data_key = "action_metadata_present"
-
-        with_action_metadata = mandatory(params, action_meta_data_key, self)
+        with_action_metadata = mandatory(params, "action-metadata-present", self)
         bulk_size = mandatory(params, "bulk-size", self)
 
         if with_action_metadata:
@@ -372,21 +363,11 @@ class BulkIndex(Runner):
         error_details = set()
         bulk_request_size_bytes = 0
         total_document_size_bytes = 0
+        with_action_metadata = mandatory(params, "action-metadata-present", self)
 
         for line_number, data in enumerate(params["body"]):
-
             line_size = len(data.encode('utf-8'))
-
-            # TODO: Remove this fallback logic with Rally 1.0
-            if "action-metadata-present" in params:
-                action_meta_data_key = "action-metadata-present"
-            else:
-                if "action_metadata_present" in params:
-                    self.logger.warning("Your parameter source uses the deprecated name [action_metadata_present]. Please change it to "
-                                   "[action-metadata-present].")
-                action_meta_data_key = "action_metadata_present"
-
-            if params[action_meta_data_key]:
+            if with_action_metadata:
                 if line_number % 2 == 1:
                     total_document_size_bytes += line_size
             else:
@@ -567,27 +548,15 @@ class Query(Runner):
         self.es = None
 
     def __call__(self, es, params):
-        # TODO: Remove items_per_page with Rally 1.0.
-        if "pages" in params and ("results-per-page" in params or "items_per_page" in params):
+        if "pages" in params and "results-per-page" in params:
             return self.scroll_query(es, params)
         else:
             return self.request_body_query(es, params)
 
     def request_body_query(self, es, params):
-        if "request-params" in params:
-            request_params = params["request-params"]
-        elif "request_params" in params:
-            # TODO: Remove with Rally 1.0.
-            self.logger.warning("Your parameter source uses the deprecated name [request_params]. Please change it to [request-params].")
-            request_params = params["request_params"]
-        else:
-            request_params = {}
+        request_params = params.get("request-params", {})
         if "cache" in params:
             request_params["request_cache"] = params["cache"]
-        elif "use_request_cache" in params:
-            # TODO: Remove with Rally 1.0.
-            self.logger.warning("Your parameter source uses the deprecated name [use_request_cache]. Please change it to [cache].")
-            request_params["request_cache"] = params["use_request_cache"]
         r = es.search(
             index=params.get("index", "_all"),
             doc_type=params.get("type"),
@@ -603,14 +572,8 @@ class Query(Runner):
         }
 
     def scroll_query(self, es, params):
-        if "request-params" in params:
-            request_params = params["request-params"]
-        elif "request_params" in params:
-            # TODO: Remove with Rally 1.0.
-            self.logger.warning("Your parameter source uses the deprecated name [request_params]. Please change it to [request-params].")
-            request_params = params["request_params"]
-        else:
-            request_params = {}
+        request_params = params.get("request-params", {})
+        cache = params.get("cache")
         hits = 0
         retrieved_pages = 0
         timed_out = False
@@ -618,22 +581,7 @@ class Query(Runner):
         self.es = es
         # explicitly convert to int to provoke an error otherwise
         total_pages = sys.maxsize if params["pages"] == "all" else int(params["pages"])
-        if "cache" in params:
-            cache = params["cache"]
-        elif "use_request_cache" in params:
-            # TODO: Remove with Rally 1.0.
-            self.logger.warning("Your parameter source uses the deprecated name [use_request_cache]. Please change it to [cache].")
-            cache = params["use_request_cache"]
-        else:
-            cache = None
-        if "results-per-page" in params:
-            size = params["results-per-page"]
-        elif "items_per_page" in params:
-            # TODO: Remove with Rally 1.0.
-            self.logger.warning("Your parameter source uses the deprecated name [items_per_page]. Please change it to [results-per-page].")
-            size = params["items_per_page"]
-        else:
-            size = None
+        size = params.get("results-per-page")
 
         for page in range(total_pages):
             if page == 0:

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -122,7 +122,7 @@ class BulkIndexRunnerTests(TestCase):
 
         with self.assertRaises(exceptions.DataError) as ctx:
             bulk(es, bulk_params)
-        self.assertEqual("Parameter source for operation 'bulk-index' did not provide the mandatory parameter 'action_metadata_present'. "
+        self.assertEqual("Parameter source for operation 'bulk-index' did not provide the mandatory parameter 'action-metadata-present'. "
                          "Please add it to your parameter source.", ctx.exception.args[0])
 
     @mock.patch("elasticsearch.Elasticsearch")

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -887,7 +887,6 @@ class BulkDataGeneratorTests(TestCase):
         self.assertEqual(2, len(all_bulks))
         self.assertEqual({
             "action-metadata-present": True,
-            "action_metadata_present": True,
             "body": ["1", "2", "3", "4", "5"],
             "bulk-id": "0-1",
             "bulk-size": 5,
@@ -899,7 +898,6 @@ class BulkDataGeneratorTests(TestCase):
 
         self.assertEqual({
             "action-metadata-present": True,
-            "action_metadata_present": True,
             "body": ["6", "7", "8"],
             "bulk-id": "0-2",
             "bulk-size": 3,
@@ -947,7 +945,6 @@ class BulkDataGeneratorTests(TestCase):
         self.assertEqual(3, len(all_bulks))
         self.assertEqual({
             "action-metadata-present": True,
-            "action_metadata_present": True,
             "body": ["1", "2", "3", "4", "5"],
             "bulk-id": "0-1",
             "bulk-size": 5,
@@ -959,7 +956,6 @@ class BulkDataGeneratorTests(TestCase):
 
         self.assertEqual({
             "action-metadata-present": True,
-            "action_metadata_present": True,
             "body": ["1", "2", "3", "4", "5"],
             "bulk-id": "0-2",
             "bulk-size": 5,
@@ -971,7 +967,6 @@ class BulkDataGeneratorTests(TestCase):
 
         self.assertEqual({
             "action-metadata-present": True,
-            "action_metadata_present": True,
             "body": ["1", "2", "3", "4", "5"],
             "bulk-id": "0-3",
             "bulk-size": 5,
@@ -1003,7 +998,6 @@ class BulkDataGeneratorTests(TestCase):
         # body must not contain 'foo'!
         self.assertEqual({
             "action-metadata-present": True,
-            "action_metadata_present": True,
             "body": ["1", "2", "3"],
             "bulk-id": "0-1",
             "bulk-size": 3,
@@ -1461,7 +1455,7 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(7, len(p))
+        self.assertEqual(5, len(p))
         self.assertEqual("index1", p["index"])
         self.assertIsNone(p["type"])
         self.assertEqual({
@@ -1473,11 +1467,6 @@ class SearchParamSourceTests(TestCase):
                 "match_all": {}
             }
         }, p["body"])
-        # backwards-compatibility options
-        self.assertFalse(p["use_request_cache"])
-        self.assertEqual({
-            "_source_include": "some_field"
-        }, p["request_params"])
 
     def test_user_specified_overrides_defaults(self):
         index1 = track.Index(name="index1", types=["type1"])
@@ -1493,7 +1482,7 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(7, len(p))
+        self.assertEqual(5, len(p))
         self.assertEqual("_all", p["index"])
         self.assertEqual("type1", p["type"])
         self.assertDictEqual({}, p["request-params"])
@@ -1503,9 +1492,6 @@ class SearchParamSourceTests(TestCase):
                 "match_all": {}
             }
         }, p["body"])
-        # backwards-compatibility options
-        self.assertFalse(p["use_request_cache"])
-        self.assertDictEqual({}, p["request_params"])
 
     def test_replaces_body_params(self):
         import copy


### PR DESCRIPTION
With this commit we remove the backwards-compatibility layer for several
parameters that have been deprecated for a while now. We also remove the
backwards-compabibility layer for deprecated signatures in custom
parameter sources. Finally we document this also in the migration docs.