### PR TITLE
Fix parsing of boolean values datastore.secure

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -9,7 +9,7 @@ from enum import Enum, IntEnum
 
 import tabulate
 from esrally import time, exceptions, config, version, paths
-from esrally.utils import console, io, versions
+from esrally.utils import convert, console, io, versions
 from http.client import responses
 
 
@@ -123,7 +123,7 @@ class EsClientFactory:
         self._config = cfg
         host = self._config.opts("reporting", "datastore.host")
         port = self._config.opts("reporting", "datastore.port")
-        secure = str(self._config.opts("reporting", "datastore.secure")).capitalize() == "True"
+        secure = convert.to_bool(self._config.opts("reporting", "datastore.secure"))
         user = self._config.opts("reporting", "datastore.user")
         password = self._config.opts("reporting", "datastore.password")
         verify = self._config.opts("reporting", "datastore.ssl.verification_mode", default_value="full", mandatory=False) != "none"

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -123,8 +123,7 @@ class EsClientFactory:
         self._config = cfg
         host = self._config.opts("reporting", "datastore.host")
         port = self._config.opts("reporting", "datastore.port")
-        # poor man's boolean conversion
-        secure = self._config.opts("reporting", "datastore.secure") == "True"
+        secure = str(self._config.opts("reporting", "datastore.secure")).capitalize() == "True"
         user = self._config.opts("reporting", "datastore.user")
         password = self._config.opts("reporting", "datastore.password")
         verify = self._config.opts("reporting", "datastore.ssl.verification_mode", default_value="full", mandatory=False) != "none"

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import unittest.mock as mock
 import random
+import string
 from unittest import TestCase
 import elasticsearch.exceptions
 
@@ -123,23 +124,34 @@ class EsClientTests(TestCase):
     @mock.patch("esrally.client.EsClientFactory")
     def test_config_opts_parsing(self, client_esclientfactory):
         cfg = config.Config()
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.host", "127.0.0.1")
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.port", 9200)
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.secure", random.choice(["True", "true"]))
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.user", "elastic")
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.password", "elastic")
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.ssl.verification_mode", "true")
-        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.ssl.certification_authorities", "foobar")
+
+        _datastore_host = ".".join([str(random.randint(1,254)) for _ in range(4)])
+        _datastore_port = random.randint(1024,65535)
+        _datastore_secure = random.choice(["True", "true"])
+        _datastore_user = "".join([random.choice(string.ascii_letters) for _ in range(8)])
+        _datastore_password = "".join([random.choice(string.ascii_letters + string.digits + "_-@#$/") for _ in range(12)])
+        _datastore_verify_certs = random.choice([True, False])
+
+        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.host", _datastore_host)
+        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.port", _datastore_port)
+        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.secure", _datastore_secure)
+        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.user", _datastore_user)
+        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.password", _datastore_password)
+        if not _datastore_verify_certs:
+            cfg.add(config.Scope.applicationOverride, "reporting", "datastore.ssl.verification_mode", "none")
+
         f = metrics.EsClientFactory(cfg)
+        expected_client_options = {
+            "use_ssl": True,
+            "timeout": 120,
+            "basic_auth_user": _datastore_user,
+            "basic_auth_password": _datastore_password,
+            "verify_certs": _datastore_verify_certs
+        }
+
         client_esclientfactory.assert_called_with(
-            hosts=[{"host": "127.0.0.1", "port": 9200}],
-            client_options={
-                "use_ssl": True,
-                "verify_certs": True,
-                "timeout": 120,
-                "basic_auth_user": "elastic",
-                "basic_auth_password": "elastic"
-            }
+            hosts=[{"host": _datastore_host, "port": _datastore_port}],
+            client_options=expected_client_options
         )
 
     def test_raises_sytem_setup_error_on_connection_problems(self):


### PR DESCRIPTION
Allow any capitalization for `datastore.secure` configuration setting in reporting section of `rally.ini`.
Also add randomized tests cases for the parsing of reporting configuration options.

Resolves #543 
