### PR TITLE
Pass JAVA12_HOME in integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ passenv =
     JAVA9_HOME
     JAVA10_HOME
     JAVA11_HOME
+    JAVA12_HOME
     SSH_AUTH_SOCK
 # we do not pass LANG and LC_ALL anymore in order to isolate integration tests
 # from the test environment. Rally needs to enforce UTF-8 encoding in every


### PR DESCRIPTION
With this commit we pass the environment variable JAVA12_HOME to Rally's
integration tests.