### PR TITLE
Option track-revision should work with track-repository

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -191,7 +191,7 @@ def create_arg_parser():
         track_source_group.add_argument(
             "--track-path",
             help="Define the path to a track.")
-        track_source_group.add_argument(
+        p.add_argument(
             "--track-revision",
             help="Define a specific revision in the track repository that Rally should use.",
             default=None)
@@ -607,13 +607,17 @@ def main():
 
     cfg.add(config.Scope.applicationOverride, "race", "pipeline", args.pipeline)
     cfg.add(config.Scope.applicationOverride, "race", "user.tag", args.user_tag)
+    
+    cfg.add(config.Scope.applicationOverride, "track", "repository.revision", args.track_revision)
 
     # We can assume here that if a track-path is given, the user did not specify a repository either (although argparse sets it to
     # its default value)
     if args.track_path:
         cfg.add(config.Scope.applicationOverride, "track", "track.path", os.path.abspath(io.normalize_path(args.track_path)))
         cfg.add(config.Scope.applicationOverride, "track", "repository.name", None)
-        cfg.add(config.Scope.applicationOverride, "track", "repository.revision", None)
+        if args.track_revision:
+            # stay as close as possible to argparse errors although we have a custom validation.
+            arg_parser.error("argument --track-revision not allowed with argument --track-path")
         if args.track:
             # stay as close as possible to argparse errors although we have a custom validation.
             arg_parser.error("argument --track not allowed with argument --track-path")
@@ -621,7 +625,6 @@ def main():
     else:
         # cfg.add(config.Scope.applicationOverride, "track", "track.path", None)
         cfg.add(config.Scope.applicationOverride, "track", "repository.name", args.track_repository)
-        cfg.add(config.Scope.applicationOverride, "track", "repository.revision", args.track_revision)
         # set the default programmatically because we need to determine whether the user has provided a value
         chosen_track = args.track if args.track else "geonames"
         cfg.add(config.Scope.applicationOverride, "track", "track.name", chosen_track)

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -228,6 +228,8 @@ function test_list {
     esrally list elasticsearch-plugins --configuration-name="${cfg}"
     info "test list tracks [${cfg}]"
     esrally list tracks --configuration-name="${cfg}"
+    info "test list can use track revision together with track repository"
+    esrally list tracks --configuration-name="${cfg}" --track-repository=default --track-revision=4080dc9850d07e23b6fc7cfcdc7cf57b14e5168d
     info "test list telemetry [${cfg}]"
     esrally list telemetry --configuration-name="${cfg}"
 }


### PR DESCRIPTION
Both options track-repository and track-revision should work together but not with track-path option.

Fixes: https://github.com/elastic/rally/issues/740