### PR TITLE
Avoid throughput throttling in test mode

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -586,6 +586,11 @@ def post_process_for_test_mode(t):
                 if leaf_task.time_period is not None and leaf_task.time_period > 10:
                     leaf_task.time_period = 10
                     logger.info("Resetting measurement time period for [%s] to [%d] seconds.", str(leaf_task), leaf_task.time_period)
+
+                logger.info("Avoiding throughput throttling")
+                leaf_task.params.pop("target-throughput", None)
+                leaf_task.params.pop("target-interval", None)
+
     return t
 
 

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -840,14 +840,16 @@ class TrackPostProcessingTests(TestCase):
                                         "clients": 4,
                                         "operation": "search",
                                         "warmup-iterations": 1000,
-                                        "iterations": 2000
+                                        "iterations": 2000,
+                                        "target-interval": 30
                                     },
                                     {
                                         "name": "search #2",
                                         "clients": 1,
                                         "operation": "search",
                                         "warmup-iterations": 1000,
-                                        "iterations": 2000
+                                        "iterations": 2000,
+                                        "target-throughput": 200
                                     },
                                     {
                                         "name": "search #3",


### PR DESCRIPTION
Test mode is intended to finish quickly and we only run a small number
of requests per task anyway. Therefore we remove any specified target
througput or target interval from all tasks.