### PR TITLE
Change logging level for esrally command line to DEBUG

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -608,7 +608,7 @@ def main():
     logger.info("OS [%s]", str(os.uname()))
     logger.info("Python [%s]", str(sys.implementation))
     logger.info("Rally version [%s]", version.version())
-    logger.info("Command line arguments: %s", args)
+    logger.debug("Command line arguments: %s", args)
     # Configure networking
     net.init()
     if not args.offline:


### PR DESCRIPTION
All command line arguments were logged in a generic fashion and among 
them can be passwords. We want to avoid the passwords being logged by
default if they are provided but still keep the ability to configure
the command line arguments to get logged if necessary.