### PR TITLE
Provide a platform-independent Rally binary

### DIFF
--- a/scripts/offline-install.sh
+++ b/scripts/offline-install.sh
@@ -55,7 +55,7 @@ function main {
 
     mkdir -p "${ABSOLUTE_DOWNLOAD_BIN_DIR}"
     # Prepare install
-    pip3 download esrally=="${RALLY_VERSION}" --dest "${ABSOLUTE_DOWNLOAD_BIN_DIR}"
+    pip3 download esrally=="${RALLY_VERSION}" --dest "${ABSOLUTE_DOWNLOAD_BIN_DIR}" --no-binary=MarkupSafe
 
 
     echo "Preparing NOTICE file"


### PR DESCRIPTION
With this commit we configure pip in the offline install script to use
the source package of MarkupSafe to avoid platform-dependent offline
packages.