### PR TITLE
Don't pass request_cache by default

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -670,8 +670,9 @@ class Query(Runner):
 
     def _default_request_params(self, params):
         request_params = params.get("request-params", {})
-        if "cache" in params:
-            request_params["request_cache"] = str(params["cache"]).lower()
+        cache = params.get("cache")
+        if cache is not None:
+            request_params["request_cache"] = str(cache).lower()
         return request_params
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -343,7 +343,7 @@ class SearchParamSource(ParamSource):
 
         index_name = params.get("index", default_index)
         type_name = params.get("type")
-        request_cache = params.get("cache", False)
+        request_cache = params.get("cache", None)
         query_body = params.get("body", None)
         query_body_params = params.get("body-params", None)
         pages = params.get("pages", None)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -844,6 +844,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "cache": True,
             "body": {
                 "query": {
                     "match_all": {}
@@ -861,6 +862,15 @@ class QueryRunnerTests(TestCase):
         self.assertFalse(result["timed_out"])
         self.assertEqual(5, result["took"])
         self.assertFalse("error-type" in result)
+
+        es.search.assert_called_once_with(
+            index="_all",
+            doc_type=None,
+            body=params["body"],
+            params={
+                "request_cache": "true"
+            }
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     def test_query_match_all(self, es):
@@ -888,7 +898,7 @@ class QueryRunnerTests(TestCase):
         params = {
             "index": "unittest",
             "type": "type",
-            "cache": False,
+            "cache": None,
             "body": {
                 "query": {
                     "match_all": {}
@@ -906,6 +916,13 @@ class QueryRunnerTests(TestCase):
         self.assertFalse(result["timed_out"])
         self.assertEqual(5, result["took"])
         self.assertFalse("error-type" in result)
+
+        es.search.assert_called_once_with(
+            index="unittest",
+            doc_type="type",
+            body=params["body"],
+            params={}
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     def test_scroll_query_only_one_page(self, es):


### PR DESCRIPTION
With this commit Rally will only pass the `request_cache` query
parameter to Elasticsearch iff the `cache` property is defined in the
track. Otherwise, it will adhere to the default that has been specified
in the index settings.

Closes #596