### PR TITLE
Use a single shard for metrics indices

### DIFF
--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -2,7 +2,8 @@
   "template": "rally-metrics-*",
   "settings": {
     "index": {
-      "refresh_interval": "5s"
+      "refresh_interval": "5s",
+      "number_of_shards": 1
     }
   },
   "mappings": {

--- a/esrally/resources/races-template.json
+++ b/esrally/resources/races-template.json
@@ -2,7 +2,8 @@
   "template": "rally-races-*",
   "settings": {
     "index": {
-      "refresh_interval": "5s"
+      "refresh_interval": "5s",
+      "number_of_shards": 1
     }
   },
   "mappings": {

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -2,7 +2,8 @@
   "template": "rally-results-*",
   "settings": {
     "index": {
-      "refresh_interval": "5s"
+      "refresh_interval": "5s",
+      "number_of_shards": 1
     }
   },
   "mappings": {


### PR DESCRIPTION
With this commit we explicitly set the number of shards in all metrics
indices to one. We roll indices every month so there is no reason to
have multiple shards.