### PR TITLE
Allow to use ES 7.x as metrics store

### DIFF
--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -39,6 +39,8 @@ def create_config():
     cfg.add(config.Scope.application, "reporting", "datastore.secure", False)
     cfg.add(config.Scope.application, "reporting", "datastore.user", "")
     cfg.add(config.Scope.application, "reporting", "datastore.password", "")
+    # disable version probing to avoid any network calls in tests
+    cfg.add(config.Scope.application, "reporting", "datastore.probe.cluster_version", False)
     # only internal devices are active
     cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
     return cfg

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -538,7 +538,7 @@ class EsMetricsTests(TestCase):
 
         actual_throughput = self.metrics_store.get_one("indexing_throughput", lap=3)
 
-        self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", doc_type="_doc", body=expected_query)
+        self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 
         self.assertEqual(throughput, actual_throughput)
 
@@ -595,7 +595,7 @@ class EsMetricsTests(TestCase):
 
         actual_median_throughput = self.metrics_store.get_median("indexing_throughput", lap=3)
 
-        self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", doc_type="_doc", body=expected_query)
+        self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 
         self.assertEqual(median_throughput, actual_median_throughput)
 
@@ -732,7 +732,7 @@ class EsMetricsTests(TestCase):
         }
 
         actual_error_rate = self.metrics_store.get_error_rate("scroll_query", lap=3)
-        self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", doc_type="_doc", body=expected_query)
+        self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
         return actual_error_rate
 
 


### PR DESCRIPTION
With this commit we implement the changes necessary to talk to 7.x
metrics stores while retaining compatibility with older versions.

Relates #605 