### PR TITLE
Drop support for Elasticsearch 1.x

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,7 +4,7 @@ Elasticsearch Version Support
 Minimum supported version
 =========================
 
-Rally |release| can benchmark Elasticsearch 1.7.0 and above.
+Rally |release| can benchmark Elasticsearch 2.0.0 and above.
 
 End-of-life Policy
 ==================

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -21,7 +21,7 @@ set -e
 
 readonly CONFIGURATIONS=(integration-test es-integration-test)
 
-readonly DISTRIBUTIONS=(1.7.6 2.4.6 5.6.9)
+readonly DISTRIBUTIONS=(2.4.6 5.6.16 6.8.0 7.1.1)
 readonly TRACKS=(geonames nyc_taxis http_logs nested)
 
 readonly ES_METRICS_STORE_JAVA_HOME="${JAVA8_HOME}"

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1116,7 +1116,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.transport.perform_request.side_effect = [
+        es.scroll.side_effect = [
             # page 2
             {
                 "_scroll_id": "some-scroll-id",
@@ -1178,7 +1178,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.transport.perform_request.side_effect = [
+        es.scroll.side_effect = [
             # page 2 has no results
             {
                 "_scroll_id": "some-scroll-id",
@@ -1236,7 +1236,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.transport.perform_request.side_effect = [
+        es.scroll.side_effect = [
             # page 2 has no results
             {
                 "_scroll_id": "some-scroll-id",
@@ -1300,7 +1300,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.transport.perform_request.side_effect = [
+        es.scroll.side_effect = [
             # page 2 has no results
             {
                 "_scroll_id": "some-scroll-id",

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ deps =
     pytest-benchmark==3.1.1
 passenv =
     HOME
-    JAVA7_HOME
     JAVA8_HOME
     JAVA9_HOME
     JAVA10_HOME


### PR DESCRIPTION
With this commit we remove support in Rally to benchmark Elasticsearch
1.x.

Closes #715