### PR TITLE
Retry metric store for more transport errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV HOME /home/${NEW_USER}
 ENV PYENV_ROOT=/home/${NEW_USER}/.pyenv
 ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 ENV JAVA_HOME=/opt/jdk-10
+ENV JAVA10_HOME=/opt/jdk-10
 ENV RUNTIME_JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 RUN pyenv install 3.4.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ ENV HOME /home/${NEW_USER}
 ENV PYENV_ROOT=/home/${NEW_USER}/.pyenv
 ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 ENV JAVA_HOME=/opt/jdk-10
-ENV JAVA10_HOME=/opt/jdk-10
 ENV RUNTIME_JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 RUN pyenv install 3.4.8

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -94,11 +94,10 @@ class EsClient:
                 self.logger.exception(msg)
                 raise exceptions.SystemSetupError(msg)
             except elasticsearch.TransportError as e:
-                retriable_responses_with_sleep = {502: 1, 503: 1, 504: 1, 429: 3}
-                if e.status_code in retriable_responses_with_sleep.keys() and execution_count < max_execution_count:
+                if e.status_code in (502, 503, 504, 429) and execution_count < max_execution_count:
                     self.logger.debug("%s (code: %d) in attempt [%d/%d].",
                                       responses[e.status_code], e.status_code, execution_count, max_execution_count)
-                    time.sleep(retriable_responses_with_sleep[e.status_code])
+                    time.sleep(3)
                 else:
                     node = self._client.transport.hosts[0]
                     msg = "A transport error occurred while running the operation [%s] against your Elasticsearch metrics store on " \

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -151,8 +151,11 @@ class EsClientTests(TestCase):
         with mock.patch.object(logger, "debug") as mocked_debug_logger:
             test_result = client.guarded(operation)
             mocked_sleep.assert_called_with(1)
-            mocked_debug_logger.assert_called_with('%s (code: %d) in attempt [%d/%d].', 'Bad Gateway', 502, 2, 3)
-            mocked_debug_logger.assert_called_with('%s (code: %d) in attempt [%d/%d].', 'Bad Gateway', 502, 2, 3)
+            mocked_debug_logger.assert_has_calls([
+                mock.call("%s (code: %d) in attempt [%d/%d].", "Bad Gateway", 502, 1, 3),
+                mock.call("%s (code: %d) in attempt [%d/%d].", "Bad Gateway", 502, 2, 3)],
+                any_order=True
+            )
             self.assertEqual("success", test_result)
 
             operation.assert_has_calls([
@@ -188,8 +191,11 @@ class EsClientTests(TestCase):
         with mock.patch.object(logger, "debug") as mocked_debug_logger:
             test_result = client.guarded(operation)
             mocked_sleep.assert_called_with(1)
-            mocked_debug_logger.assert_called_with('%s (code: %d) in attempt [%d/%d].', 'Service Unavailable', 503, 2, 3)
-            mocked_debug_logger.assert_called_with('%s (code: %d) in attempt [%d/%d].', 'Service Unavailable', 503, 2, 3)
+            mocked_debug_logger.assert_has_calls([
+                mock.call("%s (code: %d) in attempt [%d/%d].", "Service Unavailable", 503, 1, 3),
+                mock.call("%s (code: %d) in attempt [%d/%d].", "Service Unavailable", 503, 2, 3)],
+                any_order=True
+            )
             self.assertEqual("success", test_result)
 
             operation.assert_has_calls([
@@ -223,8 +229,11 @@ class EsClientTests(TestCase):
         logger = logging.getLogger("esrally.metrics")
         with mock.patch.object(logger, "debug") as mocked_debug_logger:
             test_result = client.guarded(operation)
-            mocked_debug_logger.assert_called_with('%s (code: %d) in attempt [%d/%d].', 'Gateway Timeout', 504, 2, 3)
-            mocked_debug_logger.assert_called_with('%s (code: %d) in attempt [%d/%d].', 'Gateway Timeout', 504, 2, 3)
+            mocked_debug_logger.assert_has_calls([
+                mock.call('%s (code: %d) in attempt [%d/%d].', 'Gateway Timeout', 504, 1, 3),
+                mock.call('%s (code: %d) in attempt [%d/%d].', 'Gateway Timeout', 504, 2, 3)],
+                any_order=True
+            )
             mocked_sleep.assert_called_with(1)
             self.assertEqual("success", test_result)
 
@@ -259,8 +268,11 @@ class EsClientTests(TestCase):
         logger = logging.getLogger("esrally.metrics")
         with mock.patch.object(logger, "debug") as mocked_debug_logger:
             test_result = client.guarded(operation)
-            mocked_debug_logger.assert_called_with('%s (code: %d) in attempt [%d/%d].', 'Too Many Requests', 429, 2, 3)
-            mocked_debug_logger.assert_called_with('%s (code: %d) in attempt [%d/%d].', 'Too Many Requests', 429, 2, 3)
+            mocked_debug_logger.assert_has_calls([
+                mock.call('%s (code: %d) in attempt [%d/%d].', 'Too Many Requests', 429, 1, 3),
+                mock.call('%s (code: %d) in attempt [%d/%d].', 'Too Many Requests', 429, 2, 3)],
+                any_order=True
+            )
             mocked_sleep.assert_called_with(3)
             self.assertEqual("success", test_result)
 


### PR DESCRIPTION
Improve the resiliency of Rally when using an Elasticsearch remote metrics store by retrying certain transport errors.

Also enhance existing tests to check that retries/debug output and sleep are executed properly.