### PR TITLE
Provide default for datastore.secure in all cases

### DIFF
--- a/esrally/config.py
+++ b/esrally/config.py
@@ -351,7 +351,7 @@ class ConfigFactory:
             if data_store_choice == "1":
                 env_name = "local"
                 data_store_type = "in-memory"
-                data_store_host, data_store_port, data_store_secure, data_store_user, data_store_password = "", "", "", "", ""
+                data_store_host, data_store_port, data_store_secure, data_store_user, data_store_password = "", "", "False", "", ""
             else:
                 data_store_type = "elasticsearch"
                 data_store_host, data_store_port, data_store_secure, data_store_user, data_store_password = self._ask_data_store()
@@ -365,7 +365,7 @@ class ConfigFactory:
             # Does not matter for an in-memory store
             env_name = "local"
             data_store_type = "in-memory"
-            data_store_host, data_store_port, data_store_secure, data_store_user, data_store_password = "", "", "", "", ""
+            data_store_host, data_store_port, data_store_secure, data_store_user, data_store_password = "", "", "False", "", ""
             preserve_install = False
 
         config = configparser.ConfigParser()

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -292,7 +292,7 @@ class ConfigFactoryTests(TestCase):
         self.assertEqual("in-memory", config_store.config["reporting"]["datastore.type"])
         self.assertEqual("", config_store.config["reporting"]["datastore.host"])
         self.assertEqual("", config_store.config["reporting"]["datastore.port"])
-        self.assertEqual("", config_store.config["reporting"]["datastore.secure"])
+        self.assertEqual("False", config_store.config["reporting"]["datastore.secure"])
         self.assertEqual("", config_store.config["reporting"]["datastore.user"])
         self.assertEqual("", config_store.config["reporting"]["datastore.password"])
 


### PR DESCRIPTION
With this commit we choose `False` as default value for the
configuration property `datastore.secure` even when an in-memory metrics
store is used. Contrary to the previous default (`""` (empty string)),
this avoids errors when the user manually changes their configuration
file to use an Elasticsearch metrics store but only provides host and
port.