### PR TITLE
Improve compatibility when loading invalid JSON

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -633,7 +633,7 @@ class TrackFileReader:
         except jinja2.exceptions.TemplateNotFound:
             self.logger.exception("Could not load [%s]", track_spec_file)
             raise exceptions.SystemSetupError("Track {} does not exist".format(track_name))
-        except (json.JSONDecodeError, jinja2.exceptions.TemplateError) as e:
+        except Exception as e:
             self.logger.exception("Could not load [%s].", track_spec_file)
             # Convert to string early on to avoid serialization errors with Jinja exceptions.
             raise TrackSyntaxError("Could not load '{}'".format(track_spec_file), str(e))
@@ -775,7 +775,7 @@ class TrackSpecificationReader:
                                        template_name="default",
                                        template_vars=self.track_params)
             return json.loads(rendered)
-        except (json.JSONDecodeError, jinja2.exceptions.TemplateError) as e:
+        except Exception as e:
             self.logger.exception("Could not load file template for %s.", description)
             raise TrackSyntaxError("Could not load file template for '%s'" % description, str(e))
 


### PR DESCRIPTION
Previously we caught `JSONDecodeError` in the error handler when loading
JSON. However, this class has been introduced in Python 3.5 and thus we
fail on Python 3.4 with a confusing error message:

```
AttributeError: 'module' object has no attribute 'JSONDecodeError'
```

To avoid this situation, we broaden the `except` clause and also
introduce a new test case to ensure error handling works correctly on
all supported Python versions.

Closes #564