### PR TITLE
Make types optional

### DIFF
--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -92,6 +92,10 @@ Then store the following mapping file as ``index.json`` in the tutorial director
       }
     }
 
+.. note::
+   This tutorial assumes that you want to benchmark a version of Elasticsearch prior to 7.0.0. If you want to benchmark Elasticsearch 7.0.0 or later you need to remove the mapping type above.
+
+
 For details on the allowed syntax, see the Elasticsearch documentation on `mappings <https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html>`_ and the `create index API <https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html>`__.
 
 Finally, store the track as ``track.json`` in the tutorial directory::
@@ -170,6 +174,9 @@ Finally, store the track as ``track.json`` in the tutorial directory::
 
 
 The numbers under the ``documents`` property are needed to verify integrity and provide progress reports. Determine the correct document count with ``wc -l documents.json`` and the size in bytes with ``stat -f "%z" documents.json``.
+
+.. note::
+   This tutorial assumes that you want to benchmark a version of Elasticsearch prior to 7.0.0. If you want to benchmark Elasticsearch 7.0.0 or later you need to remove the ``types`` property above.
 
 .. note::
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -177,7 +177,7 @@ Each index in this list consists of the following properties:
 
 * ``name`` (mandatory): The name of the index.
 * ``body`` (optional): File name of the corresponding index definition that will be used as body in the create index API call.
-* ``types`` (optional): A list of type names in this index.
+* ``types`` (optional): A list of type names in this index. Types have been removed in Elasticsearch 7.0.0 so you must not specify this property if you want to benchmark Elasticsearch 7.0.0 or later.
 
 Example::
 
@@ -228,7 +228,7 @@ Each entry in the ``documents`` list consists of the following properties:
 * ``compressed-bytes`` (optional but recommended): The size in bytes of the compressed source file. This number is used to show users how much data will be downloaded by Rally and also to check whether the download is complete.
 * ``uncompressed-bytes`` (optional but recommended): The size in bytes of the source file after decompression. This number is used by Rally to show users how much disk space the decompressed file will need and to check that the whole file could be decompressed successfully.
 * ``target-index``: Defines the name of the index which should be targeted for bulk operations. Rally will automatically derive this value if you have defined exactly one index in the ``indices`` section. Ignored if ``includes-action-and-meta-data`` is ``true``.
-* ``target-type``: Defines the name of the document type which should be targeted for bulk operations. Rally will automatically derive this value if you have defined exactly one index in the ``indices`` section and this index has exactly one type. Ignored if ``includes-action-and-meta-data`` is ``true``.
+* ``target-type`` (optional): Defines the name of the document type which should be targeted for bulk operations. Rally will automatically derive this value if you have defined exactly one index in the ``indices`` section and this index has exactly one type. Ignored if ``includes-action-and-meta-data`` is ``true``. Types have been removed in Elasticsearch 7.0.0 so you must not specify this property if you want to benchmark Elasticsearch 7.0.0 or later.
 
 To avoid repetition, you can specify default values on document corpus level for the following properties:
 
@@ -367,7 +367,7 @@ search
 With the operation type ``search`` you can execute `request body searches <http://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html>`_. It supports the following properties:
 
 * ``index`` (optional): An `index pattern <https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html>`_ that defines which indices should be targeted by this query. Only needed if the ``index`` section contains more than one index. Otherwise, Rally will automatically derive the index to use. If you have defined multiple indices and want to query all of them, just specify ``"index": "_all"``.
-* ``type`` (optional): Defines the type within the specified index for this query. By default, no ``type`` will be used and the query will be performed across all types in the provided index.
+* ``type`` (optional): Defines the type within the specified index for this query. By default, no ``type`` will be used and the query will be performed across all types in the provided index. Also, types have been removed in Elasticsearch 7.0.0 so you must not specify this property if you want to benchmark Elasticsearch 7.0.0 or later.
 * ``cache`` (optional): Whether to use the query request cache. By default, Rally will define no value thus the default depends on the benchmark candidate settings and Elasticsearch version.
 * ``request-params`` (optional): A structure containing arbitrary request parameters. The supported parameters names are documented in the `Python ES client API docs <http://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.search>`_. Parameters that are implicitly set by Rally (e.g. `body` or `request_cache`) are not supported (i.e. you should not try to set them and if so expect unspecified behavior).
 * ``body`` (mandatory): The query body.
@@ -516,6 +516,9 @@ With the following snippet we will create a new index that is not defined in the
       }
     }
 
+.. note::
+   Types have been removed in Elasticsearch 7.0.0. If you want to benchmark Elasticsearch 7.0.0 or later you need to remove the mapping type above.
+
 This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
 
 delete-index
@@ -608,6 +611,9 @@ With the following snippet we will create a new index template that is not defin
         }
       }
     }
+
+.. note::
+   Types have been removed in Elasticsearch 7.0.0. If you want to benchmark Elasticsearch 7.0.0 or later you need to remove the mapping type above.
 
 This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -375,7 +375,7 @@ class BulkIndex(Runner):
             # only half of the lines are documents
             response = es.bulk(body=params["body"], params=bulk_params)
         else:
-            response = es.bulk(body=params["body"], index=index, doc_type=params["type"], params=bulk_params)
+            response = es.bulk(body=params["body"], index=index, doc_type=params.get("type"), params=bulk_params)
 
         stats = self.detailed_stats(params, bulk_size, response) if detailed_results else self.simple_stats(bulk_size, response)
 

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -850,10 +850,10 @@ class TrackSpecificationReader:
                         target_idx = None
                         target_type = None
                     else:
-                        # we need an index and a type name if no meta-data are present
+                        # we need an index if no meta-data are present.
                         target_idx = self._r(doc_spec, "target-index", mandatory=corpus_target_idx is None,
                                              default_value=corpus_target_idx, error_ctx=docs)
-                        target_type = self._r(doc_spec, "target-type", mandatory=corpus_target_type is None,
+                        target_type = self._r(doc_spec, "target-type", mandatory=False,
                                               default_value=corpus_target_type, error_ctx=docs)
 
                     docs = track.Documents(source_format=source_format,

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -703,13 +703,22 @@ def bulk_data_based(num_clients, client_index, corpora, batch_size, bulk_size, i
 class GenerateActionMetaData:
     RECENCY_SLOPE = 30
 
-    def __init__(self, index_name, type_name, conflicting_ids=None, conflict_probability=None, on_conflict=None, recency=None,
-                 rand=random.random, randint=random.randint, randexp=random.expovariate):
-        self.index_name = index_name
-        self.type_name = type_name
+    def __init__(self, index_name, type_name, conflicting_ids=None, conflict_probability=None, on_conflict=None,
+                 recency=None, rand=random.random, randint=random.randint, randexp=random.expovariate):
+        if type_name:
+            self.meta_data_index_with_id = '{"index": {"_index": "%s", "_type": "%s", "_id": "%s"}}' % \
+                                           (index_name, type_name, "%s")
+            self.meta_data_update_with_id = '{"update": {"_index": "%s", "_type": "%s", "_id": "%s"}}' % \
+                                            (index_name, type_name, "%s")
+            self.meta_data_index_no_id = '{"index": {"_index": "%s", "_type": "%s"}}' % (index_name, type_name)
+        else:
+            self.meta_data_index_with_id = '{"index": {"_index": "%s", "_id": "%s"}}' % (index_name, "%s")
+            self.meta_data_update_with_id = '{"update": {"_index": "%s", "_id": "%s"}}' % (index_name, "%s")
+            self.meta_data_index_no_id = '{"index": {"_index": "%s"}}' % index_name
+
         self.conflicting_ids = conflicting_ids
         self.on_conflict = on_conflict
-        # random() produces numbers between 0 and 1 and the user denotes the probability in percentage between 0 and 100.
+        # random() produces numbers between 0 and 1 and the user denotes the probability in percentage between 0 and 100
         self.conflict_probability = conflict_probability / 100.0 if conflict_probability is not None else 0
         self.recency = recency if recency is not None else 0
 
@@ -748,13 +757,13 @@ class GenerateActionMetaData:
                 action = "index"
 
             if action == "index":
-                return "index", '{"index": {"_index": "%s", "_type": "%s", "_id": "%s"}}' % (self.index_name, self.type_name, doc_id)
+                return "index", self.meta_data_index_with_id % doc_id
             elif action == "update":
-                return "update", '{"update": {"_index": "%s", "_type": "%s", "_id": "%s"}}' % (self.index_name, self.type_name, doc_id)
+                return "update", self.meta_data_update_with_id % doc_id
             else:
                 raise exceptions.RallyAssertionError("Unknown action [{}]".format(action))
         else:
-            return "index", '{"index": {"_index": "%s", "_type": "%s"}}' % (self.index_name, self.type_name)
+            return "index", self.meta_data_index_no_id
 
 
 class SourceActionMetaData:


### PR DESCRIPTION
With this commit we make types an optional concept in Rally as types
have been removed from the Elasticsearch APIs with 7.0.0. It is still
possible to use types for older versions of Elasticsearch though.