### PR TITLE
Assume string type for params by default

### DIFF
--- a/esrally/utils/opts.py
+++ b/esrally/utils/opts.py
@@ -42,7 +42,7 @@ def to_bool(v):
 
 def kv_to_map(kvs):
     def convert(v):
-        # string
+        # string (specified explicitly)
         if v.startswith("'"):
             return v[1:-1]
 
@@ -59,7 +59,12 @@ def kv_to_map(kvs):
             pass
 
         # boolean
-        return to_bool(v)
+        try:
+            return to_bool(v)
+        except ValueError:
+            pass
+        # treat it as string by default
+        return v
 
     result = {}
     for kv in kvs:

--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -22,6 +22,7 @@ from unittest import TestCase
 from esrally import exceptions
 from esrally.utils import opts
 
+
 class ConfigHelperFunctionTests(TestCase):
     def test_csv_to_list(self):
         self.assertEqual([], opts.csv_to_list(""))
@@ -30,7 +31,11 @@ class ConfigHelperFunctionTests(TestCase):
 
     def test_kv_to_map(self):
         self.assertEqual({}, opts.kv_to_map([]))
-        self.assertEqual({"k": "v"}, opts.kv_to_map(["k:'v'"]))
+        # explicit treatment as string
+        self.assertEqual({"k": "3"}, opts.kv_to_map(["k:'3'"]))
+        self.assertEqual({"k": 3}, opts.kv_to_map(["k:3"]))
+        # implicit treatment as string
+        self.assertEqual({"k": "v"}, opts.kv_to_map(["k:v"]))
         self.assertEqual({"k": "v", "size": 4, "empty": False, "temperature": 0.5},
                          opts.kv_to_map(["k:'v'", "size:4", "empty:false", "temperature:0.5"]))
 


### PR DESCRIPTION
With this commit we allow users to skip enclosing quotes for params
(like `track-params` or `team-params`) when the value is clearly a
string (i.e. it cannot be coerced to a number or a boolean value). It is
still possible to surround a parameter with single-quotes to enforce
treatment as a string.