### PR TITLE
Update DiskIo telemetry device to persist the counters

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -173,12 +173,13 @@ class DockerLauncher:
             node_name = node_configuration.node_name
             host_name = node_configuration.ip
             binary_path = node_configuration.binary_path
+            node_telemetry_dir = os.path.join(node_configuration.node_root_path, "telemetry")
             self.binary_paths[node_name] = binary_path
             self._start_process(binary_path)
             # only support a subset of telemetry for Docker hosts
             # (specifically, we do not allow users to enable any devices)
             node_telemetry = [
-                telemetry.DiskIo(self.metrics_store, len(node_configurations)),
+                telemetry.DiskIo(self.metrics_store, len(node_configurations), node_telemetry_dir, node_name),
                 telemetry.NodeEnvironmentInfo(self.metrics_store)
             ]
             t = telemetry.Telemetry(devices=node_telemetry)

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -306,7 +306,7 @@ class ProcessLauncher:
         enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
         telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
         node_telemetry = [
-            telemetry.DiskIo(self.metrics_store, node_count_on_host, node_telemetry_dir, car, node_name),
+            telemetry.DiskIo(self.metrics_store, node_count_on_host, node_telemetry_dir, node_name),
             telemetry.NodeEnvironmentInfo(self.metrics_store),
             telemetry.IndexSize(data_paths, self.metrics_store),
             telemetry.MergeParts(self.metrics_store, node_configuration.log_path),

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -306,7 +306,7 @@ class ProcessLauncher:
         enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
         telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
         node_telemetry = [
-            telemetry.DiskIo(self.metrics_store, node_count_on_host),
+            telemetry.DiskIo(self.metrics_store, node_count_on_host, node_telemetry_dir, car, node_name),
             telemetry.NodeEnvironmentInfo(self.metrics_store),
             telemetry.IndexSize(data_paths, self.metrics_store),
             telemetry.MergeParts(self.metrics_store, node_configuration.log_path),

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -771,10 +771,11 @@ class MergeParts(InternalTelemetryDevice):
 
 
 class DiskIo(InternalTelemetryDevice):
+    human_name = "Disk IO"
     """
     Gathers disk I/O stats.
     """
-    def __init__(self, metrics_store, node_count_on_host):
+    def __init__(self, metrics_store, node_count_on_host, log_root, car, node_name):
         super().__init__()
         self.metrics_store = metrics_store
         self.node_count_on_host = node_count_on_host
@@ -782,6 +783,9 @@ class DiskIo(InternalTelemetryDevice):
         self.process = None
         self.disk_start = None
         self.process_start = None
+        self.car = car
+        self.node_name = node_name
+        self.log_root = log_root
 
     def attach_to_node(self, node):
         self.node = node
@@ -790,35 +794,53 @@ class DiskIo(InternalTelemetryDevice):
     def on_benchmark_start(self):
         if self.process is not None:
             self.process_start = sysstats.process_io_counters(self.process)
+            read_bytes = 0
+            write_bytes = 0
+            io.ensure_dir(self.log_root)
+            log_file = "%s/%s-%s.io" % (self.log_root, self.car.safe_name, self.node.node_name)
+            console.info("%s: Writing start I/O stats to [%s]" % (self.human_name, log_file), logger=self.logger)
             if self.process_start:
+                read_bytes = self.process_start.read_bytes
+                write_bytes = self.process_start.write_bytes
                 self.logger.info("Using more accurate process-based I/O counters.")
             else:
                 try:
                     self.disk_start = sysstats.disk_io_counters()
+                    read_bytes = self.disk_start.read_bytes
+                    write_bytes = self.disk_start.write_bytes
                     self.logger.warning("Process I/O counters are not supported on this platform. Falling back to less accurate disk "
                                         "I/O counters.")
                 except RuntimeError:
                     self.logger.exception("Could not determine I/O stats at benchmark start.")
+            with open(log_file, "wt", encoding="utf-8") as f:
+                diskio_str = "%d %d" % (read_bytes, write_bytes)
+                f.write(diskio_str)
 
     def on_benchmark_stop(self):
         if self.process is not None:
+            process_end = sysstats.process_io_counters(self.process)
+            disk_end = sysstats.disk_io_counters()
+            io.ensure_dir(self.log_root)
+            log_file = "%s/%s-%s.io" % (self.log_root, self.car.safe_name, self.node.node_name)
+            io_str = ""
+            with open(log_file, "rt", encoding="utf-8") as f:
+                io_str = f.read()
+            io_bytes = io_str.split()
             # Be aware the semantics of write counts etc. are different for disk and process statistics.
             # Thus we're conservative and only report I/O bytes now.
             # noinspection PyBroadException
             try:
                 # we have process-based disk counters, no need to worry how many nodes are on this host
-                if self.process_start:
-                    process_end = sysstats.process_io_counters(self.process)
-                    read_bytes = process_end.read_bytes - self.process_start.read_bytes
-                    write_bytes = process_end.write_bytes - self.process_start.write_bytes
-                elif self.disk_start:
+                if process_end:
+                    read_bytes = process_end.read_bytes - int(io_bytes[0])
+                    write_bytes = process_end.write_bytes - int(io_bytes[1])
+                elif disk_end:
                     if self.node_count_on_host > 1:
                         self.logger.info("There are [%d] nodes on this host and Rally fell back to disk I/O counters. Attributing [1/%d] "
                                          "of total I/O to [%s].", self.node_count_on_host, self.node_count_on_host, self.node.node_name)
 
-                    disk_end = sysstats.disk_io_counters()
-                    read_bytes = (disk_end.read_bytes - self.disk_start.read_bytes) // self.node_count_on_host
-                    write_bytes = (disk_end.write_bytes - self.disk_start.write_bytes) // self.node_count_on_host
+                    read_bytes = (disk_end.read_bytes - int(io_bytes[0])) // self.node_count_on_host
+                    write_bytes = (disk_end.write_bytes - int(io_bytes[0])) // self.node_count_on_host
                 else:
                     raise RuntimeError("Neither process nor disk I/O counters are available")
 

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -775,7 +775,7 @@ class DiskIo(InternalTelemetryDevice):
     """
     Gathers disk I/O stats.
     """
-    def __init__(self, metrics_store, node_count_on_host, log_root, car, node_name):
+    def __init__(self, metrics_store, node_count_on_host, log_root, node_name):
         super().__init__()
         self.metrics_store = metrics_store
         self.node_count_on_host = node_count_on_host
@@ -783,7 +783,6 @@ class DiskIo(InternalTelemetryDevice):
         self.process = None
         self.disk_start = None
         self.process_start = None
-        self.car = car
         self.node_name = node_name
         self.log_root = log_root
 

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -840,7 +840,7 @@ class DiskIo(InternalTelemetryDevice):
                                          "of total I/O to [%s].", self.node_count_on_host, self.node_count_on_host, self.node.node_name)
 
                     read_bytes = (disk_end.read_bytes - int(io_bytes[0])) // self.node_count_on_host
-                    write_bytes = (disk_end.write_bytes - int(io_bytes[0])) // self.node_count_on_host
+                    write_bytes = (disk_end.write_bytes - int(io_bytes[1])) // self.node_count_on_host
                 else:
                     raise RuntimeError("Neither process nor disk I/O counters are available")
 

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -772,7 +772,6 @@ class MergeParts(InternalTelemetryDevice):
 
 
 class DiskIo(InternalTelemetryDevice):
-    human_name = "Disk IO"
     """
     Gathers disk I/O stats.
     """
@@ -798,8 +797,7 @@ class DiskIo(InternalTelemetryDevice):
             read_bytes = 0
             write_bytes = 0
             io.ensure_dir(self.log_root)
-            log_file = "%s/%s-%s.io" % (self.log_root, self.car.safe_name, self.node.node_name)
-            console.info("%s: Writing start I/O stats to [%s]" % (self.human_name, log_file), logger=self.logger)
+            tmp_io_file = os.path.join(self.log_root, "%s.io" % self.node.node_name)
             if self.process_start:
                 read_bytes = self.process_start.read_bytes
                 write_bytes = self.process_start.write_bytes
@@ -813,27 +811,26 @@ class DiskIo(InternalTelemetryDevice):
                                         "I/O counters.")
                 except RuntimeError:
                     self.logger.exception("Could not determine I/O stats at benchmark start.")
-            diskio_str = {"read_bytes": read_bytes, "write_bytes": write_bytes}
-            with open(log_file, "wt", encoding="utf-8") as f:
-                json.dump(diskio_str, f)
+            with open(tmp_io_file, "wt", encoding="utf-8") as f:
+                json.dump({"read_bytes": read_bytes, "write_bytes": write_bytes}, f)
 
     def on_benchmark_stop(self):
         if self.process is not None:
             process_end = sysstats.process_io_counters(self.process)
             disk_end = sysstats.disk_io_counters()
             io.ensure_dir(self.log_root)
-            log_file = "%s/%s-%s.io" % (self.log_root, self.car.safe_name, self.node.node_name)
-            io_str = ""
-            with open(log_file, "rt", encoding="utf-8") as f:
+            tmp_io_file = os.path.join(self.log_root, "%s.io" % self.node.node_name)
+            with open(tmp_io_file, "rt", encoding="utf-8") as f:
                 io_bytes = json.load(f)
+            os.remove(tmp_io_file)
             # Be aware the semantics of write counts etc. are different for disk and process statistics.
             # Thus we're conservative and only report I/O bytes now.
             # noinspection PyBroadException
             try:
                 # we have process-based disk counters, no need to worry how many nodes are on this host
                 if process_end:
-                    read_bytes = process_end.read_bytes - io_bytes['read_bytes']
-                    write_bytes = process_end.write_bytes - io_bytes['write_bytes']
+                    read_bytes = process_end.read_bytes - io_bytes["read_bytes"]
+                    write_bytes = process_end.write_bytes - io_bytes["write_bytes"]
                 elif disk_end:
                     if self.node_count_on_host > 1:
                         self.logger.info("There are [%d] nodes on this host and Rally fell back to disk I/O counters. Attributing [1/%d] "

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -23,6 +23,7 @@ import signal
 import subprocess
 import tabulate
 import threading
+import json
 
 from esrally import metrics, time, exceptions
 from esrally.utils import io, sysstats, console, versions, opts
@@ -812,9 +813,9 @@ class DiskIo(InternalTelemetryDevice):
                                         "I/O counters.")
                 except RuntimeError:
                     self.logger.exception("Could not determine I/O stats at benchmark start.")
+            diskio_str = {"read_bytes": read_bytes, "write_bytes": write_bytes}
             with open(log_file, "wt", encoding="utf-8") as f:
-                diskio_str = "%d %d" % (read_bytes, write_bytes)
-                f.write(diskio_str)
+                json.dump(diskio_str, f)
 
     def on_benchmark_stop(self):
         if self.process is not None:
@@ -824,23 +825,22 @@ class DiskIo(InternalTelemetryDevice):
             log_file = "%s/%s-%s.io" % (self.log_root, self.car.safe_name, self.node.node_name)
             io_str = ""
             with open(log_file, "rt", encoding="utf-8") as f:
-                io_str = f.read()
-            io_bytes = io_str.split()
+                io_bytes = json.load(f)
             # Be aware the semantics of write counts etc. are different for disk and process statistics.
             # Thus we're conservative and only report I/O bytes now.
             # noinspection PyBroadException
             try:
                 # we have process-based disk counters, no need to worry how many nodes are on this host
                 if process_end:
-                    read_bytes = process_end.read_bytes - int(io_bytes[0])
-                    write_bytes = process_end.write_bytes - int(io_bytes[1])
+                    read_bytes = process_end.read_bytes - io_bytes['read_bytes']
+                    write_bytes = process_end.write_bytes - io_bytes['write_bytes']
                 elif disk_end:
                     if self.node_count_on_host > 1:
                         self.logger.info("There are [%d] nodes on this host and Rally fell back to disk I/O counters. Attributing [1/%d] "
                                          "of total I/O to [%s].", self.node_count_on_host, self.node_count_on_host, self.node.node_name)
 
-                    read_bytes = (disk_end.read_bytes - int(io_bytes[0])) // self.node_count_on_host
-                    write_bytes = (disk_end.write_bytes - int(io_bytes[1])) // self.node_count_on_host
+                    read_bytes = (disk_end.read_bytes - io_bytes['read_bytes']) // self.node_count_on_host
+                    write_bytes = (disk_end.write_bytes - io_bytes['write_bytes']) // self.node_count_on_host
                 else:
                     raise RuntimeError("Neither process nor disk I/O counters are available")
 

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -2161,12 +2161,11 @@ class DiskIoTests(TestCase):
         node = cluster.Node(pid=None, host_name="localhost", node_name="rally0", telemetry=t)
         t.attach_to_node(node)
         t.on_benchmark_start()
+        device2 = telemetry.DiskIo(metrics_store, node_count_on_host=1, log_root=tmp_dir, node_name="rally0")
+        t2 = telemetry.Telemetry(enabled_devices=[], devices=[device2])
+        t2.on_benchmark_stop()
         t.detach_from_node(node, running=True)
         t.detach_from_node(node, running=False)
-        node2 = cluster.Node(pid=None, host_name="localhost", node_name="rally0", telemetry=t)
-        t.on_benchmark_stop()
-        t.detach_from_node(node2, running=True)
-        t.detach_from_node(node2, running=False)
 
         metrics_store_node_count.assert_has_calls([
             mock.call("rally0", "disk_io_write_bytes", 1, "byte"),
@@ -2193,14 +2192,14 @@ class DiskIoTests(TestCase):
         node = cluster.Node(pid=None, host_name="localhost", node_name="rally0", telemetry=t)
         t.attach_to_node(node)
         t.on_benchmark_start()
+        device2 = telemetry.DiskIo(metrics_store, node_count_on_host=2, log_root=tmp_dir, node_name="rally0")
+        t2 = telemetry.Telemetry(enabled_devices=[], devices=[device2])
+        t2.on_benchmark_stop()
         t.detach_from_node(node, running=True)
         t.detach_from_node(node, running=False)
-        node2 = cluster.Node(pid=None, host_name="localhost", node_name="rally0", telemetry=t)
-        t.on_benchmark_stop()
-        t.detach_from_node(node2, running=True)
-        t.detach_from_node(node2, running=False)
 
-        # expected result is 1 byte because there are two nodes on the machine. Result is calculated with total_bytes / node_count
+        # expected result is 1 byte because there are two nodes on the machine. Result is calculated 
+        # with total_bytes / node_count
         metrics_store_node_count.assert_has_calls([
             mock.call("rally0", "disk_io_write_bytes", 1, "byte"),
             mock.call("rally0", "disk_io_read_bytes", 1, "byte")

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -17,6 +17,8 @@
 
 import random
 import collections
+import os
+import tempfile
 import unittest.mock as mock
 import elasticsearch
 
@@ -25,6 +27,7 @@ from esrally import config, metrics, exceptions
 from esrally.mechanic import telemetry, team, cluster
 from esrally.metrics import MetaInfoScope
 from esrally.utils import console
+from collections import namedtuple
 
 
 def create_config():
@@ -2140,6 +2143,66 @@ class ClusterMetaDataInfoTests(TestCase):
         self.assertIsNone(n.ip)
 
 
+class DiskIoTests(TestCase):
+    
+    @mock.patch("esrally.utils.sysstats.process_io_counters")
+    @mock.patch("esrally.metrics.EsMetricsStore.put_count_node_level")
+    def test_diskio_process_io_counters(self, metrics_store_node_count, process_io_counters):
+        Diskio = namedtuple("Diskio", "read_bytes write_bytes")
+        process_start = Diskio(10,10)
+        process_stop = Diskio(11,11)
+        process_io_counters.side_effect = [process_start, process_stop]
+
+        tmp_dir = tempfile.mkdtemp()
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        
+        device = telemetry.DiskIo(metrics_store, 1, tmp_dir, "rally0")
+        t = telemetry.Telemetry(enabled_devices=[], devices=[device])
+        node = cluster.Node(pid=None, host_name="localhost", node_name="rally0", telemetry=t)
+        t.attach_to_node(node)
+        t.on_benchmark_start()
+        t.on_benchmark_stop()
+        t.detach_from_node(node, running=True)
+        t.detach_from_node(node, running=False)
+
+        metrics_store_node_count.assert_has_calls([
+            mock.call("rally0", "disk_io_write_bytes", 1, "byte"),
+            mock.call("rally0", "disk_io_read_bytes", 1, "byte")
+            
+        ])
+        
+    @mock.patch("esrally.utils.sysstats.disk_io_counters")
+    @mock.patch("esrally.utils.sysstats.process_io_counters")
+    @mock.patch("esrally.metrics.EsMetricsStore.put_count_node_level")
+    def test_diskio_disk_io_counters(self, metrics_store_node_count, process_io_counters, disk_io_counters):
+        Diskio = namedtuple("Diskio", "read_bytes write_bytes")
+        process_start = Diskio(10,10)
+        process_stop = Diskio(13,13)
+        disk_io_counters.side_effect = [process_start, process_stop]
+        process_io_counters.side_effect = [None, None]
+        
+
+        tmp_dir = tempfile.mkdtemp()
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        
+        device = telemetry.DiskIo(metrics_store, 2, tmp_dir, "rally0")
+        t = telemetry.Telemetry(enabled_devices=[], devices=[device])
+        node = cluster.Node(pid=None, host_name="localhost", node_name="rally0", telemetry=t)
+        t.attach_to_node(node)
+        t.on_benchmark_start()
+        t.on_benchmark_stop()
+        t.detach_from_node(node, running=True)
+        t.detach_from_node(node, running=False)
+
+        metrics_store_node_count.assert_has_calls([
+            mock.call("rally0", "disk_io_write_bytes", 1, "byte"),
+            mock.call("rally0", "disk_io_read_bytes", 1, "byte")
+            
+        ])
+
+
 class JvmStatsSummaryTests(TestCase):
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
@@ -2786,7 +2849,6 @@ class MlBucketProcessingTimeTests(TestCase):
                 "unit": "ms"
             }, level=metrics.MetaInfoScope.cluster)
         ])
-
 
 class IndexSizeTests(TestCase):
     @mock.patch("esrally.utils.io.get_size")

--- a/tests/mechanic/telemetry_test.py
+++ b/tests/mechanic/telemetry_test.py
@@ -2164,8 +2164,8 @@ class DiskIoTests(TestCase):
         device2 = telemetry.DiskIo(metrics_store, node_count_on_host=1, log_root=tmp_dir, node_name="rally0")
         t2 = telemetry.Telemetry(enabled_devices=[], devices=[device2])
         t2.on_benchmark_stop()
-        t.detach_from_node(node, running=True)
-        t.detach_from_node(node, running=False)
+        t2.detach_from_node(node, running=True)
+        t2.detach_from_node(node, running=False)
 
         metrics_store_node_count.assert_has_calls([
             mock.call("rally0", "disk_io_write_bytes", 1, "byte"),
@@ -2195,8 +2195,8 @@ class DiskIoTests(TestCase):
         device2 = telemetry.DiskIo(metrics_store, node_count_on_host=2, log_root=tmp_dir, node_name="rally0")
         t2 = telemetry.Telemetry(enabled_devices=[], devices=[device2])
         t2.on_benchmark_stop()
-        t.detach_from_node(node, running=True)
-        t.detach_from_node(node, running=False)
+        t2.detach_from_node(node, running=True)
+        t2.detach_from_node(node, running=False)
 
         # expected result is 1 byte because there are two nodes on the machine. Result is calculated 
         # with total_bytes / node_count


### PR DESCRIPTION
Ensure that DiskIo telemetry does not rely on Rally being a parent
process of Elasticsearch and persists the disk counters at the beginning
of a benchmark and can read it again afterwards.

Relates to #697