### PR TITLE
Allow specifying Indices stats metrics to collect from Node stats

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -77,7 +77,7 @@ node-stats
 
     This telemetry device will record a lot of metrics and likely skew your measurement results.
 
-The node-stats telemetry devices regularly calls the node-stats API and records metrics from the following sections:
+The node-stats telemetry devices regularly calls the `cluster node-stats API <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html>`_ and records metrics from the following sections:
 
 * Indices stats (key ``indices`` in the node-stats API)
 * Thread pool stats (key ``jvm.thread_pool`` in the node-stats API)
@@ -90,6 +90,9 @@ Supported telemetry parameters:
 
 * ``node-stats-sample-interval`` (default: 1): A positive number greater than zero denoting the sampling interval in seconds.
 * ``node-stats-include-indices`` (default: ``false``): A boolean indicating whether indices stats should be included.
+* ``node-stats-include-indices-metrics`` (default: ``false``): A comma-separated string specifying the Indices stats metrics to include. This is useful, for example, to restrict the collected Indices stats metrics. Specifying this parameter implicitly enables collection of Indices stats, so you don't also need to specify ``node-stats-include-indices: true``.
+
+  Example: ``node-stats-include-indices-metrics: "docs, refresh"`` will **only** collect the ``docs`` and ``refresh`` metrics from Indices stats.
 * ``node-stats-include-thread-pools`` (default: ``true``): A boolean indicating whether thread pool stats should be included.
 * ``node-stats-include-buffer-pools`` (default: ``true``): A boolean indicating whether buffer pool stats should be included.
 * ``node-stats-include-breakers`` (default: ``true``): A boolean indicating whether circuit breaker stats should be included.

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -557,94 +557,99 @@ class CcrStatsRecorderTests(TestCase):
 
 class NodeStatsRecorderTests(TestCase):
     node_stats_response = {
-        "cluster_name" : "elasticsearch",
-        "nodes" : {
-            "Zbl_e8EyRXmiR47gbHgPfg" : {
-                "timestamp" : 1524379617017,
-                "name" : "rally0",
-                "transport_address" : "127.0.0.1:9300",
-                "host" : "127.0.0.1",
-                "ip" : "127.0.0.1:9300",
-                "roles" : [
+        "cluster_name": "elasticsearch",
+        "nodes": {
+            "Zbl_e8EyRXmiR47gbHgPfg": {
+                "timestamp": 1524379617017,
+                "name": "rally0",
+                "transport_address": "127.0.0.1:9300",
+                "host": "127.0.0.1",
+                "ip": "127.0.0.1:9300",
+                "roles": [
                     "master",
                     "data",
                     "ingest"
                 ],
-                "indices" : {
-                    "docs" : {
-                        "count" : 0,
-                        "deleted" : 0
+                "indices": {
+                    "docs": {
+                        "count": 0,
+                        "deleted": 0
                     },
-                    "store" : {
-                        "size_in_bytes" : 0
+                    "store": {
+                        "size_in_bytes": 0
                     },
-                    "indexing" : {
-                        "is_throttled" : False,
-                        "throttle_time_in_millis" : 0
+                    "indexing": {
+                        "is_throttled": False,
+                        "throttle_time_in_millis": 0
                     },
-                    "search" : {
-                        "open_contexts" : 0,
-                        "query_total" : 0,
-                        "query_time_in_millis" : 0
+                    "search": {
+                        "open_contexts": 0,
+                        "query_total": 0,
+                        "query_time_in_millis": 0
                     },
-                    "merges" : {
-                        "current" : 0,
-                        "current_docs" : 0,
-                        "current_size_in_bytes" : 0
+                    "merges": {
+                        "current": 0,
+                        "current_docs": 0,
+                        "current_size_in_bytes": 0
                     },
-                    "query_cache" : {
-                        "memory_size_in_bytes" : 0,
-                        "total_count" : 0,
-                        "hit_count" : 0,
-                        "miss_count" : 0,
-                        "cache_size" : 0,
-                        "cache_count" : 0,
-                        "evictions" : 0
+                    "refresh": {
+                        "total": 747,
+                        "total_time_in_millis": 277382,
+                        "listeners": 0
                     },
-                    "completion" : {
-                        "size_in_bytes" : 0
+                    "query_cache": {
+                        "memory_size_in_bytes": 0,
+                        "total_count": 0,
+                        "hit_count": 0,
+                        "miss_count": 0,
+                        "cache_size": 0,
+                        "cache_count": 0,
+                        "evictions": 0
                     },
-                    "segments" : {
-                        "count" : 0,
-                        "memory_in_bytes" : 0,
-                        "max_unsafe_auto_id_timestamp" : -9223372036854775808,
-                        "file_sizes" : { }
+                    "completion": {
+                        "size_in_bytes": 0
                     },
-                    "translog" : {
-                        "operations" : 0,
-                        "size_in_bytes" : 0,
-                        "uncommitted_operations" : 0,
-                        "uncommitted_size_in_bytes" : 0
+                    "segments": {
+                        "count": 0,
+                        "memory_in_bytes": 0,
+                        "max_unsafe_auto_id_timestamp": -9223372036854775808,
+                        "file_sizes": {}
                     },
-                    "request_cache" : {
-                        "memory_size_in_bytes" : 0,
-                        "evictions" : 0,
-                        "hit_count" : 0,
-                        "miss_count" : 0
+                    "translog": {
+                        "operations": 0,
+                        "size_in_bytes": 0,
+                        "uncommitted_operations": 0,
+                        "uncommitted_size_in_bytes": 0
                     },
-                    "recovery" : {
-                        "current_as_source" : 0,
-                        "current_as_target" : 0,
-                        "throttle_time_in_millis" : 0
+                    "request_cache": {
+                        "memory_size_in_bytes": 0,
+                        "evictions": 0,
+                        "hit_count": 0,
+                        "miss_count": 0
+                    },
+                    "recovery": {
+                        "current_as_source": 0,
+                        "current_as_target": 0,
+                        "throttle_time_in_millis": 0
                     }
                 },
-                "jvm" : {
-                    "buffer_pools" : {
-                        "mapped" : {
-                            "count" : 7,
-                            "used_in_bytes" : 3120,
-                            "total_capacity_in_bytes" : 9999
+                "jvm": {
+                    "buffer_pools": {
+                        "mapped": {
+                            "count": 7,
+                            "used_in_bytes": 3120,
+                            "total_capacity_in_bytes": 9999
                         },
-                        "direct" : {
-                            "count" : 6,
-                            "used_in_bytes" : 73868,
-                            "total_capacity_in_bytes" : 73867
+                        "direct": {
+                            "count": 6,
+                            "used_in_bytes": 73868,
+                            "total_capacity_in_bytes": 73867
                         }
                     },
-                    "classes" : {
-                        "current_loaded_count" : 9992,
-                        "total_loaded_count" : 9992,
-                        "total_unloaded_count" : 0
+                    "classes": {
+                        "current_loaded_count": 9992,
+                        "total_loaded_count": 9992,
+                        "total_unloaded_count": 0
                     },
                     "mem": {
                         "heap_used_in_bytes": 119073552,
@@ -687,24 +692,24 @@ class NodeStatsRecorderTests(TestCase):
                         "total_virtual_in_bytes": 2472173568
                     }
                 },
-                "thread_pool" : {
-                    "generic" : {
-                        "threads" : 4,
-                        "queue" : 0,
-                        "active" : 0,
-                        "rejected" : 0,
-                        "largest" : 4,
-                        "completed" : 8
+                "thread_pool": {
+                    "generic": {
+                        "threads": 4,
+                        "queue": 0,
+                        "active": 0,
+                        "rejected": 0,
+                        "largest": 4,
+                        "completed": 8
                     }
                 },
-                "breakers" : {
-                    "parent" : {
-                        "limit_size_in_bytes" : 726571417,
-                        "limit_size" : "692.9mb",
-                        "estimated_size_in_bytes" : 0,
-                        "estimated_size" : "0b",
-                        "overhead" : 1.0,
-                        "tripped" : 0
+                "breakers": {
+                    "parent": {
+                        "limit_size_in_bytes": 726571417,
+                        "limit_size": "692.9mb",
+                        "estimated_size_in_bytes": 0,
+                        "estimated_size": "0b",
+                        "overhead": 1.0,
+                        "tripped": 0
                     }
                 }
             }
@@ -722,6 +727,9 @@ class NodeStatsRecorderTests(TestCase):
         "indices_merges_current": 0,
         "indices_merges_current_docs": 0,
         "indices_merges_current_size_in_bytes": 0,
+        "indices_refresh_total": 747,
+        "indices_refresh_total_time_in_millis": 277382,
+        "indices_refresh_listeners": 0,
         "indices_query_cache_memory_size_in_bytes": 0,
         "indices_query_cache_total_count": 0,
         "indices_query_cache_hit_count": 0,
@@ -864,6 +872,11 @@ class NodeStatsRecorderTests(TestCase):
                             "current": 0,
                             "current_docs": 0,
                             "current_size_in_bytes": 0
+                        },
+                        "refresh": {
+                            "total": 747,
+                            "total_time_in_millis": 277382,
+                            "listeners": 0
                         },
                         "query_cache": {
                             "memory_size_in_bytes": 0,
@@ -1081,6 +1094,255 @@ class NodeStatsRecorderTests(TestCase):
             level=MetaInfoScope.node,
             node_name="rally0",
             meta_data=metrics_store_meta_data)
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    def test_stores_selected_indices_metrics_from_nodes_stats(self, metrics_store_put_doc):
+        node_stats_response = {
+            "cluster_name": "elasticsearch",
+            "nodes": {
+                "Zbl_e8EyRXmiR47gbHgPfg": {
+                    "timestamp": 1524379617017,
+                    "name": "rally0",
+                    "transport_address": "127.0.0.1:9300",
+                    "host": "127.0.0.1",
+                    "ip": "127.0.0.1:9300",
+                    "roles": [
+                        "master",
+                        "data",
+                        "ingest"
+                    ],
+                    "indices": {
+                        "docs": {
+                            "count": 76892364,
+                            "deleted": 324530
+                        },
+                        "store": {
+                            "size_in_bytes": 983409834
+                        },
+                        "indexing": {
+                            "is_throttled": False,
+                            "throttle_time_in_millis": 0
+                        },
+                        "search": {
+                            "open_contexts": 0,
+                            "query_total": 0,
+                            "query_time_in_millis": 0
+                        },
+                        "merges": {
+                            "current": 0,
+                            "current_docs": 0,
+                            "current_size_in_bytes": 0
+                        },
+                        "refresh": {
+                            "total": 747,
+                            "total_time_in_millis": 277382,
+                            "listeners": 0
+                        },
+                        "query_cache": {
+                            "memory_size_in_bytes": 0,
+                            "total_count": 0,
+                            "hit_count": 0,
+                            "miss_count": 0,
+                            "cache_size": 0,
+                            "cache_count": 0,
+                            "evictions": 0
+                        },
+                        "fielddata": {
+                            "memory_size_in_bytes": 6936,
+                            "evictions": 17
+                        },
+                        "completion": {
+                            "size_in_bytes": 0
+                        },
+                        "segments": {
+                            "count": 0,
+                            "memory_in_bytes": 0,
+                            "max_unsafe_auto_id_timestamp": -9223372036854775808,
+                            "file_sizes": {}
+                        },
+                        "translog": {
+                            "operations": 0,
+                            "size_in_bytes": 0,
+                            "uncommitted_operations": 0,
+                            "uncommitted_size_in_bytes": 0
+                        },
+                        "request_cache": {
+                            "memory_size_in_bytes": 0,
+                            "evictions": 0,
+                            "hit_count": 0,
+                            "miss_count": 0
+                        },
+                        "recovery": {
+                            "current_as_source": 0,
+                            "current_as_target": 0,
+                            "throttle_time_in_millis": 0
+                        }
+                    },
+                    "jvm": {
+                        "buffer_pools": {
+                            "mapped": {
+                                "count": 7,
+                                "used_in_bytes": 3120,
+                                "total_capacity_in_bytes": 9999
+                            },
+                            "direct": {
+                                "count": 6,
+                                "used_in_bytes": 73868,
+                                "total_capacity_in_bytes": 73867
+                            }
+                        },
+                        "classes": {
+                            "current_loaded_count": 9992,
+                            "total_loaded_count": 9992,
+                            "total_unloaded_count": 0
+                        },
+                        "mem": {
+                            "heap_used_in_bytes": 119073552,
+                            "heap_used_percent": 19,
+                            "heap_committed_in_bytes": 626393088,
+                            "heap_max_in_bytes": 626393088,
+                            "non_heap_used_in_bytes": 110250424,
+                            "non_heap_committed_in_bytes": 118108160,
+                            "pools": {
+                                "young": {
+                                    "used_in_bytes": 66378576,
+                                    "max_in_bytes": 139591680,
+                                    "peak_used_in_bytes": 139591680,
+                                    "peak_max_in_bytes": 139591680
+                                },
+                                "survivor": {
+                                    "used_in_bytes": 358496,
+                                    "max_in_bytes": 17432576,
+                                    "peak_used_in_bytes": 17432576,
+                                    "peak_max_in_bytes": 17432576
+                                },
+                                "old": {
+                                    "used_in_bytes": 52336480,
+                                    "max_in_bytes": 469368832,
+                                    "peak_used_in_bytes": 52336480,
+                                    "peak_max_in_bytes": 469368832
+                                }
+                            }
+                        }
+                    },
+                    "process": {
+                        "timestamp": 1526045135857,
+                        "open_file_descriptors": 312,
+                        "max_file_descriptors": 1048576,
+                        "cpu": {
+                            "percent": 10,
+                            "total_in_millis": 56520
+                        },
+                        "mem": {
+                            "total_virtual_in_bytes": 2472173568
+                        }
+                    },
+                    "thread_pool": {
+                        "generic": {
+                            "threads": 4,
+                            "queue": 0,
+                            "active": 0,
+                            "rejected": 0,
+                            "largest": 4,
+                            "completed": 8
+                        }
+                    },
+                    "transport": {
+                        "server_open": 12,
+                        "rx_count": 77,
+                        "rx_size_in_bytes": 98723498,
+                        "tx_count": 88,
+                        "tx_size_in_bytes": 23879803
+                    },
+                    "breakers": {
+                        "parent": {
+                            "limit_size_in_bytes": 726571417,
+                            "limit_size": "692.9mb",
+                            "estimated_size_in_bytes": 0,
+                            "estimated_size": "0b",
+                            "overhead": 1.0,
+                            "tripped": 0
+                        }
+                    }
+                }
+            }
+        }
+
+        client = Client(nodes=SubClient(stats=node_stats_response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        metrics_store_meta_data = {"cluster": "remote"}
+        telemetry_params = {
+            "node-stats-include-indices-metrics": "refresh,docs"
+        }
+        recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
+        recorder.record()
+
+        metrics_store_put_doc.assert_called_once_with(
+            {"name": "node-stats",
+             "indices_docs_count": 76892364,
+             "indices_docs_deleted": 324530,
+             "indices_refresh_total": 747,
+             "indices_refresh_total_time_in_millis": 277382,
+             "indices_refresh_listeners": 0,
+             "thread_pool_generic_active": 0,
+             "thread_pool_generic_completed": 8,
+             "thread_pool_generic_largest": 4,
+             "thread_pool_generic_queue": 0,
+             "thread_pool_generic_rejected": 0,
+             "thread_pool_generic_threads": 4,
+             "breakers_parent_estimated_size_in_bytes": 0,
+             "breakers_parent_limit_size_in_bytes": 726571417,
+             "breakers_parent_overhead": 1.0,
+             "breakers_parent_tripped": 0,
+             "jvm_buffer_pools_direct_count": 6,
+             "jvm_buffer_pools_direct_total_capacity_in_bytes": 73867,
+             "jvm_buffer_pools_direct_used_in_bytes": 73868,
+             "jvm_buffer_pools_mapped_count": 7,
+             "jvm_buffer_pools_mapped_total_capacity_in_bytes": 9999,
+             "jvm_buffer_pools_mapped_used_in_bytes": 3120,
+             "jvm_mem_heap_committed_in_bytes": 626393088,
+             "jvm_mem_heap_max_in_bytes": 626393088,
+             "jvm_mem_heap_used_in_bytes": 119073552,
+             "jvm_mem_heap_used_percent": 19,
+             "jvm_mem_non_heap_committed_in_bytes": 118108160,
+             "jvm_mem_non_heap_used_in_bytes": 110250424,
+             "jvm_mem_pools_old_max_in_bytes": 469368832,
+             "jvm_mem_pools_old_peak_max_in_bytes": 469368832,
+             "jvm_mem_pools_old_peak_used_in_bytes": 52336480,
+             "jvm_mem_pools_old_used_in_bytes": 52336480,
+             "jvm_mem_pools_survivor_max_in_bytes": 17432576,
+             "jvm_mem_pools_survivor_peak_max_in_bytes": 17432576,
+             "jvm_mem_pools_survivor_peak_used_in_bytes": 17432576,
+             "jvm_mem_pools_survivor_used_in_bytes": 358496,
+             "jvm_mem_pools_young_max_in_bytes": 139591680,
+             "jvm_mem_pools_young_peak_max_in_bytes": 139591680,
+             "jvm_mem_pools_young_peak_used_in_bytes": 139591680,
+             "jvm_mem_pools_young_used_in_bytes": 66378576,
+             "transport_rx_count": 77,
+             "transport_rx_size_in_bytes": 98723498,
+             "transport_server_open": 12,
+             "transport_tx_count": 88,
+             "transport_tx_size_in_bytes": 23879803,
+             "process_cpu_percent": 10,
+             "process_cpu_total_in_millis": 56520},
+            level=MetaInfoScope.node,
+            node_name="rally0",
+            meta_data=metrics_store_meta_data)
+
+    def test_exception_when_include_indices_metrics_not_valid(self):
+        node_stats_response = {}
+
+        client = Client(nodes=SubClient(stats=node_stats_response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        telemetry_params = {
+            "node-stats-include-indices-metrics": {"bad": "input"}
+        }
+        with self.assertRaisesRegex(exceptions.SystemSetupError,
+                                    "The telemetry parameter 'node-stats-include-indices-metrics' must be "
+                                    "a comma-separated string but was <class 'dict'>"):
+            telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
 
 
 class ClusterEnvironmentInfoTests(TestCase):


### PR DESCRIPTION
Currently the metrics collected from node-stats indices are a fixed
list.

Introduce a new telemetry parameter to allow users explicitly specify
which metrics to collect from the Indices stats section in Node stats.