### PR TITLE
Add node_name in node-stats docs for ...

### DIFF
--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -637,7 +637,7 @@ class NodeStatsRecorder:
         self.include_gc_stats = telemetry_params.get("node-stats-include-gc", True)
         self.client = client
         self.metrics_store = metrics_store
-        self.metrics_store_meta_data = {"cluster": cluster_name}
+        self.cluster_name = cluster_name
 
     def __str__(self):
         return "node stats"
@@ -646,6 +646,10 @@ class NodeStatsRecorder:
         current_sample = self.sample()
         for node_stats in current_sample:
             node_name = node_stats["name"]
+            metrics_store_meta_data = {
+                "cluster": self.cluster_name,
+                "node_name": node_name
+            }
             collected_node_stats = collections.OrderedDict()
             collected_node_stats["name"] = "node-stats"
 
@@ -670,7 +674,7 @@ class NodeStatsRecorder:
             self.metrics_store.put_doc(dict(collected_node_stats),
                                        level=MetaInfoScope.node,
                                        node_name=node_name,
-                                       meta_data=self.metrics_store_meta_data)
+                                       meta_data=metrics_store_meta_data)
 
     def flatten_stats_fields(self, prefix=None, stats=None):
         """

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -1148,7 +1148,10 @@ class NodeStatsRecorderTests(TestCase):
         client = Client(nodes=SubClient(stats=NodeStatsRecorderTests.node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        metrics_store_meta_data = {"cluster": "remote"}
+        node_name = [NodeStatsRecorderTests.node_stats_response["nodes"][node]["name"]
+                     for node in NodeStatsRecorderTests.node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
+
         telemetry_params = {}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         recorder.record()
@@ -1350,7 +1353,8 @@ class NodeStatsRecorderTests(TestCase):
         client = Client(nodes=SubClient(stats=node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        metrics_store_meta_data = {"cluster": "remote"}
+        node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
         telemetry_params = {
             "node-stats-include-indices": True
         }
@@ -1626,7 +1630,8 @@ class NodeStatsRecorderTests(TestCase):
         client = Client(nodes=SubClient(stats=node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        metrics_store_meta_data = {"cluster": "remote"}
+        node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
         telemetry_params = {
             "node-stats-include-indices-metrics": "refresh,docs"
         }


### PR DESCRIPTION
... non-default clusters

Until #645 gets resolved, add node name meta information for node stats
collected from non default clusters.