### PR TITLE
Consistently render links to the documentation

### DIFF
--- a/esrally/__init__.py
+++ b/esrally/__init__.py
@@ -17,6 +17,7 @@
 
 import os
 import sys
+import urllib
 import pkg_resources
 
 __version__ = pkg_resources.require("esrally")[0].version
@@ -72,3 +73,7 @@ $$$$$$$$$$""""           ""$$$$$$$$$$$"
 def check_python_version():
     if sys.version_info.major != 3 or sys.version_info.minor < 5:
         raise RuntimeError("Rally requires at least Python 3.5 but you are using:\n\nPython %s" % str(sys.version))
+
+
+def doc_link(path=None):
+    return urllib.parse.urljoin(DOC_LINK, path) if path else DOC_LINK

--- a/esrally/client.py
+++ b/esrally/client.py
@@ -19,7 +19,7 @@ import logging
 import certifi
 import urllib3
 
-from esrally import exceptions, DOC_LINK
+from esrally import exceptions, doc_link
 from esrally.utils import console
 
 
@@ -82,16 +82,15 @@ class EsClientFactory:
                 console.println(
                     "'{}' is missing from client-options but '{}' has been specified.\n"
                     "If your Elasticsearch setup requires client certificate verification both need to be supplied.\n"
-                    "Read the documentation at {}/command_line_reference.html#client-options\n".format(
+                    "Read the documentation at {}\n".format(
                         missing_client_ssl_option,
                         defined_client_ssl_option,
-                        console.format.link(DOC_LINK))
+                        console.format.link(doc_link("command_line_reference.html#client-options")))
                 )
                 raise exceptions.SystemSetupError(
                     "Cannot specify '{}' without also specifying '{}' in client-options.".format(
                         defined_client_ssl_option,
-                        missing_client_ssl_option,
-                        DOC_LINK))
+                        missing_client_ssl_option))
             elif client_cert and client_key:
                 self.logger.info("SSL client authentication: on")
                 self.ssl_context.load_cert_chain(certfile=client_cert,

--- a/esrally/config.py
+++ b/esrally/config.py
@@ -23,7 +23,7 @@ import re
 import shutil
 from enum import Enum
 
-from esrally import PROGRAM_NAME, DOC_LINK, exceptions
+from esrally import PROGRAM_NAME, doc_link, exceptions
 from esrally.utils import io, git, console, convert
 
 
@@ -302,7 +302,7 @@ class ConfigFactory:
         if advanced_config:
             self.o("Running advanced configuration. You can get additional help at:")
             self.o("")
-            self.o("  %s" % console.format.link("%sconfiguration.html" % DOC_LINK))
+            self.o("  %s" % console.format.link(doc_link("configuration.html")))
             self.o("")
         else:
             self.o("Running simple configuration. Run the advanced configuration with:")
@@ -416,7 +416,7 @@ class ConfigFactory:
         self.o("More info about Rally:")
         self.o("")
         self.o("* Type %s --help" % PROGRAM_NAME)
-        self.o("* Read the documentation at %s" % console.format.link(DOC_LINK))
+        self.o("* Read the documentation at %s" % console.format.link(doc_link()))
         self.o("* Ask a question on the forum at %s" % console.format.link("https://discuss.elastic.co/c/elasticsearch/rally"))
 
     def print_detection_result(self, what, result, warn_if_missing=False, additional_message=None):
@@ -629,7 +629,7 @@ def migrate(config_file, current_version, target_version, out=print, i=input):
                         "  [{} = {}] to [{} = <the full command>]."
                         "  Please refer to the documentation for more details:"
                         "  {}.\n".format(plugin_match.group(1), config_file.location, k, v, new_key,
-                                         console.format.link("%selasticsearch_plugins.html#running-a-benchmark-with-plugins" % DOC_LINK)))
+                                         console.format.link(doc_link("elasticsearch_plugins.html#running-a-benchmark-with-plugins"))))
 
         if "build" in config:
             logger.info("Removing Gradle configuration as Rally now uses the Gradle Wrapper to build Elasticsearch.")

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -21,9 +21,8 @@ import os
 import sys
 import tabulate
 import thespian.actors
-import urllib
 
-from esrally import actor, config, exceptions, track, driver, mechanic, reporter, metrics, doc_link, PROGRAM_NAME
+from esrally import actor, config, doc_link, driver, exceptions, mechanic, metrics, reporter, track, PROGRAM_NAME
 from esrally.utils import console, opts
 
 # benchmarks with external candidates are really scary and we should warn users.

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -23,8 +23,8 @@ import tabulate
 import thespian.actors
 import urllib
 
-from esrally import actor, config, exceptions, track, driver, mechanic, reporter, metrics, time, DOC_LINK, PROGRAM_NAME
-from esrally.utils import console, convert, opts
+from esrally import actor, config, exceptions, track, driver, mechanic, reporter, metrics, doc_link, PROGRAM_NAME
+from esrally.utils import console, opts
 
 # benchmarks with external candidates are really scary and we should warn users.
 BOGUS_RESULTS_WARNING = """
@@ -354,7 +354,7 @@ def run(cfg):
                 "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n"
                 "Add --pipeline=benchmark-only in your Rally arguments and try again.\n"
                 "For more details read the docs for the benchmark-only pipeline in {}\n".format(
-                    urllib.parse.urljoin(DOC_LINK, "pipelines.html#benchmark-only")))
+                    doc_link("pipelines.html#benchmark-only")))
 
     try:
         pipeline = pipelines[name]

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -24,7 +24,7 @@ import time
 import uuid
 
 from esrally import version, actor, config, paths, racecontrol, reporter, metrics, track, chart_generator, exceptions, log
-from esrally import PROGRAM_NAME, BANNER, SKULL, doc_link, check_python_version
+from esrally import PROGRAM_NAME, BANNER, SKULL, check_python_version, doc_link
 from esrally.mechanic import team, telemetry, mechanic
 from esrally.utils import io, convert, process, console, net, opts
 
@@ -46,7 +46,7 @@ def create_arg_parser():
 
     parser = argparse.ArgumentParser(prog=PROGRAM_NAME,
                                      description=BANNER + "\n\n You Know, for Benchmarking Elasticsearch.",
-                                     epilog="Find out more about Rally at %s" % console.format.link(doc_link()),
+                                     epilog="Find out more about Rally at {}".format(console.format.link(doc_link())),
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version', version="%(prog)s " + version.version())
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -24,7 +24,7 @@ import time
 import uuid
 
 from esrally import version, actor, config, paths, racecontrol, reporter, metrics, track, chart_generator, exceptions, log
-from esrally import PROGRAM_NAME, DOC_LINK, BANNER, SKULL, check_python_version
+from esrally import PROGRAM_NAME, BANNER, SKULL, doc_link, check_python_version
 from esrally.mechanic import team, telemetry, mechanic
 from esrally.utils import io, convert, process, console, net, opts
 
@@ -46,7 +46,7 @@ def create_arg_parser():
 
     parser = argparse.ArgumentParser(prog=PROGRAM_NAME,
                                      description=BANNER + "\n\n You Know, for Benchmarking Elasticsearch.",
-                                     epilog="Find out more about Rally at %s" % console.format.link(DOC_LINK),
+                                     epilog="Find out more about Rally at %s" % console.format.link(doc_link()),
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version', version="%(prog)s " + version.version())
 
@@ -416,7 +416,7 @@ def print_help_on_errors():
     console.println(console.format.bold(heading))
     console.println(console.format.underline_for(heading))
     console.println("* Check the log files in {} for errors.".format(log.default_log_path()))
-    console.println("* Read the documentation at {}".format(console.format.link(DOC_LINK)))
+    console.println("* Read the documentation at {}".format(console.format.link(doc_link())))
     console.println("* Ask a question on the forum at {}".format(console.format.link("https://discuss.elastic.co/c/elasticsearch/rally")))
     console.println("* Raise an issue at {} and include the log files in {}."
                     .format(console.format.link("https://github.com/elastic/rally/issues"), log.default_log_path()))

--- a/esrally/rallyd.py
+++ b/esrally/rallyd.py
@@ -20,7 +20,7 @@ import time
 import logging
 import argparse
 
-from esrally import actor, version, exceptions, DOC_LINK, BANNER, PROGRAM_NAME, check_python_version, log
+from esrally import actor, version, exceptions, doc_link, BANNER, PROGRAM_NAME, check_python_version, log
 from esrally.utils import console
 
 
@@ -76,7 +76,7 @@ def main():
 
     parser = argparse.ArgumentParser(prog=PROGRAM_NAME,
                                      description=BANNER + "\n\n Rally daemon to support remote benchmarks",
-                                     epilog="Find out more about Rally at %s" % console.format.link(DOC_LINK),
+                                     epilog="Find out more about Rally at %s" % console.format.link(doc_link()),
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version', version="%(prog)s " + version.version())
 

--- a/esrally/rallyd.py
+++ b/esrally/rallyd.py
@@ -76,7 +76,7 @@ def main():
 
     parser = argparse.ArgumentParser(prog=PROGRAM_NAME,
                                      description=BANNER + "\n\n Rally daemon to support remote benchmarks",
-                                     epilog="Find out more about Rally at %s" % console.format.link(doc_link()),
+                                     epilog="Find out more about Rally at {}".format(console.format.link(doc_link())),
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--version', action='version', version="%(prog)s " + version.version())
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -23,7 +23,7 @@ import ssl
 from copy import deepcopy
 from unittest import TestCase, mock
 
-from esrally import client, exceptions, DOC_LINK
+from esrally import client, exceptions, doc_link
 from esrally.utils import console
 
 
@@ -183,10 +183,10 @@ class EsClientFactoryTests(TestCase):
         mocked_console_println.assert_called_once_with(
             "'{}' is missing from client-options but '{}' has been specified.\n"
             "If your Elasticsearch setup requires client certificate verification both need to be supplied.\n"
-            "Read the documentation at {}/command_line_reference.html#client-options\n".format(
+            "Read the documentation at {}\n".format(
                 missing_client_ssl_option,
                 random_client_ssl_option,
-                console.format.link(DOC_LINK)
+                console.format.link(doc_link("command_line_reference.html#client-options"))
             )
         )
         self.assertEqual(

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -17,11 +17,9 @@
 
 import unittest.mock as mock
 import os
-import random
 from unittest import TestCase
 
-from esrally import racecontrol, config, exceptions, DOC_LINK
-from esrally.utils import console
+from esrally import racecontrol, config, exceptions
 
 
 class RaceControlTests(TestCase):

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -19,7 +19,7 @@ import unittest.mock as mock
 import os
 from unittest import TestCase
 
-from esrally import racecontrol, config, exceptions
+from esrally import config, exceptions, racecontrol
 
 
 class RaceControlTests(TestCase):


### PR DESCRIPTION
With this commit we render all links to Rally's documentation
consistently with a newly introduced function `doc_link` that can also
handle paths to specific pages in the documentation.