### PR TITLE
[Experimental] Capture peak usage of JVM mem pools

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -91,7 +91,7 @@ class ClusterLauncher:
             telemetry.NodeStats(telemetry_params, es, self.metrics_store),
             telemetry.ClusterMetaDataInfo(es_default),
             telemetry.ClusterEnvironmentInfo(es_default, self.metrics_store),
-            telemetry.GcTimesSummary(es_default, self.metrics_store),
+            telemetry.JvmStatsSummary(es_default, self.metrics_store),
             telemetry.IndexStats(es_default, self.metrics_store),
             telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
             telemetry.CcrStats(telemetry_params, es, self.metrics_store),

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -1126,60 +1126,80 @@ class ClusterMetaDataInfo(InternalTelemetryDevice):
                 }
 
 
-class GcTimesSummary(InternalTelemetryDevice):
+class JvmStatsSummary(InternalTelemetryDevice):
     """
-    Gathers a summary of the total young gen/old gen GC runtime during the whole race.
+    Gathers a summary of various JVM statistics during the whole race.
     """
     def __init__(self, client, metrics_store):
         super().__init__()
         self.metrics_store = metrics_store
         self.client = client
-        self.gc_times_per_node = {}
+        self.jvm_stats_per_node = {}
 
     def on_benchmark_start(self):
-        self.gc_times_per_node = self.gc_times()
+        self.jvm_stats_per_node = self.jvm_stats()
 
     def on_benchmark_stop(self):
-        gc_times_at_end = self.gc_times()
+        jvm_stats_at_end = self.jvm_stats()
         total_old_gen_collection_time = 0
         total_young_gen_collection_time = 0
 
-        for node_name, gc_times_end in gc_times_at_end.items():
-            if node_name in self.gc_times_per_node:
-                gc_times_start = self.gc_times_per_node[node_name]
-                young_gc_time = max(gc_times_end[0] - gc_times_start[0], 0)
-                old_gc_time = max(gc_times_end[1] - gc_times_start[1], 0)
+        for node_name, jvm_stats_end in jvm_stats_at_end.items():
+            if node_name in self.jvm_stats_per_node:
+                jvm_stats_start = self.jvm_stats_per_node[node_name]
+                young_gc_time = max(jvm_stats_end["young_gc"] - jvm_stats_start["young_gc"], 0)
+                old_gc_time = max(jvm_stats_end["old_gc"] - jvm_stats_start["old_gc"], 0)
 
                 total_young_gen_collection_time += young_gc_time
                 total_old_gen_collection_time += old_gc_time
 
                 self.metrics_store.put_value_node_level(node_name, "node_young_gen_gc_time", young_gc_time, "ms")
                 self.metrics_store.put_value_node_level(node_name, "node_old_gen_gc_time", old_gc_time, "ms")
+
+                all_pool_stats = {
+                    "name": "jvm_memory_pool_stats"
+                }
+                for pool_name, pool_stats in jvm_stats_end["pools"].items():
+                    all_pool_stats[pool_name] = {
+                        "peak_usage": pool_stats["peak"],
+                        "unit": "byte"
+                    }
+                self.metrics_store.put_doc(all_pool_stats, level=MetaInfoScope.node, node_name=node_name)
+
             else:
-                self.logger.warning("Cannot determine GC times for [%s] (not in the cluster at the start of the benchmark).", node_name)
+                self.logger.warning("Cannot determine JVM stats for [%s] (not in the cluster at the start of the benchmark).", node_name)
 
         self.metrics_store.put_value_cluster_level("node_total_young_gen_gc_time", total_young_gen_collection_time, "ms")
         self.metrics_store.put_value_cluster_level("node_total_old_gen_gc_time", total_old_gen_collection_time, "ms")
 
-        self.gc_times_per_node = None
+        self.jvm_stats_per_node = None
 
-    def gc_times(self):
-        self.logger.debug("Gathering GC times")
-        gc_times = {}
+    def jvm_stats(self):
+        self.logger.debug("Gathering JVM stats")
+        jvm_stats = {}
         import elasticsearch
         try:
             stats = self.client.nodes.stats(metric="_all")
         except elasticsearch.TransportError:
             self.logger.exception("Could not retrieve GC times.")
-            return gc_times
+            return jvm_stats
         nodes = stats["nodes"]
         for node in nodes.values():
             node_name = node["name"]
             gc = node["jvm"]["gc"]["collectors"]
             old_gen_collection_time = gc["old"]["collection_time_in_millis"]
             young_gen_collection_time = gc["young"]["collection_time_in_millis"]
-            gc_times[node_name] = (young_gen_collection_time, old_gen_collection_time)
-        return gc_times
+            jvm_stats[node_name] = {
+                "young_gc": young_gen_collection_time,
+                "old_gc": old_gen_collection_time,
+                "pools": {}
+            }
+            pool_usage = node["jvm"]["mem"]["pools"]
+            for pool_name, pool_stats in pool_usage.items():
+                jvm_stats[node_name]["pools"][pool_name] = {
+                    "peak": pool_stats["peak_used_in_bytes"]
+                }
+        return jvm_stats
 
 
 class IndexStats(InternalTelemetryDevice):


### PR DESCRIPTION
With this commit we store peak usage of all JVM memory pool at the end
of a benchmark. We will start with this limited scope to get more
insights on the usefulness of this feature and might expand this later:

* Capture peak usage also at other times during the benchmark
* Store peak usage also per race or show it in the summary report

We consider this feature experimental and as such it is intentionally
undocumented. It may change in incompatible ways or disappear at any
point.