### PR TITLE
Allow to specify a team revision

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -150,6 +150,12 @@ You can use ``--include-tasks`` to specify a comma-separated list of tasks that 
 
 Selects the team repository that Rally should use to resolve cars. By default the ``default`` team repository is used, which is available in the Github project `rally-teams <https://github.com/elastic/rally-teams>`__. See the documentation about :doc:`cars </car>` on how to add your own team repositories.
 
+``team-revision``
+~~~~~~~~~~~~~~~~~
+
+Selects a specific revision in the team repository. By default, Rally will choose the most appropriate branch on its own (see the :doc:`car reference </car>` for more details) but in some cases it is necessary to specify a certain commit. This is mostly needed when benchmarking specific historic commits of Elasticsearch which are incompatible with the current master branch of the team repository.
+
+
 ``team-path``
 ~~~~~~~~~~~~~
 

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -132,6 +132,7 @@ def team_path(cfg):
     else:
         distribution_version = cfg.opts("mechanic", "distribution.version", mandatory=False)
         repo_name = cfg.opts("mechanic", "repository.name")
+        repo_revision = cfg.opts("mechanic", "repository.revision")
         offline = cfg.opts("system", "offline.mode")
         remote_url = cfg.opts("teams", "%s.url" % repo_name, mandatory=False)
         root = cfg.opts("node", "root.dir")
@@ -139,7 +140,10 @@ def team_path(cfg):
         teams_dir = os.path.join(root, team_repositories)
 
         current_team_repo = repo.RallyRepository(remote_url, teams_dir, repo_name, "teams", offline)
-        current_team_repo.update(distribution_version)
+        if repo_revision:
+            current_team_repo.checkout(repo_revision)
+        else:
+            current_team_repo.update(distribution_version)
         return current_team_repo.repo_dir
 
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -172,6 +172,10 @@ def create_arg_parser():
             help="Define the repository from where Rally will load teams and cars (default: default).",
             default="default")
         p.add_argument(
+            "--team-revision",
+            help="Define a specific revision in the team repository that Rally should use.",
+            default=None)
+        p.add_argument(
             "--offline",
             help="Assume that Rally has no connection to the Internet (default: false).",
             default=False,
@@ -542,8 +546,10 @@ def main():
     if args.team_path:
         cfg.add(config.Scope.applicationOverride, "mechanic", "team.path", os.path.abspath(io.normalize_path(args.team_path)))
         cfg.add(config.Scope.applicationOverride, "mechanic", "repository.name", None)
+        cfg.add(config.Scope.applicationOverride, "mechanic", "repository.revision", None)
     else:
         cfg.add(config.Scope.applicationOverride, "mechanic", "repository.name", args.team_repository)
+        cfg.add(config.Scope.applicationOverride, "mechanic", "repository.revision", args.team_revision)
     cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", opts.csv_to_list(args.elasticsearch_plugins))
     cfg.add(config.Scope.applicationOverride, "mechanic", "car.params", opts.to_dict(args.car_params))
     cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", opts.to_dict(args.plugin_params))

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -82,3 +82,7 @@ class RallyRepository:
         except exceptions.SupplyError as e:
             tb = sys.exc_info()[2]
             raise exceptions.DataError("Cannot update %s in [%s] (%s)." % (self.resource_name, self.repo_dir, e.message)).with_traceback(tb)
+
+    def checkout(self, revision):
+        self.logger.info("Checking out revision [%s] in [%s].", revision, self.repo_dir)
+        git.checkout(self.repo_dir, revision)

--- a/tests/utils/repo_test.py
+++ b/tests/utils/repo_test.py
@@ -253,4 +253,19 @@ class RallyRepositoryTests(TestCase):
         self.assertEqual(0, checkout.call_count)
         self.assertEqual(0, rebase.call_count)
 
+    @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
+    @mock.patch("esrally.utils.git.fetch", autospec=True)
+    @mock.patch("esrally.utils.git.checkout", autospec=True)
+    def test_checkout_revision(self, checkout, fetch, is_working_copy):
+        is_working_copy.return_value = True
 
+        r = repo.RallyRepository(
+            remote_url=None,
+            root_dir="/rally-resources",
+            repo_name="unit-test",
+            resource_name="unittest-resources",
+            offline=False)
+
+        r.checkout("abcdef123")
+
+        checkout.assert_called_with("/rally-resources/unit-test", "abcdef123")


### PR DESCRIPTION
With this commit we add the ability to override Rally's logic to match
rally-teams with an Elasticsearch version. This allows us to benchmark
arbitrary historic commits of Elasticsearch even if incompatible
configuration changes have been introduced meanwhile.