### PR TITLE
Warn when cluster settings cannot be applied

### DIFF
--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 from collections import defaultdict
 
@@ -270,6 +269,12 @@ class MechanicActor(actor.RallyActor):
 
         if msg.external:
             self.logger.info("Cluster will not be provisioned by Rally.")
+            if msg.cluster_settings:
+                import json
+                pretty_settings = json.dumps(msg.cluster_settings, indent=2)
+                warning = "Ensure that these settings are defined in elasticsearch.yml:\n\n{}\n\nIf they are absent, running this track " \
+                          "will fail or lead to unexpected results.".format(pretty_settings)
+                console.warn(warning, logger=self.logger)
             # just create one actor for this special case and run it on the coordinator node (i.e. here)
             m = self.createActor(NodeMechanicActor,
                                  targetActorRequirements={"coordinator": True})
@@ -634,10 +639,6 @@ def create(cfg, metrics_store, all_node_ips, cluster_settings=None, sources=Fals
             p.append(provisioner.local_provisioner(cfg, car, plugins, cluster_settings, all_node_ips, challenge_root_path, node_id))
         l = launcher.InProcessLauncher(cfg, metrics_store, races_root)
     elif external:
-        if cluster_settings:
-            logging.getLogger(__name__).warning(
-                "Cannot apply challenge-specific cluster settings [%s] for an externally provisioned cluster. Please ensure that the cluster "
-                "settings are present or the benchmark may fail or behave unexpectedly." % cluster_settings)
         if len(plugins) > 0:
             raise exceptions.SystemSetupError("You cannot specify any plugins for externally provisioned clusters. Please remove "
                                               "\"--elasticsearch-plugins\" and try again.")

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -1,4 +1,5 @@
 import sys
+import json
 from collections import defaultdict
 
 import thespian.actors
@@ -270,7 +271,6 @@ class MechanicActor(actor.RallyActor):
         if msg.external:
             self.logger.info("Cluster will not be provisioned by Rally.")
             if msg.cluster_settings:
-                import json
                 pretty_settings = json.dumps(msg.cluster_settings, indent=2)
                 warning = "Ensure that these settings are defined in elasticsearch.yml:\n\n{}\n\nIf they are absent, running this track " \
                           "will fail or lead to unexpected results.".format(pretty_settings)


### PR DESCRIPTION
With this commit we issue a warning on the terminal when a user runs a
track that specifies cluster settings but uses the benchmark-only
pipeline. Previously we issued a warning in the logs but this is not the
first place user is looking (nor should they be required to in this
case).

Closes #541