### PR TITLE
Fix conflicting pipelines and distribution version

### DIFF
--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -368,7 +368,9 @@ def list_pipelines():
 def run(cfg):
     logger = logging.getLogger(__name__)
     name = cfg.opts("race", "pipeline")
+
     if len(name) == 0:
+        # assume from-distribution pipeline if distribution.version has been specified and --pipeline cli arg not set
         if cfg.exists("mechanic", "distribution.version"):
             name = "from-distribution"
         else:
@@ -376,6 +378,14 @@ def run(cfg):
         logger.info("User specified no pipeline. Automatically derived pipeline [%s].", name)
         cfg.add(config.Scope.applicationOverride, "race", "pipeline", name)
     else:
+        if (cfg.exists("mechanic", "distribution.version") and
+                name in ["from-sources-complete", "from-sources-skip-build", "benchmark-only"]):
+            raise exceptions.SystemSetupError(
+                "--distribution-version can only be used together with pipeline from-distribution, """
+                "but you specified {}.\n"
+                "If you intend to benchmark an externally provisioned cluster, don't specify --distribution-version otherwise\n"
+                "please read the docs for from-distribution pipeline at "
+                "https://esrally.readthedocs.io/en/stable/pipelines.html#from-distribution".format(name))
         logger.info("User specified pipeline [%s].", name)
 
     try:

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -5,7 +5,7 @@ import sys
 import tabulate
 import thespian.actors
 
-from esrally import actor, config, exceptions, track, driver, mechanic, reporter, metrics, time, PROGRAM_NAME
+from esrally import actor, config, exceptions, track, driver, mechanic, reporter, metrics, time, DOC_LINK, PROGRAM_NAME
 from esrally.utils import console, convert, opts
 
 # benchmarks with external candidates are really scary and we should warn users.
@@ -385,7 +385,7 @@ def run(cfg):
                 "but you specified {}.\n"
                 "If you intend to benchmark an externally provisioned cluster, don't specify --distribution-version otherwise\n"
                 "please read the docs for from-distribution pipeline at "
-                "https://esrally.readthedocs.io/en/stable/pipelines.html#from-distribution".format(name))
+                "{}/pipelines.html#from-distribution".format(name, DOC_LINK))
         logger.info("User specified pipeline [%s].", name)
 
     try:

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -1,4 +1,5 @@
 import unittest.mock as mock
+import random
 from unittest import TestCase
 
 from esrally import racecontrol, config, exceptions
@@ -35,6 +36,32 @@ class RaceControlTests(TestCase):
         racecontrol.run(cfg)
 
         mock_pipeline.assert_called_once_with(cfg)
+
+        # ensure we remove it again from the list of registered pipelines to avoid unwanted side effects
+        del p
+
+    def test_conflicting_pipeline_and_distribution_version(self):
+        mock_pipeline = mock.Mock()
+        rnd_pipeline_name = False
+
+        while not rnd_pipeline_name or rnd_pipeline_name == "from-distribution":
+            rnd_pipeline_name = random.choice(racecontrol.available_pipelines())[0]
+
+        p = racecontrol.Pipeline("unit-test-pipeline", "Pipeline intended for unit-testing", mock_pipeline)
+
+        cfg = config.Config()
+        cfg.add(config.Scope.benchmark, "race", "pipeline", rnd_pipeline_name)
+        cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "6.5.3")
+
+        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+            racecontrol.run(cfg)
+        self.assertRegex(
+            ctx.exception.args[0],
+            r"--distribution-version can only be used together with pipeline from-distribution, "
+            "but you specified {}.\n"
+            "If you intend to benchmark an externally provisioned cluster, don't specify --distribution-version otherwise\n"
+            "please read the docs for from-distribution pipeline at "
+            "https://esrally.readthedocs.io/en/stable/pipelines.html#from-distribution".format(rnd_pipeline_name))
 
         # ensure we remove it again from the list of registered pipelines to avoid unwanted side effects
         del p


### PR DESCRIPTION
Users frequently combine --distribution-version together with non
compatible pipelines.

Exit with a descriptive error message and don't allow choosing an
incompatible pipeline together with with `--distribution-version`.