### PR TITLE
Check tags in track and team repos

### DIFF
--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -57,7 +57,7 @@ def clone(src, remote):
 def fetch(src, remote="origin"):
     # Don't swallow output but silence git at least a bit... (--quiet)
     if process.run_subprocess(
-            "git -C {0} fetch --prune --quiet {1}".format(src, remote)):
+            "git -C {0} fetch --prune --prune-tags --tags --quiet {1}".format(src, remote)):
         raise exceptions.SupplyError("Could not fetch source tree from [%s]" % remote)
 
 
@@ -65,7 +65,7 @@ def fetch(src, remote="origin"):
 def checkout(src_dir, branch="master"):
     if process.run_subprocess(
             "git -C {0} checkout --quiet {1}".format(src_dir, branch)):
-        raise exceptions.SupplyError("Could not checkout branch [%s]. Do you have uncommitted changes?" % branch)
+        raise exceptions.SupplyError("Could not checkout [%s]. Do you have uncommitted changes?" % branch)
 
 
 @probed
@@ -83,17 +83,17 @@ def pull(src_dir, remote="origin", branch="master"):
 
 @probed
 def pull_ts(src_dir, ts):
-    if process.run_subprocess(
-            "git -C {0} fetch --prune --quiet origin && git -C {0} checkout --quiet `git -C {0} rev-list -n 1 --before=\"{1}\" "
-            "--date=iso8601 origin/master`".format(src_dir, ts)):
-        raise exceptions.SupplyError("Could not fetch source tree for timestamped revision [%s]" % ts)
+    fetch(src_dir)
+    if process.run_subprocess("git -C {0} checkout --quiet `git -C {0} rev-list -n 1 --before=\"{1}\" "
+                              "--date=iso8601 origin/master`".format(src_dir, ts)):
+        raise exceptions.SupplyError("Could not checkout source tree for timestamped revision [%s]" % ts)
 
 
 @probed
 def pull_revision(src_dir, revision):
-    if process.run_subprocess(
-                    "git -C {0} fetch --prune --quiet origin && git -C {0} checkout --quiet {1}".format(src_dir, revision)):
-        raise exceptions.SupplyError("Could not fetch source tree for revision [%s]" % revision)
+    fetch(src_dir)
+    if process.run_subprocess("git -C {0} checkout --quiet {1}".format(src_dir, revision)):
+        raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
 
 
 @probed
@@ -118,9 +118,18 @@ def branches(src_dir, remote=True):
                         "git -C {src} for-each-ref refs/heads/ --format='%(refname:short)'".format(src=src_dir)))
 
 
+@probed
+def tags(src_dir):
+    return _cleanup_tag_names(process.run_subprocess_with_output("git -C {0} tag".format(src_dir)))
+
+
 def _cleanup_remote_branch_names(branch_names):
     return [(b[b.index("/") + 1:]).strip() for b in branch_names if not b.endswith("/HEAD")]
 
 
 def _cleanup_local_branch_names(branch_names):
     return [b.strip() for b in branch_names if not b.endswith("HEAD")]
+
+
+def _cleanup_tag_names(tag_names):
+    return [t.strip() for t in tag_names]

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -75,7 +75,7 @@ class GitTests(TestCase):
         run_subprocess_with_logging.return_value = 0
         run_subprocess.return_value = False
         git.fetch("/src", remote="my-origin")
-        run_subprocess.assert_called_with("git -C /src fetch --prune --quiet my-origin")
+        run_subprocess.assert_called_with("git -C /src fetch --prune --prune-tags --tags --quiet my-origin")
 
     @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
@@ -85,7 +85,7 @@ class GitTests(TestCase):
         with self.assertRaises(exceptions.SupplyError) as ctx:
             git.fetch("/src", remote="my-origin")
         self.assertEqual("Could not fetch source tree from [my-origin]", ctx.exception.args[0])
-        run_subprocess.assert_called_with("git -C /src fetch --prune --quiet my-origin")
+        run_subprocess.assert_called_with("git -C /src fetch --prune --prune-tags --tags --quiet my-origin")
 
     @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
@@ -102,7 +102,7 @@ class GitTests(TestCase):
         run_subprocess.return_value = True
         with self.assertRaises(exceptions.SupplyError) as ctx:
             git.checkout("/src", "feature-branch")
-        self.assertEqual("Could not checkout branch [feature-branch]. Do you have uncommitted changes?", ctx.exception.args[0])
+        self.assertEqual("Could not checkout [feature-branch]. Do you have uncommitted changes?", ctx.exception.args[0])
         run_subprocess.assert_called_with("git -C /src checkout --quiet feature-branch")
 
     @mock.patch("esrally.utils.process.run_subprocess")
@@ -124,7 +124,7 @@ class GitTests(TestCase):
         run_subprocess.return_value = False
         git.pull("/src", remote="my-origin", branch="feature-branch")
         calls = [
-            mock.call("git -C /src fetch --prune --quiet my-origin"),
+            mock.call("git -C /src fetch --prune --prune-tags --tags --quiet my-origin"),
             mock.call("git -C /src checkout --quiet feature-branch"),
             mock.call("git -C /src rebase --quiet my-origin/feature-branch")
         ]
@@ -134,19 +134,24 @@ class GitTests(TestCase):
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_pull_ts(self, run_subprocess_with_logging, run_subprocess):
         run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = False
+        run_subprocess.side_effect = [False, False]
         git.pull_ts("/src", "20160101T110000Z")
-        run_subprocess.assert_called_with(
-                "git -C /src fetch --prune --quiet origin && git -C /src checkout "
-                "--quiet `git -C /src rev-list -n 1 --before=\"20160101T110000Z\" --date=iso8601 origin/master`")
+        run_subprocess.has_calls([
+            mock.call("git -C /src fetch --prune --prune-tags --tags --quiet origin"),
+            mock.call("git -C /src checkout --quiet `git -C /src rev-list -n 1 --before=\"20160101T110000Z\" "
+                      "--date=iso8601 origin/master`"),
+        ])
 
     @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_pull_revision(self, run_subprocess_with_logging, run_subprocess):
         run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = False
+        run_subprocess.side_effect = [False, False]
         git.pull_revision("/src", "3694a07")
-        run_subprocess.assert_called_with("git -C /src fetch --prune --quiet origin && git -C /src checkout --quiet 3694a07")
+        run_subprocess.has_calls([
+            mock.call("git -C /src fetch --prune --prune-tags --tags --quiet origin"),
+            mock.call("git -C /src checkout --quiet 3694a07"),
+        ])
 
     @mock.patch("esrally.utils.process.run_subprocess_with_output")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
@@ -177,3 +182,20 @@ class GitTests(TestCase):
                                        "  5"]
         self.assertEqual(["master", "5.0.0-alpha1", "5"], git.branches("/src", remote=False))
         run_subprocess.assert_called_with("git -C /src for-each-ref refs/heads/ --format='%(refname:short)'")
+
+    @mock.patch("esrally.utils.process.run_subprocess_with_output")
+    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
+    def test_list_tags_with_tags_present(self, run_subprocess_with_logging, run_subprocess):
+        run_subprocess_with_logging.return_value = 0
+        run_subprocess.return_value = ["  v1",
+                                       "  v2"]
+        self.assertEqual(["v1", "v2"], git.tags("/src"))
+        run_subprocess.assert_called_with("git -C /src tag")
+
+    @mock.patch("esrally.utils.process.run_subprocess_with_output")
+    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
+    def test_list_tags_no_tags_available(self, run_subprocess_with_logging, run_subprocess):
+        run_subprocess_with_logging.return_value = 0
+        run_subprocess.return_value = ""
+        self.assertEqual([], git.tags("/src"))
+        run_subprocess.assert_called_with("git -C /src tag")


### PR DESCRIPTION
With this commit Rally does not only check for branch matches but also
for matching tags in track and team repos. This allows to "freeze"
support for older versions of Elasticsearch, i.e. once we drop support
for Elasticsearch 1.x, we can tag the branch `1` in rally-teams and
rally-tracks as `v1` (using a `v` prefix as convention for tags). Rally
can then still pick up configurations for these older versions that are
out of maintenance.