### PR TITLE
Correct recorder-based sampling interval

### DIFF
--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -422,7 +422,6 @@ class CcrStatsRecorder:
                         "The 'indices' key in {0} does not contain an 'index' or 'shards' key "
                         "Maybe the output format of the {0} endpoint has changed. Skipping.".format(ccr_stats_api_endpoint)
                     )
-        time.sleep(self.sample_interval)
 
     def record_stats_per_index(self, name, stats):
         """

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -548,8 +548,6 @@ class NodeStatsRecorder:
                                        node_name=node_name,
                                        meta_data=self.metrics_store_meta_data)
 
-        time.sleep(self.sample_interval)
-
     def flatten_stats_fields(self, prefix=None, stats=None):
         """
         Flatten provided dict using an optional prefix and top level key filters.


### PR DESCRIPTION
With this commit we remove the call to `time.sleep` from the node stats and CCR
stats recorder's `record` method. Thes calls are redundant because the sampler
thread that manages the recorder already calls `time.sleep`. This means that the
effective sample rate is effectively half of the specified one.