### PR TITLE
Store mean for response-related metrics

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -812,6 +812,20 @@ class MetricsStore:
         percentiles = self.get_percentiles(name, task, operation_type, sample_type, lap, percentiles=[median])
         return percentiles[median] if percentiles else None
 
+    def get_mean(self, name, task=None, operation_type=None, sample_type=None, lap=None):
+        """
+        Retrieves mean of the given metric.
+
+        :param name: The metric name to query.
+        :param task The task name to query. Optional.
+        :param operation_type The operation type to query. Optional.
+        :param sample_type The sample type to query. Optional. By default, all samples are considered.
+        :param lap The lap to query. Optional. By default, all laps are considered.
+        :return: The mean.
+        """
+        stats = self.get_stats(name, task, operation_type, sample_type, lap)
+        return stats["avg"] if stats else None
+
 
 class EsMetricsStore(MetricsStore):
     """

--- a/tests/reporter_test.py
+++ b/tests/reporter_test.py
@@ -46,6 +46,7 @@ class StatsCalculatorTests(TestCase):
 
         store.put_value_cluster_level("throughput", 500, unit="docs/s", task="index #1", operation_type=track.OperationType.Bulk)
         store.put_value_cluster_level("throughput", 1000, unit="docs/s", task="index #1", operation_type=track.OperationType.Bulk)
+        store.put_value_cluster_level("throughput", 1000, unit="docs/s", task="index #1", operation_type=track.OperationType.Bulk)
         store.put_value_cluster_level("throughput", 2000, unit="docs/s", task="index #1", operation_type=track.OperationType.Bulk)
 
         store.put_value_cluster_level("latency", 2800, unit="ms", task="index #1", operation_type=track.OperationType.Bulk,
@@ -60,7 +61,7 @@ class StatsCalculatorTests(TestCase):
                                       meta_data={"success": True})
         store.put_value_cluster_level("service_time", 200, unit="ms", task="index #1", operation_type=track.OperationType.Bulk,
                                       meta_data={"success": False})
-        store.put_value_cluster_level("service_time", 215, unit="ms", task="index #1", operation_type=track.OperationType.Bulk,
+        store.put_value_cluster_level("service_time", 210, unit="ms", task="index #1", operation_type=track.OperationType.Bulk,
                                       meta_data={"success": True})
         store.put_doc(doc={
             "name": "ml_processing_time",
@@ -79,9 +80,10 @@ class StatsCalculatorTests(TestCase):
         del store
 
         opm = stats.metrics("index #1")
-        self.assertEqual(collections.OrderedDict([("min", 500), ("median", 1000), ("max", 2000), ("unit", "docs/s")]), opm["throughput"])
-        self.assertEqual(collections.OrderedDict([("50_0", 220), ("100_0", 225)]), opm["latency"])
-        self.assertEqual(collections.OrderedDict([("50_0", 200), ("100_0", 215)]), opm["service_time"])
+        self.assertEqual(collections.OrderedDict(
+            [("min", 500), ("mean", 1125), ("median", 1000), ("max", 2000), ("unit", "docs/s")]), opm["throughput"])
+        self.assertEqual(collections.OrderedDict([("50_0", 220), ("100_0", 225), ("mean", 215)]), opm["latency"])
+        self.assertEqual(collections.OrderedDict([("50_0", 200), ("100_0", 210), ("mean", 200)]), opm["service_time"])
         self.assertAlmostEqual(0.3333333333333333, opm["error_rate"])
 
         self.assertEqual(6144, stats.index_size)


### PR DESCRIPTION
With this commit we calculate and store the mean of response-related
metrics (i.e. throughput, service time and latency). This can be useful
because mean sample values tend to be normally distributed even if the
population distribution (the underlying distribution that is represented
by each individual mean) is not. This is also known as the central limit
theorem. This is useful because certain statistical tests, like the
t-test, assume normally distributed values.