### PR TITLE
Fix release charts after #684

### DIFF
--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -59,7 +59,7 @@ class BarCharts:
 
     @staticmethod
     # flavor's unused but we need the same signature used by the corresponding method in TimeSeriesCharts
-    def format_title(environment, track_name, flavor=None, suffix=None):
+    def format_title(environment, track_name, flavor=None, es_license=None, suffix=None):
         title = "{}-{}".format(environment, track_name)
 
         if suffix:


### PR DESCRIPTION
PR #684 is now passing es_license, but this is missing from the
`format_title()` method signature in the BarCharts class.