### PR TITLE
Temporarily disable Python 3.4 in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ PYENV_PREREQ_HELP = "\033[0;31mIMPORTANT\033[0m: please add \033[0;31meval \"\$$
 VE_MISSING_HELP = "\033[0;31mIMPORTANT\033[0m: Couldn't find $(PWD)/$(VENV_NAME); have you executed make venv-create?\033[0m\n"
 
 prereq: make-requirements.txt
-	pyenv install $(PY34)
+# Temporarily disable Python 3.4 builds
+#	pyenv install $(PY34)
 	pyenv install $(PY35)
 	pyenv install $(PY36)
 	pyenv install $(PY37)
@@ -88,9 +89,10 @@ test: check-venv
 it: check-venv python-caches-clean
 	. $(VENV_ACTIVATE_FILE); tox
 
-it34: check-venv python-caches-clean
-	. $(VENV_ACTIVATE_FILE); tox -e py34
-
+# Temporarily disable Python 3.4 builds
+#it34: check-venv python-caches-clean
+#	. $(VENV_ACTIVATE_FILE); tox -e py34
+#
 it35: check-venv python-caches-clean
 	. $(VENV_ACTIVATE_FILE); tox -e py35
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,11 @@
 #
 ###############################################################################
 [tox]
+# Temporarily disable Python 3.4 builds
+#envlist =
+#    docs, py34, py35, py36, py37
 envlist =
-    docs, py34, py35, py36, py37
+    docs, py35, py36, py37
 platform =
     linux|darwin
 


### PR DESCRIPTION
With this commit we temporarily remove Python 3.4 testing from our
builds. Due an OS upgrade in the CI matrix, Python 3.4 is not easily
available anymore so we will build only with 3.5, 3.6 and 3.7 for the
time being. We will decide at a later point whether we will drop testing
on 3.4 completely or we use a different solution for testing with Python
3.4