### PR TITLE
Improved formatting of document count in list tracks output

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -44,7 +44,7 @@ def list_tracks(cfg):
 
     data = []
     for t in available_tracks:
-        line = [t.name, t.description, convert.number_of_documents_to_human_string(t.number_of_documents),
+        line = [t.name, t.description, convert.number_to_human_string(t.number_of_documents),
                 convert.bytes_to_human_string(t.compressed_size_in_bytes),
                 convert.bytes_to_human_string(t.uncompressed_size_in_bytes)]
         if not only_auto_generated_challenges:

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -44,7 +44,8 @@ def list_tracks(cfg):
 
     data = []
     for t in available_tracks:
-        line = [t.name, t.description, t.number_of_documents, convert.bytes_to_human_string(t.compressed_size_in_bytes),
+        line = [t.name, t.description, convert.number_of_documents_to_human_string(t.number_of_documents),
+                convert.bytes_to_human_string(t.compressed_size_in_bytes),
                 convert.bytes_to_human_string(t.uncompressed_size_in_bytes)]
         if not only_auto_generated_challenges:
             line.append(t.default_challenge)

--- a/esrally/utils/convert.py
+++ b/esrally/utils/convert.py
@@ -25,8 +25,8 @@ def bytes_to_human_string(b):
     return "%d bytes" % b
 
 
-def number_of_documents_to_human_string(number_of_documents):
-    return "{:,}".format(number_of_documents)
+def number_to_human_string(number):
+    return "{:,}".format(number)
 
 
 def mb_to_bytes(mb):

--- a/esrally/utils/convert.py
+++ b/esrally/utils/convert.py
@@ -25,6 +25,10 @@ def bytes_to_human_string(b):
     return "%d bytes" % b
 
 
+def number_of_documents_to_human_string(number_of_documents):
+    return "{:,}".format(number_of_documents)
+
+
 def mb_to_bytes(mb):
     return int(mb * 1024 * 1024) if mb else mb
 


### PR DESCRIPTION
Added thousand seperators to document count in list tracks output. E.g. instead of showing 11396505, new change will show 11,396,505

Relates #327