### PR TITLE
Allow stdout print when running in Docker

### DIFF
--- a/esrally/__init__.py
+++ b/esrally/__init__.py
@@ -24,7 +24,6 @@ __version__ = pkg_resources.require("esrally")[0].version
 # Allow an alternative program name be set in case Rally is invoked a wrapper script
 PROGRAM_NAME = os.getenv("RALLY_ALTERNATIVE_BINARY_NAME", os.path.basename(sys.argv[0]))
 
-
 if __version__.endswith("dev0"):
     DOC_LINK = "https://esrally.readthedocs.io/en/latest/"
 else:
@@ -71,5 +70,5 @@ $$$$$$$$$$""""           ""$$$$$$$$$$$"
 
 
 def check_python_version():
-    if sys.version_info.major != 3 or sys.version_info.minor < 4:
-        raise RuntimeError("Rally requires at least Python 3.4 but you are using:\n\nPython %s" % str(sys.version))
+    if sys.version_info.major != 3 or sys.version_info.minor < 5:
+        raise RuntimeError("Rally requires at least Python 3.5 but you are using:\n\nPython %s" % str(sys.version))

--- a/esrally/__init__.py
+++ b/esrally/__init__.py
@@ -70,5 +70,5 @@ $$$$$$$$$$""""           ""$$$$$$$$$$$"
 
 
 def check_python_version():
-    if sys.version_info.major != 3 or sys.version_info.minor < 5:
-        raise RuntimeError("Rally requires at least Python 3.5 but you are using:\n\nPython %s" % str(sys.version))
+    if sys.version_info.major != 3 or sys.version_info.minor < 4:
+        raise RuntimeError("Rally requires at least Python 3.4 but you are using:\n\nPython %s" % str(sys.version))

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -387,15 +387,7 @@ def run(cfg):
     logger = logging.getLogger(__name__)
     name = cfg.opts("race", "pipeline")
 
-    if os.environ.get("RALLY_RUNNING_IN_DOCKER", "").upper() == "TRUE":
-        # in this case only benchmarking remote Elasticsearch clusters makes sense
-        if name != "benchmark-only":
-            raise exceptions.SystemSetupError(
-                "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n"
-                "Add --pipeline=benchmark-only in your Rally arguments and try again.\n"
-                "For more details read the docs for the benchmark-only pipeline in {}\n".format(
-                    urllib.parse.urljoin(DOC_LINK, "pipelines.html#benchmark-only")))
-    elif len(name) == 0:
+    if len(name) == 0:
         # assume from-distribution pipeline if distribution.version has been specified and --pipeline cli arg not set
         if cfg.exists("mechanic", "distribution.version"):
             name = "from-distribution"
@@ -413,6 +405,15 @@ def run(cfg):
                 "please read the docs for from-distribution pipeline at "
                 "{}/pipelines.html#from-distribution".format(name, DOC_LINK))
         logger.info("User specified pipeline [%s].", name)
+
+    if os.environ.get("RALLY_RUNNING_IN_DOCKER", "").upper() == "TRUE":
+        # in this case only benchmarking remote Elasticsearch clusters makes sense
+        if name != "benchmark-only":
+            raise exceptions.SystemSetupError(
+                "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n"
+                "Add --pipeline=benchmark-only in your Rally arguments and try again.\n"
+                "For more details read the docs for the benchmark-only pipeline in {}\n".format(
+                    urllib.parse.urljoin(DOC_LINK, "pipelines.html#benchmark-only")))
 
     try:
         pipeline = pipelines[name]

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -345,7 +345,7 @@ def from_distribution(cfg):
 
 
 def benchmark_only(cfg):
-    console.println(BOGUS_RESULTS_WARNING)
+    console.println(BOGUS_RESULTS_WARNING, flush=True)
     set_default_hosts(cfg)
     # We'll use a special car name for external benchmarks.
     cfg.add(config.Scope.benchmark, "mechanic", "car.names", ["external"])

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -386,7 +386,10 @@ def run(cfg):
     logger = logging.getLogger(__name__)
     name = cfg.opts("race", "pipeline")
 
-    if len(name) == 0:
+    if console.RALLY_RUNNING_IN_DOCKER:
+        # in this case only benchmarking remote Elasticsearch clusters makes sense
+        cfg.add(config.Scope.applicationOverride, "race", "pipeline", "benchmark-only")
+    elif len(name) == 0:
         # assume from-distribution pipeline if distribution.version has been specified and --pipeline cli arg not set
         if cfg.exists("mechanic", "distribution.version"):
             name = "from-distribution"

--- a/esrally/utils/console.py
+++ b/esrally/utils/console.py
@@ -155,7 +155,7 @@ class CmdLineProgressReporter:
         self._width = width
         self._first_print = True
         self._plain_output = plain_output
-        self._custom_print = printer
+        self._printer = printer
 
     def print(self, message, progress):
         """
@@ -171,16 +171,16 @@ class CmdLineProgressReporter:
             return
         w = self._width
         if self._first_print:
-            self._custom_print(" " * w, end="")
+            self._printer(" " * w, end="")
             self._first_print = False
 
         final_message = self._truncate(message, self._width - len(progress))
 
         formatted_progress = progress.rjust(w - len(final_message))
         if self._plain_output:
-            self._custom_print("\n{0}{1}".format(final_message, formatted_progress), end="")
+            self._printer("\n{0}{1}".format(final_message, formatted_progress), end="")
         else:
-            self._custom_print("\033[{0}D{1}{2}".format(w, final_message, formatted_progress), end="")
+            self._printer("\033[{0}D{1}{2}".format(w, final_message, formatted_progress), end="")
         sys.stdout.flush()
 
     def _truncate(self, text, max_length, omission="..."):
@@ -193,4 +193,4 @@ class CmdLineProgressReporter:
         if QUIET or (not RALLY_RUNNING_IN_DOCKER and not sys.stdout.isatty()):
             return
         # print a final statement in order to end the progress line
-        self._custom_print("")
+        self._printer("")

--- a/esrally/utils/console.py
+++ b/esrally/utils/console.py
@@ -151,11 +151,11 @@ class CmdLineProgressReporter:
     :param custom_print: allow use of a different print method to assist with patching in unittests
     """
 
-    def __init__(self, width, plain_output=False, custom_print=print):
+    def __init__(self, width, plain_output=False, printer=print):
         self._width = width
         self._first_print = True
         self._plain_output = plain_output
-        self._custom_print = custom_print
+        self._custom_print = printer
 
     def print(self, message, progress):
         """

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import unittest.mock as mock
+import os
 import random
 from unittest import TestCase
 
@@ -43,23 +44,36 @@ class RaceControlTests(TestCase):
             racecontrol.run(cfg)
         self.assertRegex(ctx.exception.args[0], r"Unknown pipeline \[invalid\]. List the available pipelines with [\S]+? list pipelines.")
 
-    def test_uses_benchmark_only_pipeline_in_docker(self):
-        console.RALLY_RUNNING_IN_DOCKER = True
+    @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": "true"})
+    def test_passes_benchmark_only_pipeline_in_docker(self):
+        mock_pipeline = mock.Mock()
+        test_pipeline_name = "benchmark-only"
+        racecontrol.Pipeline("benchmark-only", "Mocked benchmark-only pipeline for unittest", mock_pipeline)
+        cfg = config.Config()
+        cfg.add(config.Scope.benchmark, "race", "pipeline", "benchmark-only")
+
+        racecontrol.run(cfg)
+
+        mock_pipeline.assert_called_once_with(cfg)
+
+        del racecontrol.pipelines[test_pipeline_name]
+
+    @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": "true"})
+    def test_fails_without_benchmark_only_pipeline_in_docker(self):
         mock_pipeline = mock.Mock()
         test_pipeline_name = "unit-test-pipeline"
         racecontrol.Pipeline("unit-test-pipeline", "Pipeline intended for unit-testing", mock_pipeline)
         cfg = config.Config()
         cfg.add(config.Scope.benchmark, "race", "pipeline", "unit-test-pipeline")
-        cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "7.1.1")
 
-        racecontrol.run(cfg)
+        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+            racecontrol.run(cfg)
 
         self.assertEqual(
-            "benchmark-only",
-            cfg._opts[(config.Scope.applicationOverride, "race", "pipeline")]
-        )
-        mock_pipeline.assert_called_once_with(cfg)
-
+            "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n"
+            "Add --pipeline=benchmark-only in your Rally arguments and try again.\n"
+            "For more details read the docs for the benchmark-only pipeline in https://esrally.readthedocs.io/en/latest/pipelines.html#benchmark-only\n",
+            ctx.exception.args[0])
         del racecontrol.pipelines[test_pipeline_name]
 
     def test_runs_a_known_pipeline(self):

--- a/tests/utils/console_test.py
+++ b/tests/utils/console_test.py
@@ -1,0 +1,162 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import random
+import pytest
+import unittest.mock as mock
+
+from unittest import TestCase
+from esrally.utils import console
+
+
+class ConsoleFunctionTests(TestCase):
+    @mock.patch("os.environ.get")
+    def test_global_rally_running_in_docker_is_false(self, patched_env_get):
+        patched_env_get.return_value = random.choice(["false", "False", "FALSE"])
+
+        _ = console.init()
+        self.assertEqual(False, console.RALLY_RUNNING_IN_DOCKER)
+
+    @mock.patch("os.environ.get")
+    def test_global_rally_running_in_docker_is_false_if_unset(self, patched_env_get):
+        patched_env_get.return_value = ""
+
+        _ = console.init()
+        self.assertEqual(False, console.RALLY_RUNNING_IN_DOCKER)
+
+    @mock.patch("os.environ.get")
+    def test_global_rally_running_in_docker_is_true(self, patched_env_get):
+        patched_env_get.return_value = random.choice(["true", "True", "TRUE"])
+
+        _ = console.init()
+        self.assertEqual(True, console.RALLY_RUNNING_IN_DOCKER)
+
+    @mock.patch("sys.stdout.isatty")
+    @mock.patch("builtins.print")
+    def test_println_randomized_dockertrue_or_istty_and_isnotquiet(self, patched_print, patched_isatty):
+        console.QUIET = False
+        random_boolean = random.choice([True, False])
+        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random_boolean, not random_boolean
+
+        console.println(msg="Unittest message")
+        patched_print.assert_called_once_with(
+            "Unittest message", end="\n", flush=False
+        )
+
+    @mock.patch("sys.stdout.isatty")
+    @mock.patch("builtins.print")
+    def test_println_isquiet_and_randomized_docker_or_istty(self, patched_print, patched_isatty):
+        console.QUIET = True
+        random_boolean = random.choice([True, False])
+        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random_boolean, not random_boolean
+
+        console.println(msg="Unittest message")
+        patched_print.assert_not_called()
+
+
+# pytest style class names need to start with Test and don't need to subclass
+class TestCmdLineProgressReporter:
+    @mock.patch("sys.stdout.flush")
+    @mock.patch("sys.stdout.isatty")
+    # monkey patching builtins might break pytest's internals
+    # (https://docs.pytest.org/en/latest/monkeypatch.html#global-patch-example-preventing-requests-from-remote-operations)
+    # but hopefully print doesn't fall in this category
+    @mock.patch("builtins.print")
+    @pytest.mark.parametrize("seed", range(20))
+    def test_print_when_isquiet_and_any_docker_or_istty(self, patched_print, patched_isatty, patched_flush, seed):
+        console.QUIET = True
+        random.seed(seed)
+        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random.choice([True, False]), random.choice([True, False])
+
+        message = "Unit test message"
+        width = random.randint(20, 140)
+        progress_reporter = console.CmdLineProgressReporter(width=width)
+        progress_reporter.print(message=message, progress=".")
+        patched_print.assert_not_called()
+
+
+    @mock.patch("sys.stdout.isatty")
+    @mock.patch("builtins.print")
+    def test_prints_when_isnotquiet_and_nodocker_and_isnotty(self, patched_print, patched_isatty):
+        console.QUIET = False
+        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = False, False
+
+        message = "Unit test message"
+        width = random.randint(20, 140)
+        progress_reporter = console.CmdLineProgressReporter(width=width)
+        progress_reporter.print(message=message, progress=".")
+        patched_print.assert_not_called()
+
+    @mock.patch("sys.stdout.flush")
+    @mock.patch("sys.stdout.isatty")
+    @mock.patch("builtins.print")
+    @pytest.mark.parametrize("seed", range(20))
+    def test_prints_when_isnotquiet_and_randomized_docker_or_istty(self, patched_print, patched_isatty, patched_flush, seed):
+        console.QUIET = False
+        random.seed(seed)
+        random_boolean = random.choice([True, False])
+        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random_boolean, not random_boolean
+
+        message = "Unit test message"
+        width = random.randint(20, 140)
+        progress_reporter = console.CmdLineProgressReporter(width=width)
+        progress_reporter.print(message=message, progress=".")
+        patched_print.assert_has_calls([
+            mock.call(" " * width, end=""),
+            mock.call("\x1b[{}D{}{}.".format(width, message, " "*(width-len(message)-1)), end="")
+        ])
+
+    @mock.patch("sys.stdout.flush")
+    @mock.patch("sys.stdout.isatty")
+    @mock.patch("builtins.print")
+    def test_noprint_when_isnotquiet_and_nodocker_and_noistty(self, patched_print, patched_isatty, patched_flush):
+        patched_isatty.return_value = False
+        console.QUIET = False
+        console.RALLY_RUNNING_IN_DOCKER = False
+
+        message = "Unit test message"
+        width = random.randint(20, 140)
+        progress_reporter = console.CmdLineProgressReporter(width=width)
+        progress_reporter.print(message=message, progress=".")
+        patched_print.assert_not_called()
+
+    @mock.patch("sys.stdout.isatty")
+    @mock.patch("builtins.print")
+    @pytest.mark.parametrize("seed", range(10))
+    def test_finish_noprint_when_isquiet_and_randomized_docker_or_istty(self, patched_print, patched_isatty, seed):
+        console.QUIET = True
+        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random.choice([True, False]), random.choice([True, False])
+
+        random.seed(seed)
+        width = random.randint(20, 140)
+        progress_reporter = console.CmdLineProgressReporter(width=width)
+        progress_reporter.finish()
+        patched_print.assert_not_called()
+
+    @mock.patch("sys.stdout.isatty")
+    @mock.patch("builtins.print")
+    @pytest.mark.parametrize("seed", range(30))
+    def test_finish_prints_when_isnotquiet_and_randomized_docker_or_istty(self, patched_print, patched_isatty, seed):
+        random.seed(seed)
+        random_boolean = random.choice([True, False])
+        console.QUIET = False
+        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random_boolean, not random_boolean
+
+        width = random.randint(20, 140)
+        progress_reporter = console.CmdLineProgressReporter(width=width)
+        progress_reporter.finish()
+        patched_print.assert_called_once_with("")

--- a/tests/utils/console_test.py
+++ b/tests/utils/console_test.py
@@ -18,39 +18,46 @@
 import random
 import pytest
 import unittest.mock as mock
+import os
 
 from unittest import TestCase
 from esrally.utils import console
 
 
 class ConsoleFunctionTests(TestCase):
-    @mock.patch("os.environ.get")
-    def test_global_rally_running_in_docker_is_false(self, patched_env_get):
-        patched_env_get.return_value = random.choice(["false", "False", "FALSE"])
+    @classmethod
+    def setUpClass(cls):
+        cls.oldconsole_quiet = console.QUIET
+        cls.oldconsole_rally_running_in_docker = console.RALLY_RUNNING_IN_DOCKER
 
-        _ = console.init()
+    @classmethod
+    def tearDownClass(cls):
+        console.QUIET = cls.oldconsole_quiet
+        console.RALLY_RUNNING_IN_DOCKER = cls.oldconsole_rally_running_in_docker
+
+    @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": random.choice(["false", "False", "FALSE", ""])})
+    def test_global_rally_running_in_docker_is_false(self):
+        console.init()
         self.assertEqual(False, console.RALLY_RUNNING_IN_DOCKER)
 
-    @mock.patch("os.environ.get")
-    def test_global_rally_running_in_docker_is_false_if_unset(self, patched_env_get):
-        patched_env_get.return_value = ""
-
-        _ = console.init()
+    @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": ""})
+    def test_global_rally_running_in_docker_is_false_if_unset(self):
+        console.init()
         self.assertEqual(False, console.RALLY_RUNNING_IN_DOCKER)
 
-    @mock.patch("os.environ.get")
-    def test_global_rally_running_in_docker_is_true(self, patched_env_get):
-        patched_env_get.return_value = random.choice(["true", "True", "TRUE"])
-
-        _ = console.init()
+    @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": random.choice(["True", "true", "TRUE"])})
+    def test_global_rally_running_in_docker_is_true(self):
+        console.init()
         self.assertEqual(True, console.RALLY_RUNNING_IN_DOCKER)
 
     @mock.patch("sys.stdout.isatty")
     @mock.patch("builtins.print")
     def test_println_randomized_dockertrue_or_istty_and_isnotquiet(self, patched_print, patched_isatty):
+        console.init()
         console.QUIET = False
         random_boolean = random.choice([True, False])
-        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random_boolean, not random_boolean
+        patched_isatty.return_value = random_boolean
+        console.RALLY_RUNNING_IN_DOCKER = not random_boolean
 
         console.println(msg="Unittest message")
         patched_print.assert_called_once_with(
@@ -60,103 +67,121 @@ class ConsoleFunctionTests(TestCase):
     @mock.patch("sys.stdout.isatty")
     @mock.patch("builtins.print")
     def test_println_isquiet_and_randomized_docker_or_istty(self, patched_print, patched_isatty):
+        console.init()
         console.QUIET = True
         random_boolean = random.choice([True, False])
-        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random_boolean, not random_boolean
-
+        patched_isatty.return_value = random_boolean
+        console.RALLY_RUNNING_IN_DOCKER = not random_boolean
         console.println(msg="Unittest message")
         patched_print.assert_not_called()
 
 
 # pytest style class names need to start with Test and don't need to subclass
 class TestCmdLineProgressReporter:
+    @classmethod
+    def setup_class(cls):
+        cls.oldconsole_quiet = console.QUIET
+        cls.oldconsole_rally_running_in_docker = console.RALLY_RUNNING_IN_DOCKER
+
+    @classmethod
+    def teardown_class(cls):
+        console.QUIET = cls.oldconsole_quiet
+        console.RALLY_RUNNING_IN_DOCKER = cls.oldconsole_rally_running_in_docker
+
     @mock.patch("sys.stdout.flush")
     @mock.patch("sys.stdout.isatty")
-    # monkey patching builtins might break pytest's internals
-    # (https://docs.pytest.org/en/latest/monkeypatch.html#global-patch-example-preventing-requests-from-remote-operations)
-    # but hopefully print doesn't fall in this category
-    @mock.patch("builtins.print")
     @pytest.mark.parametrize("seed", range(20))
-    def test_print_when_isquiet_and_any_docker_or_istty(self, patched_print, patched_isatty, patched_flush, seed):
+    def test_print_when_isquiet_and_any_docker_or_istty(self, patched_isatty, patched_flush, seed):
         console.QUIET = True
         random.seed(seed)
-        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random.choice([True, False]), random.choice([True, False])
+        patched_isatty.return_value = random.choice([True, False])
+        console.RALLY_RUNNING_IN_DOCKER = random.choice([True, False])
 
         message = "Unit test message"
         width = random.randint(20, 140)
-        progress_reporter = console.CmdLineProgressReporter(width=width)
+        mock_printer = mock.Mock()
+        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
+
         progress_reporter.print(message=message, progress=".")
-        patched_print.assert_not_called()
-
-
-    @mock.patch("sys.stdout.isatty")
-    @mock.patch("builtins.print")
-    def test_prints_when_isnotquiet_and_nodocker_and_isnotty(self, patched_print, patched_isatty):
-        console.QUIET = False
-        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = False, False
-
-        message = "Unit test message"
-        width = random.randint(20, 140)
-        progress_reporter = console.CmdLineProgressReporter(width=width)
-        progress_reporter.print(message=message, progress=".")
-        patched_print.assert_not_called()
+        mock_printer.assert_not_called()
+        patched_flush.assert_not_called()
 
     @mock.patch("sys.stdout.flush")
     @mock.patch("sys.stdout.isatty")
-    @mock.patch("builtins.print")
+    def test_prints_when_isnotquiet_and_nodocker_and_isnotty(self, patched_isatty, patched_flush):
+        console.QUIET = False
+        patched_isatty.return_value = False
+        console.RALLY_RUNNING_IN_DOCKER = False
+
+        message = "Unit test message"
+        width = random.randint(20, 140)
+        mock_printer = mock.Mock()
+        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
+        progress_reporter.print(message=message, progress=".")
+        mock_printer.assert_not_called()
+        patched_flush.assert_not_called()
+
+    @mock.patch("sys.stdout.flush")
+    @mock.patch("sys.stdout.isatty")
     @pytest.mark.parametrize("seed", range(20))
-    def test_prints_when_isnotquiet_and_randomized_docker_or_istty(self, patched_print, patched_isatty, patched_flush, seed):
+    def test_prints_when_isnotquiet_and_randomized_docker_or_istty(self, patched_isatty, patched_flush, seed):
         console.QUIET = False
         random.seed(seed)
         random_boolean = random.choice([True, False])
-        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random_boolean, not random_boolean
+        patched_isatty.return_value = random_boolean
+        console.RALLY_RUNNING_IN_DOCKER = not random_boolean
 
         message = "Unit test message"
         width = random.randint(20, 140)
-        progress_reporter = console.CmdLineProgressReporter(width=width)
+        mock_printer = mock.Mock()
+        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
         progress_reporter.print(message=message, progress=".")
-        patched_print.assert_has_calls([
+        mock_printer.assert_has_calls([
             mock.call(" " * width, end=""),
             mock.call("\x1b[{}D{}{}.".format(width, message, " "*(width-len(message)-1)), end="")
         ])
+        patched_flush.assert_called_once_with()
 
     @mock.patch("sys.stdout.flush")
     @mock.patch("sys.stdout.isatty")
-    @mock.patch("builtins.print")
-    def test_noprint_when_isnotquiet_and_nodocker_and_noistty(self, patched_print, patched_isatty, patched_flush):
+    def test_noprint_when_isnotquiet_and_nodocker_and_noistty(self, patched_isatty, patched_flush):
         patched_isatty.return_value = False
         console.QUIET = False
         console.RALLY_RUNNING_IN_DOCKER = False
 
         message = "Unit test message"
         width = random.randint(20, 140)
-        progress_reporter = console.CmdLineProgressReporter(width=width)
+        mock_printer = mock.Mock()
+        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
         progress_reporter.print(message=message, progress=".")
-        patched_print.assert_not_called()
+        mock_printer.assert_not_called()
+        patched_flush.assert_not_called()
 
     @mock.patch("sys.stdout.isatty")
-    @mock.patch("builtins.print")
     @pytest.mark.parametrize("seed", range(10))
-    def test_finish_noprint_when_isquiet_and_randomized_docker_or_istty(self, patched_print, patched_isatty, seed):
+    def test_finish_noprint_when_isquiet_and_randomized_docker_or_istty(self, patched_isatty, seed):
         console.QUIET = True
-        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random.choice([True, False]), random.choice([True, False])
-
         random.seed(seed)
+        patched_isatty.return_value = random.choice([True, False])
+        console.RALLY_RUNNING_IN_DOCKER = random.choice([True, False])
+
         width = random.randint(20, 140)
-        progress_reporter = console.CmdLineProgressReporter(width=width)
+        mock_printer = mock.Mock()
+        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
         progress_reporter.finish()
-        patched_print.assert_not_called()
+        mock_printer.assert_not_called()
 
     @mock.patch("sys.stdout.isatty")
-    @mock.patch("builtins.print")
     @pytest.mark.parametrize("seed", range(30))
-    def test_finish_prints_when_isnotquiet_and_randomized_docker_or_istty(self, patched_print, patched_isatty, seed):
+    def test_finish_prints_when_isnotquiet_and_randomized_docker_or_istty(self, patched_isatty, seed):
+        console.QUIET = False
         random.seed(seed)
         random_boolean = random.choice([True, False])
-        console.QUIET = False
-        patched_isatty.return_value, console.RALLY_RUNNING_IN_DOCKER = random_boolean, not random_boolean
+        patched_isatty.return_value = random_boolean
+        console.RALLY_RUNNING_IN_DOCKER = not random_boolean
 
         width = random.randint(20, 140)
-        progress_reporter = console.CmdLineProgressReporter(width=width)
+        mock_printer = mock.Mock()
+        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
         progress_reporter.finish()
-        patched_print.assert_called_once_with("")
+        mock_printer.assert_called_once_with("")

--- a/tests/utils/console_test.py
+++ b/tests/utils/console_test.py
@@ -100,7 +100,7 @@ class TestCmdLineProgressReporter:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
+        progress_reporter = console.CmdLineProgressReporter(width=width, printer=mock_printer)
 
         progress_reporter.print(message=message, progress=".")
         mock_printer.assert_not_called()
@@ -116,7 +116,7 @@ class TestCmdLineProgressReporter:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
+        progress_reporter = console.CmdLineProgressReporter(width=width, printer=mock_printer)
         progress_reporter.print(message=message, progress=".")
         mock_printer.assert_not_called()
         patched_flush.assert_not_called()
@@ -134,7 +134,7 @@ class TestCmdLineProgressReporter:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
+        progress_reporter = console.CmdLineProgressReporter(width=width, printer=mock_printer)
         progress_reporter.print(message=message, progress=".")
         mock_printer.assert_has_calls([
             mock.call(" " * width, end=""),
@@ -152,7 +152,7 @@ class TestCmdLineProgressReporter:
         message = "Unit test message"
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
+        progress_reporter = console.CmdLineProgressReporter(width=width, printer=mock_printer)
         progress_reporter.print(message=message, progress=".")
         mock_printer.assert_not_called()
         patched_flush.assert_not_called()
@@ -167,7 +167,7 @@ class TestCmdLineProgressReporter:
 
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
+        progress_reporter = console.CmdLineProgressReporter(width=width, printer=mock_printer)
         progress_reporter.finish()
         mock_printer.assert_not_called()
 
@@ -182,6 +182,6 @@ class TestCmdLineProgressReporter:
 
         width = random.randint(20, 140)
         mock_printer = mock.Mock()
-        progress_reporter = console.CmdLineProgressReporter(width=width, custom_print=mock_printer)
+        progress_reporter = console.CmdLineProgressReporter(width=width, printer=mock_printer)
         progress_reporter.finish()
         mock_printer.assert_called_once_with("")


### PR DESCRIPTION
Our current stdout.isatty() check doesn't allow Rally display normal
progress messages when running in Docker, as typically the container
isn't run with tty enabled.

Workaround this, by expecting an environment variable
RALLY_RUNNING_IN_DOCKER set to True.