### PR TITLE
Remove CPU sampling

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -132,7 +132,6 @@ Rally stores the following metrics:
 * ``merge_parts_total_docs_*``: See ``merge_parts_total_time_*``
 * ``disk_io_write_bytes``: number of bytes that have been written to disk during the benchmark. On Linux this metric reports only the bytes that have been written by Elasticsearch, on Mac OS X it reports the number of bytes written by all processes.
 * ``disk_io_read_bytes``: number of bytes that have been read from disk during the benchmark. The same caveats apply on Mac OS X as for ``disk_io_write_bytes``.
-* ``cpu_utilization_1s``: CPU usage in percent of the Elasticsearch process based on a one second sample period. The maximum value is N * 100% where N is the number of CPU cores available.
 * ``node_startup_time``: The time in seconds it took from process start until the node is up.
 * ``node_total_old_gen_gc_time``: The total runtime of the old generation garbage collector across the whole cluster as reported by the node stats API.
 * ``node_total_young_gen_gc_time``: The total runtime of the young generation garbage collector across the whole cluster as reported by the node stats API.

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,15 @@
 Migration Guide
 ===============
 
+Migrating to Rally 1.2.0
+------------------------
+
+CPU usage is not measured anymore
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With Rally 1.2.0, CPU usage will neither be measured nor reported. We suggest to use system monitoring tools like ``vmstat`` or `Metricbeat <https://www.elastic.co/downloads/beats/metricbeat>`_ to measure CPU usage instead.
+
+
 Migrating to Rally 1.1.0
 ------------------------
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -7,7 +7,7 @@ Migrating to Rally 1.2.0
 CPU usage is not measured anymore
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-With Rally 1.2.0, CPU usage will neither be measured nor reported. We suggest to use system monitoring tools like ``vmstat`` or `Metricbeat <https://www.elastic.co/downloads/beats/metricbeat>`_ to measure CPU usage instead.
+With Rally 1.2.0, CPU usage will neither be measured nor reported. We suggest to use system monitoring tools like ``mpstat``, ``sar`` or `Metricbeat <https://www.elastic.co/downloads/beats/metricbeat>`_ to measure CPU usage instead.
 
 
 Migrating to Rally 1.1.0

--- a/docs/summary_report.rst
+++ b/docs/summary_report.rst
@@ -117,13 +117,6 @@ ML processing time
 * **Corresponding metrics key**: ``ml_processing_time``
 
 
-Median CPU usage
-----------------
-
-* **Definition**: Median CPU usage in percent of the Elasticsearch process during the whole race based on a one second sample period. The maximum value is N * 100% where N is the number of CPU cores available
-* **Corresponding metrics key**: ``cpu_utilization_1s``
-
-
 Total Young Gen GC
 ------------------
 

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -226,7 +226,6 @@ class DockerLauncher:
             # only support a subset of telemetry for Docker hosts (specifically, we do not allow users to enable any devices)
             node_telemetry = [
                 telemetry.DiskIo(self.metrics_store, len(node_configurations)),
-                telemetry.CpuUsage(self.metrics_store),
                 telemetry.NodeEnvironmentInfo(self.metrics_store)
             ]
             t = telemetry.Telemetry(devices=node_telemetry)
@@ -328,7 +327,6 @@ class InProcessLauncher:
             telemetry.Gc(node_telemetry_dir, java_major_version),
             telemetry.PerfStat(node_telemetry_dir),
             telemetry.DiskIo(self.metrics_store, node_count_on_host),
-            telemetry.CpuUsage(self.metrics_store),
             telemetry.NodeEnvironmentInfo(self.metrics_store),
             telemetry.IndexSize(data_paths, self.metrics_store),
             telemetry.MergeParts(self.metrics_store, node_configuration.log_path),

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -198,9 +198,6 @@ class StatsCalculator:
         self.logger.debug("Gathering ML max processing times.")
         result.ml_processing_time = self.ml_processing_time_stats()
 
-        self.logger.debug("Gathering CPU usage metrics.")
-        result.median_cpu_usage = self.median("cpu_utilization_1s", sample_type=metrics.SampleType.Normal)
-
         self.logger.debug("Gathering garbage collection metrics.")
         result.young_gc_time = self.sum("node_total_young_gen_gc_time")
         result.old_gc_time = self.sum("node_total_old_gen_gc_time")
@@ -345,8 +342,6 @@ class Stats:
         self.merge_part_time_vectors = self.v(d, "merge_part_time_vectors")
         self.merge_part_time_points = self.v(d, "merge_part_time_points")
 
-        self.median_cpu_usage = self.v(d, "median_cpu_usage")
-
         self.young_gc_time = self.v(d, "young_gc_time")
         self.old_gc_time = self.v(d, "old_gc_time")
 
@@ -484,7 +479,6 @@ class SummaryReporter:
         metrics_table.extend(self.report_merge_part_times(stats))
         metrics_table.extend(self.report_ml_processing_times(stats))
 
-        metrics_table.extend(self.report_cpu_usage(stats))
         metrics_table.extend(self.report_gc_times(stats))
 
         metrics_table.extend(self.report_disk_usage(stats))
@@ -610,11 +604,6 @@ class SummaryReporter:
             lines.append(self.line("Median ML processing time", job_name, processing_time["median"], unit)),
             lines.append(self.line("Max ML processing time", job_name, processing_time["max"], unit))
         return lines
-
-    def report_cpu_usage(self, stats):
-        return self.join(
-            self.line("Median CPU usage", "", stats.median_cpu_usage, "%")
-        )
 
     def report_gc_times(self, stats):
         return self.join(

--- a/esrally/utils/sysstats.py
+++ b/esrally/utils/sysstats.py
@@ -91,12 +91,3 @@ def setup_process_stats(pid):
     :return: An opaque handle that has to be provided for all subsequent calls to process stats APIs.
     """
     return psutil.Process(pid)
-
-
-def cpu_utilization(handle, interval=1.0):
-    """
-    :param handle: handle retrieved by calling setup_process_stats(pid).
-    :param interval: The measurement interval in seconds. Optional. Defaults to 1 second.
-    :return: The CPU usage in percent.
-    """
-    return handle.cpu_percent(interval=interval)


### PR DESCRIPTION
With this commit we remove the ability to sample CPU usage. For
coarse-grained analysis we instead suggest to use system monitoring
tools (e.g. Metricbeat) and for fine-grained analysis a profiler is a
better choice.