### PR TITLE
Add distribution flavor to metrics metadata

### DIFF
--- a/esrally/mechanic/cluster.py
+++ b/esrally/mechanic/cluster.py
@@ -78,6 +78,7 @@ class Cluster:
         self.nodes = nodes
         self.telemetry = telemetry
         self.distribution_version = None
+        self.distribution_flavor = None
         self.source_revision = None
         self.preserve = preserve
 

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -34,17 +34,19 @@ METRIC_FLUSH_INTERVAL_SECONDS = 30
 ##############################
 
 class ClusterMetaInfo:
-    def __init__(self, nodes, revision, distribution_version):
+    def __init__(self, nodes, revision, distribution_version, distribution_flavor):
         self.nodes = nodes
         self.revision = revision
         self.distribution_version = distribution_version
+        self.distribution_flavor = distribution_flavor
 
     def as_dict(self):
         return {
             "nodes": [n.as_dict() for n in self.nodes],
             "node-count": len(self.nodes),
             "revision": self.revision,
-            "distribution-version": self.distribution_version
+            "distribution-version": self.distribution_version,
+            "distribution-flavor": self.distribution_flavor
         }
 
 
@@ -402,7 +404,8 @@ class MechanicActor(actor.RallyActor):
         self.send(self.race_control,
                   EngineStarted(ClusterMetaInfo([NodeMetaInfo(n) for n in self.cluster.nodes],
                                                 self.cluster.source_revision,
-                                                self.cluster.distribution_version),
+                                                self.cluster.distribution_version,
+                                                self.cluster.distribution_flavor),
                                 self.metrics_store.meta_info))
         self.wakeupAfter(METRIC_FLUSH_INTERVAL_SECONDS, payload=MechanicActor.WAKEUP_FLUSH_METRICS)
 

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -980,8 +980,11 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
         client_info = self.client.info()
         revision = client_info["version"]["build_hash"]
         distribution_version = client_info["version"]["number"]
+        # older versions (pre 6.3.0) don't expose a build_flavor property because the only (implicit) flavor was "oss".
+        distribution_flavor = client_info["version"].get("build_flavor", "oss")
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "source_revision", revision)
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "distribution_version", distribution_version)
+        self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "distribution_flavor", distribution_flavor)
 
         info = self.client.nodes.info(node_id="_all")
         nodes_info = info["nodes"].values()
@@ -1062,8 +1065,11 @@ class ClusterMetaDataInfo(InternalTelemetryDevice):
         client_info = self.client.info()
         revision = client_info["version"]["build_hash"]
         distribution_version = client_info["version"]["number"]
+        # older versions (pre 6.3.0) don't expose a build_flavor property because the only (implicit) flavor was "oss".
+        distribution_flavor = client_info["version"].get("build_flavor", "oss")
 
         cluster.distribution_version = distribution_version
+        cluster.distribution_flavor = distribution_flavor
         cluster.source_revision = revision
 
         for node_stats in self.client.nodes.stats(metric="_all")["nodes"].values():

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1295,6 +1295,7 @@ class Race:
             "trial-id": self.trial_id,
             "trial-timestamp": time.to_iso8601(self.trial_timestamp),
             "distribution-version": self.cluster.distribution_version,
+            "distribution-flavor": self.cluster.distribution_flavor,
             "distribution-major-version": versions.major_version(self.cluster.distribution_version),
             "user-tags": self.user_tags,
             "track": self.track_name,

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -59,6 +59,9 @@
         "plugins": {
           "type": "keyword"
         },
+        "distribution-flavor": {
+          "type": "keyword"
+        },
         "distribution-version": {
           "type": "keyword"
         },

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -1783,6 +1783,7 @@ class ClusterEnvironmentInfoTests(TestCase):
         calls = [
             mock.call(metrics.MetaInfoScope.cluster, None, "source_revision", "abc123"),
             mock.call(metrics.MetaInfoScope.cluster, None, "distribution_version", "6.0.0-alpha1"),
+            mock.call(metrics.MetaInfoScope.cluster, None, "distribution_flavor", "oss"),
             mock.call(metrics.MetaInfoScope.node, "rally0", "jvm_vendor", "Oracle Corporation"),
             mock.call(metrics.MetaInfoScope.node, "rally0", "jvm_version", "1.8.0_74"),
             mock.call(metrics.MetaInfoScope.node, "rally1", "jvm_vendor", "Oracle Corporation"),
@@ -2007,21 +2008,21 @@ class ClusterMetaDataInfoTests(TestCase):
                     "plugins": [
                         {
                             "name": "analysis-icu",
-                            "version": "5.0.0",
+                            "version": "6.5.1",
                             "description": "The ICU Analysis plugin integrates Lucene ICU module ...",
                             "classname": "org.elasticsearch.plugin.analysis.icu.AnalysisICUPlugin",
                             "has_native_controller": False
                         },
                         {
                             "name": "ingest-geoip",
-                            "version": "5.0.0",
+                            "version": "6.5.1",
                             "description": "Ingest processor that uses looksup geo data ...",
                             "classname": "org.elasticsearch.ingest.geoip.IngestGeoIpPlugin",
                             "has_native_controller": False
                         },
                         {
                             "name": "ingest-user-agent",
-                            "version": "5.0.0",
+                            "version": "6.5.1",
                             "description": "Ingest processor that extracts information from a user agent",
                             "classname": "org.elasticsearch.ingest.useragent.IngestUserAgentPlugin",
                             "has_native_controller": False
@@ -2031,11 +2032,11 @@ class ClusterMetaDataInfoTests(TestCase):
             }
         }
         cluster_info = {
-            "version":
-                {
-                    "build_hash": "253032b",
-                    "number": "5.0.0"
-                }
+            "version": {
+                "number": "6.5.1",
+                "build_flavor": "default",
+                "build_hash": "8c58350",
+            }
         }
         client = Client(nodes=SubClient(stats=nodes_stats, info=nodes_info), info=cluster_info)
 
@@ -2047,8 +2048,9 @@ class ClusterMetaDataInfoTests(TestCase):
 
         t.attach_to_cluster(c)
 
-        self.assertEqual("5.0.0", c.distribution_version)
-        self.assertEqual("253032b", c.source_revision)
+        self.assertEqual("6.5.1", c.distribution_version)
+        self.assertEqual("default", c.distribution_flavor)
+        self.assertEqual("8c58350", c.source_revision)
         self.assertEqual(1, len(c.nodes))
         n = c.nodes[0]
         self.assertEqual("127.0.0.1", n.ip)
@@ -2130,6 +2132,7 @@ class ClusterMetaDataInfoTests(TestCase):
         t.attach_to_cluster(c)
 
         self.assertEqual("1.7.5", c.distribution_version)
+        self.assertEqual("oss", c.distribution_flavor)
         self.assertEqual("c730b59357f8ebc555286794dcd90b3411f517c9", c.source_revision)
         self.assertEqual(1, len(c.nodes))
         n = c.nodes[0]

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -880,6 +880,7 @@ class EsResultsStoreTests(TestCase):
 
         c = cluster.Cluster([], [], None)
         c.distribution_version = "5.0.0"
+        c.distribution_flavor = "oss"
         node = c.add_node("localhost", "rally-node-0")
         node.plugins.append("x-pack")
 
@@ -923,6 +924,7 @@ class EsResultsStoreTests(TestCase):
                 "environment": "unittest",
                 "trial-id": EsResultsStoreTests.TRIAL_ID,
                 "trial-timestamp": "20160131T000000Z",
+                "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
                 "user-tags": {
@@ -947,6 +949,7 @@ class EsResultsStoreTests(TestCase):
                 "environment": "unittest",
                 "trial-id": EsResultsStoreTests.TRIAL_ID,
                 "trial-timestamp": "20160131T000000Z",
+                "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
                 "user-tags": {
@@ -972,6 +975,7 @@ class EsResultsStoreTests(TestCase):
                 "environment": "unittest",
                 "trial-id": EsResultsStoreTests.TRIAL_ID,
                 "trial-timestamp": "20160131T000000Z",
+                "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
                 "user-tags": {
@@ -1001,6 +1005,7 @@ class EsResultsStoreTests(TestCase):
                 "environment": "unittest",
                 "trial-id": EsResultsStoreTests.TRIAL_ID,
                 "trial-timestamp": "20160131T000000Z",
+                "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
                 "user-tags": {


### PR DESCRIPTION
With this commit we add the distribution flavor (either `default` or
`oss`) to metrics store metadata for metrics, races and results. For
older versions of Elasticsearch that did not expose a build flavor we
default to `oss` as the build flavor.