### PR TITLE
Add download subcommand

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -41,6 +41,19 @@ This subcommand is needed for :doc:`tournament mode </tournament>` and its usage
 
 This subcommand is needed to :doc:`configure </configuration>` Rally. It is implicitly chosen if you start Rally for the first time but you can rerun this command at any time.
 
+``download``
+~~~~~~~~~~~~~
+
+This subcommand can be used to download Elasticsearch distributions. Example::
+
+    esrally download --distribution-version=7.1.0 --car=defaults,basic-license --quiet
+
+This will download the default distribution of Elasticsearch 7.1.0. Because ``--quiet`` is specified, Rally will suppress all non-essential output (banners, progress messages etc.) and only return the location of the binary on the local machine after it has downloaded it::
+
+    {
+      "elasticsearch": "/Users/dm/.rally/benchmarks/distributions/elasticsearch-6.8.0.tar.gz"
+    }
+
 Command Line Flags
 ------------------
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -46,9 +46,9 @@ This subcommand is needed to :doc:`configure </configuration>` Rally. It is impl
 
 This subcommand can be used to download Elasticsearch distributions. Example::
 
-    esrally download --distribution-version=7.1.0 --car=defaults,basic-license --quiet
+    esrally download --distribution-version=6.8.0 --car=defaults,basic-license --quiet
 
-This will download the default distribution of Elasticsearch 7.1.0. Because ``--quiet`` is specified, Rally will suppress all non-essential output (banners, progress messages etc.) and only return the location of the binary on the local machine after it has downloaded it::
+This will download the default distribution of Elasticsearch 6.8.0. Because ``--quiet`` is specified, Rally will suppress all non-essential output (banners, progress messages etc.) and only return the location of the binary on the local machine after it has downloaded it::
 
     {
       "elasticsearch": "/Users/dm/.rally/benchmarks/distributions/elasticsearch-6.8.0.tar.gz"

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -46,13 +46,24 @@ This subcommand is needed to :doc:`configure </configuration>` Rally. It is impl
 
 This subcommand can be used to download Elasticsearch distributions. Example::
 
-    esrally download --distribution-version=6.8.0 --car=defaults,basic-license --quiet
+    esrally download --distribution-version=6.8.0 --quiet
 
-This will download the default distribution of Elasticsearch 6.8.0. Because ``--quiet`` is specified, Rally will suppress all non-essential output (banners, progress messages etc.) and only return the location of the binary on the local machine after it has downloaded it::
+This will download the OSS distribution of Elasticsearch 6.8.0. Because ``--quiet`` is specified, Rally will suppress all non-essential output (banners, progress messages etc.) and only return the location of the binary on the local machine after it has downloaded it::
+
+    {
+      "elasticsearch": "/Users/dm/.rally/benchmarks/distributions/elasticsearch-oss-6.8.0.tar.gz"
+    }
+
+To download the default distribution you need to specify a license (via ``--car``)::
+
+    esrally download --distribution-version=6.8.0 --car=basic-license --quiet
+
+This will show the path to the default distribution::
 
     {
       "elasticsearch": "/Users/dm/.rally/benchmarks/distributions/elasticsearch-6.8.0.tar.gz"
     }
+
 
 Command Line Flags
 ------------------

--- a/esrally/mechanic/__init__.py
+++ b/esrally/mechanic/__init__.py
@@ -16,5 +16,6 @@
 # under the License.
 
 # expose only the minimum API
-from .mechanic import ClusterMetaInfo, NodeMetaInfo, StartEngine, EngineStarted, StopEngine, EngineStopped, OnBenchmarkStart, \
-    BenchmarkStarted, OnBenchmarkStop, BenchmarkStopped, ResetRelativeTime, MechanicActor, cluster_distribution_version
+from .mechanic import ClusterMetaInfo, NodeMetaInfo, StartEngine, EngineStarted, StopEngine, EngineStopped, \
+    OnBenchmarkStart, BenchmarkStarted, OnBenchmarkStop, BenchmarkStopped, ResetRelativeTime, MechanicActor, \
+    cluster_distribution_version, download

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -29,6 +29,16 @@ from esrally.mechanic import supplier, provisioner, launcher, team
 METRIC_FLUSH_INTERVAL_SECONDS = 30
 
 
+def download(cfg):
+    challenge_root_path = paths.race_root(cfg)
+    car, plugins = load_team(cfg, external=False)
+
+    s = supplier.create(cfg, sources=False, distribution=True, build=False,
+                        challenge_root_path=challenge_root_path, car=car, plugins=plugins)
+    binaries = s()
+    console.println(json.dumps(binaries, indent=2), force=True)
+
+
 ##############################
 # Public Messages
 ##############################

--- a/esrally/utils/console.py
+++ b/esrally/utils/console.py
@@ -112,24 +112,25 @@ def init(quiet=False):
             pass
 
 
-def info(msg, end="\n", flush=False, logger=None, overline=None, underline=None):
-    println(msg, console_prefix="[INFO]", end=end, flush=flush, overline=overline, underline=underline,
+def info(msg, end="\n", flush=False, force=False, logger=None, overline=None, underline=None):
+    println(msg, console_prefix="[INFO]", end=end, flush=flush, force=force, overline=overline, underline=underline,
             logger=logger.info if logger else None)
 
 
-def warn(msg, end="\n", flush=False, logger=None, overline=None, underline=None):
-    println(msg, console_prefix="[WARNING]", end=end, flush=flush, overline=overline, underline=underline
+def warn(msg, end="\n", flush=False, force=False, logger=None, overline=None, underline=None):
+    println(msg, console_prefix="[WARNING]", end=end, flush=flush, force=force, overline=overline, underline=underline
             , logger=logger.warning if logger else None)
 
 
-def error(msg, end="\n", flush=False, logger=None, overline=None, underline=None):
-    println(msg, console_prefix="[ERROR]", end=end, flush=flush, overline=overline, underline=underline
+def error(msg, end="\n", flush=False, force=False, logger=None, overline=None, underline=None):
+    println(msg, console_prefix="[ERROR]", end=end, flush=flush, force=force, overline=overline, underline=underline
             , logger=logger.error if logger else None)
 
 
-def println(msg, console_prefix=None, end="\n", flush=False, logger=None, overline=None, underline=None):
+def println(msg, console_prefix=None, end="\n", flush=False, force=False, logger=None, overline=None, underline=None):
     # TODO: Checking for sys.stdout.isatty() prevents shell redirections and pipes (useful for list commands). Can we remove this check?
-    if not QUIET and (RALLY_RUNNING_IN_DOCKER or sys.stdout.isatty()):
+    allow_print = force or (not QUIET and (RALLY_RUNNING_IN_DOCKER or sys.stdout.isatty()))
+    if allow_print:
         complete_msg = "%s %s" % (console_prefix, msg) if console_prefix else msg
         if overline:
             print(format.underline_for(complete_msg, underline_symbol=overline), flush=flush)
@@ -148,7 +149,7 @@ class CmdLineProgressReporter:
     """
     CmdLineProgressReporter supports displaying an updating progress indication together with an information message.
 
-    :param custom_print: allow use of a different print method to assist with patching in unittests
+    :param printer: allow use of a different print method to assist with patching in unittests
     """
 
     def __init__(self, width, plain_output=False, printer=print):

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -234,6 +234,19 @@ function test_list {
     esrally list telemetry --configuration-name="${cfg}"
 }
 
+function test_download {
+    local cfg
+    random_configuration cfg
+
+    for dist in "${DISTRIBUTIONS[@]}"
+    do
+        random_configuration cfg
+        info "test download [--configuration-name=${cfg}], [--distribution-version=${dist}]"
+        kill_rally_processes
+        esrally download --configuration-name="${cfg}" --distribution-version="${dist}" --quiet
+    done
+}
+
 function test_sources {
     local cfg
     random_configuration cfg
@@ -406,6 +419,8 @@ function run_test {
     test_list
     echo "**************************************** TESTING RALLY FAILS WITH UNUSED TRACK-PARAMS **************************"
     test_distribution_fails_with_wrong_track_params
+    echo "**************************************** TESTING RALLY DOWNLOAD COMMAND ***********************************"
+    test_download
     echo "**************************************** TESTING RALLY WITH ES FROM SOURCES ************************************"
     test_sources
     echo "**************************************** TESTING RALLY WITH ES DISTRIBUTIONS ***********************************"

--- a/tests/utils/console_test.py
+++ b/tests/utils/console_test.py
@@ -25,6 +25,9 @@ from esrally.utils import console
 
 
 class ConsoleFunctionTests(TestCase):
+    oldconsole_quiet = None
+    oldconsole_rally_running_in_docker = None
+
     @classmethod
     def setUpClass(cls):
         cls.oldconsole_quiet = console.QUIET
@@ -75,9 +78,23 @@ class ConsoleFunctionTests(TestCase):
         console.println(msg="Unittest message")
         patched_print.assert_not_called()
 
+    @mock.patch("sys.stdout.isatty")
+    @mock.patch("builtins.print")
+    def test_println_force_prints_even_when_quiet(self, patched_print, patched_isatty):
+        console.init(quiet=True)
+        patched_isatty.return_value = random.choice([True, False])
+
+        console.println(msg="Unittest message", force=True)
+        patched_print.assert_called_once_with(
+            "Unittest message", end="\n", flush=False
+        )
+
 
 # pytest style class names need to start with Test and don't need to subclass
 class TestCmdLineProgressReporter:
+    oldconsole_quiet = None
+    oldconsole_rally_running_in_docker = None
+
     @classmethod
     def setup_class(cls):
         cls.oldconsole_quiet = console.QUIET


### PR DESCRIPTION
With this commit we add a new subcommand `download` to Rally that can be
used to download a binary. This can be useful in automated workflows
that still want to abstract how the download artefact is actually
retrieved (this has to be handled differently for different releases).