### PR TITLE
Use --prune for all git fetch operations

### DIFF
--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -84,7 +84,7 @@ def pull(src_dir, remote="origin", branch="master"):
 @probed
 def pull_ts(src_dir, ts):
     if process.run_subprocess(
-            "git -C {0} fetch --quiet origin && git -C {0} checkout --quiet `git -C {0} rev-list -n 1 --before=\"{1}\" "
+            "git -C {0} fetch --prune --quiet origin && git -C {0} checkout --quiet `git -C {0} rev-list -n 1 --before=\"{1}\" "
             "--date=iso8601 origin/master`".format(src_dir, ts)):
         raise exceptions.SupplyError("Could not fetch source tree for timestamped revision [%s]" % ts)
 
@@ -92,7 +92,7 @@ def pull_ts(src_dir, ts):
 @probed
 def pull_revision(src_dir, revision):
     if process.run_subprocess(
-                    "git -C {0} fetch --quiet origin && git -C {0} checkout --quiet {1}".format(src_dir, revision)):
+                    "git -C {0} fetch --prune --quiet origin && git -C {0} checkout --quiet {1}".format(src_dir, revision)):
         raise exceptions.SupplyError("Could not fetch source tree for revision [%s]" % revision)
 
 

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -137,7 +137,7 @@ class GitTests(TestCase):
         run_subprocess.return_value = False
         git.pull_ts("/src", "20160101T110000Z")
         run_subprocess.assert_called_with(
-                "git -C /src fetch --quiet origin && git -C /src checkout "
+                "git -C /src fetch --prune --quiet origin && git -C /src checkout "
                 "--quiet `git -C /src rev-list -n 1 --before=\"20160101T110000Z\" --date=iso8601 origin/master`")
 
     @mock.patch("esrally.utils.process.run_subprocess")
@@ -146,7 +146,7 @@ class GitTests(TestCase):
         run_subprocess_with_logging.return_value = 0
         run_subprocess.return_value = False
         git.pull_revision("/src", "3694a07")
-        run_subprocess.assert_called_with("git -C /src fetch --quiet origin && git -C /src checkout --quiet 3694a07")
+        run_subprocess.assert_called_with("git -C /src fetch --prune --quiet origin && git -C /src checkout --quiet 3694a07")
 
     @mock.patch("esrally.utils.process.run_subprocess_with_output")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")


### PR DESCRIPTION
In environments with long lived git checkouts git fetch operations can
fail after time, due to rebasing operations or other reasons with
messages like:

```
There are too many unreachable loose objects; run 'git prune' to
remove them.
```

Ensure `git fetch` always uses the --prune flag.