### PR TITLE
Allow passing any request parameter to the create index API

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -783,7 +783,12 @@ class CreateIndex(Runner):
         indices = mandatory(params, "indices", self)
         request_params = params.get("request-params", {})
         for index, body in indices:
-            es.indices.create(index=index, body=body, **request_params)
+            # We don't use es.indices.create() because it doesn't support params
+            # Ref: https://elasticsearch-py.readthedocs.io/en/master/api.html?highlight=indices%20create#elasticsearch.client.IndicesClient.create
+            es.transport.perform_request(method="PUT",
+                                         url="/{}".format(index),
+                                         body=body,
+                                         params=request_params)
         return len(indices), "ops"
 
     def __repr__(self, *args, **kwargs):

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1275,23 +1275,25 @@ class CreateIndexRunnerTests(TestCase):
     def test_creates_multiple_indices(self, es):
         r = runner.CreateIndex()
 
+        request_params = {
+            "wait_for_active_shards": True
+        }
+
         params = {
             "indices": [
                 ("indexA", {"settings": {}}),
                 ("indexB", {"settings": {}}),
             ],
-            "request-params": {
-                "wait_for_active_shards": True
-            }
+            "request-params": request_params
         }
 
         result = r(es, params)
 
         self.assertEqual((2, "ops"), result)
 
-        es.indices.create.assert_has_calls([
-            mock.call(index="indexA", body={"settings": {}}, wait_for_active_shards=True),
-            mock.call(index="indexB", body={"settings": {}}, wait_for_active_shards=True)
+        es.transport.perform_request.assert_has_calls([
+            mock.call(method="PUT", url="/indexA", body={"settings": {}}, params=request_params),
+            mock.call(method="PUT", url="/indexB", body={"settings": {}}, params=request_params)
         ])
 
     @mock.patch("elasticsearch.Elasticsearch")


### PR DESCRIPTION
https://github.com/elastic/rally-tracks/pull/64 requires passing a
parameter in the create-index runner, however, the underlying ES Python
client method[1] doesn't support it. Additionally our docs[2] hint
that this is possible, but it isn't.
This leads to errors like: 
`create() got an unexpected keyword argument 'include_type_name'`.

This isn't caught by unit tests as the ES client is mocked and an
integration test is needed (TODO in a separate PR).

Directly call es.transport.perform_request to create an index, allowing
passing of any arbitrary parameter (such as `include_type_name`) to
the create index Elasticsearch API.

[1] https://elasticsearch-py.readthedocs.io/en/master/api.html?highlight=indices%20create#elasticsearch.client.IndicesClient.create
[2] https://esrally.readthedocs.io/en/stable/track.html#create-index