### PR TITLE
Retrieve timestamped commit hash separately

### DIFF
--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -81,8 +81,9 @@ def pull(src_dir, remote="origin", branch="master"):
 @probed
 def pull_ts(src_dir, ts):
     fetch(src_dir)
-    if process.run_subprocess_with_logging("git -C {0} checkout `git -C {0} rev-list -n 1 --before=\"{1}\" "
-                                           "--date=iso8601 origin/master`".format(src_dir, ts)):
+    revision = process.run_subprocess_with_output(
+        "git -C {0} rev-list -n 1 --before=\"{1}\" --date=iso8601 origin/master".format(src_dir, ts))[0].strip()
+    if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(src_dir, revision)):
         raise exceptions.SupplyError("Could not checkout source tree for timestamped revision [%s]" % ts)
 
 

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -129,15 +129,19 @@ class GitTests(TestCase):
         run_subprocess_with_logging.assert_has_calls(calls)
 
     @mock.patch("esrally.utils.process.run_subprocess")
+    @mock.patch("esrally.utils.process.run_subprocess_with_output")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_pull_ts(self, run_subprocess_with_logging, run_subprocess):
+    def test_pull_ts(self, run_subprocess_with_logging, run_subprocess_with_output, run_subprocess):
         run_subprocess_with_logging.return_value = 0
+        run_subprocess_with_output.return_value = ["3694a07"]
         run_subprocess.side_effect = [False, False]
         git.pull_ts("/src", "20160101T110000Z")
+
+        run_subprocess_with_output.assert_called_with(
+            "git -C /src rev-list -n 1 --before=\"20160101T110000Z\" --date=iso8601 origin/master")
         run_subprocess.has_calls([
             mock.call("git -C /src fetch --prune --tags --quiet origin"),
-            mock.call("git -C /src checkout --quiet `git -C /src rev-list -n 1 --before=\"20160101T110000Z\" "
-                      "--date=iso8601 origin/master`"),
+            mock.call("git -C /src checkout 3694a07")
         ])
 
     @mock.patch("esrally.utils.process.run_subprocess")


### PR DESCRIPTION
With this commit we retrieve the correct commit hash for a given
timestamp separately from the actual checkout call as this has caused
problems.

Relates #747