### PR TITLE
Add user tags when comparing races

### DIFF
--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -677,7 +677,7 @@ class ComparisonReporter:
         print_internal("  Car: %s" % r1.car_name)
         if r1.user_tags:
             r1_user_tags = ", ".join(["%s=%s" % (k, v) for k, v in sorted(r1.user_tags.items())])
-            print_internal("  User Tags: %s" % r1_user_tags)
+            print_internal("  User tags: %s" % r1_user_tags)
         print_internal("")
         print_internal("with contender")
         print_internal("  Race timestamp: %s" % r2.trial_timestamp)
@@ -686,7 +686,7 @@ class ComparisonReporter:
         print_internal("  Car: %s" % r2.car_name)
         if r2.user_tags:
             r2_user_tags = ", ".join(["%s=%s" % (k, v) for k, v in sorted(r2.user_tags.items())])
-            print_internal("  User Tags: %s" % r2_user_tags)
+            print_internal("  User tags: %s" % r2_user_tags)
         print_header(FINAL_SCORE)
 
         metric_table_plain = self.metrics_table(baseline_stats, contender_stats, plain=True)

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -675,12 +675,18 @@ class ComparisonReporter:
         if r1.challenge_name:
             print_internal("  Challenge: %s" % r1.challenge_name)
         print_internal("  Car: %s" % r1.car_name)
+        if r1.user_tags:
+            r1_user_tags = ", ".join(["%s=%s" % (k, v) for k, v in sorted(r1.user_tags.items())])
+            print_internal("  User Tags: %s" % r1_user_tags)
         print_internal("")
         print_internal("with contender")
         print_internal("  Race timestamp: %s" % r2.trial_timestamp)
         if r2.challenge_name:
             print_internal("  Challenge: %s" % r2.challenge_name)
         print_internal("  Car: %s" % r2.car_name)
+        if r2.user_tags:
+            r2_user_tags = ", ".join(["%s=%s" % (k, v) for k, v in sorted(r2.user_tags.items())])
+            print_internal("  User Tags: %s" % r2_user_tags)
         print_header(FINAL_SCORE)
 
         metric_table_plain = self.metrics_table(baseline_stats, contender_stats, plain=True)


### PR DESCRIPTION
This change will include the race user tags along side with the date, challenge,
car

Example:
```bash
$ ./rally compare --contender=20190227T161026Z --baseline=20190228T150825Z  

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/


Comparing baseline
  Race timestamp: 2019-02-28 15:08:25
  Challenge: append-no-conflicts-with-ingest-pipeline
  Car: external
  User Tags: intention=combined, template=io

with contender
  Race timestamp: 2019-02-27 16:10:26
  Challenge: append-no-conflicts-with-ingest-pipeline
  Car: external
  User Tags: intention=combined, template=io
```

Fixes: https://github.com/elastic/rally/issues/657
