### PR TITLE
Add sleep operation

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -793,6 +793,18 @@ With the operation ``raw-request`` you can execute arbitrary HTTP requests again
 * ``request-params`` (optional): A structure containing HTTP request parameters.
 * ``ignore`` (optional): An array of HTTP response status codes to ignore (i.e. consider as successful).
 
+sleep
+~~~~~
+
+With the operation ``sleep`` you can sleep for a certain duration to ensure no requests are executed by the corresponding clients. The ``sleep`` operation supports the following parameter:
+
+* ``duration`` (mandatory): A non-negative number that defines the sleep duration in seconds.
+
+.. note::
+    The ``sleep`` operation is only useful in very limited circumstances. To throttle throughput, specify a ``target-throughput`` on the corresponding task instead.
+
+This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
 schedule
 ~~~~~~~~
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -36,6 +36,8 @@ def register_default_runners():
     register_runner(track.OperationType.NodesStats.name, NodeStats())
     register_runner(track.OperationType.Search.name, Query())
     register_runner(track.OperationType.RawRequest.name, RawRequest())
+    # This is an administrative operation but there is no need for a retry here as we don't issue a request
+    register_runner(track.OperationType.Sleep.name, Sleep())
 
     # We treat the following as administrative commands and thus already start to wrap them in a retry.
     register_runner(track.OperationType.ClusterHealth.name, Retry(ClusterHealth()))
@@ -1068,6 +1070,18 @@ class RawRequest(Runner):
 
     def __repr__(self, *args, **kwargs):
         return "raw-request"
+
+
+class Sleep(Runner):
+    """
+    Sleeps for the specified duration not issuing any request.
+    """
+
+    def __call__(self, es, params):
+        time.sleep(mandatory(params, "duration", "sleep"))
+
+    def __repr__(self, *args, **kwargs):
+        return "sleep"
 
 
 # TODO: Allow to use this from (selected) regular runners and add user documentation.

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -436,6 +436,7 @@ class OperationType(Enum):
     DeleteMlJob = 1015
     OpenMlJob = 1016
     CloseMlJob = 1017
+    Sleep = 1018
 
     @property
     def admin_op(self):
@@ -487,6 +488,8 @@ class OperationType(Enum):
             return OperationType.OpenMlJob
         elif v == "close-ml-job":
             return OperationType.CloseMlJob
+        elif v == "sleep":
+            return OperationType.Sleep
         else:
             raise KeyError("No enum value for [%s]" % v)
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1798,6 +1798,31 @@ class RawRequestRunnerTests(TestCase):
                                                              params={})
 
 
+class SleepTests(TestCase):
+    @mock.patch("elasticsearch.Elasticsearch")
+    # To avoid real sleeps in unit tests
+    @mock.patch("time.sleep")
+    def test_missing_parameter(self, sleep, es):
+        r = runner.Sleep()
+        with self.assertRaisesRegex(exceptions.DataError,
+                                    "Parameter source for operation 'sleep' did not provide the mandatory parameter "
+                                    "'duration'. Please add it to your parameter source."):
+            r(es, params={})
+
+        self.assertEqual(0, es.call_count)
+        self.assertEqual(0, sleep.call_count)
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    # To avoid real sleeps in unit tests
+    @mock.patch("time.sleep")
+    def test_sleep(self, sleep, es):
+        r = runner.Sleep()
+        r(es, params={"duration": 4.3})
+
+        self.assertEqual(0, es.call_count)
+        sleep.assert_called_once_with(4.3)
+
+
 class ShrinkIndexTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     # To avoid real sleeps in unit tests

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1184,6 +1184,26 @@ class ParamsRegistrationTests(TestCase):
         params._unregister_param_source_for_name(source_name)
 
 
+class SleepParamSourceTests(TestCase):
+    def test_missing_duration_parameter(self):
+        with self.assertRaisesRegex(exceptions.InvalidSyntax, "parameter 'duration' is mandatory for sleep operation"):
+            params.SleepParamSource(track.Track(name="unit-test"), params={})
+
+    def test_duration_parameter_wrong_type(self):
+        with self.assertRaisesRegex(exceptions.InvalidSyntax,
+                                    "parameter 'duration' for sleep operation must be a number"):
+            params.SleepParamSource(track.Track(name="unit-test"), params={"duration": "this is a string"})
+
+    def test_duration_parameter_negative_number(self):
+        with self.assertRaisesRegex(exceptions.InvalidSyntax,
+                                    "parameter 'duration' must be non-negative but was -1.0"):
+            params.SleepParamSource(track.Track(name="unit-test"), params={"duration": -1.0})
+
+    def test_param_source_passes_all_parameters(self):
+        p = params.SleepParamSource(track.Track(name="unit-test"), params={"duration": 3.4, "additional": True})
+        self.assertDictEqual({"duration": 3.4, "additional": True}, p.params())
+
+
 class CreateIndexParamSourceTests(TestCase):
     def test_create_index_inline_with_body(self):
         source = params.CreateIndexParamSource(track.Track(name="unit-test"), params={


### PR DESCRIPTION
With this commit we add a new operation `sleep` to Rally which allows to
sleep for a configurable amount of time. This can be useful in certain
scenarios, e.g. when we want to kick off an async background process in
Elasticsearch, let it run for a while then continue the benchmark. This
operation is not meant for throttling throughput though.

Closes #624