### PR TITLE
ES as a Daemon (again)

### DIFF
--- a/esrally/mechanic/cluster.py
+++ b/esrally/mechanic/cluster.py
@@ -15,21 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
 class Node:
     """
     Represents an Elasticsearch cluster node.
     """
 
-    def __init__(self, process, host_name, node_name, telemetry):
+    def __init__(self, pid, host_name, node_name, telemetry):
         """
         Creates a new node.
 
-        :param process: Process handle for this node.
+        :param pid: PID for this node.
         :param host_name: The name of the host where this node is running.
         :param node_name: The name of this node.
         :param telemetry: The attached telemetry.
         """
-        self.process = process
+        self.pid = pid
         self.host_name = host_name
         self.node_name = node_name
         self.ip = None
@@ -102,7 +103,7 @@ class Cluster:
         return self.node(name) is not None
 
     def add_node(self, host_name, node_name):
-        new_node = Node(process=None, host_name=host_name, node_name=node_name, telemetry=None)
+        new_node = Node(pid=None, host_name=host_name, node_name=node_name, telemetry=None)
         self.nodes.append(new_node)
         return new_node
 

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -14,13 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 import logging
 import os
 import signal
 import subprocess
-import threading
 import shlex
+
+import psutil
+from time import monotonic as _time
 
 from esrally import config, time, exceptions, client
 from esrally.mechanic import telemetry, cluster, java_resolver
@@ -48,6 +49,7 @@ class ClusterLauncher:
     The cluster launcher performs cluster-wide tasks that need to be done in the startup / shutdown phase.
 
     """
+
     def __init__(self, cfg, metrics_store, client_factory_class=client.EsClientFactory):
         """
 
@@ -110,7 +112,8 @@ class ClusterLauncher:
             # Just stop the cluster here and raise. The caller is responsible for terminating individual nodes.
             self.logger.error("REST API layer is not yet available. Forcefully terminating cluster.")
             self.stop(c)
-            raise exceptions.LaunchError("Elasticsearch REST API layer is not available. Forcefully terminated cluster.")
+            raise exceptions.LaunchError(
+                "Elasticsearch REST API layer is not available. Forcefully terminated cluster.")
         return c
 
     def stop(self, c):
@@ -122,83 +125,29 @@ class ClusterLauncher:
         c.telemetry.detach_from_cluster(c)
 
 
-class StartupWatcher:
-    def __init__(self, node_name, server, startup_event):
-        self.node_name = node_name
-        self.server = server
-        self.startup_event = startup_event
-        self.logger = logging.getLogger(__name__)
+def _get_container_id(compose_config):
+    compose_ps_cmd = _get_docker_compose_cmd(compose_config, "ps -q")
 
-    def watch(self):
-        """
-        Reads the output from the ES (node) subprocess.
-        """
-        lines_to_log = 0
-        while True:
-            line = self.server.stdout.readline().decode("utf-8")
-            if len(line) == 0:
-                self.logger.info("%s (stdout): No more output. Process has likely terminated.", self.node_name)
-                self.await_termination(self.server)
-                self.startup_event.set()
-                break
-            line = line.rstrip()
-
-            # if an error occurs, log the next few lines
-            if "error" in line.lower():
-                lines_to_log = 10
-            # don't log each output line as it is contained in the node's log files anyway and we just risk spamming our own log.
-            if not self.startup_event.isSet() or lines_to_log > 0:
-                self.logger.info("%s (stdout): %s", self.node_name, line)
-                lines_to_log -= 1
-
-            # no need to check as soon as we have detected node startup
-            if not self.startup_event.isSet():
-                if line.find("Initialization Failed") != -1 or line.find("A fatal exception has occurred") != -1:
-                    self.logger.error("[%s] encountered initialization errors.", self.node_name)
-                    # wait a moment to ensure the process has terminated before we signal that we detected a (failed) startup.
-                    self.await_termination(self.server)
-                    self.startup_event.set()
-                if line.endswith("started") and not self.startup_event.isSet():
-                    self.startup_event.set()
-                    self.logger.info("[%s] has successfully started.", self.node_name)
-
-    def await_termination(self, server, timeout=5):
-        # wait a moment to ensure the process has terminated
-        wait = timeout
-        while not server.returncode or wait == 0:
-            time.sleep(0.1)
-            server.poll()
-            wait -= 1
+    output = subprocess.check_output(args=shlex.split(compose_ps_cmd))
+    return output.decode("utf-8").rstrip()
 
 
-def _start(process, node_name):
-    log = logging.getLogger(__name__)
-    startup_event = threading.Event()
-    watcher = StartupWatcher(node_name, process, startup_event)
-    t = threading.Thread(target=watcher.watch)
-    t.setDaemon(True)
-    t.start()
-    if startup_event.wait(timeout=InProcessLauncher.PROCESS_WAIT_TIMEOUT_SECONDS):
-        process.poll()
-        # has the process terminated?
-        if process.returncode:
-            msg = "Node [%s] has terminated with exit code [%s]." % (node_name, str(process.returncode))
-            log.error(msg)
-            raise exceptions.LaunchError(msg)
-        else:
-            log.info("Started node [%s] with PID [%s].", node_name, process.pid)
-            return process
-    else:
-        msg = "Could not start node [%s] within timeout period of [%s] seconds." % (
-            node_name, InProcessLauncher.PROCESS_WAIT_TIMEOUT_SECONDS)
-        # check if the process has terminated already
-        process.poll()
-        if process.returncode:
-            msg += " The process has already terminated with exit code [%s]." % str(process.returncode)
-        else:
-            msg += " The process seems to be still running with PID [%s]." % process.pid
-        log.error(msg)
-        raise exceptions.LaunchError(msg)
+def _wait_for_healthy_running_container(container_id, timeout=60):
+    cmd = 'docker ps -a --filter "id={}" --filter "status=running" --filter "health=healthy" -q'.format(container_id)
+    endtime = _time() + timeout
+    while _time() < endtime:
+        output = subprocess.check_output(shlex.split(cmd))
+        containers = output.decode("utf-8").rstrip()
+        if len(containers) > 0:
+            return
+        time.sleep(0.5)
+    msg = "No healthy running container after {} seconds!".format(timeout)
+    logging.error(msg)
+    raise exceptions.LaunchError(msg)
+
+
+def _get_docker_compose_cmd(compose_config, cmd):
+    return "docker-compose -f {} {}".format(compose_config, cmd)
 
 
 class DockerLauncher:
@@ -209,32 +158,38 @@ class DockerLauncher:
         self.cfg = cfg
         self.metrics_store = metrics_store
         self.binary_paths = {}
-        self.node_name = None
         self.keep_running = self.cfg.opts("mechanic", "keep.running")
         self.logger = logging.getLogger(__name__)
 
     def start(self, node_configurations):
         nodes = []
         for node_configuration in node_configurations:
-
             node_name = node_configuration.node_name
             host_name = node_configuration.ip
             binary_path = node_configuration.binary_path
             self.binary_paths[node_name] = binary_path
-
-            p = self._start_process(cmd="docker-compose -f %s up" % binary_path, node_name=node_name)
-            # only support a subset of telemetry for Docker hosts (specifically, we do not allow users to enable any devices)
+            self._start_process(binary_path)
+            # only support a subset of telemetry for Docker hosts
+            # (specifically, we do not allow users to enable any devices)
             node_telemetry = [
                 telemetry.DiskIo(self.metrics_store, len(node_configurations)),
                 telemetry.NodeEnvironmentInfo(self.metrics_store)
             ]
             t = telemetry.Telemetry(devices=node_telemetry)
-            nodes.append(cluster.Node(p, host_name, node_name, t))
+            nodes.append(cluster.Node(0, host_name, node_name, t))
         return nodes
 
-    def _start_process(self, cmd, node_name):
-        return _start(subprocess.Popen(shlex.split(cmd),
-                                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL), node_name)
+    def _start_process(self, binary_path):
+        compose_cmd = _get_docker_compose_cmd(binary_path, "up -d")
+
+        ret = process.run_subprocess_with_logging(compose_cmd)
+        if ret != 0:
+            msg = "Docker daemon startup failed with exit code[{}]".format(ret)
+            logging.error(msg)
+            raise exceptions.LaunchError(msg)
+
+        container_id = _get_container_id(binary_path)
+        _wait_for_healthy_running_container(container_id)
 
     def stop(self, nodes):
         if self.keep_running:
@@ -243,7 +198,7 @@ class DockerLauncher:
             self.logger.info("Stopping Docker container")
             for node in nodes:
                 node.telemetry.detach_from_node(node, running=True)
-                process.run_subprocess_with_logging("docker-compose -f %s down" % self.binary_paths[node.node_name])
+                process.run_subprocess_with_logging(_get_docker_compose_cmd(self.binary_paths[node.node_name], "down"))
                 node.telemetry.detach_from_node(node, running=False)
 
 
@@ -267,12 +222,14 @@ class ExternalLauncher:
             telemetry.ExternalEnvironmentInfo(es, self.metrics_store),
         ])
         # We create a pseudo-cluster here to get information about all nodes.
-        # cluster nodes will be populated by the external environment info telemetry device. We cannot know this upfront.
+        # cluster nodes will be populated by the external environment info telemetry device. We cannot know this
+        # upfront.
         c = cluster.Cluster(hosts, [], t)
         user_defined_version = self.cfg.opts("mechanic", "distribution.version", mandatory=False)
         distribution_version = es.info()["version"]["number"]
         if not user_defined_version or user_defined_version.strip() == "":
-            self.logger.info("Distribution version was not specified by user. Rally-determined version is [%s]", distribution_version)
+            self.logger.info("Distribution version was not specified by user. Rally-determined version is [%s]",
+                             distribution_version)
             self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", distribution_version)
         elif user_defined_version != distribution_version:
             self.logger.warning("Distribution version '%s' on command line differs from actual cluster version '%s'.",
@@ -281,11 +238,26 @@ class ExternalLauncher:
         return c.nodes
 
     def stop(self, nodes):
-        # nothing to do here, externally provisioned clusters / nodes don't have any specific telemetry devices attached.
+        # nothing to do here, externally provisioned clusters / nodes don't have any specific telemetry devices
+        # attached.
         pass
 
 
-class InProcessLauncher:
+def wait_for_pidfile(pidfilename, timeout=60):
+    endtime = _time() + timeout
+    while _time() < endtime:
+        try:
+            with open(pidfilename, "rb") as f:
+                return int(f.read())
+        except FileNotFoundError:
+            time.sleep(0.5)
+
+    msg = "pid file not available after {} seconds!".format(timeout)
+    logging.error(msg)
+    raise exceptions.LaunchError(msg)
+
+
+class ProcessLauncher:
     """
     Launcher is responsible for starting and stopping the benchmark candidate.
     """
@@ -300,7 +272,8 @@ class InProcessLauncher:
         self.logger = logging.getLogger(__name__)
 
     def start(self, node_configurations):
-        # we're very specific which nodes we kill as there is potentially also an Elasticsearch based metrics store running on this machine
+        # we're very specific which nodes we kill as there is potentially also an Elasticsearch based metrics store
+        # running on this machine
         # The only specific trait of a Rally-related process is that is started "somewhere" in the races root directory.
         #
         # We also do this only once per host otherwise we would kill instances that we've just launched.
@@ -332,8 +305,8 @@ class InProcessLauncher:
         t = telemetry.Telemetry(enabled_devices, devices=node_telemetry)
         env = self._prepare_env(car, node_name, java_home, t)
         t.on_pre_node_start(node_name)
-        node_process = self._start_process(env, node_name, binary_path)
-        node = cluster.Node(node_process, host_name, node_name, t)
+        node_pid = self._start_process(binary_path, env)
+        node = cluster.Node(node_pid, host_name, node_name, t)
         self.logger.info("Attaching telemetry devices to node [%s].", node_name)
         t.attach_to_node(node)
 
@@ -357,12 +330,23 @@ class InProcessLauncher:
             else:  # merge
                 env[k] = v + separator + env[k]
 
-    def _start_process(self, env, node_name, binary_path):
+    @staticmethod
+    def _start_process(binary_path, env):
         if os.geteuid() == 0:
             raise exceptions.LaunchError("Cannot launch Elasticsearch as root. Please run Rally as a non-root user.")
         os.chdir(binary_path)
         cmd = ["bin/elasticsearch"]
-        return _start(subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, env=env), node_name)
+        cmd.extend(["-d", "-p", "pid"])
+        proc = subprocess.Popen(cmd,
+                                env=env,
+                                close_fds=True)
+        ret = proc.wait()
+        if ret != 0:
+            msg = "Daemon startup failed with exit code[{}]".format(ret)
+            logging.error(msg)
+            raise exceptions.LaunchError(msg)
+
+        return wait_for_pidfile("./pid")
 
     def stop(self, nodes):
         if self.keep_running:
@@ -370,35 +354,23 @@ class InProcessLauncher:
         else:
             self.logger.info("Shutting down [%d] nodes on this host.", len(nodes))
         for node in nodes:
-            process = node.process
+            proc = psutil.Process(pid=node.pid)
             node_name = node.node_name
             node.telemetry.detach_from_node(node, running=True)
             if not self.keep_running:
                 stop_watch = self._clock.stop_watch()
                 stop_watch.start()
                 try:
-                    os.kill(process.pid, signal.SIGINT)
-                    process.wait(10.0)
-                    self.logger.info("Done shutdown node [%s] in [%.1f] s.", node_name, stop_watch.split_time())
+                    os.kill(proc.pid, signal.SIGTERM)
+                    proc.wait(10.0)
                 except ProcessLookupError:
-                    self.logger.warning("No process found with PID [%s] for node [%s]", process.pid, node_name)
-                except subprocess.TimeoutExpired:
-                    # kill -9
-                    self.logger.warning("Node [%s] did not shut down after 10 seconds; now kill -QUIT node, to see threads:", node_name)
-                    try:
-                        os.kill(process.pid, signal.SIGQUIT)
-                    except OSError:
-                        self.logger.warning("No process found with PID [%s] for node [%s]", process.pid, node_name)
-                        break
-                    try:
-                        process.wait(120.0)
-                        self.logger.info("Done shutdown node [%s] in [%.1f] s.", node_name, stop_watch.split_time())
-                        break
-                    except subprocess.TimeoutExpired:
-                        pass
+                    self.logger.warning("No process found with PID [%s] for node [%s]", proc.pid, node_name)
+                except psutil.TimeoutExpired:
                     self.logger.info("kill -KILL node [%s]", node_name)
                     try:
-                        process.kill()
+                        # kill -9
+                        proc.kill()
                     except ProcessLookupError:
-                        self.logger.warning("No process found with PID [%s] for node [%s]", process.pid, node_name)
+                        self.logger.warning("No process found with PID [%s] for node [%s]", proc.pid, node_name)
                 node.telemetry.detach_from_node(node, running=False)
+                self.logger.info("Done shutdown node [%s] in [%.1f] s.", node_name, stop_watch.split_time())

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -337,10 +337,7 @@ class ProcessLauncher:
         os.chdir(binary_path)
         cmd = ["bin/elasticsearch"]
         cmd.extend(["-d", "-p", "pid"])
-        proc = subprocess.Popen(cmd,
-                                env=env,
-                                close_fds=True)
-        ret = proc.wait()
+        ret = process.run_subprocess_with_logging(command_line=" ".join(cmd), env=env)
         if ret != 0:
             msg = "Daemon startup failed with exit code[{}]".format(ret)
             logging.error(msg)

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -667,7 +667,7 @@ def create(cfg, metrics_store, all_node_ips, cluster_settings=None, sources=Fals
         p = []
         for node_id in node_ids:
             p.append(provisioner.local_provisioner(cfg, car, plugins, cluster_settings, all_node_ips, challenge_root_path, node_id))
-        l = launcher.InProcessLauncher(cfg, metrics_store, races_root)
+        l = launcher.ProcessLauncher(cfg, metrics_store, races_root)
     elif external:
         if len(plugins) > 0:
             raise exceptions.SystemSetupError("You cannot specify any plugins for externally provisioned clusters. Please remove "

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -192,8 +192,8 @@ class BareProvisioner:
             installer.invoke_install_hook(team.BootstrapPhase.post_install, provisioner_vars.copy())
 
         return NodeConfiguration(self.es_installer.car, self.es_installer.node_ip, self.es_installer.node_name,
-                                 self.es_installer.node_root_dir, self.es_installer.es_home_path, self.es_installer.node_log_dir,
-                                 self.es_installer.data_paths)
+                                 self.es_installer.node_root_dir, self.es_installer.es_home_path,
+                                 self.es_installer.node_log_dir, self.es_installer.data_paths)
 
     def cleanup(self):
         self.es_installer.cleanup(self.preserve)
@@ -525,7 +525,7 @@ class DockerProvisioner:
             raise exceptions.SystemSetupError("%s in %s" % (str(e), template_name))
 
     def _render_template_from_file(self, variables):
-        compose_file = "%s/resources/docker-compose.yml" % self.rally_root
+        compose_file = "%s/resources/docker-compose.yml.j2" % self.rally_root
         return self._render_template(loader=jinja2.FileSystemLoader(io.dirname(compose_file)),
                                      template_name=io.basename(compose_file),
                                      variables=variables)

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -790,7 +790,7 @@ class DiskIo(InternalTelemetryDevice):
 
     def attach_to_node(self, node):
         self.node = node
-        self.process = sysstats.setup_process_stats(node.process.pid)
+        self.process = sysstats.setup_process_stats(node.pid)
 
     def on_benchmark_start(self):
         if self.process is not None:

--- a/esrally/resources/docker-compose.yml.j2
+++ b/esrally/resources/docker-compose.yml.j2
@@ -24,3 +24,8 @@ services:
 {%- for host_path, docker_path in mounts.items() %}
       - {{host_path}}:{{docker_path}}
 {%- endfor %}
+    healthcheck:
+      test: nc -z 127.0.0.1 {{http_port}}
+      interval: 5s
+      timeout: 2s
+      retries: 10

--- a/esrally/utils/sysstats.py
+++ b/esrally/utils/sysstats.py
@@ -45,7 +45,11 @@ def cpu_model():
     """
     :return: The CPU model name.
     """
-    return cpuinfo.get_cpu_info()["brand"] if cpuinfo_available else "Unknown"
+    if cpuinfo_available:
+        cpu_info = cpuinfo.get_cpu_info()
+        if "brand" in cpu_info:
+            return cpu_info["brand"]
+    return "Unknown"
 
 
 def disks():

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -14,15 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import datetime
-import logging
-import os
+import io
 from unittest import TestCase, mock
 
-from esrally import config, exceptions, metrics, paths
-from esrally.mechanic import launcher, provisioner, team
+from esrally import config, exceptions, paths
+from esrally.mechanic import launcher
 from esrally.utils import opts
-from esrally.utils.io import guess_java_home
 
 
 class MockMetricsStore:
@@ -102,9 +99,17 @@ class MockPopen:
         # ProcessLauncherTests are telemetry.  If we return 1 for them we can skip
         # mocking them as their optional functionality is disabled.
         self.returncode = 1
+        self.stdout = io.StringIO()
 
     def communicate(self, input=None, timeout=None):
         return [b"", b""]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # process.run_subprocess_with_logging uses Popen context manager, so let its return be 0
+        self.returncode = 0
 
     def wait(self):
         return 0

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -14,12 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import datetime
+import logging
+import os
 from unittest import TestCase, mock
 
-from esrally import config, exceptions
+from esrally import config, exceptions, metrics, paths
+from esrally.mechanic import launcher, provisioner, team
 from esrally.utils import opts
-from esrally.mechanic import launcher
+from esrally.utils.io import guess_java_home
 
 
 class MockMetricsStore:
@@ -93,6 +96,46 @@ class SubClient:
         return self._info
 
 
+class MockPopen:
+    def __init__(self, *args, **kwargs):
+        # Currently, the only code that checks returncode directly during
+        # ProcessLauncherTests are telemetry.  If we return 1 for them we can skip
+        # mocking them as their optional functionality is disabled.
+        self.returncode = 1
+
+    def communicate(self, input=None, timeout=None):
+        return [b"", b""]
+
+    def wait(self):
+        return 0
+
+
+MOCK_PID_VALUE = 1234
+
+
+class ProcessLauncherTests(TestCase):
+    @mock.patch('os.kill')
+    @mock.patch('subprocess.Popen',new=MockPopen)
+    @mock.patch('esrally.mechanic.java_resolver.java_home', return_value=(12, "/java_home/"))
+    @mock.patch('esrally.utils.jvm.supports_option', return_value=True)
+    @mock.patch('os.chdir')
+    @mock.patch('esrally.config.Config')
+    @mock.patch('esrally.metrics.MetricsStore')
+    @mock.patch('esrally.mechanic.provisioner.NodeConfiguration')
+    @mock.patch('esrally.mechanic.launcher.wait_for_pidfile', return_value=MOCK_PID_VALUE)
+    @mock.patch('psutil.Process')
+    def test_daemon_start_stop(self, process, wait_for_pidfile, node_config, ms, cfg, chdir, supports, java_home, kill):
+        proc_launcher = launcher.ProcessLauncher(cfg, ms, paths.races_root(cfg))
+
+        nodes = proc_launcher.start([node_config])
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0].pid, MOCK_PID_VALUE)
+
+        proc_launcher.keep_running = False
+        proc_launcher.stop(nodes)
+        self.assertTrue(kill.called)
+
+
 class ExternalLauncherTests(TestCase):
     test_host = opts.TargetHosts("127.0.0.1:9200,10.17.0.5:19200")
     client_options = opts.ClientOptions("timeout:60")
@@ -102,7 +145,7 @@ class ExternalLauncherTests(TestCase):
 
         cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
         cfg.add(config.Scope.application, "client", "hosts", self.test_host)
-        cfg.add(config.Scope.application, "client", "options",self.client_options)
+        cfg.add(config.Scope.application, "client", "options", self.client_options)
 
         m = launcher.ExternalLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
         m.start()
@@ -138,7 +181,7 @@ class ClusterLauncherTests(TestCase):
         cluster_launcher = launcher.ClusterLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
         cluster = cluster_launcher.start()
 
-        self.assertEqual([{"host": "10.0.0.10", "port":9200}, {"host": "10.0.0.11", "port":9200}], cluster.hosts)
+        self.assertEqual([{"host": "10.0.0.10", "port": 9200}, {"host": "10.0.0.11", "port": 9200}], cluster.hosts)
         self.assertIsNotNone(cluster.telemetry)
 
     def test_launches_cluster_with_telemetry_client_timeout_enabled(self):

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -597,7 +597,12 @@ services:
     volumes:
       - %s:/usr/share/elasticsearch/data
       - %s:/var/log/elasticsearch
-      - %s:/usr/share/elasticsearch/heapdump""" % (data_dir, log_dir, heap_dump_dir), docker_cfg)
+      - %s:/usr/share/elasticsearch/heapdump
+    healthcheck:
+      test: nc -z 127.0.0.1 39200
+      interval: 5s
+      timeout: 2s
+      retries: 10""" % (data_dir, log_dir, heap_dump_dir), docker_cfg)
 
     @mock.patch("uuid.uuid4")
     def test_provisioning_with_variables(self, uuid4):
@@ -646,4 +651,9 @@ services:
     volumes:
       - %s:/usr/share/elasticsearch/data
       - %s:/var/log/elasticsearch
-      - %s:/usr/share/elasticsearch/heapdump""" % (data_dir, log_dir, heap_dump_dir), docker_cfg)
+      - %s:/usr/share/elasticsearch/heapdump
+    healthcheck:
+      test: nc -z 127.0.0.1 39200
+      interval: 5s
+      timeout: 2s
+      retries: 10""" % (data_dir, log_dir, heap_dump_dir), docker_cfg)

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -2052,7 +2052,7 @@ class ClusterMetaDataInfoTests(TestCase):
         t = telemetry.Telemetry(devices=[telemetry.ClusterMetaDataInfo(client)])
 
         c = cluster.Cluster(hosts=[{"host": "localhost", "port": 39200}],
-                            nodes=[cluster.Node(process=None, host_name="local", node_name="rally0", telemetry=None)],
+                            nodes=[cluster.Node(pid=None, host_name="local", node_name="rally0", telemetry=None)],
                             telemetry=t)
 
         t.attach_to_cluster(c)
@@ -2135,7 +2135,7 @@ class ClusterMetaDataInfoTests(TestCase):
         t = telemetry.Telemetry(devices=[telemetry.ClusterMetaDataInfo(client)])
 
         c = cluster.Cluster(hosts=[{"host": "localhost", "port": 39200}],
-                            nodes=[cluster.Node(process=None, host_name="local", node_name="rally0", telemetry=None)],
+                            nodes=[cluster.Node(pid=None, host_name="local", node_name="rally0", telemetry=None)],
                             telemetry=t)
 
         t.attach_to_cluster(c)
@@ -2821,7 +2821,7 @@ class IndexSizeTests(TestCase):
         metrics_store = metrics.EsMetricsStore(cfg)
         device = telemetry.IndexSize(["/var/elasticsearch/data/1", "/var/elasticsearch/data/2"], metrics_store)
         t = telemetry.Telemetry(enabled_devices=[], devices=[device])
-        node = cluster.Node(process=None, host_name="localhost", node_name="rally-node-0", telemetry=t)
+        node = cluster.Node(pid=None, host_name="localhost", node_name="rally-node-0", telemetry=t)
         t.attach_to_node(node)
         t.on_benchmark_start()
         t.on_benchmark_stop()
@@ -2843,7 +2843,7 @@ class IndexSizeTests(TestCase):
         metrics_store = metrics.EsMetricsStore(cfg)
         device = telemetry.IndexSize(data_paths=[], metrics_store=metrics_store)
         t = telemetry.Telemetry(devices=[device])
-        node = cluster.Node(process=None, host_name="localhost", node_name="rally-node-0", telemetry=t)
+        node = cluster.Node(pid=None, host_name="localhost", node_name="rally-node-0", telemetry=t)
         t.attach_to_node(node)
         t.on_benchmark_start()
         t.on_benchmark_stop()


### PR DESCRIPTION
Change Rally to launch ES with -d to daemonize the process, for both Docker and direct process launches.

Previous version of this PR had issues with starting Elasticsearch without piping process file descriptors.  We now log the startup script, so as to fix this issue as well as log any errors that may come up.