### PR TITLE
Add ML API runners

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -682,6 +682,94 @@ Example::
 
 This will shrink the index ``src`` to ``target``. The target index will consist of one shard and have one replica. With ``shrink-node`` we also explicitly specify the name of the node where we want the source index to be relocated to.
 
+delete-ml-datafeed
+~~~~~~~~~~~~~~~~~~
+
+With the operation ``delete-ml-datafeed`` you can execute the `delete datafeeds API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html>`_. The ``delete-ml-datafeed`` operation supports the following parameters:
+
+* ``datafeed-id`` (mandatory): The name of the machine learning datafeed to delete.
+* ``force`` (optional, defaults to ``false``): Whether to force deletion of a datafeed that has already been started.
+
+This runner will intentionally ignore 404s from Elasticsearch so it is safe to execute this runner regardless whether a corresponding machine learning datafeed exists.
+
+This operation works only if `machine-learning <https://www.elastic.co/products/stack/machine-learning>`__ is properly installed and enabled. This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+create-ml-datafeed
+~~~~~~~~~~~~~~~~~~
+
+With the operation ``create-ml-datafeed`` you can execute the `create datafeeds API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html>`__. The ``create-ml-datafeed`` operation supports the following parameters:
+
+* ``datafeed-id`` (mandatory): The name of the machine learning datafeed to create.
+* ``body`` (mandatory): Request body containing the definition of the datafeed. Please see the `create datafeed API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html>`__ documentation for more details.
+
+This operation works only if `machine-learning <https://www.elastic.co/products/stack/machine-learning>`__ is properly installed and enabled. This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+start-ml-datafeed
+~~~~~~~~~~~~~~~~~
+
+With the operation ``start-ml-datafeed`` you can execute the `start datafeeds API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html>`__. The ``start-ml-datafeed`` operation supports the following parameters:
+
+* ``datafeed-id`` (mandatory): The name of the machine learning datafeed to start.
+* ``body`` (optional, defaults to empty): Request body with start parameters. Please see the `start datafeed API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html>`__ documentation for more details.
+* ``start`` (optional, defaults to empty): Start timestamp of the datafeed. Please see the `start datafeed API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html>`__ documentation for more details.
+* ``end`` (optional, defaults to empty): End timestamp of the datafeed. Please see the `start datafeed API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html>`__ documentation for more details.
+* ``timeout`` (optional, defaults to empty): Amount of time to wait until a datafeed starts. Please see the `start datafeed API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html>`__ documentation for more details.
+
+This operation works only if `machine-learning <https://www.elastic.co/products/stack/machine-learning>`__ is properly installed and enabled. This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+stop-ml-datafeed
+~~~~~~~~~~~~~~~~
+
+With the operation ``stop-ml-datafeed`` you can execute the `stop datafeed API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html>`_. The ``stop-ml-datafeed`` operation supports the following parameters:
+
+* ``datafeed-id`` (mandatory): The name of the machine learning datafeed to start.
+* ``force`` (optional, defaults to ``false``): Whether to forcefully stop an already started datafeed.
+* ``timeout`` (optional, defaults to empty): Amount of time to wait until a datafeed stops.
+
+This operation works only if `machine-learning <https://www.elastic.co/products/stack/machine-learning>`__ is properly installed and enabled. This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+delete-ml-job
+~~~~~~~~~~~~~
+
+With the operation ``delete-ml-job`` you can execute the `delete jobs API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html>`_. The ``delete-ml-job`` operation supports the following parameters:
+
+* ``job-id`` (mandatory): The name of the machine learning job to delete.
+* ``force`` (optional, defaults to ``false``): Whether to force deletion of a job that has already been opened.
+
+This runner will intentionally ignore 404s from Elasticsearch so it is safe to execute this runner regardless whether a corresponding machine learning job exists.
+
+This operation works only if `machine-learning <https://www.elastic.co/products/stack/machine-learning>`__ is properly installed and enabled. This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+create-ml-job
+~~~~~~~~~~~~~
+
+With the operation ``create-ml-job`` you can execute the `create jobs API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html>`__. The ``create-ml-job`` operation supports the following parameters:
+
+* ``job-id`` (mandatory): The name of the machine learning job to create.
+* ``body`` (mandatory): Request body containing the definition of the job. Please see the `create job API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html>`__ documentation for more details.
+
+This operation works only if `machine-learning <https://www.elastic.co/products/stack/machine-learning>`__ is properly installed and enabled. This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+open-ml-job
+~~~~~~~~~~~
+
+With the operation ``open-ml-job`` you can execute the `open jobs API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html>`_. The ``open-ml-job`` operation supports the following parameters:
+
+* ``job-id`` (mandatory): The name of the machine learning job to open.
+
+This operation works only if `machine-learning <https://www.elastic.co/products/stack/machine-learning>`__ is properly installed and enabled. This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+close-ml-job
+~~~~~~~~~~~~
+
+With the operation ``close-ml-job`` you can execute the `close jobs API. The ``close-ml-job`` operation supports the following parameters:
+
+* ``job-id`` (mandatory): The name of the machine learning job to start.
+* ``force`` (optional, defaults to ``false``): Whether to forcefully stop an already opened job.
+* ``timeout`` (optional, defaults to empty): Amount of time to wait until a job stops.
+
+This operation works only if `machine-learning <https://www.elastic.co/products/stack/machine-learning>`__ is properly installed and enabled. This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
 raw-request
 ~~~~~~~~~~~
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -29,6 +29,14 @@ def register_default_runners():
     register_runner(track.OperationType.CreateIndexTemplate.name, Retry(CreateIndexTemplate()))
     register_runner(track.OperationType.DeleteIndexTemplate.name, Retry(DeleteIndexTemplate()))
     register_runner(track.OperationType.ShrinkIndex.name, Retry(ShrinkIndex()))
+    register_runner(track.OperationType.CreateMlDatafeed.name, Retry(CreateMlDatafeed()))
+    register_runner(track.OperationType.DeleteMlDatafeed.name, Retry(DeleteMlDatafeed()))
+    register_runner(track.OperationType.StartMlDatafeed.name, Retry(StartMlDatafeed()))
+    register_runner(track.OperationType.StopMlDatafeed.name, Retry(StopMlDatafeed()))
+    register_runner(track.OperationType.CreateMlJob.name, Retry(CreateMlJob()))
+    register_runner(track.OperationType.DeleteMlJob.name, Retry(DeleteMlJob()))
+    register_runner(track.OperationType.OpenMlJob.name, Retry(OpenMlJob()))
+    register_runner(track.OperationType.CloseMlJob.name, Retry(CloseMlJob()))
 
 
 def runner_for(operation_type):
@@ -893,6 +901,124 @@ class ShrinkIndex(Runner):
 
     def __repr__(self, *args, **kwargs):
         return "shrink-index"
+
+
+class CreateMlDatafeed(Runner):
+    """
+    Execute the `create datafeed API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html>`_.
+    """
+
+    def __call__(self, es, params):
+        datafeed_id = mandatory(params, "datafeed-id", self)
+        body = mandatory(params, "body", self)
+        es.xpack.ml.put_datafeed(datafeed_id=datafeed_id, body=body)
+
+    def __repr__(self, *args, **kwargs):
+        return "create-ml-datafeed"
+
+
+class DeleteMlDatafeed(Runner):
+    """
+    Execute the `delete datafeed API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html>`_.
+    """
+
+    def __call__(self, es, params):
+        datafeed_id = mandatory(params, "datafeed-id", self)
+        force = params.get("force", False)
+        # we don't want to fail if a datafeed does not exist, thus we ignore 404s.
+        es.xpack.ml.delete_datafeed(datafeed_id=datafeed_id, force=force, ignore=[404])
+
+    def __repr__(self, *args, **kwargs):
+        return "delete-ml-datafeed"
+
+
+class StartMlDatafeed(Runner):
+    """
+    Execute the `start datafeed API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html>`_.
+    """
+
+    def __call__(self, es, params):
+        datafeed_id = mandatory(params, "datafeed-id", self)
+        body = params.get("body")
+        start = params.get("start")
+        end = params.get("end")
+        timeout = params.get("timeout")
+        es.xpack.ml.start_datafeed(datafeed_id=datafeed_id, body=body, start=start, end=end, timeout=timeout)
+
+    def __repr__(self, *args, **kwargs):
+        return "start-ml-datafeed"
+
+
+class StopMlDatafeed(Runner):
+    """
+    Execute the `stop datafeed API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html>`_.
+    """
+
+    def __call__(self, es, params):
+        datafeed_id = mandatory(params, "datafeed-id", self)
+        force = params.get("force", False)
+        timeout = params.get("timeout")
+        es.xpack.ml.stop_datafeed(datafeed_id=datafeed_id, force=force, timeout=timeout)
+
+    def __repr__(self, *args, **kwargs):
+        return "stop-ml-datafeed"
+
+
+class CreateMlJob(Runner):
+    """
+    Execute the `create job API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html>`_.
+    """
+
+    def __call__(self, es, params):
+        job_id = mandatory(params, "job-id", self)
+        body = mandatory(params, "body", self)
+        es.xpack.ml.put_job(job_id=job_id, body=body)
+
+    def __repr__(self, *args, **kwargs):
+        return "create-ml-job"
+
+
+class DeleteMlJob(Runner):
+    """
+    Execute the `delete job API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html>`_.
+    """
+
+    def __call__(self, es, params):
+        job_id = mandatory(params, "job-id", self)
+        force = params.get("force", False)
+        # we don't want to fail if a job does not exist, thus we ignore 404s.
+        es.xpack.ml.delete_job(job_id=job_id, force=force, ignore=[404])
+
+    def __repr__(self, *args, **kwargs):
+        return "delete-ml-job"
+
+
+class OpenMlJob(Runner):
+    """
+    Execute the `open job API <https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html>`_.
+    """
+
+    def __call__(self, es, params):
+        job_id = mandatory(params, "job-id", self)
+        es.xpack.ml.open_job(job_id=job_id)
+
+    def __repr__(self, *args, **kwargs):
+        return "open-ml-job"
+
+
+class CloseMlJob(Runner):
+    """
+    Execute the `close job API <http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html>`_.
+    """
+
+    def __call__(self, es, params):
+        job_id = mandatory(params, "job-id", self)
+        force = params.get("force", False)
+        timeout = params.get("timeout")
+        es.xpack.ml.close_job(job_id=job_id, force=force, timeout=timeout)
+
+    def __repr__(self, *args, **kwargs):
+        return "close-ml-job"
 
 
 class RawRequest(Runner):

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -411,6 +411,14 @@ class OperationType(Enum):
     CreateIndexTemplate = 1007
     DeleteIndexTemplate = 1008
     ShrinkIndex = 1009
+    CreateMlDatafeed = 1010
+    DeleteMlDatafeed = 1011
+    StartMlDatafeed = 1012
+    StopMlDatafeed = 1013
+    CreateMlJob = 1014
+    DeleteMlJob = 1015
+    OpenMlJob = 1016
+    CloseMlJob = 1017
 
     @property
     def admin_op(self):
@@ -446,6 +454,22 @@ class OperationType(Enum):
             return OperationType.DeleteIndexTemplate
         elif v == "shrink-index":
             return OperationType.ShrinkIndex
+        elif v == "create-ml-datafeed":
+            return OperationType.CreateMlDatafeed
+        elif v == "delete-ml-datafeed":
+            return OperationType.DeleteMlDatafeed
+        elif v == "start-ml-datafeed":
+            return OperationType.StartMlDatafeed
+        elif v == "stop-ml-datafeed":
+            return OperationType.StopMlDatafeed
+        elif v == "create-ml-job":
+            return OperationType.CreateMlJob
+        elif v == "delete-ml-job":
+            return OperationType.DeleteMlJob
+        elif v == "open-ml-job":
+            return OperationType.OpenMlJob
+        elif v == "close-ml-job":
+            return OperationType.CloseMlJob
         else:
             raise KeyError("No enum value for [%s]" % v)
 


### PR DESCRIPTION
With this commit we add runners so Rally supports the most important
ML-related API calls w.r.t. managing datafeeds and jobs.