### PR TITLE
Small change in the venv-create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ venv-create:
 		printf $(PYENV_ERROR); \
 		exit 1; \
 	fi;
-	@if [[ ! $(PATH) =~ $(PYENV_REGEX) ]]; then \
+	@if [[ ! "$(PATH)" =~ $(PYENV_REGEX) ]]; then \
 		printf $(PYENV_PATH_ERROR); \
 		exit 1; \
 	fi;


### PR DESCRIPTION
My $PATH contained a location with a space character and that caused issues when
expanding the $PATH variable. Wrapping it in `"` solved that