### PR TITLE
Document which ES versions are supported by Rally

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -384,16 +384,7 @@ If you want to benchmark a binary distribution, you can specify the version here
    esrally --distribution-version=2.3.3
 
 
-Rally will then benchmark the official Elasticsearch 2.3.3 distribution.
-
-Rally works with all releases of Elasticsearch that are `supported by Elastic <https://www.elastic.co/support/matrix#show_compatibility>`_.
-
-The following versions are already end-of-life:
-
-* ``0.x``: Rally is not tested, and not expected to work for this version; we will make no effort to make Rally work.
-* ``1.x``: Rally works on a best-effort basis with this version but support may be removed at any time.
-
-Additionally, Rally will always work with the current development version of Elasticsearch (by using either a snapshot repository or by building Elasticsearch from sources).
+Rally will then benchmark the official Elasticsearch 2.3.3 distribution. Please check our :doc:`version support page </versions>` to see which Elasticsearch versions are currently supported by Rally.
 
 ``distribution-repository``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,8 +19,6 @@ You want to benchmark Elasticsearch? Then Rally is for you. It can help you with
 
 We have also put considerable effort in Rally to ensure that benchmarking data are reproducible.
 
-In general, Rally works with all versions of Elasticsearch starting from 1.x. :doc:`Benchmarking with plugins </elasticsearch_plugins>` and :ref:`benchmarking source builds <pipelines_from-sources-complete>` will only work from Elasticsearch 5.0 onwards.
-
 Getting Help or Contributing to Rally
 -------------------------------------
 
@@ -55,6 +53,7 @@ Rally's source code is available on `Github <https://github.com/elastic/rally>`_
    :caption: Reference Documentation
    :maxdepth: 2
 
+   versions
    command_line_reference
    offline
    track

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -1,0 +1,20 @@
+Elasticsearch Version Support
+-----------------------------
+
+Minimum supported version
+=========================
+
+Rally |release| can benchmark Elasticsearch 2.0.0 and above.
+
+End-of-life Policy
+==================
+
+The latest version of Rally allows to benchmark all currently supported versions of Elasticsearch. Once an `Elasticsearch version reaches end-of-life <https://www.elastic.co/support/eol>`_, Rally will support benchmarking the corresponding version for two more years. For example, Elasticsearch 1.7.x has been supported until 2017-01-16. Rally drops support for Elasticsearch 1.7.x two years after that date on 2019-01-16. Version support is dropped in the next Rally maintenance release after that date.
+
+Version-specific Limitations
+============================
+
+The following features require at least Elasticsearch 5.0.0:
+
+* :doc:`Benchmarking with plugins </elasticsearch_plugins>`
+* :ref:`Benchmarking source builds <pipelines_from-sources-complete>`

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,7 +4,7 @@ Elasticsearch Version Support
 Minimum supported version
 =========================
 
-Rally |release| can benchmark Elasticsearch 2.0.0 and above.
+Rally |release| can benchmark Elasticsearch 1.7.0 and above.
 
 End-of-life Policy
 ==================


### PR DESCRIPTION
With this commit we add a dedicated page to our documentation that
explains which Elasticsearch versions can be benchmarked with which
Rally version.