### PR TITLE
Be resilient upon startup

### DIFF
--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -17,6 +17,7 @@
 
 import sys
 import json
+import logging
 from collections import defaultdict
 
 import thespian.actors
@@ -207,7 +208,12 @@ def cluster_distribution_version(cfg, client_factory=client.EsClientFactory):
     hosts = cfg.opts("client", "hosts").default
     client_options = cfg.opts("client", "options").default
     es = client_factory(hosts, client_options).create()
-    return es.info()["version"]["number"]
+    # noinspection PyBroadException
+    try:
+        return es.info()["version"]["number"]
+    except BaseException:
+        logging.getLogger(__name__).exception("Could not retrieve cluster distribution version")
+        return None
 
 
 def to_ip_port(hosts):

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -350,6 +350,12 @@ def create_arg_parser():
             help=argparse.SUPPRESS,
             action="store_true",
             default=False)
+        # skips checking that the REST API is available before proceeding with the benchmark
+        p.add_argument(
+            "--skip-rest-api-check",
+            help=argparse.SUPPRESS,
+            action="store_true",
+            default=False)
 
     for p in [parser, config_parser, list_parser, race_parser, compare_parser, download_parser]:
         # This option is needed to support a separate configuration for the integration tests on the same machine
@@ -599,6 +605,7 @@ def main():
     else:
         cfg.add(config.Scope.applicationOverride, "mechanic", "keep.running", False)
         cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
+    cfg.add(config.Scope.applicationOverride, "mechanic", "skip.rest.api.check", convert.to_bool(args.skip_rest_api_check))
     cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
     cfg.add(config.Scope.applicationOverride, "mechanic", "telemetry.devices", opts.csv_to_list(args.telemetry))
     cfg.add(config.Scope.applicationOverride, "mechanic", "telemetry.params", opts.to_dict(args.telemetry_params))

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -170,6 +170,20 @@ class ExternalLauncherTests(TestCase):
         # did not change user defined value
         self.assertEqual(cfg.opts("mechanic", "distribution.version"), "2.3.3")
 
+    def test_setup_external_cluster_cannot_determine_version(self):
+        client_options = opts.ClientOptions("timeout:60,raise-error-on-info:true")
+        cfg = config.Config()
+
+        cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
+        cfg.add(config.Scope.application, "client", "hosts", self.test_host)
+        cfg.add(config.Scope.application, "client", "options", client_options)
+
+        m = launcher.ExternalLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
+        m.start()
+
+        # automatically determined by launcher on attach
+        self.assertIsNone(cfg.opts("mechanic", "distribution.version"))
+
 
 class ClusterLauncherTests(TestCase):
     test_host = opts.TargetHosts("10.0.0.10:9200,10.0.0.11:9200")
@@ -182,6 +196,7 @@ class ClusterLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
         cfg.add(config.Scope.application, "mechanic", "telemetry.params", {})
         cfg.add(config.Scope.application, "mechanic", "preserve.install", False)
+        cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", False)
 
         cluster_launcher = launcher.ClusterLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
         cluster = cluster_launcher.start()
@@ -196,6 +211,7 @@ class ClusterLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
         cfg.add(config.Scope.application, "mechanic", "telemetry.params", {})
         cfg.add(config.Scope.application, "mechanic", "preserve.install", False)
+        cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", False)
 
         cluster_launcher = launcher.ClusterLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
         cluster = cluster_launcher.start()
@@ -217,6 +233,7 @@ class ClusterLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
         cfg.add(config.Scope.application, "mechanic", "telemetry.params", {})
         cfg.add(config.Scope.application, "mechanic", "preserve.install", False)
+        cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", False)
 
         cluster_launcher = launcher.ClusterLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
         with self.assertRaisesRegex(exceptions.LaunchError,

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -148,30 +148,46 @@ class MergePartsDeviceTests(TestCase):
 class Client:
     def __init__(self, nodes=None, info=None, indices=None, transport_client=None):
         self.nodes = nodes
-        self._info = info
+        self._info = wrap(info)
         self.indices = indices
         if transport_client:
             self.transport = transport_client
 
     def info(self):
-        return self._info
+        return self._info()
 
 
 class SubClient:
     def __init__(self, stats=None, info=None, recovery=None):
-        self._stats = stats
-        self._info = info
-        self._recovery = recovery
+        self._stats = wrap(stats)
+        self._info = wrap(info)
+        self._recovery = wrap(recovery)
 
     def stats(self, *args, **kwargs):
-        return self._stats
+        return self._stats()
 
     def info(self, *args, **kwargs):
-        return self._info
+        return self._info()
 
     def recovery(self, *args, **kwargs):
-        return self._recovery
+        return self._recovery()
 
+def wrap(it):
+    return it if callable(it) else ResponseSupplier(it)
+
+class ResponseSupplier:
+    def __init__(self, response):
+        self.response = response
+
+    def __call__(self, *args, **kwargs):
+        return self.response
+
+
+class TransportErrorSupplier:
+    def __call__(self, *args, **kwargs):
+        raise elasticsearch.TransportError
+
+raiseTransportError = TransportErrorSupplier()
 
 class TransportClient:
     def __init__(self, response=None, force_error=False):
@@ -1807,6 +1823,17 @@ class ClusterEnvironmentInfoTests(TestCase):
 
         metrics_store_add_meta_info.assert_has_calls(calls)
 
+    @mock.patch("esrally.metrics.EsMetricsStore.add_meta_info")
+    def test_resilient_if_error_response(self, metrics_store_add_meta_info):
+        cfg = create_config()
+        client = Client(nodes=SubClient(stats=raiseTransportError, info=raiseTransportError), info=raiseTransportError)
+        metrics_store = metrics.EsMetricsStore(cfg)
+        env_device = telemetry.ClusterEnvironmentInfo(client, metrics_store)
+        t = telemetry.Telemetry(cfg, devices=[env_device])
+        t.attach_to_cluster(cluster.Cluster([], [], t))
+
+        self.assertEqual(0, metrics_store_add_meta_info.call_count)
+
 
 class NodeEnvironmentInfoTests(TestCase):
     @mock.patch("esrally.metrics.EsMetricsStore.add_meta_info")
@@ -1966,6 +1993,16 @@ class ExternalEnvironmentInfoTests(TestCase):
         ]
         metrics_store_add_meta_info.assert_has_calls(calls)
 
+    @mock.patch("esrally.metrics.EsMetricsStore.add_meta_info")
+    def test_resilient_if_error_response(self, metrics_store_add_meta_info):
+        client = Client(nodes=SubClient(stats=raiseTransportError, info=raiseTransportError), info=raiseTransportError)
+        metrics_store = metrics.EsMetricsStore(self.cfg)
+        env_device = telemetry.ExternalEnvironmentInfo(client, metrics_store)
+        t = telemetry.Telemetry(self.cfg, devices=[env_device])
+        t.attach_to_cluster(cluster.Cluster([], [], t))
+
+        self.assertEqual(0, metrics_store_add_meta_info.call_count)
+
 
 class ClusterMetaDataInfoTests(TestCase):
     def setUp(self):
@@ -2079,6 +2116,24 @@ class ClusterMetaDataInfoTests(TestCase):
         self.assertEqual("ntfs", n.fs[1]["type"])
         self.assertEqual("unknown", n.fs[1]["spins"])
         self.assertEqual(["analysis-icu", "ingest-geoip", "ingest-user-agent"], n.plugins)
+
+    def test_resilient_if_error_response(self):
+        client = Client(nodes=SubClient(stats=raiseTransportError, info=raiseTransportError), info=raiseTransportError)
+
+        t = telemetry.Telemetry(devices=[telemetry.ClusterMetaDataInfo(client)])
+
+        c = cluster.Cluster(hosts=[{"host": "localhost", "port": 39200}],
+                            nodes=[cluster.Node(pid=None, host_name="local", node_name="rally0", telemetry=None)],
+                            telemetry=t)
+
+        t.attach_to_cluster(c)
+
+        self.assertIsNone(c.distribution_version)
+        self.assertIsNone(c.distribution_flavor)
+        self.assertIsNone(c.source_revision)
+        self.assertEqual(1, len(c.nodes))
+        n = c.nodes[0]
+        self.assertIsNone(n.ip)
 
 
 class JvmStatsSummaryTests(TestCase):

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -172,8 +172,10 @@ class SubClient:
     def recovery(self, *args, **kwargs):
         return self._recovery()
 
+
 def wrap(it):
     return it if callable(it) else ResponseSupplier(it)
+
 
 class ResponseSupplier:
     def __init__(self, response):
@@ -187,7 +189,9 @@ class TransportErrorSupplier:
     def __call__(self, *args, **kwargs):
         raise elasticsearch.TransportError
 
+
 raiseTransportError = TransportErrorSupplier()
+
 
 class TransportClient:
     def __init__(self, response=None, force_error=False):


### PR DESCRIPTION
With this commit we make Rally more resilient when it is not able to
determine some information upon startup of the cluster.