### PR TITLE
Allow function-level invocation of integration-test.sh.

### DIFF
--- a/integration-test.sh
+++ b/integration-test.sh
@@ -543,12 +543,14 @@ function main {
 
 check_prerequisites
 
-# allow invocation from release-docker.sh
-if [[ $1 == "test-docker-release" ]]; then
-    test_docker_release_image
+trap "tear_down" EXIT
+
+# if argument is the name of a function, set up and call it
+if declare -f "$1" > /dev/null
+then
+    set_up
+    $1
     exit
 fi
-
-trap "tear_down" EXIT
 
 main

--- a/release-docker.sh
+++ b/release-docker.sh
@@ -46,7 +46,7 @@ echo "======================================================="
 echo "Testing Docker image for Rally release $RALLY_VERSION  "
 echo "======================================================="
 
-./integration-test.sh test-docker-release
+./integration-test.sh test_docker_release_image
 
 echo "======================================================="
 echo "Publishing Docker image elastic/rally:$RALLY_VERSION   "


### PR DESCRIPTION
Use the first argument as the name of a function in integration-test.sh to call directly, in order to:
 - speed up testing during development
 - generalize release-docker.sh's invocation