### PR TITLE
Use single node discovery type if suitable

### DIFF
--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -401,6 +401,7 @@ class DockerProvisioner:
             "heap_dump_path": "/usr/share/elasticsearch/heapdump",
             # Docker container needs to expose service on external interfaces
             "network_host": "0.0.0.0",
+            "discovery_type": "single-node",
             "http_port": "%d-%d" % (self.http_port, self.http_port + 100),
             "transport_port": "%d-%d" % (self.http_port + 100, self.http_port + 200),
             "node_count_per_host": 1,

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -562,6 +562,7 @@ class DockerProvisionerTests(TestCase):
             "data_paths": ["/usr/share/elasticsearch/data"],
             "log_path": "/var/log/elasticsearch",
             "heap_dump_path": "/usr/share/elasticsearch/heapdump",
+            "discovery_type": "single-node",
             "network_host": "0.0.0.0",
             "http_port": "39200-39300",
             "transport_port": "39300-39400",


### PR DESCRIPTION
With this commit we use the discovery type "single-node" when it makes
sense.