### PR TITLE
Change telemetry devices to rely on jvm.config instead of ES_JAVA_OPTS

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -322,9 +322,6 @@ class InProcessLauncher:
         enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
         telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
         node_telemetry = [
-            telemetry.FlightRecorder(telemetry_params, node_telemetry_dir, java_major_version),
-            telemetry.JitCompiler(node_telemetry_dir),
-            telemetry.Gc(node_telemetry_dir, java_major_version),
             telemetry.DiskIo(self.metrics_store, node_count_on_host),
             telemetry.NodeEnvironmentInfo(self.metrics_store),
             telemetry.IndexSize(data_paths, self.metrics_store),
@@ -349,10 +346,6 @@ class InProcessLauncher:
         self._set_env(env, "PATH", os.path.join(java_home, "bin"), separator=os.pathsep)
         # Don't merge here!
         env["JAVA_HOME"] = java_home
-
-        # we just blindly trust telemetry here...
-        for k, v in t.instrument_candidate_env(car, node_name).items():
-            self._set_env(env, k, v)
 
         exit_on_oome_flag = "-XX:+ExitOnOutOfMemoryError"
         if jvm.supports_option(java_home, exit_on_oome_flag):

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -347,13 +347,6 @@ class InProcessLauncher:
         # Don't merge here!
         env["JAVA_HOME"] = java_home
 
-        exit_on_oome_flag = "-XX:+ExitOnOutOfMemoryError"
-        if jvm.supports_option(java_home, exit_on_oome_flag):
-            self.logger.info("Setting [%s] to detect out of memory errors during the benchmark.", exit_on_oome_flag)
-            self._set_env(env, "ES_JAVA_OPTS", exit_on_oome_flag)
-        else:
-            self.logger.info("JVM does not support [%s]. A JDK upgrade is recommended.", exit_on_oome_flag)
-
         self.logger.debug("env for [%s]: %s", node_name, str(env))
         return env
 

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -247,7 +247,6 @@ class BareProvisioner:
         
         java_opts = self._prepare_java_opts()
         if java_opts:
-            print("here not empty")
             provisioner_vars["additional_java_settings"] = java_opts
         
 

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -39,7 +39,7 @@ def local_provisioner(cfg, car, plugins, cluster_settings, all_node_ips, target_
 
     _, java_home = java_resolver.java_home(car, cfg)
     
-    node_telemetry_dir = "%s/telemetry" % node_root_dir
+    node_telemetry_dir = os.path.join(node_root_dir, "telemetry")
     java_major_version, java_home = java_resolver.java_home(car, cfg)
     enabled_devices = cfg.opts("mechanic", "telemetry.devices")
     telemetry_params = cfg.opts("mechanic", "telemetry.params")
@@ -178,9 +178,6 @@ class BareProvisioner:
         target_root_path = self.es_installer.es_home_path
         provisioner_vars = self._provisioner_variables()
         
-        # add java options for telemetry devices
-        provisioner_vars.update({"additional_java_settings" : self.telemetry.instrument_candidate_env(self.es_installer.car, self.es_installer.node_name)})
-
         for p in self.es_installer.config_source_paths:
             self.apply_config(p, target_root_path, provisioner_vars)
 
@@ -232,6 +229,7 @@ class BareProvisioner:
         provisioner_vars.update(self.es_installer.variables)
         provisioner_vars.update(plugin_variables)
         provisioner_vars["cluster_settings"] = cluster_settings
+        provisioner_vars["additional_java_settings"] = self.telemetry.instrument_candidate_java_opts(self.es_installer.car, self.es_installer.node_name)
 
         return provisioner_vars
 

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -158,7 +158,7 @@ class BareProvisioner:
     of the benchmark candidate to the appropriate place.
     """
 
-    def __init__(self, cluster_settings, es_installer, plugin_installers, preserve, telemetry, distribution_version=None, apply_config=_apply_config):
+    def __init__(self, cluster_settings, es_installer, plugin_installers, preserve, telemetry=None, distribution_version=None, apply_config=_apply_config):
         self.preserve = preserve
         self._cluster_settings = cluster_settings
         self.es_installer = es_installer
@@ -229,7 +229,8 @@ class BareProvisioner:
         provisioner_vars.update(self.es_installer.variables)
         provisioner_vars.update(plugin_variables)
         provisioner_vars["cluster_settings"] = cluster_settings
-        provisioner_vars["additional_java_settings"] = self.telemetry.instrument_candidate_java_opts(self.es_installer.car, self.es_installer.node_name)
+        if self.telemetry is not None:
+            provisioner_vars["additional_java_settings"] = self.telemetry.instrument_candidate_java_opts(self.es_installer.car, self.es_installer.node_name)
 
         return provisioner_vars
 

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -178,7 +178,6 @@ class BareProvisioner:
         # determine after installation because some variables will depend on the install directory
         target_root_path = self.es_installer.es_home_path
         provisioner_vars = self._provisioner_variables()
-        
         for p in self.es_installer.config_source_paths:
             self.apply_config(p, target_root_path, provisioner_vars)
 
@@ -249,8 +248,6 @@ class BareProvisioner:
         if java_opts:
             provisioner_vars["additional_java_settings"] = java_opts
         
-
-
         return provisioner_vars
 
 

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -186,31 +186,32 @@ class FlightRecorder(TelemetryDevice):
         java_opts = self.java_opts(log_file)
 
         self.logger.info("jfr: Adding JVM arguments: [%s].", java_opts)
-        return java_opts.split()
+        return java_opts
 
     def java_opts(self, log_file):
         recording_template = self.telemetry_params.get("recording-template")
-        java_opts = "-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints "
-
+        java_opts = ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"]
+        jfr_cmd = ""
         if self.java_major_version < 11:
-            java_opts += "-XX:+UnlockCommercialFeatures "
+            java_opts.append("-XX:+UnlockCommercialFeatures")
 
         if self.java_major_version < 9:
-            java_opts += "-XX:+FlightRecorder "
-            java_opts += "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath={} ".format(log_file)
-            java_opts += "-XX:StartFlightRecording=defaultrecording=true"
+            java_opts.append("-XX:+FlightRecorder")
+            java_opts.append("-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath={}".format(log_file))
+            jfr_cmd = "-XX:StartFlightRecording=defaultrecording=true"
             if recording_template:
                 self.logger.info("jfr: Using recording template [%s].", recording_template)
-                java_opts += ",settings={}".format(recording_template)
+                jfr_cmd += ",settings={}".format(recording_template)
             else:
                 self.logger.info("jfr: Using default recording template.")
         else:
-            java_opts += "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename={}".format(log_file)
+            jfr_cmd += "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename={}".format(log_file)
             if recording_template:
                 self.logger.info("jfr: Using recording template [%s].", recording_template)
-                java_opts += ",settings={}".format(recording_template)
+                jfr_cmd += ",settings={}".format(recording_template)
             else:
                 self.logger.info("jfr: Using default recording template.")
+        java_opts.append(jfr_cmd)
         return java_opts
 
 

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -230,7 +230,7 @@ class JitCompiler(TelemetryDevice):
         log_file = "%s/%s-%s.jit.log" % (self.log_root, car.safe_name, candidate_id)
         console.info("%s: Writing JIT compiler log to [%s]" % (self.human_name, log_file), logger=self.logger)
         return ["-XX:+UnlockDiagnosticVMOptions", "-XX:+TraceClassLoading", "-XX:+LogCompilation",
-                                "-XX:LogFile={}".format(log_file), "-XX:+PrintAssembly"]
+                "-XX:LogFile={}".format(log_file), "-XX:+PrintAssembly"]
 
 
 class Gc(TelemetryDevice):
@@ -253,8 +253,8 @@ class Gc(TelemetryDevice):
     def java_opts(self, log_file):
         if self.java_major_version < 9:
             return ["-Xloggc:{}".format(log_file), "-XX:+PrintGCDetails", "-XX:+PrintGCDateStamps", "-XX:+PrintGCTimeStamps",
-                                    "-XX:+PrintGCApplicationStoppedTime", "-XX:+PrintGCApplicationConcurrentTime",
-                                    "-XX:+PrintTenuringDistribution"]
+                    "-XX:+PrintGCApplicationStoppedTime", "-XX:+PrintGCApplicationConcurrentTime",
+                    "-XX:+PrintTenuringDistribution"]
         else:
             # see https://docs.oracle.com/javase/9/tools/java.htm#JSWOR-GUID-BE93ABDC-999C-4CB5-A88B-1994AAAC74D5
             return ["-Xlog:gc*=info,safepoint=info,age*=trace:file={}:utctime,uptimemillis,level,tags:filecount=0".format(log_file)]

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -189,22 +189,22 @@ class JfrTests(TestCase):
     def test_sets_options_for_pre_java_9_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(0, 8))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual("-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+UnlockCommercialFeatures -XX:+FlightRecorder "
+        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder",
                          "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,"
-                         "dumponexitpath=/var/log/test-recording.jfr -XX:StartFlightRecording=defaultrecording=true", java_opts)
+                         "dumponexitpath=/var/log/test-recording.jfr", "-XX:StartFlightRecording=defaultrecording=true"], java_opts)
 
     def test_sets_options_for_java_9_or_10_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(9, 10))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual("-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+UnlockCommercialFeatures "
-                         "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr",
+        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
+                         "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr"],
                          java_opts)
 
     def test_sets_options_for_java_11_or_above_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(11, 999))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual("-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints "
-                         "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr",
+        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints",
+                         "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr"],
                          java_opts)
 
     def test_sets_options_for_pre_java_9_custom_recording_template(self):
@@ -212,9 +212,9 @@ class JfrTests(TestCase):
                                        log_root="/var/log",
                                        java_major_version=random.randint(0, 8))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual("-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+UnlockCommercialFeatures -XX:+FlightRecorder "
+        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder",
                          "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,"
-                         "dumponexitpath=/var/log/test-recording.jfr -XX:StartFlightRecording=defaultrecording=true,settings=profile",
+                         "dumponexitpath=/var/log/test-recording.jfr", "-XX:StartFlightRecording=defaultrecording=true,settings=profile"],
                          java_opts)
 
     def test_sets_options_for_java_9_or_10_custom_recording_template(self):
@@ -222,9 +222,9 @@ class JfrTests(TestCase):
                                        log_root="/var/log",
                                        java_major_version=random.randint(9, 10))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual("-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+UnlockCommercialFeatures "
+        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
                          "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
-                         "filename=/var/log/test-recording.jfr,settings=profile",
+                         "filename=/var/log/test-recording.jfr,settings=profile"],
                          java_opts)
 
     def test_sets_options_for_java_11_or_above_custom_recording_template(self):
@@ -232,9 +232,9 @@ class JfrTests(TestCase):
                                        log_root="/var/log",
                                        java_major_version=random.randint(11, 999))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual("-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints "
+        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints",
                          "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
-                         "filename=/var/log/test-recording.jfr,settings=profile",
+                         "filename=/var/log/test-recording.jfr,settings=profile"],
                          java_opts)
 
 

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -47,12 +47,12 @@ def create_config():
 
 
 class MockTelemetryDevice(telemetry.InternalTelemetryDevice):
-    def __init__(self, mock_env):
+    def __init__(self, mock_java_opts):
         super().__init__()
-        self.mock_env = mock_env
+        self.mock_java_opts = mock_java_opts
 
-    def instrument_env(self, car, candidate_id):
-        return self.mock_env
+    def instrument_java_opts(self, car, candidate_id):
+        return self.mock_java_opts
 
 
 class TelemetryTests(TestCase):
@@ -63,20 +63,19 @@ class TelemetryTests(TestCase):
         cfg.add(config.Scope.application, "benchmarks", "metrics.log.dir", "telemetry")
 
         devices = [
-            MockTelemetryDevice({"ES_JAVA_OPTS": "-Xms256M"}),
-            MockTelemetryDevice({"ES_JAVA_OPTS": "-Xmx512M"}),
-            MockTelemetryDevice({"ES_NET_HOST": "127.0.0.1"})
+            MockTelemetryDevice(["-Xms256M"]),
+            MockTelemetryDevice(["-Xmx512M"]),
+            MockTelemetryDevice(["-Des.network.host=127.0.0.1"])
         ]
 
         t = telemetry.Telemetry(enabled_devices=None, devices=devices)
 
         default_car = team.Car(names="default-car", root_path=None, config_paths=["/tmp/rally-config"])
-        opts = t.instrument_candidate_env(default_car, "default-node")
+        opts = t.instrument_candidate_java_opts(default_car, "default-node")
 
-        self.assertTrue(opts)
-        self.assertEqual(len(opts), 2)
-        self.assertEqual("-Xms256M -Xmx512M", opts["ES_JAVA_OPTS"])
-        self.assertEqual("127.0.0.1", opts["ES_NET_HOST"])
+        self.assertIsNotNone(opts)
+        self.assertEqual(len(opts), 3)
+        self.assertEqual(["-Xms256M", "-Xmx512M", "-Des.network.host=127.0.0.1"], opts)
 
 
 class StartupTimeTests(TestCase):
@@ -242,19 +241,19 @@ class JfrTests(TestCase):
 class GcTests(TestCase):
     def test_sets_options_for_pre_java_9(self):
         gc = telemetry.Gc("/var/log", java_major_version=random.randint(0, 8))
-        env = gc.java_opts("/var/log/defaults-node-0.gc.log")
-        self.assertEqual(1, len(env))
-        self.assertEqual("-Xloggc:/var/log/defaults-node-0.gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps "
-                         "-XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+PrintTenuringDistribution",
-                         env["ES_JAVA_OPTS"])
+        gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
+        self.assertEqual(7, len(gc_java_opts))
+        self.assertEqual(["-Xloggc:/var/log/defaults-node-0.gc.log", "-XX:+PrintGCDetails", "-XX:+PrintGCDateStamps", "-XX:+PrintGCTimeStamps",
+                         "-XX:+PrintGCApplicationStoppedTime", "-XX:+PrintGCApplicationConcurrentTime", "-XX:+PrintTenuringDistribution"],
+                         gc_java_opts)
 
     def test_sets_options_for_java_9_or_above(self):
         gc = telemetry.Gc("/var/log", java_major_version=random.randint(9, 999))
-        env = gc.java_opts("/var/log/defaults-node-0.gc.log")
-        self.assertEqual(1, len(env))
+        gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
+        self.assertEqual(1, len(gc_java_opts))
         self.assertEqual(
-            "-Xlog:gc*=info,safepoint=info,age*=trace:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0",
-            env["ES_JAVA_OPTS"])
+            ["-Xlog:gc*=info,safepoint=info,age*=trace:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"],
+            gc_java_opts)
 
 
 class CcrStatsTests(TestCase):

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -190,22 +190,22 @@ class JfrTests(TestCase):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(0, 8))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
         self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder",
-                         "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,"
-                         "dumponexitpath=/var/log/test-recording.jfr", "-XX:StartFlightRecording=defaultrecording=true"], java_opts)
+                          "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,"
+                          "dumponexitpath=/var/log/test-recording.jfr", "-XX:StartFlightRecording=defaultrecording=true"], java_opts)
 
     def test_sets_options_for_java_9_or_10_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(9, 10))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
         self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
-                         "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr"],
-                         java_opts)
+                          "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,"
+                          "dumponexit=true,filename=/var/log/test-recording.jfr"], java_opts)
 
     def test_sets_options_for_java_11_or_above_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(11, 999))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
         self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints",
-                         "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr"],
-                         java_opts)
+                          "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,"
+                          "dumponexit=true,filename=/var/log/test-recording.jfr"], java_opts)
 
     def test_sets_options_for_pre_java_9_custom_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={"recording-template": "profile"},
@@ -213,9 +213,8 @@ class JfrTests(TestCase):
                                        java_major_version=random.randint(0, 8))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
         self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder",
-                         "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,"
-                         "dumponexitpath=/var/log/test-recording.jfr", "-XX:StartFlightRecording=defaultrecording=true,settings=profile"],
-                         java_opts)
+                          "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,"
+                          "dumponexitpath=/var/log/test-recording.jfr", "-XX:StartFlightRecording=defaultrecording=true,settings=profile"], java_opts)
 
     def test_sets_options_for_java_9_or_10_custom_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={"recording-template": "profile"},
@@ -223,9 +222,8 @@ class JfrTests(TestCase):
                                        java_major_version=random.randint(9, 10))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
         self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
-                         "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
-                         "filename=/var/log/test-recording.jfr,settings=profile"],
-                         java_opts)
+                          "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
+                          "filename=/var/log/test-recording.jfr,settings=profile"], java_opts)
 
     def test_sets_options_for_java_11_or_above_custom_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={"recording-template": "profile"},
@@ -233,9 +231,8 @@ class JfrTests(TestCase):
                                        java_major_version=random.randint(11, 999))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
         self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints",
-                         "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
-                         "filename=/var/log/test-recording.jfr,settings=profile"],
-                         java_opts)
+                          "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
+                          "filename=/var/log/test-recording.jfr,settings=profile"], java_opts)
 
 
 class GcTests(TestCase):
@@ -244,8 +241,8 @@ class GcTests(TestCase):
         gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
         self.assertEqual(7, len(gc_java_opts))
         self.assertEqual(["-Xloggc:/var/log/defaults-node-0.gc.log", "-XX:+PrintGCDetails", "-XX:+PrintGCDateStamps", "-XX:+PrintGCTimeStamps",
-                         "-XX:+PrintGCApplicationStoppedTime", "-XX:+PrintGCApplicationConcurrentTime", "-XX:+PrintTenuringDistribution"],
-                         gc_java_opts)
+                          "-XX:+PrintGCApplicationStoppedTime", "-XX:+PrintGCApplicationConcurrentTime",
+                          "-XX:+PrintTenuringDistribution"], gc_java_opts)
 
     def test_sets_options_for_java_9_or_above(self):
         gc = telemetry.Gc("/var/log", java_major_version=random.randint(9, 999))


### PR DESCRIPTION
Move telemetry devices that currently rely on ES_JAVA_OPTS from the
launcher to the provisioner and instead persist the necessary
information in config/jvm.options