### PR TITLE
Always exit on OOME

### DIFF
--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -199,17 +199,10 @@ class BareProvisioner:
         self.es_installer.cleanup(self.preserve)
         
     def _prepare_java_opts(self):
-        java_opts = []
+        # To detect out of memory errors during the benchmark
+        java_opts = ["-XX:+ExitOnOutOfMemoryError"]
         if self.telemetry is not None:
             java_opts.extend(self.telemetry.instrument_candidate_java_opts(self.es_installer.car, self.es_installer.node_name))
-        
-        exit_on_oome_flag = "-XX:+ExitOnOutOfMemoryError"
-        if jvm.supports_option(self.es_installer.java_home, exit_on_oome_flag):
-            self.logger.info("Setting [%s] to detect out of memory errors during the benchmark.", exit_on_oome_flag)
-            java_opts.append(exit_on_oome_flag)
-        else:
-            self.logger.info("JVM does not support [%s]. A JDK upgrade is recommended.", exit_on_oome_flag)
-        
         return java_opts
 
     def _provisioner_variables(self):

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -70,6 +70,7 @@ class BareProvisionerTests(TestCase):
             "cluster_settings": {
                 "indices.query.bool.max_clause_count": 50000,
             },
+            "additional_java_settings": ["-XX:+ExitOnOutOfMemoryError"],
             "heap": "4g",
             "cluster_name": "rally-benchmark",
             "node_name": "rally-node-0",
@@ -184,6 +185,7 @@ class BareProvisionerTests(TestCase):
                 "indices.query.bool.max_clause_count": 50000,
                 "plugin.mandatory": ["x-pack-security"]
             },
+            "additional_java_settings": ["-XX:+ExitOnOutOfMemoryError"],
             "heap": "4g",
             "cluster_name": "rally-benchmark",
             "node_name": "rally-node-0",
@@ -261,6 +263,7 @@ class BareProvisionerTests(TestCase):
                 "indices.query.bool.max_clause_count": 50000,
                 "plugin.mandatory": ["x-pack"]
             },
+            "additional_java_settings": ["-XX:+ExitOnOutOfMemoryError"],
             "heap": "4g",
             "cluster_name": "rally-benchmark",
             "node_name": "rally-node-0",


### PR DESCRIPTION
With this commit we add the JVM flag `ExitOnOutOfMemoryError`
unconditionally when Elasticsearch is configured by Rally. Previously we
had to check whether the JVM in use supports this flag because we
supported Elasticsearch 1.x which can be run with Java 1.7. As the JVM flag
has only been introduced with Java 8, we had a check in place. Now that
we have dropped support for Elasticsearch 1.x (in #716), we can safely
assume that the JVM supports this flag and unconditionally set it.

Relates #715