### PR TITLE
Always use remote branch for updates

### DIFF
--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -35,7 +35,7 @@ class RallyRepository:
 
     def update(self, distribution_version):
         try:
-            if self.remote and not self.offline:
+            if self.remote:
                 branch = versions.best_match(git.branches(self.repo_dir, remote=self.remote), distribution_version)
                 if branch:
                     # Allow uncommitted changes iff we do not have to change the branch

--- a/tests/utils/repo_test.py
+++ b/tests/utils/repo_test.py
@@ -1,3 +1,4 @@
+import random
 from unittest import TestCase
 import unittest.mock as mock
 
@@ -112,7 +113,7 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=False)
+            offline=random.choice([True, False]))
 
         r.update(distribution_version="1.7.3")
 


### PR DESCRIPTION
With this commit we always attempt to checkout the remote branch first.
In a scenario where a user has already cloned the repository but uses
the `--offline` flag the correct branches might not be proper local
tracking branches but are already available on the target machine as
remote branches.

Closes #573