### PR TITLE
Log git output

### DIFF
--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -55,23 +55,20 @@ def clone(src, remote):
 
 @probed
 def fetch(src, remote="origin"):
-    # Don't swallow output but silence git at least a bit... (--quiet)
-    if process.run_subprocess(
-            "git -C {0} fetch --prune --tags --quiet {1}".format(src, remote)):
+    if process.run_subprocess_with_logging("git -C {0} fetch --prune --tags {1}".format(src, remote)):
         raise exceptions.SupplyError("Could not fetch source tree from [%s]" % remote)
 
 
 @probed
 def checkout(src_dir, branch="master"):
-    if process.run_subprocess(
-            "git -C {0} checkout --quiet {1}".format(src_dir, branch)):
+    if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(src_dir, branch)):
         raise exceptions.SupplyError("Could not checkout [%s]. Do you have uncommitted changes?" % branch)
 
 
 @probed
 def rebase(src_dir, remote="origin", branch="master"):
     checkout(src_dir, branch)
-    if process.run_subprocess("git -C {0} rebase --quiet {1}/{2}".format(src_dir, remote, branch)):
+    if process.run_subprocess_with_logging("git -C {0} rebase {1}/{2}".format(src_dir, remote, branch)):
         raise exceptions.SupplyError("Could not rebase on branch [%s]" % branch)
 
 
@@ -84,15 +81,15 @@ def pull(src_dir, remote="origin", branch="master"):
 @probed
 def pull_ts(src_dir, ts):
     fetch(src_dir)
-    if process.run_subprocess("git -C {0} checkout --quiet `git -C {0} rev-list -n 1 --before=\"{1}\" "
-                              "--date=iso8601 origin/master`".format(src_dir, ts)):
+    if process.run_subprocess_with_logging("git -C {0} checkout `git -C {0} rev-list -n 1 --before=\"{1}\" "
+                                           "--date=iso8601 origin/master`".format(src_dir, ts)):
         raise exceptions.SupplyError("Could not checkout source tree for timestamped revision [%s]" % ts)
 
 
 @probed
 def pull_revision(src_dir, revision):
     fetch(src_dir)
-    if process.run_subprocess("git -C {0} checkout --quiet {1}".format(src_dir, revision)):
+    if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(src_dir, revision)):
         raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
 
 

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -69,66 +69,64 @@ class GitTests(TestCase):
         ensure_dir.assert_called_with(src)
         run_subprocess_with_logging.assert_called_with("git clone http://github.com/some/project /src")
 
-    @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_fetch_successful(self, run_subprocess_with_logging, run_subprocess):
+    def test_fetch_successful(self, run_subprocess_with_logging):
         run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = False
         git.fetch("/src", remote="my-origin")
-        run_subprocess.assert_called_with("git -C /src fetch --prune --tags --quiet my-origin")
+        run_subprocess_with_logging.assert_called_with("git -C /src fetch --prune --tags my-origin")
 
-    @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_fetch_with_error(self, run_subprocess_with_logging, run_subprocess):
-        run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = True
+    def test_fetch_with_error(self, run_subprocess_with_logging):
+        # first call is to check the git version (0 -> succeeds), the second call is the failing checkout (1 -> fails)
+        run_subprocess_with_logging.side_effect = [0, 1]
         with self.assertRaises(exceptions.SupplyError) as ctx:
             git.fetch("/src", remote="my-origin")
         self.assertEqual("Could not fetch source tree from [my-origin]", ctx.exception.args[0])
-        run_subprocess.assert_called_with("git -C /src fetch --prune --tags --quiet my-origin")
+        run_subprocess_with_logging.assert_called_with("git -C /src fetch --prune --tags my-origin")
 
-    @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_checkout_successful(self, run_subprocess_with_logging, run_subprocess):
+    def test_checkout_successful(self, run_subprocess_with_logging):
         run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = False
         git.checkout("/src", "feature-branch")
-        run_subprocess.assert_called_with("git -C /src checkout --quiet feature-branch")
+        run_subprocess_with_logging.assert_called_with("git -C /src checkout feature-branch")
 
-    @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_checkout_with_error(self, run_subprocess_with_logging, run_subprocess):
-        run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = True
+    def test_checkout_with_error(self, run_subprocess_with_logging):
+        # first call is to check the git version (0 -> succeeds), the second call is the failing checkout (1 -> fails)
+        run_subprocess_with_logging.side_effect = [0, 1]
         with self.assertRaises(exceptions.SupplyError) as ctx:
             git.checkout("/src", "feature-branch")
         self.assertEqual("Could not checkout [feature-branch]. Do you have uncommitted changes?", ctx.exception.args[0])
-        run_subprocess.assert_called_with("git -C /src checkout --quiet feature-branch")
+        run_subprocess_with_logging.assert_called_with("git -C /src checkout feature-branch")
 
-    @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_rebase(self, run_subprocess_with_logging, run_subprocess):
+    def test_rebase(self, run_subprocess_with_logging):
         run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = False
         git.rebase("/src", remote="my-origin", branch="feature-branch")
         calls = [
-            mock.call("git -C /src checkout --quiet feature-branch"),
-            mock.call("git -C /src rebase --quiet my-origin/feature-branch")
+            mock.call("git -C /src checkout feature-branch"),
+            mock.call("git -C /src rebase my-origin/feature-branch")
         ]
-        run_subprocess.assert_has_calls(calls)
+        run_subprocess_with_logging.assert_has_calls(calls)
 
-    @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_pull(self, run_subprocess_with_logging, run_subprocess):
+    def test_pull(self, run_subprocess_with_logging):
         run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = False
         git.pull("/src", remote="my-origin", branch="feature-branch")
         calls = [
-            mock.call("git -C /src fetch --prune --tags --quiet my-origin"),
-            mock.call("git -C /src checkout --quiet feature-branch"),
-            mock.call("git -C /src rebase --quiet my-origin/feature-branch")
+            # pull
+            mock.call('git -C /src --version', level=logging.DEBUG),
+            # fetch
+            mock.call('git -C /src --version', level=logging.DEBUG),
+            mock.call("git -C /src fetch --prune --tags my-origin"),
+            # rebase
+            mock.call('git -C /src --version', level=logging.DEBUG),
+            # checkout
+            mock.call('git -C /src --version', level=logging.DEBUG),
+            mock.call("git -C /src checkout feature-branch"),
+            mock.call("git -C /src rebase my-origin/feature-branch")
         ]
-        run_subprocess.assert_has_calls(calls)
+        run_subprocess_with_logging.assert_has_calls(calls)
 
     @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")


### PR DESCRIPTION
With this commit we send git output to logs (except when cloning a repo
initially as it might require the user to enter credentials). This
avoids that git output interferes with Rally's. This is needed e.g. when
Rally's `download` subcommand is invoked where we usually expect only a
JSON fragment as output.

Closes #745