### PR TITLE
More fine-grained ML metrics

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -152,3 +152,4 @@ Rally stores the following metrics:
 * ``final_index_size_bytes``: Final resulting index size on the file system after all nodes have been shutdown at the end of the benchmark. It includes all files in the nodes' data directories (actual index files and translog).
 * ``store_size_in_bytes``: The size in bytes of the index (excluding the translog) as reported by the indices stats API.
 * ``translog_size_in_bytes``: The size in bytes of the translog as reported by the indices stats API.
+* ``ml_processing_time``: A structure containing the minimum, mean, median and maximum bucket processing time in milliseconds per machine learning job. These metrics are only available if a machine learning job has been created in the respective benchmark.

--- a/docs/summary_report.rst
+++ b/docs/summary_report.rst
@@ -92,6 +92,12 @@ Where ``X`` is one of:
 * **Definition**: Different merge times as reported by Lucene. Only available if Lucene index writer trace logging is enabled (use ``--car-params="verbose_iw_logging_enabled:true"`` for that).
 * **Corresponding metrics keys**: ``merge_parts_total_time_*``
 
+ML processing time
+------------------
+
+* **Definition**: Minimum, mean, median and maximum time in milliseconds that a machine learning job has spent processing a single bucket.
+* **Corresponding metrics key**: ``ml_processing_time``
+
 
 Median CPU usage
 ----------------

--- a/tests/reporter_test.py
+++ b/tests/reporter_test.py
@@ -45,6 +45,14 @@ class StatsCalculatorTests(TestCase):
                                       meta_data={"success": False})
         store.put_value_cluster_level("service_time", 215, unit="ms", task="index #1", operation_type=track.OperationType.Bulk,
                                       meta_data={"success": True})
+        store.put_doc(doc={
+            "name": "ml_processing_time",
+            "job_name": "benchmark_ml_job_1",
+            "min_millis": 2.2,
+            "mean_millis": 12.3,
+            "median_millis": 17.2,
+            "max_millis": 36.0
+        }, level=metrics.MetaInfoScope.cluster)
         store.put_count_node_level("rally-node-0", "final_index_size_bytes", 2048, unit="bytes")
         store.put_count_node_level("rally-node-1", "final_index_size_bytes", 4096, unit="bytes")
 
@@ -59,6 +67,12 @@ class StatsCalculatorTests(TestCase):
         self.assertAlmostEqual(0.3333333333333333, opm["error_rate"])
 
         self.assertEqual(6144, stats.index_size)
+        self.assertEqual(1, len(stats.ml_processing_time))
+        self.assertEqual("benchmark_ml_job_1", stats.ml_processing_time[0]["job_name"])
+        self.assertEqual(2.2, stats.ml_processing_time[0]["min_millis"])
+        self.assertEqual(12.3, stats.ml_processing_time[0]["mean_millis"])
+        self.assertEqual(17.2, stats.ml_processing_time[0]["median_millis"])
+        self.assertEqual(36.0, stats.ml_processing_time[0]["max_millis"])
 
 
 def select(l, name, operation=None, node=None):


### PR DESCRIPTION
With this commit we retrieve and store ML-related metrics per machine
learning job (instead of all jobs globally). We also store not only the
maximum bucket processing time but in addition the minimum, median and
mean.