### PR TITLE
Fixup ProcessLauncherTests issues

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -321,7 +321,7 @@ class MetricsStore:
         self._trial_id = None
         self._trial_timestamp = None
         self._track = None
-        self._track_params = cfg.opts("track", "params")
+        self._track_params = cfg.opts("track", "params", default_value={}, mandatory=False)
         self._challenge = None
         self._car = None
         self._car_name = None

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -134,9 +134,6 @@ class MockProcess:
 
 
 def get_metrics_store(cfg):
-    cfg.add(config.Scope.application, "track", "params", None)
-    cfg.add(config.Scope.application, "system", "env.name", None)
-
     ms = InMemoryMetricsStore(cfg)
     ms.open(trial_id=str(uuid.uuid4()),
             trial_timestamp=datetime.now(),
@@ -164,19 +161,18 @@ class ProcessLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "keep.running", False)
         cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
         cfg.add(config.Scope.application, "mechanic", "telemetry.params", None)
+        cfg.add(config.Scope.application, "system", "env.name", "test")
 
         ms = get_metrics_store(cfg)
         proc_launcher = launcher.ProcessLauncher(cfg, ms, paths.races_root(cfg))
 
-        tmpdir = tempfile.mkdtemp()
         node_config = NodeConfiguration(car=Car("default", root_path=None, config_paths=[]), ip="127.0.0.1", node_name="testnode",
-                                        node_root_path=tmpdir, binary_path=tmpdir, log_path=tmpdir, data_paths=tmpdir)
+                                        node_root_path="/tmp", binary_path="/tmp", log_path="/tmp", data_paths="/tmp")
 
         nodes = proc_launcher.start([node_config])
         self.assertEqual(len(nodes), 1)
         self.assertEqual(nodes[0].pid, MOCK_PID_VALUE)
 
-        proc_launcher.keep_running = False
         proc_launcher.stop(nodes)
         self.assertTrue(kill.called)
 
@@ -191,6 +187,7 @@ class ExternalLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
         cfg.add(config.Scope.application, "client", "hosts", self.test_host)
         cfg.add(config.Scope.application, "client", "options", self.client_options)
+        cfg.add(config.Scope.application, "system", "env.name", "test")
 
         ms = get_metrics_store(cfg)
 
@@ -206,6 +203,7 @@ class ExternalLauncherTests(TestCase):
         cfg.add(config.Scope.application, "client", "hosts", self.test_host)
         cfg.add(config.Scope.application, "client", "options", self.client_options)
         cfg.add(config.Scope.application, "mechanic", "distribution.version", "2.3.3")
+        cfg.add(config.Scope.application, "system", "env.name", "test")
 
         ms = get_metrics_store(cfg)
 
@@ -221,6 +219,7 @@ class ExternalLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
         cfg.add(config.Scope.application, "client", "hosts", self.test_host)
         cfg.add(config.Scope.application, "client", "options", client_options)
+        cfg.add(config.Scope.application, "system", "env.name", "test")
 
         ms = get_metrics_store(cfg)
 
@@ -243,6 +242,7 @@ class ClusterLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "telemetry.params", {})
         cfg.add(config.Scope.application, "mechanic", "preserve.install", False)
         cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", False)
+        cfg.add(config.Scope.application, "system", "env.name", "test")
 
         ms = get_metrics_store(cfg)
 
@@ -260,6 +260,7 @@ class ClusterLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "telemetry.params", {})
         cfg.add(config.Scope.application, "mechanic", "preserve.install", False)
         cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", False)
+        cfg.add(config.Scope.application, "system", "env.name", "test")
 
         ms = get_metrics_store(cfg)
 
@@ -284,6 +285,7 @@ class ClusterLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "telemetry.params", {})
         cfg.add(config.Scope.application, "mechanic", "preserve.install", False)
         cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", False)
+        cfg.add(config.Scope.application, "system", "env.name", "test")
 
         ms = get_metrics_store(cfg)
 

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -14,17 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import datetime
 import io
+import uuid
 from unittest import TestCase, mock
 
 from esrally import config, exceptions, paths
 from esrally.mechanic import launcher
+from esrally.metrics import InMemoryMetricsStore
 from esrally.utils import opts
-
-
-class MockMetricsStore:
-    def add_meta_info(self, scope, scope_key, key, value):
-        pass
 
 
 class MockClientFactory:
@@ -115,6 +113,19 @@ class MockPopen:
         return 0
 
 
+def get_metrics_store(cfg):
+    cfg.add(config.Scope.application, "track", "params", None)
+    cfg.add(config.Scope.application, "system", "env.name", None)
+
+    ms = InMemoryMetricsStore(cfg)
+    ms.open(trial_id=str(uuid.uuid4()),
+            trial_timestamp=datetime.now(),
+            track_name="test",
+            challenge_name="test",
+            car_name="test")
+    return ms
+
+
 MOCK_PID_VALUE = 1234
 
 
@@ -124,12 +135,18 @@ class ProcessLauncherTests(TestCase):
     @mock.patch('esrally.mechanic.java_resolver.java_home', return_value=(12, "/java_home/"))
     @mock.patch('esrally.utils.jvm.supports_option', return_value=True)
     @mock.patch('os.chdir')
-    @mock.patch('esrally.config.Config')
-    @mock.patch('esrally.metrics.MetricsStore')
     @mock.patch('esrally.mechanic.provisioner.NodeConfiguration')
     @mock.patch('esrally.mechanic.launcher.wait_for_pidfile', return_value=MOCK_PID_VALUE)
     @mock.patch('psutil.Process')
-    def test_daemon_start_stop(self, process, wait_for_pidfile, node_config, ms, cfg, chdir, supports, java_home, kill):
+    def test_daemon_start_stop(self, process, wait_for_pidfile, node_config, chdir, supports, java_home, kill):
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "node", "root.dir", "test")
+        cfg.add(config.Scope.application, "mechanic", "keep.running", False)
+        cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
+        cfg.add(config.Scope.application, "mechanic", "telemetry.params", None)
+
+        ms = get_metrics_store(cfg)
+
         proc_launcher = launcher.ProcessLauncher(cfg, ms, paths.races_root(cfg))
 
         nodes = proc_launcher.start([node_config])
@@ -152,7 +169,9 @@ class ExternalLauncherTests(TestCase):
         cfg.add(config.Scope.application, "client", "hosts", self.test_host)
         cfg.add(config.Scope.application, "client", "options", self.client_options)
 
-        m = launcher.ExternalLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
+        ms = get_metrics_store(cfg)
+
+        m = launcher.ExternalLauncher(cfg, ms, client_factory_class=MockClientFactory)
         m.start()
 
         # automatically determined by launcher on attach
@@ -165,7 +184,9 @@ class ExternalLauncherTests(TestCase):
         cfg.add(config.Scope.application, "client", "options", self.client_options)
         cfg.add(config.Scope.application, "mechanic", "distribution.version", "2.3.3")
 
-        m = launcher.ExternalLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
+        ms = get_metrics_store(cfg)
+
+        m = launcher.ExternalLauncher(cfg, ms, client_factory_class=MockClientFactory)
         m.start()
         # did not change user defined value
         self.assertEqual(cfg.opts("mechanic", "distribution.version"), "2.3.3")
@@ -178,7 +199,9 @@ class ExternalLauncherTests(TestCase):
         cfg.add(config.Scope.application, "client", "hosts", self.test_host)
         cfg.add(config.Scope.application, "client", "options", client_options)
 
-        m = launcher.ExternalLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
+        ms = get_metrics_store(cfg)
+
+        m = launcher.ExternalLauncher(cfg, ms, client_factory_class=MockClientFactory)
         m.start()
 
         # automatically determined by launcher on attach
@@ -198,7 +221,9 @@ class ClusterLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "preserve.install", False)
         cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", False)
 
-        cluster_launcher = launcher.ClusterLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
+        ms = get_metrics_store(cfg)
+
+        cluster_launcher = launcher.ClusterLauncher(cfg, ms, client_factory_class=MockClientFactory)
         cluster = cluster_launcher.start()
 
         self.assertEqual([{"host": "10.0.0.10", "port": 9200}, {"host": "10.0.0.11", "port": 9200}], cluster.hosts)
@@ -213,7 +238,9 @@ class ClusterLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "preserve.install", False)
         cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", False)
 
-        cluster_launcher = launcher.ClusterLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
+        ms = get_metrics_store(cfg)
+
+        cluster_launcher = launcher.ClusterLauncher(cfg, ms, client_factory_class=MockClientFactory)
         cluster = cluster_launcher.start()
 
         for telemetry_device in cluster.telemetry.devices:
@@ -235,7 +262,9 @@ class ClusterLauncherTests(TestCase):
         cfg.add(config.Scope.application, "mechanic", "preserve.install", False)
         cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", False)
 
-        cluster_launcher = launcher.ClusterLauncher(cfg, MockMetricsStore(), client_factory_class=MockClientFactory)
+        ms = get_metrics_store(cfg)
+
+        cluster_launcher = launcher.ClusterLauncher(cfg, ms, client_factory_class=MockClientFactory)
         with self.assertRaisesRegex(exceptions.LaunchError,
                                     "Elasticsearch REST API layer is not available. Forcefully terminated cluster."):
             cluster_launcher.start()


### PR DESCRIPTION
The start_stop test in ProcessLauncherTests uses a MagicMock object for Process, which is incompatible with telemetry operations.
- Replace Process MagicMock with a minimal hand-mocked class.  
 - Also, remove Config + MetricsStore mocks while we're at it.

Relates to PRs #743, #744 