### PR TITLE
Capture team and track revisions in metrics metadata

### DIFF
--- a/esrally/mechanic/cluster.py
+++ b/esrally/mechanic/cluster.py
@@ -81,6 +81,7 @@ class Cluster:
         self.distribution_version = None
         self.distribution_flavor = None
         self.source_revision = None
+        self.team_revision = None
         self.preserve = preserve
 
     def node(self, name):

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 import thespian.actors
 
 from esrally import actor, client, paths, config, metrics, exceptions
-from esrally.utils import net, console, git
+from esrally.utils import net, console
 from esrally.mechanic import supplier, provisioner, launcher, team
 
 
@@ -303,10 +303,8 @@ class MechanicActor(actor.RallyActor):
         self.metrics_store = cls(self.cfg)
         self.metrics_store.open(ctx=msg.open_metrics_context)
         name = self.cfg.opts("race", "pipeline")
-        team_path = self.cfg.opts("mechanic", "team.path", mandatory=False)
-        if not (name == "benchmark-only" or team_path):
-            self.team_revision = git.head_revision(team.team_path(self.cfg))
         self.car, _ = load_team(self.cfg, msg.external)
+        self.team_revision = self.cfg.opts("mechanic", "repository.revision")
 
         # In our startup procedure we first create all mechanics. Only if this succeeds we'll continue.
         hosts = self.cfg.opts("client", "hosts").default

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -425,6 +425,7 @@ class MechanicActor(actor.RallyActor):
     def on_cluster_started(self):
         # We don't need to store the original node meta info when the node started up (NodeStarted message) because we actually gather it
         # in ``on_all_nodes_started`` via the ``ClusterLauncher``.
+        self.cluster.team_revision = self.team_revision
         self.send(self.race_control,
                   EngineStarted(ClusterMetaInfo([NodeMetaInfo(n) for n in self.cluster.nodes],
                                                 self.cluster.source_revision,

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -53,14 +53,17 @@ class ClusterMetaInfo:
         self.team_revision = team_revision
 
     def as_dict(self):
-        return {
+        d = {
             "nodes": [n.as_dict() for n in self.nodes],
             "node-count": len(self.nodes),
             "revision": self.revision,
             "distribution-version": self.distribution_version,
             "distribution-flavor": self.distribution_flavor,
-            "team-revision": self.team_revision
+            
         }
+        if self.team_revision:
+            d["team-revision"] = self.team_revision
+        return d
 
 
 class NodeMetaInfo:
@@ -268,6 +271,7 @@ class MechanicActor(actor.RallyActor):
         self.cluster_launcher = None
         self.cluster = None
         self.car = None
+        self.team_revision = None
 
     def receiveUnrecognizedMessage(self, msg, sender):
         self.logger.info("MechanicActor#receiveMessage unrecognized(msg = [%s] sender = [%s])", str(type(msg)), str(sender))

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -22,8 +22,8 @@ from enum import Enum
 
 import tabulate
 
-from esrally import exceptions, PROGRAM_NAME
-from esrally.utils import console, repo, io, modules
+from esrally import exceptions, PROGRAM_NAME, config
+from esrally.utils import console, repo, io, modules, git
 
 TEAM_FORMAT_VERSION = 1
 
@@ -144,6 +144,8 @@ def team_path(cfg):
             current_team_repo.checkout(repo_revision)
         else:
             current_team_repo.update(distribution_version)
+            team_revision = git.head_revision(current_team_repo.repo_dir)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "repository.revision", team_revision)
         return current_team_repo.repo_dir
 
 

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -23,7 +23,7 @@ from enum import Enum
 import tabulate
 
 from esrally import exceptions, PROGRAM_NAME, config
-from esrally.utils import console, repo, io, modules, git
+from esrally.utils import console, repo, io, modules
 
 TEAM_FORMAT_VERSION = 1
 
@@ -144,8 +144,7 @@ def team_path(cfg):
             current_team_repo.checkout(repo_revision)
         else:
             current_team_repo.update(distribution_version)
-            team_revision = git.head_revision(current_team_repo.repo_dir)
-            cfg.add(config.Scope.applicationOverride, "mechanic", "repository.revision", team_revision)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "repository.revision", current_team_repo.revision)
         return current_team_repo.repo_dir
 
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1328,6 +1328,8 @@ class Race:
         if plugins:
             result_template["plugins"] = list(plugins)
 
+        if self.cluster.team_revision:
+            result_template["team-revision"] = self.cluster.team_revision
         if self.track_revision:
             result_template["track-revision"] = self.track_revision
         if not self.challenge.auto_generated:

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1203,7 +1203,7 @@ def list_races(cfg):
         console.println("No recent races found.")
 
 
-def create_race(cfg, track, challenge, track_revision):
+def create_race(cfg, track, challenge, track_revision=None):
     car = cfg.opts("mechanic", "car.names")
     environment = cfg.opts("system", "env.name")
     trial_id = cfg.opts("system", "trial.id")
@@ -1222,7 +1222,7 @@ def create_race(cfg, track, challenge, track_revision):
 
 class Race:
     def __init__(self, rally_version, environment_name, trial_id, trial_timestamp, pipeline, user_tags, track, track_params, challenge, car,
-                 car_params, plugin_params, total_laps, track_revision, cluster=None, lap_results=None, results=None):
+                 car_params, plugin_params, total_laps, track_revision=None, cluster=None, lap_results=None, results=None):
         if results is None:
             results = {}
         if lap_results is None:
@@ -1285,12 +1285,13 @@ class Race:
             "pipeline": self.pipeline,
             "user-tags": self.user_tags,
             "track": self.track_name,
-            "track-revision": self.track_revision,
             "car": self.car,
             "total-laps": self.total_laps,
             "cluster": self.cluster.as_dict(),
             "results": self.results.as_dict()
         }
+        if self.track_revision:
+            d["track-revision"] = self.track_revision
         if not self.challenge.auto_generated:
             d["challenge"] = self.challenge_name
         if self.track_params:
@@ -1315,7 +1316,6 @@ class Race:
             "distribution-major-version": versions.major_version(self.cluster.distribution_version),
             "user-tags": self.user_tags,
             "track": self.track_name,
-            "track-revision": self.track_revision,
             "car": self.car_name,
             "node-count": len(self.cluster.nodes),
             # allow to logically delete records, e.g. for UI purposes when we only want to show the latest result on graphs
@@ -1328,6 +1328,8 @@ class Race:
         if plugins:
             result_template["plugins"] = list(plugins)
 
+        if self.track_revision:
+            result_template["track-revision"] = self.track_revision
         if not self.challenge.auto_generated:
             result_template["challenge"] = self.challenge_name
         if self.track_params:

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1203,7 +1203,7 @@ def list_races(cfg):
         console.println("No recent races found.")
 
 
-def create_race(cfg, track, challenge):
+def create_race(cfg, track, challenge, track_revision):
     car = cfg.opts("mechanic", "car.names")
     environment = cfg.opts("system", "env.name")
     trial_id = cfg.opts("system", "trial.id")
@@ -1217,12 +1217,12 @@ def create_race(cfg, track, challenge):
     rally_version = version.version()
 
     return Race(rally_version, environment, trial_id, trial_timestamp, pipeline, user_tags, track, track_params, challenge, car,
-                car_params, plugin_params, total_laps)
+                car_params, plugin_params, total_laps, track_revision)
 
 
 class Race:
     def __init__(self, rally_version, environment_name, trial_id, trial_timestamp, pipeline, user_tags, track, track_params, challenge, car,
-                 car_params, plugin_params, total_laps, cluster=None, lap_results=None, results=None):
+                 car_params, plugin_params, total_laps, track_revision, cluster=None, lap_results=None, results=None):
         if results is None:
             results = {}
         if lap_results is None:
@@ -1244,6 +1244,7 @@ class Race:
         self.cluster = cluster
         self.lap_results = lap_results
         self.results = results
+        self.track_revision = track_revision
 
     @property
     def track_name(self):
@@ -1284,6 +1285,7 @@ class Race:
             "pipeline": self.pipeline,
             "user-tags": self.user_tags,
             "track": self.track_name,
+            "track-revision": self.track_revision,
             "car": self.car,
             "total-laps": self.total_laps,
             "cluster": self.cluster.as_dict(),
@@ -1313,6 +1315,7 @@ class Race:
             "distribution-major-version": versions.major_version(self.cluster.distribution_version),
             "user-tags": self.user_tags,
             "track": self.track_name,
+            "track-revision": self.track_revision,
             "car": self.car_name,
             "node-count": len(self.cluster.nodes),
             # allow to logically delete records, e.g. for UI purposes when we only want to show the latest result on graphs

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -24,7 +24,7 @@ import thespian.actors
 import urllib
 
 from esrally import actor, config, exceptions, track, driver, mechanic, reporter, metrics, time, DOC_LINK, PROGRAM_NAME
-from esrally.utils import console, convert, opts, git
+from esrally.utils import console, convert, opts
 
 # benchmarks with external candidates are really scary and we should warn users.
 BOGUS_RESULTS_WARNING = """

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -106,7 +106,7 @@ class BenchmarkActor(actor.RallyActor):
         self.start_sender = None
         self.mechanic = None
         self.main_driver = None
-        self.track_revision= None
+        self.track_revision = None
 
     def receiveMsg_PoisonMessage(self, msg, sender):
         self.logger.info("BenchmarkActor got notified of poison message [%s] (forwarding).", (str(msg)))
@@ -208,10 +208,8 @@ class BenchmarkActor(actor.RallyActor):
             self.logger.info("Automatically derived distribution version [%s]", distribution_version)
             self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", distribution_version)
         
-        name = self.cfg.opts("race", "pipeline")
-        if not (name == "benchmark-only" or track.is_simple_track_mode(self.cfg)):
-            self.track_revision = git.head_revision(track.track_path(self.cfg))
         t = track.load_track(self.cfg)
+        self.track_revision = self.cfg.opts("track", "repository.revision", mandatory=False)
         challenge_name = self.cfg.opts("track", "challenge.name")
         challenge = t.find_challenge_or_default(challenge_name)
         if challenge is None:

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -106,6 +106,7 @@ class BenchmarkActor(actor.RallyActor):
         self.start_sender = None
         self.mechanic = None
         self.main_driver = None
+        self.track_revision= None
 
     def receiveMsg_PoisonMessage(self, msg, sender):
         self.logger.info("BenchmarkActor got notified of poison message [%s] (forwarding).", (str(msg)))
@@ -209,7 +210,7 @@ class BenchmarkActor(actor.RallyActor):
         
         name = self.cfg.opts("race", "pipeline")
         if not (name == "benchmark-only" or track.is_simple_track_mode(self.cfg)):
-            track_revision = git.head_revision(track.track_path(self.cfg))
+            self.track_revision = git.head_revision(track.track_path(self.cfg))
         t = track.load_track(self.cfg)
         challenge_name = self.cfg.opts("track", "challenge.name")
         challenge = t.find_challenge_or_default(challenge_name)
@@ -218,7 +219,7 @@ class BenchmarkActor(actor.RallyActor):
                                               % (t.name, challenge_name, PROGRAM_NAME))
         if challenge.user_info:
             console.info(challenge.user_info)
-        self.race = metrics.create_race(self.cfg, t, challenge, track_revision)
+        self.race = metrics.create_race(self.cfg, t, challenge, self.track_revision)
 
         self.metrics_store = metrics.metrics_store(
             self.cfg,

--- a/esrally/track/__init__.py
+++ b/esrally/track/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from .loader import list_tracks, load_track, load_track_plugins, track_repo, prepare_track, operation_parameters, set_absolute_data_path
+from .loader import list_tracks, load_track, is_simple_track_mode, track_path, load_track_plugins, track_repo, prepare_track, operation_parameters, set_absolute_data_path
 
 # expose the complete track API
 from .track import *

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -28,9 +28,9 @@ import jinja2.exceptions
 import jsonschema
 import tabulate
 
-from esrally import exceptions, time, PROGRAM_NAME
+from esrally import exceptions, time, PROGRAM_NAME, config
 from esrally.track import params, track
-from esrally.utils import io, convert, net, console, modules, opts, repo
+from esrally.utils import io, convert, net, console, modules, opts, repo, git
 from jinja2 import meta
 
 
@@ -211,6 +211,8 @@ class GitTrackRepository:
                 self.repo.checkout(repo_revision)
             else:
                 self.repo.update(distribution_version)
+                track_revision = git.head_revision(self.track_dir(self.track_name))
+                cfg.add(config.Scope.applicationOverride, "track", "repository.revision", track_revision)
 
     @property
     def track_names(self):

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -30,7 +30,7 @@ import tabulate
 
 from esrally import exceptions, time, PROGRAM_NAME, config
 from esrally.track import params, track
-from esrally.utils import io, convert, net, console, modules, opts, repo, git
+from esrally.utils import io, convert, net, console, modules, opts, repo
 from jinja2 import meta
 
 
@@ -211,8 +211,7 @@ class GitTrackRepository:
                 self.repo.checkout(repo_revision)
             else:
                 self.repo.update(distribution_version)
-                track_revision = git.head_revision(self.track_dir(self.track_name))
-                cfg.add(config.Scope.applicationOverride, "track", "repository.revision", track_revision)
+                cfg.add(config.Scope.applicationOverride, "track", "repository.revision", self.repo.revision)
 
     @property
     def track_names(self):

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -157,6 +157,13 @@ def is_simple_track_mode(cfg):
     return cfg.exists("track", "track.path")
 
 
+def track_path(cfg):
+    repo = track_repo(cfg)
+    track_name = repo.track_name
+    track_dir = repo.track_dir(track_name)
+    return track_dir
+
+
 def track_repo(cfg, fetch=True, update=True):
     if is_simple_track_mode(cfg):
         track_path = cfg.opts("track", "track.path")

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -36,6 +36,7 @@ class RallyRepository:
         self.resource_name = resource_name
         self.offline = offline
         self.logger = logging.getLogger(__name__)
+        self.revision = None
         if self.remote and not self.offline and fetch:
             # a normal git repo with a remote
             if not git.is_working_copy(self.repo_dir):
@@ -66,6 +67,7 @@ class RallyRepository:
                     self.logger.info("Rebasing on [%s] in [%s] for distribution version [%s].", branch, self.repo_dir, distribution_version)
                     try:
                         git.rebase(self.repo_dir, branch=branch)
+                        self.revision = git.head_revision(self.repo_dir)
                     except exceptions.SupplyError:
                         self.logger.exception("Cannot rebase due to local changes in [%s]", self.repo_dir)
                         console.warn(
@@ -82,6 +84,7 @@ class RallyRepository:
                     self.logger.info("Checking out [%s] in [%s] for distribution version [%s].",
                                      branch, self.repo_dir, distribution_version)
                     git.checkout(self.repo_dir, branch=branch)
+                    self.revision = git.head_revision(self.repo_dir)
             else:
                 self.logger.info("No local branch found for distribution version [%s] in [%s]. Checking tags.",
                                  distribution_version, self.repo_dir)
@@ -90,6 +93,7 @@ class RallyRepository:
                     self.logger.info("Checking out tag [%s] in [%s] for distribution version [%s].",
                                      tag, self.repo_dir, distribution_version)
                     git.checkout(self.repo_dir, branch=tag)
+                    self.revision = git.head_revision(self.repo_dir)
                 else:
                     raise exceptions.SystemSetupError("Cannot find %s for distribution version %s"
                                                       % (self.resource_name, distribution_version))

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -941,6 +941,7 @@ class EsResultsStoreTests(TestCase):
         c = cluster.Cluster([], [], None)
         c.distribution_version = "5.0.0"
         c.distribution_flavor = "oss"
+        c.team_revision = "123ab"
         node = c.add_node("localhost", "rally-node-0")
         node.plugins.append("x-pack")
 
@@ -992,6 +993,7 @@ class EsResultsStoreTests(TestCase):
                     "os": "Linux"
                 },
                 "track": "unittest-track",
+                "team-revision": "123ab",
                 "track-revision": "abc1",
                 "challenge": "index",
                 "car": "4gheap",
@@ -1018,6 +1020,7 @@ class EsResultsStoreTests(TestCase):
                     "os": "Linux"
                 },
                 "track": "unittest-track",
+                "team-revision": "123ab",
                 "track-revision": "abc1",
                 "challenge": "index",
                 "car": "4gheap",
@@ -1045,6 +1048,7 @@ class EsResultsStoreTests(TestCase):
                     "os": "Linux"
                 },
                 "track": "unittest-track",
+                "team-revision": "123ab",
                 "track-revision": "abc1",
                 "challenge": "index",
                 "car": "4gheap",
@@ -1076,6 +1080,7 @@ class EsResultsStoreTests(TestCase):
                     "os": "Linux"
                 },
                 "track": "unittest-track",
+                "team-revision": "123ab",
                 "track-revision": "abc1",
                 "challenge": "index",
                 "car": "4gheap",

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -830,6 +830,7 @@ class EsRaceStoreTests(TestCase):
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params={"shard-count": 3},
                             challenge=t.default_challenge, car="defaults", car_params={"heap_size": "512mb"}, plugin_params=None,
                             total_laps=12,
+                            track_revision="abc1",
                             cluster=EsRaceStoreTests.DictHolder(
                                 {
                                     "distribution-version": "5.0.0",
@@ -873,6 +874,7 @@ class EsRaceStoreTests(TestCase):
                 "shard-count": 3
             },
             "challenge": "index",
+            "track-revision": "abc1",
             "car": "defaults",
             "car-params": {
                 "heap_size": "512mb"
@@ -947,6 +949,7 @@ class EsResultsStoreTests(TestCase):
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params=None,
                             challenge=t.default_challenge, car="4gheap", car_params=None, plugin_params={"some-param": True},
                             total_laps=12,
+                            track_revision="abc1",
                             cluster=c,
                             lap_results=[],
                             results=reporter.Stats(
@@ -989,6 +992,7 @@ class EsResultsStoreTests(TestCase):
                     "os": "Linux"
                 },
                 "track": "unittest-track",
+                "track-revision": "abc1",
                 "challenge": "index",
                 "car": "4gheap",
                 "plugin-params": {
@@ -1014,6 +1018,7 @@ class EsResultsStoreTests(TestCase):
                     "os": "Linux"
                 },
                 "track": "unittest-track",
+                "track-revision": "abc1",
                 "challenge": "index",
                 "car": "4gheap",
                 "plugin-params": {
@@ -1040,6 +1045,7 @@ class EsResultsStoreTests(TestCase):
                     "os": "Linux"
                 },
                 "track": "unittest-track",
+                "track-revision": "abc1",
                 "challenge": "index",
                 "car": "4gheap",
                 "plugin-params": {
@@ -1070,6 +1076,7 @@ class EsResultsStoreTests(TestCase):
                     "os": "Linux"
                 },
                 "track": "unittest-track",
+                "track-revision": "abc1",
                 "challenge": "index",
                 "car": "4gheap",
                 "plugin-params": {
@@ -1303,6 +1310,7 @@ class FileRaceStoreTests(TestCase):
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params={"clients": 12},
                             challenge=t.default_challenge, car="4gheap", car_params=None, plugin_params=None,
                             total_laps=12,
+                            track_revision="abc1",
                             cluster=FileRaceStoreTests.DictHolder(
                                 {
                                     "distribution-version": "5.0.0",


### PR DESCRIPTION
Still missing track revision info.

Closes https://github.com/elastic/rally/issues/664