### PR TITLE
Update DiskIo telemetry device to persist the counters

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,7 +4,7 @@ Elasticsearch Version Support
 Minimum supported version
 =========================
 
-Rally |release| can benchmark Elasticsearch 1.7.0 and above.
+Rally |release| can benchmark Elasticsearch 2.0.0 and above.
 
 End-of-life Policy
 ==================

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -295,7 +295,7 @@ class ProcessLauncher:
         enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
         telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
         node_telemetry = [
-            telemetry.DiskIo(self.metrics_store, node_count_on_host, node_telemetry_dir, car, node_name),
+            telemetry.DiskIo(self.metrics_store, node_count_on_host, node_telemetry_dir, node_name),
             telemetry.NodeEnvironmentInfo(self.metrics_store),
             telemetry.IndexSize(data_paths, self.metrics_store),
             telemetry.MergeParts(self.metrics_store, node_configuration.log_path),

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -295,7 +295,7 @@ class ProcessLauncher:
         enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
         telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
         node_telemetry = [
-            telemetry.DiskIo(self.metrics_store, node_count_on_host),
+            telemetry.DiskIo(self.metrics_store, node_count_on_host, node_telemetry_dir, car, node_name),
             telemetry.NodeEnvironmentInfo(self.metrics_store),
             telemetry.IndexSize(data_paths, self.metrics_store),
             telemetry.MergeParts(self.metrics_store, node_configuration.log_path),

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -199,17 +199,10 @@ class BareProvisioner:
         self.es_installer.cleanup(self.preserve)
         
     def _prepare_java_opts(self):
-        java_opts = []
+        # To detect out of memory errors during the benchmark
+        java_opts = ["-XX:+ExitOnOutOfMemoryError"]
         if self.telemetry is not None:
             java_opts.extend(self.telemetry.instrument_candidate_java_opts(self.es_installer.car, self.es_installer.node_name))
-        
-        exit_on_oome_flag = "-XX:+ExitOnOutOfMemoryError"
-        if jvm.supports_option(self.es_installer.java_home, exit_on_oome_flag):
-            self.logger.info("Setting [%s] to detect out of memory errors during the benchmark.", exit_on_oome_flag)
-            java_opts.append(exit_on_oome_flag)
-        else:
-            self.logger.info("JVM does not support [%s]. A JDK upgrade is recommended.", exit_on_oome_flag)
-        
         return java_opts
 
     def _provisioner_variables(self):

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -845,7 +845,7 @@ class DiskIo(InternalTelemetryDevice):
                                          "of total I/O to [%s].", self.node_count_on_host, self.node_count_on_host, self.node.node_name)
 
                     read_bytes = (disk_end.read_bytes - int(io_bytes[0])) // self.node_count_on_host
-                    write_bytes = (disk_end.write_bytes - int(io_bytes[0])) // self.node_count_on_host
+                    write_bytes = (disk_end.write_bytes - int(io_bytes[1])) // self.node_count_on_host
                 else:
                     raise RuntimeError("Neither process nor disk I/O counters are available")
 

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -1012,7 +1012,7 @@ class ClusterMetaDataInfo(InternalTelemetryDevice):
             else:
                 host = node_stats.get("host", "unknown")
                 cluster_node = cluster.add_node(host, node_name)
-            self.add_node_stats(cluster, cluster_node, node_stats)
+            self.add_node_stats(cluster_node, node_stats)
 
         for node_info in self.client.nodes.info(node_id="_all")["nodes"].values():
             self.add_node_info(cluster, node_info)
@@ -1038,12 +1038,7 @@ class ClusterMetaDataInfo(InternalTelemetryDevice):
                 if "name" in plugin:
                     cluster_node.plugins.append(plugin["name"])
 
-            if versions.major_version(cluster.distribution_version) == 1:
-                cluster_node.memory = {
-                    "total_bytes": extract_value(node_info, ["os", "mem", "total_in_bytes"], fallback=None)
-                }
-
-    def add_node_stats(self, cluster, cluster_node, stats):
+    def add_node_stats(self, cluster_node, stats):
         if cluster_node:
             data_dirs = extract_value(stats, ["fs", "data"], fallback=[])
             for data_dir in data_dirs:
@@ -1053,10 +1048,9 @@ class ClusterMetaDataInfo(InternalTelemetryDevice):
                     "spins": data_dir.get("spins", "unknown")
                 }
                 cluster_node.fs.append(fs_meta_data)
-            if versions.major_version(cluster.distribution_version) > 1:
-                cluster_node.memory = {
-                    "total_bytes": extract_value(stats, ["os", "mem", "total_in_bytes"], fallback=None)
-                }
+            cluster_node.memory = {
+                "total_bytes": extract_value(stats, ["os", "mem", "total_in_bytes"], fallback=None)
+            }
 
 
 class JvmStatsSummary(InternalTelemetryDevice):

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -780,7 +780,7 @@ class DiskIo(InternalTelemetryDevice):
     """
     Gathers disk I/O stats.
     """
-    def __init__(self, metrics_store, node_count_on_host, log_root, car, node_name):
+    def __init__(self, metrics_store, node_count_on_host, log_root, node_name):
         super().__init__()
         self.metrics_store = metrics_store
         self.node_count_on_host = node_count_on_host
@@ -788,7 +788,6 @@ class DiskIo(InternalTelemetryDevice):
         self.process = None
         self.disk_start = None
         self.process_start = None
-        self.car = car
         self.node_name = node_name
         self.log_root = log_root
 

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -23,6 +23,7 @@ import signal
 import subprocess
 import tabulate
 import threading
+import json
 
 from esrally import metrics, time, exceptions
 from esrally.utils import io, sysstats, console, versions, opts
@@ -817,9 +818,9 @@ class DiskIo(InternalTelemetryDevice):
                                         "I/O counters.")
                 except RuntimeError:
                     self.logger.exception("Could not determine I/O stats at benchmark start.")
+            diskio_str = {"read_bytes": read_bytes, "write_bytes": write_bytes}
             with open(log_file, "wt", encoding="utf-8") as f:
-                diskio_str = "%d %d" % (read_bytes, write_bytes)
-                f.write(diskio_str)
+                json.dump(diskio_str, f)
 
     def on_benchmark_stop(self):
         if self.process is not None:
@@ -829,23 +830,22 @@ class DiskIo(InternalTelemetryDevice):
             log_file = "%s/%s-%s.io" % (self.log_root, self.car.safe_name, self.node.node_name)
             io_str = ""
             with open(log_file, "rt", encoding="utf-8") as f:
-                io_str = f.read()
-            io_bytes = io_str.split()
+                io_bytes = json.load(f)
             # Be aware the semantics of write counts etc. are different for disk and process statistics.
             # Thus we're conservative and only report I/O bytes now.
             # noinspection PyBroadException
             try:
                 # we have process-based disk counters, no need to worry how many nodes are on this host
                 if process_end:
-                    read_bytes = process_end.read_bytes - int(io_bytes[0])
-                    write_bytes = process_end.write_bytes - int(io_bytes[1])
+                    read_bytes = process_end.read_bytes - io_bytes['read_bytes']
+                    write_bytes = process_end.write_bytes - io_bytes['write_bytes']
                 elif disk_end:
                     if self.node_count_on_host > 1:
                         self.logger.info("There are [%d] nodes on this host and Rally fell back to disk I/O counters. Attributing [1/%d] "
                                          "of total I/O to [%s].", self.node_count_on_host, self.node_count_on_host, self.node.node_name)
 
-                    read_bytes = (disk_end.read_bytes - int(io_bytes[0])) // self.node_count_on_host
-                    write_bytes = (disk_end.write_bytes - int(io_bytes[1])) // self.node_count_on_host
+                    read_bytes = (disk_end.read_bytes - io_bytes['read_bytes']) // self.node_count_on_host
+                    write_bytes = (disk_end.write_bytes - io_bytes['write_bytes']) // self.node_count_on_host
                 else:
                     raise RuntimeError("Neither process nor disk I/O counters are available")
 

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -396,14 +396,6 @@ def run(cfg):
         logger.info("User specified no pipeline. Automatically derived pipeline [%s].", name)
         cfg.add(config.Scope.applicationOverride, "race", "pipeline", name)
     else:
-        if (cfg.exists("mechanic", "distribution.version") and
-                name in ["from-sources-complete", "from-sources-skip-build", "benchmark-only"]):
-            raise exceptions.SystemSetupError(
-                "--distribution-version can only be used together with pipeline from-distribution, """
-                "but you specified {}.\n"
-                "If you intend to benchmark an externally provisioned cluster, don't specify --distribution-version otherwise\n"
-                "please read the docs for from-distribution pipeline at "
-                "{}/pipelines.html#from-distribution".format(name, DOC_LINK))
         logger.info("User specified pipeline [%s].", name)
 
     if os.environ.get("RALLY_RUNNING_IN_DOCKER", "").upper() == "TRUE":

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -310,7 +310,7 @@ function test_distribution_fails_with_wrong_track_params {
         exit ${ret_code}
     elif exit_if_docker_not_running && [[ ${ret_code} -ne 0 ]]; then
         # need to use grep -P which is unavailable with macOS grep
-        if ! docker run --rm -v ${RALLY_LOG}:/rally.log:ro ubuntu:xenial grep -Pzoq '.*CRITICAL Some of your track parameter\(s\) "number_of-replicas" are not used by this track; perhaps you intend to use "number_of_replicas" instead\.\n\nAll track parameters you provided are:\n- conflict_probability\n- number_of-replicas\n\nAll parameters exposed by this track:\n- bulk_indexing_clients\n- bulk_size\n- cluster_health\n- conflict_probability\n- index_settings\n- ingest_percentage\n- number_of_replicas\n- number_of_shards\n- on_conflict\n- recency\n- source_enabled\n*' /rally.log; then
+        if ! docker run --rm -v ${RALLY_LOG}:/rally.log:ro ubuntu:xenial grep -Pzoq '.*CRITICAL Some of your track parameter\(s\) "number_of-replicas" are not used by this track; perhaps you intend to use "number_of_replicas" instead\.\n\nAll track parameters you provided are:\n- conflict_probability\n- number_of-replicas\n\nAll parameters exposed by this track:\n*' /rally.log; then
             error ${err_msg}
             exit ${ret_code}
         fi

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -21,7 +21,7 @@ set -e
 
 readonly CONFIGURATIONS=(integration-test es-integration-test)
 
-readonly DISTRIBUTIONS=(1.7.6 2.4.6 5.6.9)
+readonly DISTRIBUTIONS=(2.4.6 5.6.16 6.8.0 7.1.1)
 readonly TRACKS=(geonames nyc_taxis http_logs nested)
 
 readonly ES_METRICS_STORE_JAVA_HOME="${JAVA8_HOME}"

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1116,7 +1116,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.transport.perform_request.side_effect = [
+        es.scroll.side_effect = [
             # page 2
             {
                 "_scroll_id": "some-scroll-id",
@@ -1178,7 +1178,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.transport.perform_request.side_effect = [
+        es.scroll.side_effect = [
             # page 2 has no results
             {
                 "_scroll_id": "some-scroll-id",
@@ -1236,7 +1236,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.transport.perform_request.side_effect = [
+        es.scroll.side_effect = [
             # page 2 has no results
             {
                 "_scroll_id": "some-scroll-id",
@@ -1300,7 +1300,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.transport.perform_request.side_effect = [
+        es.scroll.side_effect = [
             # page 2 has no results
             {
                 "_scroll_id": "some-scroll-id",

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -70,6 +70,7 @@ class BareProvisionerTests(TestCase):
             "cluster_settings": {
                 "indices.query.bool.max_clause_count": 50000,
             },
+            "additional_java_settings": ["-XX:+ExitOnOutOfMemoryError"],
             "heap": "4g",
             "cluster_name": "rally-benchmark",
             "node_name": "rally-node-0",
@@ -184,6 +185,7 @@ class BareProvisionerTests(TestCase):
                 "indices.query.bool.max_clause_count": 50000,
                 "plugin.mandatory": ["x-pack-security"]
             },
+            "additional_java_settings": ["-XX:+ExitOnOutOfMemoryError"],
             "heap": "4g",
             "cluster_name": "rally-benchmark",
             "node_name": "rally-node-0",
@@ -261,6 +263,7 @@ class BareProvisionerTests(TestCase):
                 "indices.query.bool.max_clause_count": 50000,
                 "plugin.mandatory": ["x-pack"]
             },
+            "additional_java_settings": ["-XX:+ExitOnOutOfMemoryError"],
             "heap": "4g",
             "cluster_name": "rally-benchmark",
             "node_name": "rally-node-0",

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -2093,7 +2093,6 @@ class DiskIoTests(TestCase):
         process_start = Diskio(10,10)
         process_stop = Diskio(11,11)
         process_io_counters.side_effect = [process_start, process_stop]
-
         tmp_dir = tempfile.mkdtemp()
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -1974,7 +1974,7 @@ class ClusterMetaDataInfoTests(TestCase):
     def setUp(self):
         self.cfg = create_config()
 
-    def test_enriches_cluster_nodes_for_elasticsearch_after_1_x(self):
+    def test_enriches_cluster_nodes(self):
         nodes_stats = {
             "nodes": {
                 "FCFjozkeTiOpN-SI88YEcg": {
@@ -2082,88 +2082,6 @@ class ClusterMetaDataInfoTests(TestCase):
         self.assertEqual("ntfs", n.fs[1]["type"])
         self.assertEqual("unknown", n.fs[1]["spins"])
         self.assertEqual(["analysis-icu", "ingest-geoip", "ingest-user-agent"], n.plugins)
-
-    def test_enriches_cluster_nodes_for_elasticsearch_1_x(self):
-        nodes_stats = {
-            "nodes": {
-                "FCFjozkeTiOpN-SI88YEcg": {
-                    "name": "rally0",
-                    "host": "127.0.0.1",
-                    "fs": {
-                        "data": [
-                            {
-                                "mount": "/usr/local/var/elasticsearch/data1",
-                                "type": "hfs"
-                            },
-                            {
-                                "mount": "/usr/local/var/elasticsearch/data2",
-                                "type": "ntfs"
-                            }
-                        ]
-                    }
-                }
-            }
-        }
-
-        nodes_info = {
-            "nodes": {
-                "FCFjozkeTiOpN-SI88YEcg": {
-                    "name": "rally0",
-                    "host": "127.0.0.1",
-                    "ip": "127.0.0.1",
-                    "os": {
-                        "name": "Mac OS X",
-                        "version": "10.11.4",
-                        "available_processors": 8,
-                        "mem": {
-                            "total_in_bytes": 17179869184
-                        }
-                    },
-                    "jvm": {
-                        "version": "1.8.0_74",
-                        "vm_vendor": "Oracle Corporation"
-                    }
-                }
-            }
-        }
-        cluster_info = {
-            "version":
-                {
-                    "build_hash": "c730b59357f8ebc555286794dcd90b3411f517c9",
-                    "number": "1.7.5"
-                }
-        }
-        client = Client(nodes=SubClient(stats=nodes_stats, info=nodes_info), info=cluster_info)
-
-        t = telemetry.Telemetry(devices=[telemetry.ClusterMetaDataInfo(client)])
-
-        c = cluster.Cluster(hosts=[{"host": "localhost", "port": 39200}],
-                            nodes=[cluster.Node(pid=None, host_name="local", node_name="rally0", telemetry=None)],
-                            telemetry=t)
-
-        t.attach_to_cluster(c)
-
-        self.assertEqual("1.7.5", c.distribution_version)
-        self.assertEqual("oss", c.distribution_flavor)
-        self.assertEqual("c730b59357f8ebc555286794dcd90b3411f517c9", c.source_revision)
-        self.assertEqual(1, len(c.nodes))
-        n = c.nodes[0]
-        self.assertEqual("127.0.0.1", n.ip)
-        self.assertEqual("Mac OS X", n.os["name"])
-        self.assertEqual("10.11.4", n.os["version"])
-        self.assertEqual("Oracle Corporation", n.jvm["vendor"])
-        self.assertEqual("1.8.0_74", n.jvm["version"])
-        self.assertEqual(8, n.cpu["available_processors"])
-        self.assertIsNone(n.cpu["allocated_processors"])
-        self.assertEqual(17179869184, n.memory["total_bytes"])
-
-        self.assertEqual(2, len(n.fs))
-        self.assertEqual("/usr/local/var/elasticsearch/data1", n.fs[0]["mount"])
-        self.assertEqual("hfs", n.fs[0]["type"])
-        self.assertEqual("unknown", n.fs[0]["spins"])
-        self.assertEqual("/usr/local/var/elasticsearch/data2", n.fs[1]["mount"])
-        self.assertEqual("ntfs", n.fs[1]["type"])
-        self.assertEqual("unknown", n.fs[1]["spins"])
 
 
 class DiskIoTests(TestCase):

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -92,30 +92,3 @@ class RaceControlTests(TestCase):
 
         # ensure we remove it again from the list of registered pipelines to avoid unwanted side effects
         del racecontrol.pipelines[test_pipeline_name]
-
-    def test_conflicting_pipeline_and_distribution_version(self):
-        mock_pipeline = mock.Mock()
-        test_pipeline_name = "unit-test-pipeline"
-        rnd_pipeline_name = False
-
-        while not rnd_pipeline_name or rnd_pipeline_name == "from-distribution":
-            rnd_pipeline_name = random.choice(racecontrol.available_pipelines())[0]
-
-        racecontrol.Pipeline(test_pipeline_name, "Pipeline intended for unit-testing", mock_pipeline)
-
-        cfg = config.Config()
-        cfg.add(config.Scope.benchmark, "race", "pipeline", rnd_pipeline_name)
-        cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "6.5.3")
-
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            racecontrol.run(cfg)
-        self.assertRegex(
-            ctx.exception.args[0],
-            r"--distribution-version can only be used together with pipeline from-distribution, "
-            "but you specified {}.\n"
-            "If you intend to benchmark an externally provisioned cluster, don't specify --distribution-version otherwise\n"
-            "please read the docs for from-distribution pipeline at "
-            "{}/pipelines.html#from-distribution".format(rnd_pipeline_name, DOC_LINK))
-
-        # ensure we remove it again from the list of registered pipelines to avoid unwanted side effects
-        del racecontrol.pipelines[test_pipeline_name]

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ deps =
     pytest-benchmark==3.1.1
 passenv =
     HOME
-    JAVA7_HOME
     JAVA8_HOME
     JAVA9_HOME
     JAVA10_HOME


### PR DESCRIPTION
Ensure that DiskIo telemetry does not rely on Rally being a parent
process of Elasticsearch and persists the disk counters at the beginning
of a benchmark and can read it again afterwards.

Relates to https://github.com/elastic/rally/issues/697