### PR TITLE
Add proxy support for benchmarking #382

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -108,7 +108,11 @@ To verify that Rally will connect via the proxy server you can check the log fil
 
 .. note::
 
-   Rally will use this proxy server only for downloading benchmark-related data. It will not use this proxy for the actual benchmark.
+   Rally will use this proxy server for downloading benchmark-related data, and the actual benchmark.
+   
+   If you do not need to use the proxy server to reach the cluster being benchmarked, then you can use:
+
+   ``export esrally_benchmark_no_proxy=true``
 
 Logging
 -------


### PR DESCRIPTION
This pull request adds proxy support for benchmarking via the http_proxy environment variable, and closes #382.

As suggested by @danielmitterdorfer, a `urllib3.ProxyManager` is utilised.

In addition it is necessary to monkey patch `elasticsearch.connection.Urllib3HttpConnection` in order that the `perform_request` method prepends the correct scheme, host and port to the path. This is required due to the different semantics of direct HTTP v.s. proxied requests in urllib3.

Support for SSL and round-robin-ish connection selection is included.

Real-world testing can be accomplished using a default install of squid on ubuntu.

Finally, please note that this would be a breaking change for any users who currently use a proxy for downloading benchmarking-related data, but _not_ for the benchmarking operation itself. For such cases, an additional environment variable `esrally_benchmark_no_proxy` may be set as described in `docs/configuration.rst`