### PR TITLE
Update ccr-stats telemetry device

### DIFF
--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -384,15 +384,17 @@ class CcrStatsRecorder:
 
         try:
             ccr_stats_api_endpoint = "/_ccr/stats"
-            stats = self.client.transport.perform_request("GET", ccr_stats_api_endpoint, params={"human": "false"})
+            filter_path = "follow_stats"
+            stats = self.client.transport.perform_request("GET", ccr_stats_api_endpoint, params={"human": "false",
+                                                                                                 "filter_path": filter_path})
         except elasticsearch.TransportError as e:
-            msg = "A transport error occurred while collecting CCR stats from the endpoint [{}] on " \
-                  "cluster [{}]".format(ccr_stats_api_endpoint, self.cluster_name)
+            msg = "A transport error occurred while collecting CCR stats from the endpoint [{}?filter_path={}] on " \
+                  "cluster [{}]".format(ccr_stats_api_endpoint, filter_path, self.cluster_name)
             self.logger.exception(msg)
             raise exceptions.RallyError(msg)
 
-        if "indices" in stats:
-            for indices in stats["indices"]:
+        if filter_path in stats and "indices" in stats[filter_path]:
+            for indices in stats[filter_path]["indices"]:
                 try:
                     if self.indices and indices["index"] not in self.indices:
                         # Skip metrics for indices not part of user supplied whitelist (ccr-stats-indices) in telemetry params.

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -271,7 +271,8 @@ class CcrStatsRecorderTests(TestCase):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         with self.assertRaisesRegex(exceptions.RallyError,
-                                    r"A transport error occurred while collecting CCR stats from the endpoint \[/_ccr/stats\] on "
+                                    r"A transport error occurred while collecting CCR stats from the endpoint "
+                                    r"\[/_ccr/stats\?filter_path=follow_stats\] on "
                                     r"cluster \[remote\]"):
             telemetry.CcrStatsRecorder(cluster_name="remote", client=client, metrics_store=metrics_store, sample_interval=1).record()
 
@@ -280,63 +281,79 @@ class CcrStatsRecorderTests(TestCase):
         java_signed_maxlong = CcrStatsRecorderTests.java_signed_maxlong
 
         shard_id = random.randint(0, 999)
-        leader_index = "leader_cluster:leader"
+        remote_cluster = "leader_cluster"
+        leader_index = "leader"
         follower_index = "follower"
         leader_global_checkpoint = random.randint(0, java_signed_maxlong)
         leader_max_seq_no = random.randint(0, java_signed_maxlong)
         follower_global_checkpoint = random.randint(0, java_signed_maxlong)
         follower_max_seq_no = random.randint(0, java_signed_maxlong)
         last_requested_seq_no = random.randint(0, java_signed_maxlong)
-        number_of_concurrent_reads = random.randint(0, java_signed_maxlong)
-        number_of_concurrent_writes = random.randint(0, java_signed_maxlong)
-        number_of_queued_writes = random.randint(0, java_signed_maxlong)
-        mapping_version = random.randint(0, java_signed_maxlong)
-        total_fetch_time_millis = random.randint(0, java_signed_maxlong)
-        number_of_successful_fetches = random.randint(0, java_signed_maxlong)
-        number_of_failed_fetches = random.randint(0, java_signed_maxlong)
-        operations_received = random.randint(0, java_signed_maxlong)
-        total_transferred_bytes = random.randint(0, java_signed_maxlong)
-        total_index_time_millis = random.randint(0, java_signed_maxlong)
-        time_since_last_fetch_millis = random.randint(0, java_signed_maxlong)
-        number_of_successful_bulk_operations = random.randint(0, java_signed_maxlong)
-        number_of_failed_bulk_operations = random.randint(0, java_signed_maxlong)
-        number_of_operations_indexed = random.randint(0, java_signed_maxlong)
+        outstanding_read_requests = random.randint(0, java_signed_maxlong)
+        outstanding_write_requests = random.randint(0, java_signed_maxlong)
+        write_buffer_operation_count = random.randint(0, java_signed_maxlong)
+        follower_mapping_version = random.randint(0, java_signed_maxlong)
+        total_read_time_millis = random.randint(0, java_signed_maxlong)
+        total_read_remote_exec_time_millis = random.randint(0, java_signed_maxlong)
+        successful_read_requests = random.randint(0, java_signed_maxlong)
+        failed_read_requests = random.randint(0, java_signed_maxlong)
+        operations_read = random.randint(0, java_signed_maxlong)
+        bytes_read = random.randint(0, java_signed_maxlong)
+        total_write_time_millis = random.randint(0, java_signed_maxlong)
+        successful_write_requests = random.randint(0, java_signed_maxlong)
+        failed_write_requests = random.randint(0, java_signed_maxlong)
+        operations_written = random.randint(0, java_signed_maxlong)
+        read_exceptions = []
+        time_since_last_read_millis = random.randint(0, java_signed_maxlong)
 
         ccr_stats_follower_response = {
-            "indices": [
-                {
-                    "index": follower_index,
-                    "shards": [
-                        {
-                            "shard_id": shard_id,
-                            "follower_global_checkpoint": follower_global_checkpoint,
-                            "leader_index": leader_index,
-                            "follower_index": follower_index,
-                            "follower_max_seq_no": follower_max_seq_no,
-                            "mapping_version": mapping_version,
-                            "last_requested_seq_no": last_requested_seq_no,
-                            "leader_global_checkpoint": leader_global_checkpoint,
-                            "leader_max_seq_no": leader_max_seq_no,
-                            "number_of_concurrent_reads": number_of_concurrent_reads,
-                            "number_of_concurrent_writes": number_of_concurrent_writes,
-                            "number_of_failed_bulk_operations": number_of_failed_bulk_operations,
-                            "number_of_failed_fetches": number_of_failed_fetches,
-                            "number_of_operations_indexed": number_of_operations_indexed,
-                            "number_of_queued_writes": number_of_queued_writes,
-                            "number_of_successful_bulk_operations": number_of_successful_bulk_operations,
-                            "number_of_successful_fetches": number_of_successful_fetches,
-                            "operations_received": operations_received,
-                            "time_since_last_fetch_mills": time_since_last_fetch_millis,
-                            "total_fetch_time_millis": total_fetch_time_millis,
-                            "total_index_time_millis": total_index_time_millis,
-                            "total_transferred_bytes": total_transferred_bytes
-                        }
-                    ]
-                }
-            ]
+            "auto_follow_stats": {
+                "number_of_failed_follow_indices": 0,
+                "number_of_failed_remote_cluster_state_requests": 0,
+                "number_of_successful_follow_indices": 0,
+                "recent_auto_follow_errors": []
+            },
+            "follow_stats": {
+                "indices": [
+                    {
+                        "index": follower_index,
+                        "shards": [
+                            {
+                                "shard_id": shard_id,
+                                "remote_cluster": remote_cluster,
+                                "leader_index": leader_index,
+                                "follower_index": follower_index,
+                                "leader_global_checkpoint": leader_global_checkpoint,
+                                "leader_max_seq_no": leader_max_seq_no,
+                                "follower_global_checkpoint": follower_global_checkpoint,
+                                "follower_max_seq_no": follower_max_seq_no,
+                                "last_requested_seq_no": last_requested_seq_no,
+                                "outstanding_read_requests": outstanding_read_requests,
+                                "outstanding_write_requests": outstanding_write_requests,
+                                "write_buffer_operation_count": write_buffer_operation_count,
+                                "follower_mapping_version": follower_mapping_version,
+                                "total_read_time_millis": total_read_time_millis,
+                                "total_read_remote_exec_time_millis": total_read_remote_exec_time_millis,
+                                "successful_read_requests": successful_read_requests,
+                                "failed_read_requests": failed_read_requests,
+                                "operations_read": operations_read,
+                                "bytes_read": bytes_read,
+                                "total_write_time_millis": total_write_time_millis,
+                                "successful_write_requests": successful_write_requests,
+                                "failed_write_requests": failed_write_requests,
+                                "operations_written": operations_written,
+                                "read_exceptions": read_exceptions,
+                                "time_since_last_read_millis": time_since_last_read_millis,
+                            }
+                        ]
+                    }
+                ]
+            }
         }
 
-        client = Client(transport_client=TransportClient(response=ccr_stats_follower_response))
+        ccr_stats_filtered_follower_response = {"follow_stats": ccr_stats_follower_response["follow_stats"]}
+
+        client = Client(transport_client=TransportClient(response=ccr_stats_filtered_follower_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         recorder = telemetry.CcrStatsRecorder(cluster_name="remote", client=client, metrics_store=metrics_store, sample_interval=1)
@@ -350,7 +367,7 @@ class CcrStatsRecorderTests(TestCase):
         }
 
         metrics_store_put_doc.assert_called_with(
-            ccr_stats_follower_response["indices"][0]["shards"][0],
+            ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][0],
             level=MetaInfoScope.cluster,
             meta_data=shard_metadata
         )
@@ -359,64 +376,80 @@ class CcrStatsRecorderTests(TestCase):
     def test_stores_default_ccr_stats_many_shards(self, metrics_store_put_doc):
         java_signed_maxlong = CcrStatsRecorderTests.java_signed_maxlong
 
-        leader_index="leader_cluster:leader"
-        follower_index="follower"
+        remote_cluster = "leader_cluster"
+        leader_index = "leader"
+        follower_index = "follower"
         shard_range = range(2)
         leader_global_checkpoint = [random.randint(0, java_signed_maxlong) for _ in shard_range]
         leader_max_seq_no = [random.randint(0, java_signed_maxlong) for _ in shard_range]
         follower_global_checkpoint = [random.randint(0, java_signed_maxlong) for _ in shard_range]
         follower_max_seq_no = [random.randint(0, java_signed_maxlong) for _ in shard_range]
         last_requested_seq_no = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        number_of_concurrent_reads = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        number_of_concurrent_writes = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        number_of_queued_writes = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        mapping_version = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        total_fetch_time_millis = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        number_of_successful_fetches = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        number_of_failed_fetches = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        operations_received = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        total_transferred_bytes = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        total_index_time_millis = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        time_since_last_fetch_millis = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        number_of_successful_bulk_operations = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        number_of_failed_bulk_operations = [random.randint(0, java_signed_maxlong) for _ in shard_range]
-        number_of_operations_indexed = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        outstanding_read_requests = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        outstanding_write_requests = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        write_buffer_operation_count = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        follower_mapping_version = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        total_read_time_millis = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        total_read_remote_exec_time_millis = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        successful_read_requests = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        failed_read_requests = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        operations_read = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        bytes_read = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        total_write_time_millis = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        successful_write_requests = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        failed_write_requests = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        operations_written = [random.randint(0, java_signed_maxlong) for _ in shard_range]
+        read_exceptions = [[] for _ in shard_range]
+        time_since_last_read_millis = [random.randint(0, java_signed_maxlong) for _ in shard_range]
 
         ccr_stats_follower_response = {
-            "indices": [
-                {
-                    "index": follower_index,
-                    "shards": [
-                        {
-                            "shard_id": shard_id,
-                            "follower_global_checkpoint": follower_global_checkpoint[shard_id],
-                            "leader_index": leader_index,
-                            "follower_index": follower_index,
-                            "follower_max_seq_no": follower_max_seq_no[shard_id],
-                            "mapping_version": mapping_version[shard_id],
-                            "last_requested_seq_no": last_requested_seq_no[shard_id],
-                            "leader_global_checkpoint": leader_global_checkpoint[shard_id],
-                            "leader_max_seq_no": leader_max_seq_no[shard_id],
-                            "number_of_concurrent_reads": number_of_concurrent_reads[shard_id],
-                            "number_of_concurrent_writes": number_of_concurrent_writes[shard_id],
-                            "number_of_failed_bulk_operations": number_of_failed_bulk_operations[shard_id],
-                            "number_of_failed_fetches": number_of_failed_fetches[shard_id],
-                            "number_of_operations_indexed": number_of_operations_indexed[shard_id],
-                            "number_of_queued_writes": number_of_queued_writes[shard_id],
-                            "number_of_successful_bulk_operations": number_of_successful_bulk_operations[shard_id],
-                            "number_of_successful_fetches": number_of_successful_fetches[shard_id],
-                            "operations_received": operations_received[shard_id],
-                            "total_fetch_time_millis": total_fetch_time_millis[shard_id],
-                            "total_index_time_millis": total_index_time_millis[shard_id],
-                            "total_transferred_bytes": total_transferred_bytes[shard_id],
-                            "time_since_last_fetch_millis": time_since_last_fetch_millis[shard_id]
-                        } for shard_id in shard_range
-                    ]
-                }
-            ]
+            "auto_follow_stats": {
+                "number_of_failed_follow_indices": 0,
+                "number_of_failed_remote_cluster_state_requests": 0,
+                "number_of_successful_follow_indices": 0,
+                "recent_auto_follow_errors": []
+            },
+            "follow_stats": {
+                "indices": [
+                    {
+                        "index": follower_index,
+                        "shards": [
+                            {
+                                "shard_id": shard_id,
+                                "remote_cluster": remote_cluster,
+                                "leader_index": leader_index,
+                                "follower_index": follower_index,
+                                "leader_global_checkpoint": leader_global_checkpoint[shard_id],
+                                "leader_max_seq_no": leader_max_seq_no[shard_id],
+                                "follower_global_checkpoint": follower_global_checkpoint[shard_id],
+                                "follower_max_seq_no": follower_max_seq_no[shard_id],
+                                "last_requested_seq_no": last_requested_seq_no[shard_id],
+                                "outstanding_read_requests": outstanding_read_requests[shard_id],
+                                "outstanding_write_requests": outstanding_write_requests[shard_id],
+                                "write_buffer_operation_count": write_buffer_operation_count[shard_id],
+                                "follower_mapping_version": follower_mapping_version[shard_id],
+                                "total_read_time_millis": total_read_time_millis[shard_id],
+                                "total_read_remote_exec_time_millis": total_read_remote_exec_time_millis[shard_id],
+                                "successful_read_requests": successful_read_requests[shard_id],
+                                "failed_read_requests": failed_read_requests[shard_id],
+                                "operations_read": operations_read[shard_id],
+                                "bytes_read": bytes_read[shard_id],
+                                "total_write_time_millis": total_write_time_millis[shard_id],
+                                "successful_write_requests": successful_write_requests[shard_id],
+                                "failed_write_requests": failed_write_requests[shard_id],
+                                "operations_written": operations_written[shard_id],
+                                "read_exceptions": read_exceptions[shard_id],
+                                "time_since_last_read_millis": time_since_last_read_millis[shard_id],
+                            } for shard_id in shard_range
+                        ]
+                    }
+                ]
+            }
         }
 
-        client = Client(transport_client=TransportClient(response=ccr_stats_follower_response))
+        ccr_stats_filtered_follower_response = {"follow_stats": ccr_stats_follower_response["follow_stats"]}
+
+        client = Client(transport_client=TransportClient(response=ccr_stats_filtered_follower_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         recorder = telemetry.CcrStatsRecorder("remote", client, metrics_store, 1)
@@ -438,8 +471,8 @@ class CcrStatsRecorderTests(TestCase):
         ]
 
         metrics_store_put_doc.assert_has_calls([
-            mock.call(ccr_stats_follower_response["indices"][0]["shards"][0], level=MetaInfoScope.cluster, meta_data=shard_metadata[0]),
-            mock.call(ccr_stats_follower_response["indices"][0]["shards"][1], level=MetaInfoScope.cluster, meta_data=shard_metadata[1])
+            mock.call(ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][0], level=MetaInfoScope.cluster, meta_data=shard_metadata[0]),
+            mock.call(ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][1], level=MetaInfoScope.cluster, meta_data=shard_metadata[1])
             ],
             any_order=True
         )
@@ -448,93 +481,112 @@ class CcrStatsRecorderTests(TestCase):
     def test_stores_filtered_ccr_stats(self, metrics_store_put_doc):
         java_signed_maxlong = CcrStatsRecorderTests.java_signed_maxlong
 
+        remote_cluster = "leader_cluster"
+        leader_index1 = "leader1"
+        follower_index1 = "follower1"
+        leader_index2 = "leader2"
+        follower_index2 = "follower2"
         leader_global_checkpoint = random.randint(0, java_signed_maxlong)
         leader_max_seq_no = random.randint(0, java_signed_maxlong)
         follower_global_checkpoint = random.randint(0, java_signed_maxlong)
-        leader_index1 = "leader_cluster:leader1"
-        follower_index1 = "follower1"
-        leader_index2 = "leader_cluster:leader2"
-        follower_index2 = "follower2"
         follower_max_seq_no = random.randint(0, java_signed_maxlong)
         last_requested_seq_no = random.randint(0, java_signed_maxlong)
-        number_of_concurrent_reads = random.randint(0, java_signed_maxlong)
-        number_of_concurrent_writes = random.randint(0, java_signed_maxlong)
-        number_of_queued_writes = random.randint(0, java_signed_maxlong)
-        mapping_version = random.randint(0, java_signed_maxlong)
-        total_fetch_time_millis = random.randint(0, java_signed_maxlong)
-        number_of_successful_fetches = random.randint(0, java_signed_maxlong)
-        number_of_failed_fetches = random.randint(0, java_signed_maxlong)
-        operations_received = random.randint(0, java_signed_maxlong)
-        total_transferred_bytes = random.randint(0, java_signed_maxlong)
-        total_index_time_millis = random.randint(0, java_signed_maxlong)
-        time_since_last_fetch_millis = random.randint(0, java_signed_maxlong)
-        number_of_successful_bulk_operations = random.randint(0, java_signed_maxlong)
-        number_of_failed_bulk_operations = random.randint(0, java_signed_maxlong)
-        number_of_operations_indexed = random.randint(0, java_signed_maxlong)
+        outstanding_read_requests = random.randint(0, java_signed_maxlong)
+        outstanding_write_requests = random.randint(0, java_signed_maxlong)
+        write_buffer_operation_count = random.randint(0, java_signed_maxlong)
+        follower_mapping_version = random.randint(0, java_signed_maxlong)
+        total_read_time_millis = random.randint(0, java_signed_maxlong)
+        total_read_remote_exec_time_millis = random.randint(0, java_signed_maxlong)
+        successful_read_requests = random.randint(0, java_signed_maxlong)
+        failed_read_requests = random.randint(0, java_signed_maxlong)
+        operations_read = random.randint(0, java_signed_maxlong)
+        bytes_read = random.randint(0, java_signed_maxlong)
+        total_write_time_millis = random.randint(0, java_signed_maxlong)
+        successful_write_requests = random.randint(0, java_signed_maxlong)
+        failed_write_requests = random.randint(0, java_signed_maxlong)
+        operations_written = random.randint(0, java_signed_maxlong)
+        read_exceptions = []
+        time_since_last_read_millis = random.randint(0, java_signed_maxlong)
 
         ccr_stats_follower_response = {
-            "indices": [
-                {
-                    "index": "follower1",
-                    "shards": [
-                        {
-                            "shard_id": 0,
-                            "leader_index": leader_index1,
-                            "follower_index": follower_index1,
-                            "follower_global_checkpoint": follower_global_checkpoint,
-                            "follower_max_seq_no": follower_max_seq_no,
-                            "mapping_version": mapping_version,
-                            "last_requested_seq_no": last_requested_seq_no,
-                            "leader_global_checkpoint": leader_global_checkpoint,
-                            "leader_max_seq_no": leader_max_seq_no,
-                            "number_of_concurrent_reads": number_of_concurrent_reads,
-                            "number_of_concurrent_writes": number_of_concurrent_writes,
-                            "number_of_failed_bulk_operations": number_of_failed_bulk_operations,
-                            "number_of_failed_fetches": number_of_failed_fetches,
-                            "number_of_operations_indexed": number_of_operations_indexed,
-                            "number_of_queued_writes": number_of_queued_writes,
-                            "number_of_successful_bulk_operations": number_of_successful_bulk_operations,
-                            "number_of_successful_fetches": number_of_successful_fetches,
-                            "operations_received": operations_received,
-                            "time_since_last_fetch_millis": time_since_last_fetch_millis,
-                            "total_fetch_time_millis": total_fetch_time_millis,
-                            "total_index_time_millis": total_index_time_millis,
-                            "total_transferred_bytes": total_transferred_bytes
-                        }
-                    ]
-                },
-                {
-                    "index": "follower2",
-                    "shards": [
-                        {
-                            "shard_id": 1,
-                            "leader_index": leader_index2,
-                            "follower_index": follower_index2,
-                            "follower_global_checkpoint": follower_global_checkpoint,
-                            "follower_max_seq_no": follower_max_seq_no,
-                            "mapping_version": mapping_version,
-                            "last_requested_seq_no": last_requested_seq_no,
-                            "leader_global_checkpoint": leader_global_checkpoint,
-                            "leader_max_seq_no": leader_max_seq_no,
-                            "number_of_concurrent_reads": number_of_concurrent_reads,
-                            "number_of_concurrent_writes": number_of_concurrent_writes,
-                            "number_of_failed_bulk_operations": number_of_failed_bulk_operations,
-                            "number_of_failed_fetches": number_of_failed_fetches,
-                            "number_of_operations_indexed": number_of_operations_indexed,
-                            "number_of_queued_writes": number_of_queued_writes,
-                            "number_of_successful_bulk_operations": number_of_successful_bulk_operations,
-                            "number_of_successful_fetches": number_of_successful_fetches,
-                            "operations_received": operations_received,
-                            "time_since_last_fetch_millis": time_since_last_fetch_millis,
-                            "total_fetch_time_millis": total_fetch_time_millis,
-                            "total_index_time_millis": total_index_time_millis,
-                            "total_transferred_bytes": total_transferred_bytes
-                        }
+            "auto_follow_stats": {
+                "number_of_failed_follow_indices": 0,
+                "number_of_failed_remote_cluster_state_requests": 0,
+                "number_of_successful_follow_indices": 0,
+                "recent_auto_follow_errors": []
+            },
+            "follow_stats": {
+                "indices": [
+                    {
+                        "index": follower_index1,
+                        "shards": [
+                            {
+                                "shard_id": 0,
+                                "remote_cluster": remote_cluster,
+                                "leader_index": leader_index1,
+                                "follower_index": follower_index1,
+                                "leader_global_checkpoint": leader_global_checkpoint,
+                                "leader_max_seq_no": leader_max_seq_no,
+                                "follower_global_checkpoint": follower_global_checkpoint,
+                                "follower_max_seq_no": follower_max_seq_no,
+                                "last_requested_seq_no": last_requested_seq_no,
+                                "outstanding_read_requests": outstanding_read_requests,
+                                "outstanding_write_requests": outstanding_write_requests,
+                                "write_buffer_operation_count": write_buffer_operation_count,
+                                "follower_mapping_version": follower_mapping_version,
+                                "total_read_time_millis": total_read_time_millis,
+                                "total_read_remote_exec_time_millis": total_read_remote_exec_time_millis,
+                                "successful_read_requests": successful_read_requests,
+                                "failed_read_requests": failed_read_requests,
+                                "operations_read": operations_read,
+                                "bytes_read": bytes_read,
+                                "total_write_time_millis": total_write_time_millis,
+                                "successful_write_requests": successful_write_requests,
+                                "failed_write_requests": failed_write_requests,
+                                "operations_written": operations_written,
+                                "read_exceptions": read_exceptions,
+                                "time_since_last_read_millis": time_since_last_read_millis,
+                            }
                         ]
-                }
-            ]
+                    },
+                    {
+                        "index": follower_index2,
+                        "shards": [
+                            {
+                                "shard_id": 0,
+                                "remote_cluster": remote_cluster,
+                                "leader_index": leader_index2,
+                                "follower_index": follower_index2,
+                                "leader_global_checkpoint": leader_global_checkpoint,
+                                "leader_max_seq_no": leader_max_seq_no,
+                                "follower_global_checkpoint": follower_global_checkpoint,
+                                "follower_max_seq_no": follower_max_seq_no,
+                                "last_requested_seq_no": last_requested_seq_no,
+                                "outstanding_read_requests": outstanding_read_requests,
+                                "outstanding_write_requests": outstanding_write_requests,
+                                "write_buffer_operation_count": write_buffer_operation_count,
+                                "follower_mapping_version": follower_mapping_version,
+                                "total_read_time_millis": total_read_time_millis,
+                                "total_read_remote_exec_time_millis": total_read_remote_exec_time_millis,
+                                "successful_read_requests": successful_read_requests,
+                                "failed_read_requests": failed_read_requests,
+                                "operations_read": operations_read,
+                                "bytes_read": bytes_read,
+                                "total_write_time_millis": total_write_time_millis,
+                                "successful_write_requests": successful_write_requests,
+                                "failed_write_requests": failed_write_requests,
+                                "operations_written": operations_written,
+                                "read_exceptions": read_exceptions,
+                                "time_since_last_read_millis": time_since_last_read_millis,
+                            }
+
+                        ]
+                    }
+                ]
+            }
         }
 
+        ccr_stats_filtered_follower_response = {"follow_stats": ccr_stats_follower_response["follow_stats"]}
         client = Client(transport_client=TransportClient(response=ccr_stats_follower_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
@@ -549,7 +601,7 @@ class CcrStatsRecorderTests(TestCase):
         }
 
         metrics_store_put_doc.assert_has_calls([
-            mock.call(ccr_stats_follower_response["indices"][0]["shards"][0], level=MetaInfoScope.cluster, meta_data=shard_metadata)
+            mock.call(ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][0], level=MetaInfoScope.cluster, meta_data=shard_metadata)
             ],
             any_order=True
         )


### PR DESCRIPTION
The ccr-stats API endpoint has been updated in [1]; update the
telemetry device and tests to align with the changes introduced.

[1] https://github.com/elastic/elasticsearch/pull/34912