### PR TITLE
Make Rally compatible with Python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,7 @@ target/
 # Rally specific
 .rally_it/
 # Virtualenv for development
-.venv/
+.venv*/
 
 # Emacs backup files
 *~

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ it35: python-caches-clean
 it36: python-caches-clean
 	tox -e py36
 
+it37: python-caches-clean
+	tox -e py37
+
 benchmark:
 	python3 setup.py pytest --addopts="-s benchmarks"
 

--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -127,13 +127,7 @@ def ensure_dir(directory, mode=0o777):
     :param mode: The permission flags to use (if it does not exist).
     """
     if directory:
-        # TODO Python 3.7 compatibility: Set umask first. See https://docs.python.org/3.7/whatsnew/3.7.html#changes-in-the-python-api
-        try:
-            # avoid a race condition by trying to create the checkout directory
-            os.makedirs(directory, mode)
-        except OSError as exception:
-            if exception.errno != errno.EEXIST:
-                raise
+        os.makedirs(directory, mode, exist_ok=True)
 
 
 def _zipdir(source_directory, archive):

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(name="esrally",
           "Programming Language :: Python :: 3",
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
-          "Programming Language :: Python :: 3.6"
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
       ],
       zip_safe=False)

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1,6 +1,7 @@
 import unittest.mock as mock
 import threading
 import collections
+import time
 from unittest import TestCase
 from datetime import datetime
 
@@ -616,7 +617,7 @@ class ExecutorTests(TestCase):
                           warmup_time_period=0, clients=4)
         schedule = driver.schedule_for(test_track, task, 0)
 
-        sampler = driver.Sampler(client_id=2, task=task, start_timestamp=100)
+        sampler = driver.Sampler(client_id=2, task=task, start_timestamp=time.perf_counter())
         cancel = threading.Event()
         complete = threading.Event()
 
@@ -632,9 +633,9 @@ class ExecutorTests(TestCase):
         for sample in samples:
             self.assertEqual(2, sample.client_id)
             self.assertEqual(task, sample.task)
-            self.assertTrue(previous_absolute_time < sample.absolute_time)
+            self.assertLess(previous_absolute_time, sample.absolute_time)
             previous_absolute_time = sample.absolute_time
-            self.assertTrue(previous_relative_time < sample.relative_time)
+            self.assertLess(previous_relative_time, sample.relative_time)
             previous_relative_time = sample.relative_time
             # we don't have any warmup time period
             self.assertEqual(metrics.SampleType.Normal, sample.sample_type)

--- a/tox.ini
+++ b/tox.ini
@@ -8,22 +8,23 @@
 # ==============
 #
 # * Tox (pip3 install tox)
-# * Python 3.4, 3.5 and 3.6 available (pyenv: https://github.com/yyuu/pyenv)
+# * Python 3.4, 3.5, 3.6 and 3.7 available (pyenv: https://github.com/yyuu/pyenv)
 #
 # Hint: When using pyenv, new Python interpreters can be installed with:
 #
 # pyenv install 3.4.5
 # pyenv install 3.5.2
 # pyenv install 3.6.0
+# pyenv install 3.7.0
 #
-# pyenv global system 3.6.0 3.5.2 3.4.5
+# pyenv global system 3.7.0 3.6.0 3.5.2 3.4.5
 #
 # For details see https://github.com/yyuu/pyenv#choosing-the-python-version
 #
 ###############################################################################
 [tox]
 envlist =
-    docs, py34, py35, py36
+    docs, py34, py35, py36, py37
 platform =
     linux|darwin
 


### PR DESCRIPTION
With this commit we make Rally compatible with Python 3.7. The main
change is due to [PEP 479](https://www.python.org/dev/peps/pep-0479/).
Apart from that we do a couple of smaller cleanups and document it in
our setup file.