### PR TITLE
Upgrade pip for virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ check-venv:
 	fi
 
 install: venv-create
+    . $(VENV_ACTIVATE_FILE); pip install --upgrade pip
 	. $(VENV_ACTIVATE_FILE); pip3 install -e .
 	# install tox for it tests
 	. $(VENV_ACTIVATE_FILE); pip3 install tox

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ check-venv:
 	fi
 
 install: venv-create
-    . $(VENV_ACTIVATE_FILE); pip install --upgrade pip
+	. $(VENV_ACTIVATE_FILE); pip install --upgrade pip
 	. $(VENV_ACTIVATE_FILE); pip3 install -e .
 	# install tox for it tests
 	. $(VENV_ACTIVATE_FILE); pip3 install tox


### PR DESCRIPTION
With this commit we upgrade pip to the latest version in the `make
install` target (used only for development). This avoids warnings about
an outdated version and let's us also use newer pip features in the
future.