### PR TITLE
Check that origin points to main repo for release

### DIFF
--- a/release-checks.sh
+++ b/release-checks.sh
@@ -51,7 +51,7 @@ then
 fi
 
 ORIGIN_URL=$(git remote get-url --push origin)
-if [[ $(echo ${ORIGIN_URL} | grep -c "elastic/rally") == "0" ]]
+if [[ ${ORIGIN_URL} != *"elastic/rally"* ]]
 then
     echo "Error: the git remote [origin] does not point to Rally's main repo at elastic/rally but to [${ORIGIN_URL}]."
     exit 1

--- a/release-checks.sh
+++ b/release-checks.sh
@@ -50,6 +50,13 @@ then
     exit 1
 fi
 
+ORIGIN_URL=$(git remote get-url --push origin)
+if [[ $(echo ${ORIGIN_URL} | grep -c "elastic/rally") == "0" ]]
+then
+    echo "Error: the git remote [origin] does not point to Rally's main repo at elastic/rally but to [${ORIGIN_URL}]."
+    exit 1
+fi
+
 # Check if there will be any errors during CHANGELOG.md generation
 CHANGELOG="$(python3 changelog.py ${RELEASE_VERSION})"
 


### PR DESCRIPTION
With this commit we add a new pre-release check that ensures that the
git remote named `origin` points to Rally's main repository instead of a
fork. This is necessary for releases because later during the release
process, changes will be pushed automatically to the main repository
(such as the release tags).

Closes #717