### PR TITLE
Remove node_count_per_host

### DIFF
--- a/docs/car.rst
+++ b/docs/car.rst
@@ -103,7 +103,6 @@ If you open ``vanilla/templates/config/elasticsearch.yml`` you will see a few va
 
 * ``network_host``
 * ``http_port``
-* ``node_count_per_host``
 
 These values are derived by Rally internally based on command line flags and you cannot override them in your car definition. You also cannot use these names as names for variables because Rally would simply override them.
 

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -283,8 +283,6 @@ class ElasticsearchInstaller:
             "all_node_ips": "[\"%s\"]" % "\",\"".join(self.all_node_ips),
             # at the moment we are strict and enforce that all nodes are master eligible nodes
             "minimum_master_nodes": len(self.all_node_ips),
-            # We allow multiple nodes per host but we do not allow that they share their data directories
-            "node_count_per_host": 1,
             "install_root_path": self.es_home_path
         }
         variables = {}
@@ -404,7 +402,6 @@ class DockerProvisioner:
             "discovery_type": "single-node",
             "http_port": "%d-%d" % (self.http_port, self.http_port + 100),
             "transport_port": "%d-%d" % (self.http_port + 100, self.http_port + 200),
-            "node_count_per_host": 1,
             "cluster_settings": cluster_settings
         }
 

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -81,7 +81,6 @@ class BareProvisionerTests(TestCase):
             "transport_port": "9300-9400",
             "all_node_ips": "[\"10.17.22.22\",\"10.17.22.23\"]",
             "minimum_master_nodes": 2,
-            "node_count_per_host": 1,
             "install_root_path": "/opt/elasticsearch-5.0.0"
         }, config_vars)
 
@@ -196,7 +195,6 @@ class BareProvisionerTests(TestCase):
             "transport_port": "9300-9400",
             "all_node_ips": "[\"10.17.22.22\",\"10.17.22.23\"]",
             "minimum_master_nodes": 2,
-            "node_count_per_host": 1,
             "install_root_path": "/opt/elasticsearch-5.0.0",
             "plugin_name": "x-pack-security",
             "xpack_security_enabled": True
@@ -274,7 +272,6 @@ class BareProvisionerTests(TestCase):
             "transport_port": "9300-9400",
             "all_node_ips": "[\"10.17.22.22\",\"10.17.22.23\"]",
             "minimum_master_nodes": 2,
-            "node_count_per_host": 1,
             "install_root_path": "/opt/elasticsearch-6.3.0",
             "plugin_name": "x-pack-security",
             "xpack_security_enabled": True
@@ -365,7 +362,6 @@ class ElasticsearchInstallerTests(TestCase):
             "transport_port": "9300-9400",
             "all_node_ips": "[\"10.17.22.22\",\"10.17.22.23\"]",
             "minimum_master_nodes": 2,
-            "node_count_per_host": 1,
             "install_root_path": "/install/elasticsearch-5.0.0-SNAPSHOT"
         }, installer.variables)
 
@@ -402,7 +398,6 @@ class ElasticsearchInstallerTests(TestCase):
             "transport_port": "9300-9400",
             "all_node_ips": "[\"10.17.22.22\",\"10.17.22.23\"]",
             "minimum_master_nodes": 2,
-            "node_count_per_host": 1,
             "install_root_path": "/install/elasticsearch-5.0.0-SNAPSHOT"
         }, installer.variables)
 
@@ -566,7 +561,6 @@ class DockerProvisionerTests(TestCase):
             "network_host": "0.0.0.0",
             "http_port": "39200-39300",
             "transport_port": "39300-39400",
-            "node_count_per_host": 1,
             "cluster_settings": {
                 "indices.query.bool.max_clause_count": 5000
             },


### PR DESCRIPTION
With this commit we remove the provisioner variable
`node_count_per_host` which has been used to define the setting
`node.max_local_storage_nodes` in Elasticsearch. As the only value that
we ever allow (`1`) is identical to Elasticsearch's default, we remove
support for this variable.

Relates elastic/rally-teams#27