### PR TITLE
Improve error message on missing repo directory

### DIFF
--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -20,7 +20,7 @@ import sys
 import logging
 
 from esrally import exceptions
-from esrally.utils import git, console, versions
+from esrally.utils import io, git, console, versions
 
 
 class RallyRepository:
@@ -47,8 +47,12 @@ class RallyRepository:
                     console.warn("Could not update %s. Continuing with your locally available state." % self.resource_name)
         else:
             if not git.is_working_copy(self.repo_dir):
-                raise exceptions.SystemSetupError("[{src}] must be a git repository.\n\nPlease run:\ngit -C {src} init"
-                                                  .format(src=self.repo_dir))
+                if io.exists(self.repo_dir):
+                    raise exceptions.SystemSetupError("[{src}] must be a git repository.\n\nPlease run:\ngit -C {src} init"
+                                                      .format(src=self.repo_dir))
+                else:
+                    raise exceptions.SystemSetupError("Expected a git repository at [{src}] but the directory does not exist."
+                                                      .format(src=self.repo_dir))
 
     def update(self, distribution_version):
         try:

--- a/tests/utils/repo_test.py
+++ b/tests/utils/repo_test.py
@@ -24,9 +24,11 @@ from esrally.utils import repo
 
 
 class RallyRepositoryTests(TestCase):
+    @mock.patch("esrally.utils.io.exists", autospec=True)
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
-    def test_fails_in_offline_mode_if_not_a_git_repo(self, is_working_copy):
+    def test_fails_in_offline_mode_if_not_a_git_repo(self, is_working_copy, exists):
         is_working_copy.return_value = False
+        exists.return_value = True
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             repo.RallyRepository(
@@ -38,6 +40,23 @@ class RallyRepositoryTests(TestCase):
 
         self.assertEqual("[/rally-resources/unit-test] must be a git repository.\n\n"
                          "Please run:\ngit -C /rally-resources/unit-test init", ctx.exception.args[0])
+
+    @mock.patch("esrally.utils.io.exists", autospec=True)
+    @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
+    def test_fails_in_offline_mode_if_not_existing(self, is_working_copy, exists):
+        is_working_copy.return_value = False
+        exists.return_value = False
+
+        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+            repo.RallyRepository(
+                remote_url=None,
+                root_dir="/rally-resources",
+                repo_name="unit-test",
+                resource_name="unittest-resources",
+                offline=True)
+
+        self.assertEqual("Expected a git repository at [/rally-resources/unit-test] but the directory does not exist.",
+                         ctx.exception.args[0])
 
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
     def test_does_nothing_if_working_copy_present(self, is_working_copy):


### PR DESCRIPTION
So far we only check whether repo is a valid working copy and raise an
error if it is not. With this commit we add a further check if the
directory exists at all (because that case needs to be fixed differently
by the user).