### PR TITLE
Introduce new command line parameter --track-revision

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -64,6 +64,11 @@ Examples::
 
 Selects the track repository that Rally should use to resolve tracks. By default the ``default`` track repository is used, which is available in the Github project `rally-tracks <https://github.com/elastic/rally-tracks>`_. See the :doc:`track reference </track>` on how to add your own track repositories. ``--track-path`` and ``--track-repository`` as well as ``--track`` are mutually exclusive.
 
+``track-revision``
+~~~~~~~~~~~~~~~~~
+
+Selects a specific revision in the track repository. By default, Rally will choose the most appropriate branch on its own but in some cases it is necessary to specify a certain commit. This is mostly needed when testing whether a change in performance has occurred due to a change in the workload. 
+
 ``track``
 ~~~~~~~~~
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -65,7 +65,7 @@ Examples::
 Selects the track repository that Rally should use to resolve tracks. By default the ``default`` track repository is used, which is available in the Github project `rally-tracks <https://github.com/elastic/rally-tracks>`_. See the :doc:`track reference </track>` on how to add your own track repositories. ``--track-path`` and ``--track-repository`` as well as ``--track`` are mutually exclusive.
 
 ``track-revision``
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 Selects a specific revision in the track repository. By default, Rally will choose the most appropriate branch on its own but in some cases it is necessary to specify a certain commit. This is mostly needed when testing whether a change in performance has occurred due to a change in the workload. 
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -169,7 +169,7 @@ def create_arg_parser():
             help="Define the path to a track.")
         track_source_group.add_argument(
             "--track-revision",
-            help="Define a specific revision in the tracks repository that Rally should use.",
+            help="Define a specific revision in the track repository that Rally should use.",
             default=None)
         p.add_argument(
             "--team-repository",

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -167,6 +167,10 @@ def create_arg_parser():
         track_source_group.add_argument(
             "--track-path",
             help="Define the path to a track.")
+        track_source_group.add_argument(
+            "--track-revision",
+            help="Define a specific revision in the tracks repository that Rally should use.",
+            default=None)
         p.add_argument(
             "--team-repository",
             help="Define the repository from where Rally will load teams and cars (default: default).",
@@ -573,6 +577,7 @@ def main():
     if args.track_path:
         cfg.add(config.Scope.applicationOverride, "track", "track.path", os.path.abspath(io.normalize_path(args.track_path)))
         cfg.add(config.Scope.applicationOverride, "track", "repository.name", None)
+        cfg.add(config.Scope.applicationOverride, "track", "repository.revision", None)
         if args.track:
             # stay as close as possible to argparse errors although we have a custom validation.
             arg_parser.error("argument --track not allowed with argument --track-path")
@@ -580,6 +585,7 @@ def main():
     else:
         # cfg.add(config.Scope.applicationOverride, "track", "track.path", None)
         cfg.add(config.Scope.applicationOverride, "track", "repository.name", args.track_repository)
+        cfg.add(config.Scope.applicationOverride, "track", "repository.revision", args.track_revision)
         # set the default programmatically because we need to determine whether the user has provided a value
         chosen_track = args.track if args.track else "geonames"
         cfg.add(config.Scope.applicationOverride, "track", "track.name", chosen_track)

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -185,7 +185,7 @@ class GitTrackRepository:
         self.track_name = cfg.opts("track", "track.name", mandatory=False)
         distribution_version = cfg.opts("mechanic", "distribution.version", mandatory=False)
         repo_name = cfg.opts("track", "repository.name")
-        repo_revision = cfg.opts("track", "repository.revision")
+        repo_revision = cfg.opts("track", "repository.revision", mandatory=False)
         offline = cfg.opts("system", "offline.mode")
         remote_url = cfg.opts("tracks", "%s.url" % repo_name, mandatory=False)
         root = cfg.opts("node", "root.dir")

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -185,6 +185,7 @@ class GitTrackRepository:
         self.track_name = cfg.opts("track", "track.name", mandatory=False)
         distribution_version = cfg.opts("mechanic", "distribution.version", mandatory=False)
         repo_name = cfg.opts("track", "repository.name")
+        repo_revision = cfg.opts("track", "repository.revision")
         offline = cfg.opts("system", "offline.mode")
         remote_url = cfg.opts("tracks", "%s.url" % repo_name, mandatory=False)
         root = cfg.opts("node", "root.dir")
@@ -193,7 +194,10 @@ class GitTrackRepository:
 
         self.repo = repo_class(remote_url, tracks_dir, repo_name, "tracks", offline, fetch)
         if update:
-            self.repo.update(distribution_version)
+            if repo_revision:
+                self.repo.checkout(repo_revision)
+            else:
+                self.repo.update(distribution_version)
 
     @property
     def track_names(self):


### PR DESCRIPTION
Allows a user to run against an older commit of a Rally track.

Fixes https://github.com/elastic/rally/issues/663