### PR TITLE
Add recovery-stats telemetry device

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -16,14 +16,14 @@ You probably want to gain additional insights from a race. Therefore, we have ad
 
    Available telemetry devices:
 
-    Command         Name                   Description
-    --------------  ---------------------  --------------------------------------------------------------------
-    jit             JIT Compiler Profiler  Enables JIT compiler logs.
-    gc              GC log                 Enables GC logs.
-    jfr             Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
-    perf            perf stat              Reads CPU PMU counters (requires Linux and perf)
-    node-stats      Node Stats             Regularly samples node stats
-    recovery-stats  Recovery Stats         Regularly samples shard recovery stats
+   Command         Name                   Description
+   --------------  ---------------------  --------------------------------------------------------------------
+   jit             JIT Compiler Profiler  Enables JIT compiler logs.
+   gc              GC log                 Enables GC logs.
+   jfr             Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
+   perf            perf stat              Reads CPU PMU counters (requires Linux and perf)
+   node-stats      Node Stats             Regularly samples node stats
+   recovery-stats  Recovery Stats         Regularly samples shard recovery stats
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -16,13 +16,14 @@ You probably want to gain additional insights from a race. Therefore, we have ad
 
    Available telemetry devices:
 
-   Command     Name                   Description
-   ----------  ---------------------  -----------------------------------------------------
-   jit         JIT Compiler Profiler  Enables JIT compiler logs.
-   gc          GC log                 Enables GC logs.
-   jfr         Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK)
-   perf        perf stat              Reads CPU PMU counters (requires Linux and perf)
-   node-stats  Node Stats             Regularly samples node stats
+    Command         Name                   Description
+    --------------  ---------------------  --------------------------------------------------------------------
+    jit             JIT Compiler Profiler  Enables JIT compiler logs.
+    gc              GC log                 Enables GC logs.
+    jfr             Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
+    perf            perf stat              Reads CPU PMU counters (requires Linux and perf)
+    node-stats      Node Stats             Regularly samples node stats
+    recovery-stats  Recovery Stats         Regularly samples shard recovery stats
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 
@@ -78,7 +79,7 @@ node-stats
     Using this telemetry device will skew your results because the node-stats API triggers additional refreshes.
     Additionally a lot of metrics get recorded impacting the measurement results even further.
 
-The node-stats telemetry devices regularly calls the `cluster node-stats API <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html>`_ and records metrics from the following sections:
+The node-stats telemetry device regularly calls the `cluster node-stats API <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html>`_ and records metrics from the following sections:
 
 * Indices stats (key ``indices`` in the node-stats API)
 * Thread pool stats (key ``jvm.thread_pool`` in the node-stats API)
@@ -100,3 +101,13 @@ Supported telemetry parameters:
 * ``node-stats-include-mem`` (default: ``true``): A boolean indicating whether JVM heap stats should be included.
 * ``node-stats-include-network`` (default: ``true``): A boolean indicating whether network-related stats should be included.
 * ``node-stats-include-process`` (default: ``true``): A boolean indicating whether process cpu stats should be included.
+
+recovery-stats
+--------------
+
+The recovery-stats telemetry device regularly calls the `indices recovery API <https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html>`_ and records one metrics document per shard.
+
+Supported telemetry parameters:
+
+* ``recovery-stats-indices`` (default: all indices): An index pattern for which recovery stats should be checked.
+* ``recovery-stats-sample-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -94,7 +94,8 @@ class ClusterLauncher:
             telemetry.GcTimesSummary(es_default, self.metrics_store),
             telemetry.IndexStats(es_default, self.metrics_store),
             telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
-            telemetry.CcrStats(telemetry_params, es, self.metrics_store)
+            telemetry.CcrStats(telemetry_params, es, self.metrics_store),
+            telemetry.RecoveryStats(telemetry_params, es, self.metrics_store)
         ])
 
         # The list of nodes will be populated by ClusterMetaDataInfo, so no need to do it here

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -551,13 +551,16 @@ class RecoveryStatsRecorder:
 
         for idx, idx_stats in stats.items():
             for shard in idx_stats["shards"]:
+                doc = {
+                    "name": "recovery-stats",
+                    "shard": shard
+                }
                 shard_metadata = {
                     "cluster": self.cluster_name,
                     "index": idx,
-                    "shard": shard["id"],
-                    "name": "recovery-stats"
+                    "shard": shard["id"]
                 }
-                self.metrics_store.put_doc(shard, level=MetaInfoScope.cluster, meta_data=shard_metadata)
+                self.metrics_store.put_doc(doc, level=MetaInfoScope.cluster, meta_data=shard_metadata)
 
 
 class NodeStats(TelemetryDevice):

--- a/esrally/utils/opts.py
+++ b/esrally/utils/opts.py
@@ -102,6 +102,8 @@ class ConnectOptions:
 
 
 class TargetHosts(ConnectOptions):
+    DEFAULT = "default"
+
     def __init__(self, argvalue):
         self.argname = "--target-hosts"
         self.argvalue = argvalue
@@ -118,7 +120,7 @@ class TargetHosts(ConnectOptions):
             defined as a json string or file.
             """
 
-            return {"default": _normalize_hosts(arg)}
+            return {TargetHosts.DEFAULT: _normalize_hosts(arg)}
 
         self.parsed_options = to_dict(self.argvalue, default_parser=normalize_to_dict)
 
@@ -154,7 +156,7 @@ class ClientOptions(ConnectOptions):
             defined as a json string or file.
             """
 
-            return {"default": kv_to_map(arg)}
+            return {TargetHosts.DEFAULT: kv_to_map(arg)}
 
         if self.argvalue == ClientOptions.DEFAULT_CLIENT_OPTIONS and self.target_hosts != None:
             # --client-options unset but multi-clusters used in --target-hosts? apply options defaults for all cluster names.

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -729,12 +729,14 @@ class RecoveryStatsTests(TestCase):
         shard_metadata = {
             "cluster": "leader",
             "index": "index1",
-            "shard": 0,
-            "name": "recovery-stats"
+            "shard": 0
         }
 
         metrics_store_put_doc.assert_has_calls([
-            mock.call(response["index1"]["shards"][0], level=MetaInfoScope.cluster, meta_data=shard_metadata)
+            mock.call({
+                "name": "recovery-stats",
+                "shard": response["index1"]["shards"][0]
+            }, level=MetaInfoScope.cluster, meta_data=shard_metadata)
         ],  any_order=True)
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
@@ -797,35 +799,45 @@ class RecoveryStatsTests(TestCase):
         recorder.record()
 
         metrics_store_put_doc.assert_has_calls([
-            mock.call(response["index1"]["shards"][0], level=MetaInfoScope.cluster, meta_data={
+            mock.call({
+                "name": "recovery-stats",
+                "shard": response["index1"]["shards"][0]
+            }, level=MetaInfoScope.cluster, meta_data={
                 "cluster": "leader",
                 "index": "index1",
-                "shard": 0,
-                "name": "recovery-stats"
+                "shard": 0
             }),
-            mock.call(response["index1"]["shards"][1], level=MetaInfoScope.cluster, meta_data={
+            mock.call({
+                "name": "recovery-stats",
+                "shard": response["index1"]["shards"][1]
+            }, level=MetaInfoScope.cluster, meta_data={
                 "cluster": "leader",
                 "index": "index1",
-                "shard": 1,
-                "name": "recovery-stats"
+                "shard": 1
             }),
-            mock.call(response["index2"]["shards"][0], level=MetaInfoScope.cluster, meta_data={
+            mock.call({
+                "name": "recovery-stats",
+                "shard": response["index2"]["shards"][0]
+            }, level=MetaInfoScope.cluster, meta_data={
                 "cluster": "leader",
                 "index": "index2",
-                "shard": 0,
-                "name": "recovery-stats"
+                "shard": 0
             }),
-            mock.call(response["index2"]["shards"][1], level=MetaInfoScope.cluster, meta_data={
+            mock.call({
+                "name": "recovery-stats",
+                "shard": response["index2"]["shards"][1]
+            }, level=MetaInfoScope.cluster, meta_data={
                 "cluster": "leader",
                 "index": "index2",
-                "shard": 1,
-                "name": "recovery-stats"
+                "shard": 1
             }),
-            mock.call(response["index2"]["shards"][2], level=MetaInfoScope.cluster, meta_data={
+            mock.call({
+                "name": "recovery-stats",
+                "shard": response["index2"]["shards"][2]
+            }, level=MetaInfoScope.cluster, meta_data={
                 "cluster": "leader",
                 "index": "index2",
-                "shard": 2,
-                "name": "recovery-stats"
+                "shard": 2
             }),
         ],  any_order=True)
 

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -157,15 +157,19 @@ class Client:
 
 
 class SubClient:
-    def __init__(self, stats=None, info=None):
+    def __init__(self, stats=None, info=None, recovery=None):
         self._stats = stats
         self._info = info
+        self._recovery = recovery
 
     def stats(self, *args, **kwargs):
         return self._stats
 
     def info(self, *args, **kwargs):
         return self._info
+
+    def recovery(self, *args, **kwargs):
+        return self._recovery
 
 
 class TransportClient:
@@ -623,6 +627,207 @@ class CcrStatsRecorderTests(TestCase):
             ],
             any_order=True
         )
+
+
+class RecoveryStatsTests(TestCase):
+    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    def test_no_metrics_if_no_pending_recoveries(self, metrics_store_put_doc):
+        response = {}
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        client = Client(indices=SubClient(recovery=response))
+        recorder = telemetry.RecoveryStatsRecorder(cluster_name="leader",
+                                                   client=client,
+                                                   metrics_store=metrics_store,
+                                                   sample_interval=1,
+                                                   indices=["index1"])
+        recorder.record()
+
+        self.assertEqual(0, metrics_store_put_doc.call_count)
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    def test_stores_single_shard_stats(self, metrics_store_put_doc):
+        response = {
+            "index1": {
+                "shards": [{
+                    "id": 0,
+                    "type": "STORE",
+                    "stage": "DONE",
+                    "primary": True,
+                    "start_time": "2014-02-24T12:38:06.349",
+                    "start_time_in_millis": "1393245486349",
+                    "stop_time": "2014-02-24T12:38:08.464",
+                    "stop_time_in_millis": "1393245488464",
+                    "total_time": "2.1s",
+                    "total_time_in_millis": 2115,
+                    "source": {
+                        "id": "RGMdRc-yQWWKIBM4DGvwqQ",
+                        "host": "my.fqdn",
+                        "transport_address": "my.fqdn",
+                        "ip": "10.0.1.7",
+                        "name": "my_es_node"
+                    },
+                    "target": {
+                        "id": "RGMdRc-yQWWKIBM4DGvwqQ",
+                        "host": "my.fqdn",
+                        "transport_address": "my.fqdn",
+                        "ip": "10.0.1.7",
+                        "name": "my_es_node"
+                    },
+                    "index": {
+                        "size": {
+                            "total": "24.7mb",
+                            "total_in_bytes": 26001617,
+                            "reused": "24.7mb",
+                            "reused_in_bytes": 26001617,
+                            "recovered": "0b",
+                            "recovered_in_bytes": 0,
+                            "percent": "100.0%"
+                        },
+                        "files": {
+                            "total": 26,
+                            "reused": 26,
+                            "recovered": 0,
+                            "percent": "100.0%"
+                        },
+                        "total_time": "2ms",
+                        "total_time_in_millis": 2,
+                        "source_throttle_time": "0s",
+                        "source_throttle_time_in_millis": 0,
+                        "target_throttle_time": "0s",
+                        "target_throttle_time_in_millis": 0
+                    },
+                    "translog": {
+                        "recovered": 71,
+                        "total": 0,
+                        "percent": "100.0%",
+                        "total_on_start": 0,
+                        "total_time": "2.0s",
+                        "total_time_in_millis": 2025
+                    },
+                    "verify_index": {
+                        "check_index_time": 0,
+                        "check_index_time_in_millis": 0,
+                        "total_time": "88ms",
+                        "total_time_in_millis": 88
+                    }
+                }
+                ]
+            }
+        }
+
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        client = Client(indices=SubClient(recovery=response))
+        recorder = telemetry.RecoveryStatsRecorder(cluster_name="leader",
+                                                   client=client,
+                                                   metrics_store=metrics_store,
+                                                   sample_interval=1,
+                                                   indices=["index1"])
+        recorder.record()
+
+        shard_metadata = {
+            "cluster": "leader",
+            "index": "index1",
+            "shard": 0,
+            "name": "recovery-stats"
+        }
+
+        metrics_store_put_doc.assert_has_calls([
+            mock.call(response["index1"]["shards"][0], level=MetaInfoScope.cluster, meta_data=shard_metadata)
+        ],  any_order=True)
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    def test_stores_multi_index_multi_shard_stats(self, metrics_store_put_doc):
+        response = {
+            "index1": {
+                "shards": [
+                    {
+                        # for the test we only assume a subset of the fields
+                        "id": 0,
+                        "type": "STORE",
+                        "stage": "DONE",
+                        "primary": True,
+                        "total_time_in_millis": 100
+                    },
+                    {
+                        "id": 1,
+                        "type": "STORE",
+                        "stage": "DONE",
+                        "primary": True,
+                        "total_time_in_millis": 200
+                    }
+                ]
+            },
+            "index2": {
+                "shards": [
+                    {
+                        "id": 0,
+                        "type": "STORE",
+                        "stage": "DONE",
+                        "primary": True,
+                        "total_time_in_millis": 300
+                    },
+                    {
+                        "id": 1,
+                        "type": "STORE",
+                        "stage": "DONE",
+                        "primary": True,
+                        "total_time_in_millis": 400
+                    },
+                    {
+                        "id": 2,
+                        "type": "STORE",
+                        "stage": "DONE",
+                        "primary": True,
+                        "total_time_in_millis": 500
+                    }
+                ]
+            }
+        }
+
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        client = Client(indices=SubClient(recovery=response))
+        recorder = telemetry.RecoveryStatsRecorder(cluster_name="leader",
+                                                   client=client,
+                                                   metrics_store=metrics_store,
+                                                   sample_interval=1,
+                                                   indices=["index1", "index2"])
+        recorder.record()
+
+        metrics_store_put_doc.assert_has_calls([
+            mock.call(response["index1"]["shards"][0], level=MetaInfoScope.cluster, meta_data={
+                "cluster": "leader",
+                "index": "index1",
+                "shard": 0,
+                "name": "recovery-stats"
+            }),
+            mock.call(response["index1"]["shards"][1], level=MetaInfoScope.cluster, meta_data={
+                "cluster": "leader",
+                "index": "index1",
+                "shard": 1,
+                "name": "recovery-stats"
+            }),
+            mock.call(response["index2"]["shards"][0], level=MetaInfoScope.cluster, meta_data={
+                "cluster": "leader",
+                "index": "index2",
+                "shard": 0,
+                "name": "recovery-stats"
+            }),
+            mock.call(response["index2"]["shards"][1], level=MetaInfoScope.cluster, meta_data={
+                "cluster": "leader",
+                "index": "index2",
+                "shard": 1,
+                "name": "recovery-stats"
+            }),
+            mock.call(response["index2"]["shards"][2], level=MetaInfoScope.cluster, meta_data={
+                "cluster": "leader",
+                "index": "index2",
+                "shard": 2,
+                "name": "recovery-stats"
+            }),
+        ],  any_order=True)
 
 
 class NodeStatsTests(TestCase):


### PR DESCRIPTION
With this commit we add a new telemetry device called `recovery-stats`
which can be used to retrieve statistics about ongoing recoveries while
running a benchmark.

Closes #635