### PR TITLE
Drop 1.x support for cluster metadata

### DIFF
--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -994,7 +994,7 @@ class ClusterMetaDataInfo(InternalTelemetryDevice):
             else:
                 host = node_stats.get("host", "unknown")
                 cluster_node = cluster.add_node(host, node_name)
-            self.add_node_stats(cluster, cluster_node, node_stats)
+            self.add_node_stats(cluster_node, node_stats)
 
         for node_info in self.client.nodes.info(node_id="_all")["nodes"].values():
             self.add_node_info(cluster, node_info)
@@ -1020,12 +1020,7 @@ class ClusterMetaDataInfo(InternalTelemetryDevice):
                 if "name" in plugin:
                     cluster_node.plugins.append(plugin["name"])
 
-            if versions.major_version(cluster.distribution_version) == 1:
-                cluster_node.memory = {
-                    "total_bytes": extract_value(node_info, ["os", "mem", "total_in_bytes"], fallback=None)
-                }
-
-    def add_node_stats(self, cluster, cluster_node, stats):
+    def add_node_stats(self, cluster_node, stats):
         if cluster_node:
             data_dirs = extract_value(stats, ["fs", "data"], fallback=[])
             for data_dir in data_dirs:
@@ -1035,10 +1030,9 @@ class ClusterMetaDataInfo(InternalTelemetryDevice):
                     "spins": data_dir.get("spins", "unknown")
                 }
                 cluster_node.fs.append(fs_meta_data)
-            if versions.major_version(cluster.distribution_version) > 1:
-                cluster_node.memory = {
-                    "total_bytes": extract_value(stats, ["os", "mem", "total_in_bytes"], fallback=None)
-                }
+            cluster_node.memory = {
+                "total_bytes": extract_value(stats, ["os", "mem", "total_in_bytes"], fallback=None)
+            }
 
 
 class JvmStatsSummary(InternalTelemetryDevice):

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -1971,7 +1971,7 @@ class ClusterMetaDataInfoTests(TestCase):
     def setUp(self):
         self.cfg = create_config()
 
-    def test_enriches_cluster_nodes_for_elasticsearch_after_1_x(self):
+    def test_enriches_cluster_nodes(self):
         nodes_stats = {
             "nodes": {
                 "FCFjozkeTiOpN-SI88YEcg": {
@@ -2079,88 +2079,6 @@ class ClusterMetaDataInfoTests(TestCase):
         self.assertEqual("ntfs", n.fs[1]["type"])
         self.assertEqual("unknown", n.fs[1]["spins"])
         self.assertEqual(["analysis-icu", "ingest-geoip", "ingest-user-agent"], n.plugins)
-
-    def test_enriches_cluster_nodes_for_elasticsearch_1_x(self):
-        nodes_stats = {
-            "nodes": {
-                "FCFjozkeTiOpN-SI88YEcg": {
-                    "name": "rally0",
-                    "host": "127.0.0.1",
-                    "fs": {
-                        "data": [
-                            {
-                                "mount": "/usr/local/var/elasticsearch/data1",
-                                "type": "hfs"
-                            },
-                            {
-                                "mount": "/usr/local/var/elasticsearch/data2",
-                                "type": "ntfs"
-                            }
-                        ]
-                    }
-                }
-            }
-        }
-
-        nodes_info = {
-            "nodes": {
-                "FCFjozkeTiOpN-SI88YEcg": {
-                    "name": "rally0",
-                    "host": "127.0.0.1",
-                    "ip": "127.0.0.1",
-                    "os": {
-                        "name": "Mac OS X",
-                        "version": "10.11.4",
-                        "available_processors": 8,
-                        "mem": {
-                            "total_in_bytes": 17179869184
-                        }
-                    },
-                    "jvm": {
-                        "version": "1.8.0_74",
-                        "vm_vendor": "Oracle Corporation"
-                    }
-                }
-            }
-        }
-        cluster_info = {
-            "version":
-                {
-                    "build_hash": "c730b59357f8ebc555286794dcd90b3411f517c9",
-                    "number": "1.7.5"
-                }
-        }
-        client = Client(nodes=SubClient(stats=nodes_stats, info=nodes_info), info=cluster_info)
-
-        t = telemetry.Telemetry(devices=[telemetry.ClusterMetaDataInfo(client)])
-
-        c = cluster.Cluster(hosts=[{"host": "localhost", "port": 39200}],
-                            nodes=[cluster.Node(pid=None, host_name="local", node_name="rally0", telemetry=None)],
-                            telemetry=t)
-
-        t.attach_to_cluster(c)
-
-        self.assertEqual("1.7.5", c.distribution_version)
-        self.assertEqual("oss", c.distribution_flavor)
-        self.assertEqual("c730b59357f8ebc555286794dcd90b3411f517c9", c.source_revision)
-        self.assertEqual(1, len(c.nodes))
-        n = c.nodes[0]
-        self.assertEqual("127.0.0.1", n.ip)
-        self.assertEqual("Mac OS X", n.os["name"])
-        self.assertEqual("10.11.4", n.os["version"])
-        self.assertEqual("Oracle Corporation", n.jvm["vendor"])
-        self.assertEqual("1.8.0_74", n.jvm["version"])
-        self.assertEqual(8, n.cpu["available_processors"])
-        self.assertIsNone(n.cpu["allocated_processors"])
-        self.assertEqual(17179869184, n.memory["total_bytes"])
-
-        self.assertEqual(2, len(n.fs))
-        self.assertEqual("/usr/local/var/elasticsearch/data1", n.fs[0]["mount"])
-        self.assertEqual("hfs", n.fs[0]["type"])
-        self.assertEqual("unknown", n.fs[0]["spins"])
-        self.assertEqual("/usr/local/var/elasticsearch/data2", n.fs[1]["mount"])
-        self.assertEqual("ntfs", n.fs[1]["type"])
-        self.assertEqual("unknown", n.fs[1]["spins"])
 
 
 class JvmStatsSummaryTests(TestCase):


### PR DESCRIPTION
With this commit we remove support for Elasticsearch 1.x when retrieving
cluster metadata. This is a leftover from #716

Relates #716