### PR TITLE
Change filestore to be indexed by unique ID

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -116,7 +116,7 @@ Example::
     # inspect results
     $ tree myrally/benchmarks/races/
     myrally/benchmarks/races/
-    └── 2019-06-05-14-03-44
+    └── 1d81930a-4ebe-4640-a09b-3055174bce43
         └── race.json
 
     1 directory, 1 file
@@ -138,7 +138,7 @@ To further examine the contents we can bind mount it from another image e.g.::
     root@9a7dd7b3d8df:/rallyvolume# ls
     root@9a7dd7b3d8df:/rallyvolume/.rally# ls
     benchmarks  logging.json  logs	rally.ini
-    # head -4 benchmarks/races/2019-06-05-13-51-20/race.json
+    # head -4 benchmarks/races/1d81930a-4ebe-4640-a09b-3055174bce43/race.json
     {
      "rally-version": "1.2.1.dev0",
      "environment": "local",

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,14 @@
 Migration Guide
 ===============
 
+Migrating to Rally 1.3.0
+------------------------
+Races now stored by ID instead of timestamp
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+With Rally 1.3.0, Races will be stored by their Trial ID instead of their timestamp.
+This means that on disk, a given race will be found at ``benchmarks/races/62d1e928-48b0-4d07-9899-07b45d031566/`` instead of ``benchmarks/races/2019-07-03-17-52-07``
+
+
 Migrating to Rally 1.2.1
 ------------------------
 

--- a/docs/tournament.rst
+++ b/docs/tournament.rst
@@ -25,16 +25,16 @@ After we've run both races, we want to know about the performance impact. With R
                     /____/
     Recent races:
 
-    Race Timestamp    Track    Track Parameters   Challenge            Car       User Tag
-    ----------------  -------  ------------------ -------------------  --------  ------------------------------
-    20160518T122341Z  pmc                         append-no-conflicts  defaults  intention:reduce_alloc_1234
-    20160518T112057Z  pmc                         append-no-conflicts  defaults  intention:baseline_github_1234
-    20160518T101957Z  pmc                         append-no-conflicts  defaults
+    Race ID                               Race Timestamp    Track    Track Parameters    Challenge            Car       User Tags
+    ------------------------------------  ----------------  -------  ------------------  ------------------   --------  ------------------------------
+    beb154e4-0a05-4f45-ad9f-e34f9a9e51f7  20160518T122341Z  pmc                          append-no-conflicts  defaults  intention:reduce_alloc_1234
+    0bfd4542-3821-4c79-81a2-0858636068ce  20160518T112057Z  pmc                          append-no-conflicts  defaults  intention:baseline_github_1234
+    0cfb3576-3025-4c17-b672-d6c9e811b93e  20160518T101957Z  pmc                          append-no-conflicts  defaults
 
 
 We can see that the user tag helps us to recognize races. We want to compare the two most recent races and have to provide the two race timestamps in the next step::
 
-    dm@io:~ $ esrally compare --baseline=20160518T112057Z --contender=20160518T112341Z
+    dm@io:~ $ esrally compare --baseline=beb154e4-0a05-4f45-ad9f-e34f9a9e51f7 --contender=0bfd4542-3821-4c79-81a2-0858636068ce
 
         ____        ____
        / __ \____ _/ / /_  __

--- a/docs/tournament.rst
+++ b/docs/tournament.rst
@@ -32,9 +32,9 @@ After we've run both races, we want to know about the performance impact. With R
     0cfb3576-3025-4c17-b672-d6c9e811b93e  20160518T101957Z  pmc                          append-no-conflicts  defaults
 
 
-We can see that the user tag helps us to recognize races. We want to compare the two most recent races and have to provide the two race timestamps in the next step::
+We can see that the user tag helps us to recognize races. We want to compare the two most recent races and have to provide the two race IDs in the next step::
 
-    dm@io:~ $ esrally compare --baseline=beb154e4-0a05-4f45-ad9f-e34f9a9e51f7 --contender=0bfd4542-3821-4c79-81a2-0858636068ce
+    dm@io:~ $ esrally compare --baseline=0bfd4542-3821-4c79-81a2-0858636068ce --contender=beb154e4-0a05-4f45-ad9f-e34f9a9e51f7
 
         ____        ____
        / __ \____ _/ / /_  __
@@ -44,11 +44,13 @@ We can see that the user tag helps us to recognize races. We want to compare the
                     /____/
 
     Comparing baseline
+      Race ID: 0bfd4542-3821-4c79-81a2-0858636068ce
       Race timestamp: 2016-05-18 11:20:57
       Challenge: append-no-conflicts
       Car: defaults
 
     with contender
+      Race ID: beb154e4-0a05-4f45-ad9f-e34f9a9e51f7
       Race timestamp: 2016-05-18 12:23:41
       Challenge: append-no-conflicts
       Car: defaults

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1365,9 +1365,13 @@ class RaceStore:
         self.cfg = cfg
         self.environment_name = cfg.opts("system", "env.name")
         self.trial_timestamp = cfg.opts("system", "time.start")
+        self.trial_id = cfg.opts("system", "trial.id")
         self.current_race = None
 
     def find_by_timestamp(self, timestamp):
+        raise NotImplementedError("abstract method")
+
+    def find_by_trial_id(self, uid):
         raise NotImplementedError("abstract method")
 
     def list(self):
@@ -1434,8 +1438,8 @@ class FileRaceStore(RaceStore):
         all_races = self._to_races(results)
         return all_races[:self._max_results()]
 
-    def find_by_timestamp(self, timestamp):
-        race_file = "%s/race.json" % paths.race_root(cfg=self.cfg, start=time.from_is8601(timestamp))
+    def find_by_trial_id(self, trial_id):
+        race_file = "%s/race.json" % paths.race_root(cfg=self.cfg, trial_id=trial_id)
         if io.exists(race_file):
             races = self._to_races([race_file])
             if races:

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1192,12 +1192,12 @@ def list_races(cfg):
 
     races = []
     for race in race_store(cfg).list():
-        races.append([time.to_iso8601(race.trial_timestamp), race.track, format_dict(race.track_params), race.challenge_name, race.car_name,
+        races.append([race.trial_id, time.to_iso8601(race.trial_timestamp), race.track, format_dict(race.track_params), race.challenge_name, race.car_name,
                       format_dict(race.user_tags)])
 
     if len(races) > 0:
         console.println("\nRecent races:\n")
-        console.println(tabulate.tabulate(races, headers=["Race Timestamp", "Track", "Track Parameters", "Challenge", "Car", "User Tags"]))
+        console.println(tabulate.tabulate(races, headers=["Race ID", "Race Timestamp", "Track", "Track Parameters", "Challenge", "Car", "User Tags"]))
     else:
         console.println("")
         console.println("No recent races found.")

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1368,9 +1368,6 @@ class RaceStore:
         self.trial_id = cfg.opts("system", "trial.id")
         self.current_race = None
 
-    def find_by_timestamp(self, timestamp):
-        raise NotImplementedError("abstract method")
-
     def find_by_trial_id(self, uid):
         raise NotImplementedError("abstract method")
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1396,8 +1396,8 @@ class CompositeRaceStore:
         self.es_results_store = es_results_store
         self.file_store = file_store
 
-    def find_by_timestamp(self, timestamp):
-        return self.es_store.find_by_timestamp(timestamp)
+    def find_by_trial_id(self, trial_id):
+        return self.es_store.find_by_trial_id(trial_id)
 
     def store_race(self, race):
         self.file_store.store_race(race)
@@ -1519,7 +1519,7 @@ class EsRaceStore(RaceStore):
         else:
             return []
 
-    def find_by_timestamp(self, timestamp):
+    def find_by_trial_id(self, trial_id):
         filters = [{
                 "term": {
                     "environment": self.environment_name
@@ -1527,7 +1527,7 @@ class EsRaceStore(RaceStore):
             },
             {
                 "term": {
-                    "trial-timestamp": timestamp
+                    "trial-id": trial_id
                 }
             }]
 

--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 import os
 
 
@@ -26,9 +25,8 @@ def races_root(cfg):
     return "%s/races" % cfg.opts("node", "root.dir")
 
 
-def race_root(cfg=None, start=None):
-    if not start:
-        start = cfg.opts("system", "time.start")
-    ts = "%04d-%02d-%02d-%02d-%02d-%02d" % (start.year, start.month, start.day, start.hour, start.minute, start.second)
-    return "%s/%s" % (races_root(cfg), ts)
+def race_root(cfg=None, trial_id=None):
+    if not trial_id:
+        trial_id = cfg.opts("system", "trial.id")
+    return "%s/%s" % (races_root(cfg), trial_id)
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -117,11 +117,11 @@ def create_arg_parser():
     compare_parser.add_argument(
         "--baseline",
         required=True,
-        help="Race timestamp of the baseline (see %s list races)." % PROGRAM_NAME)
+        help="Race ID of the baseline (see %s list races)." % PROGRAM_NAME)
     compare_parser.add_argument(
         "--contender",
         required=True,
-        help="Race timestamp of the contender (see %s list races)." % PROGRAM_NAME)
+        help="Race ID of the contender (see %s list races)." % PROGRAM_NAME)
     compare_parser.add_argument(
         "--report-format",
         help="Define the output format for the command line report (default: markdown).",
@@ -634,8 +634,8 @@ def main():
     cfg.add(config.Scope.applicationOverride, "reporting", "values", args.show_in_report)
     cfg.add(config.Scope.applicationOverride, "reporting", "output.path", args.report_file)
     if sub_command == "compare":
-        cfg.add(config.Scope.applicationOverride, "reporting", "baseline.timestamp", args.baseline)
-        cfg.add(config.Scope.applicationOverride, "reporting", "contender.timestamp", args.contender)
+        cfg.add(config.Scope.applicationOverride, "reporting", "baseline.id", args.baseline)
+        cfg.add(config.Scope.applicationOverride, "reporting", "contender.id", args.contender)
     if sub_command == "generate":
         cfg.add(config.Scope.applicationOverride, "generator", "chart.type", args.chart_type)
         cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -60,15 +60,15 @@ def summarize(race, cfg, lap=None):
 
 
 def compare(cfg):
-    baseline_ts = cfg.opts("reporting", "baseline.timestamp")
-    contender_ts = cfg.opts("reporting", "contender.timestamp")
+    baseline_id = cfg.opts("reporting", "baseline.id")
+    contender_id = cfg.opts("reporting", "contender.id")
 
-    if not baseline_ts or not contender_ts:
+    if not baseline_id or not contender_id:
         raise exceptions.SystemSetupError("compare needs baseline and a contender")
     race_store = metrics.race_store(cfg)
     ComparisonReporter(cfg).report(
-        race_store.find_by_timestamp(baseline_ts),
-        race_store.find_by_timestamp(contender_ts))
+        race_store.find_by_trial_id(baseline_id),
+        race_store.find_by_trial_id(contender_id))
 
 
 def print_internal(message):

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -667,6 +667,7 @@ class ComparisonReporter:
 
         print_internal("")
         print_internal("Comparing baseline")
+        print_internal("  Race ID: %s" % r1.trial_id)
         print_internal("  Race timestamp: %s" % r1.trial_timestamp)
         if r1.challenge_name:
             print_internal("  Challenge: %s" % r1.challenge_name)
@@ -676,6 +677,7 @@ class ComparisonReporter:
             print_internal("  User tags: %s" % r1_user_tags)
         print_internal("")
         print_internal("with contender")
+        print_internal("  Race ID: %s" % r2.trial_id)
         print_internal("  Race timestamp: %s" % r2.trial_timestamp)
         if r2.challenge_name:
             print_internal("  Challenge: %s" % r2.challenge_name)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -142,8 +142,8 @@ class EsClientTests(TestCase):
     def test_config_opts_parsing(self, client_esclientfactory):
         cfg = config.Config()
 
-        _datastore_host = ".".join([str(random.randint(1,254)) for _ in range(4)])
-        _datastore_port = random.randint(1024,65535)
+        _datastore_host = ".".join([str(random.randint(1, 254)) for _ in range(4)])
+        _datastore_port = random.randint(1024, 65535)
         _datastore_secure = random.choice(["True", "true"])
         _datastore_user = "".join([random.choice(string.ascii_letters) for _ in range(8)])
         _datastore_password = "".join([random.choice(string.ascii_letters + string.digits + "_-@#$/") for _ in range(12)])
@@ -250,7 +250,7 @@ class EsClientTests(TestCase):
 
         # The sec to sleep for 10 transport errors is
         # [1, 2, 4, 8, 16, 32, 64, 128, 256, 512] ~> 17.05min in total
-        sleep_slots = [float(2**i) for i in range(0, max_retry)]
+        sleep_slots = [float(2 ** i) for i in range(0, max_retry)]
         mocked_sleep_calls = [mock.call(sleep_slots[i]) for i in range(0, max_retry)]
 
         for rnd_err_idx, rnd_err_code in enumerate(rnd_err_codes):
@@ -258,7 +258,7 @@ class EsClientTests(TestCase):
             rnd_mocked_logger_calls.append(
                 mock.call("%s (code: %d) in attempt [%d/%d]. Sleeping for [%f] seconds.",
                           all_err_codes[rnd_err_code], rnd_err_code,
-                          rnd_err_idx+1, max_retry+1, sleep_slots[rnd_err_idx])
+                          rnd_err_idx + 1, max_retry + 1, sleep_slots[rnd_err_idx])
             )
 
         test_transport_error_retries(rnd_side_effects,
@@ -809,6 +809,7 @@ class EsRaceStoreTests(TestCase):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
         self.cfg.add(config.Scope.application, "system", "time.start", EsRaceStoreTests.TRIAL_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "trial.id", FileRaceStoreTests.TRIAL_ID)
         self.race_store = metrics.EsRaceStore(self.cfg,
                                               client_factory_class=MockClientFactory,
                                               index_template_provider_class=DummyIndexTemplateProvider,
@@ -1286,10 +1287,10 @@ class FileRaceStoreTests(TestCase):
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
         self.cfg.add(config.Scope.application, "system", "list.races.max_results", 100)
         self.cfg.add(config.Scope.application, "system", "time.start", FileRaceStoreTests.TRIAL_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "trial.id", FileRaceStoreTests.TRIAL_ID)
         self.race_store = metrics.FileRaceStore(self.cfg)
 
     def test_store_race(self):
-        from esrally import time
         schedule = [
             track.Task("index #1", track.Operation("index", track.OperationType.Bulk))
         ]
@@ -1332,6 +1333,6 @@ class FileRaceStoreTests(TestCase):
 
         self.race_store.store_race(race)
 
-        retrieved_race = self.race_store.find_by_timestamp(timestamp=time.to_iso8601(FileRaceStoreTests.TRIAL_TIMESTAMP))
+        retrieved_race = self.race_store.find_by_trial_id(trial_id=FileRaceStoreTests.TRIAL_ID)
         self.assertEqual(race.trial_timestamp, retrieved_race.trial_timestamp)
         self.assertEqual(1, len(self.race_store.list()))


### PR DESCRIPTION
Races in the filestore will now be stored by their Trial ID, not their timestamp.

Relates #697 