### PR TITLE
Resolve artefact name based on download URL

### DIFF
--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -293,8 +293,8 @@ class ElasticsearchDistributionSupplier:
 
     def fetch(self):
         io.ensure_dir(self.distributions_root)
-        distribution_path = "%s/elasticsearch-%s.tar.gz" % (self.distributions_root, self.version)
         download_url = self.repo.download_url
+        distribution_path = os.path.join(self.distributions_root, self.repo.file_name)
         self.logger.info("Resolved download URL [%s] for version [%s]", download_url, self.version)
         if not os.path.isfile(distribution_path) or not self.repo.cache:
             try:
@@ -486,6 +486,11 @@ class DistributionRepository:
         # rally.ini
         override_key = "{}.url".format(self.name)
         return self._url_for(override_key, default_key)
+
+    @property
+    def file_name(self):
+        url = self.download_url
+        return url[url.rfind("/") + 1:]
 
     def plugin_download_url(self, plugin_name):
         # team repo

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -512,6 +512,7 @@ class DistributionRepositoryTests(TestCase):
             "release.cache": "true"
         }, version="5.5.0")
         self.assertEqual("https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.tar.gz", repo.download_url)
+        self.assertEqual("elasticsearch-5.5.0.tar.gz", repo.file_name)
         self.assertTrue(repo.cache)
 
     def test_release_repo_config_with_user_url(self):
@@ -522,6 +523,7 @@ class DistributionRepositoryTests(TestCase):
             "release.cache": "false"
         }, version="2.4.3")
         self.assertEqual("https://es-mirror.example.org/downloads/elasticsearch/elasticsearch-2.4.3.tar.gz", repo.download_url)
+        self.assertEqual("elasticsearch-2.4.3.tar.gz", repo.file_name)
         self.assertFalse(repo.cache)
 
     def test_missing_url(self):


### PR DESCRIPTION
With this commit we resolve the artefact name based on the download URL
instead of creating a static name ourselves. This avoids situations
where there are two variations of a distribution (default and OSS) with
differently named artefacts which Rally previously resolved to the same
file name and mistakenly picked whichever has been downloaded first.

Closes #525