### PR TITLE
Sort the track parameters / user tags when listing races

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1171,7 +1171,8 @@ def race_store(cfg):
 def list_races(cfg):
     def format_dict(d):
         if d:
-            return ", ".join(["%s=%s" % (k, v) for k, v in d.items()])
+            items=sorted(d.items())
+            return ", ".join(["%s=%s" % (k, v) for k, v in items])
         else:
             return None
 


### PR DESCRIPTION
Sort the track parameters and user tags when listing races.

Closes https://github.com/elastic/rally/issues/658