### PR TITLE
Simplify development setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # We assume an active virtualenv for development
 install:
 	-@python3 setup.py -q develop --upgrade
+	# also install development dependencies
+	# workaround for https://github.com/elastic/rally/issues/439
+	-@pip3 install -q sphinx sphinx_rtd_theme
 
 clean: nondocs-clean docs-clean
 


### PR DESCRIPTION
With this commit we amend the `make install` command to also include
development dependencies so developers don't need to perform this step
manually when setting up Rally. However, this is only a workaround and
should be properly addressed by #439.

Relates #439