### PR TITLE
Allow to set distribution version as parameter

### DIFF
--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -396,14 +396,6 @@ def run(cfg):
         logger.info("User specified no pipeline. Automatically derived pipeline [%s].", name)
         cfg.add(config.Scope.applicationOverride, "race", "pipeline", name)
     else:
-        if (cfg.exists("mechanic", "distribution.version") and
-                name in ["from-sources-complete", "from-sources-skip-build", "benchmark-only"]):
-            raise exceptions.SystemSetupError(
-                "--distribution-version can only be used together with pipeline from-distribution, """
-                "but you specified {}.\n"
-                "If you intend to benchmark an externally provisioned cluster, don't specify --distribution-version otherwise\n"
-                "please read the docs for from-distribution pipeline at "
-                "{}/pipelines.html#from-distribution".format(name, DOC_LINK))
         logger.info("User specified pipeline [%s].", name)
 
     if os.environ.get("RALLY_RUNNING_IN_DOCKER", "").upper() == "TRUE":


### PR DESCRIPTION
With this commit we allow (again) to set the distribution version as a
command line parameter even in cases where it does not seem to be useful
initially, like the `benchmark-only` pipeline. However, if Rally fails
to determine the cluster version (for whatever reason) it can be useful
to be able to override this on the command line. Similarly, it can be
useful to override this when benchmarking a source build that is *not*
based on master but rather of an older branch. In these cases, Rally
would still take the right decisions with some guidance by the user.