### PR TITLE
Run a task completely even without time-periods

### DIFF
--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -804,7 +804,7 @@ In ``register`` you bind the name in the track specification to your parameter s
 * The constructor needs to have the signature ``__init__(self, track, params, **kwargs)``.
 * ``partition(self, partition_index, total_partitions)`` is called by Rally to "assign" the parameter source across multiple clients. Typically you can just return ``self``. If each client needs to act differently then you can provide different parameter source instances here as well.
 * ``params(self)``: This method returns a dictionary with all parameters that the corresponding "runner" expects. This method will be invoked once for every iteration during the race. In the example, we parameterize the query by randomly selecting a profession from a list.
-* ``infinite``: This property helps Rally to determine whether to let the parameter source determine when a task should be finished (usually when ``infinite`` is ``False``) or whether the task properties (e.g. ``iterations`` or ``time-period``) determine when a task should be finished.
+* ``infinite``: This property helps Rally to determine whether to let the parameter source determine when a task should be finished (when ``infinite`` is ``False``) or whether the task properties (e.g. ``iterations`` or ``time-period``) determine when a task should be finished. In the former case, the parameter source needs to raise ``StopIteration`` to indicate when it is finished.
 
 For cases, where you want to provide a progress indication (this is typically the case when ``infinite`` is ``False``), you can implement a property ``percent_completed`` which returns a floating point value between ``0.0`` and ``1.0``. Rally will query this value before each call to ``params()`` and uses it to indicate progress. However:
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,67 @@
 Migration Guide
 ===============
 
+Migrating to Rally 1.4.0
+------------------------
+
+Custom Parameter Sources
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+With Rally 1.4.0, we have changed the API for custom parameter sources. The ``size()`` method is now deprecated and is instead replaced with a new property called ``infinite``. If you have previously returned ``None`` in ``size()``, ``infinite`` should be set to ``True``, otherwise ``False``. Also, we recommend to implement the property ``percent_completed`` as Rally might not be able to determine progress in some cases. See below for some examples.
+
+Old::
+
+    class CustomFiniteParamSource:
+        # ...
+        def size():
+            return calculate_size()
+
+        def params():
+            return next_parameters()
+
+    class CustomInfiniteParamSource:
+        # ...
+        def size():
+            return None
+
+        # ...
+
+
+New::
+
+    class CustomFiniteParamSource:
+        def __init__(self, track, params, **kwargs):
+            self.infinite = False
+            # to track progress
+            self.current_invocation = 0
+
+        # ...
+        # Note that we have removed the size() method
+
+        def params():
+            self.current_invocation += 1
+            return next_parameters()
+
+        # Implementing this is optional but recommended for proper progress reports
+        @property
+        def percent_completed(self):
+            # for demonstration purposes we use calculate_size() here
+            # to determine the expected number of invocations. However, if
+            # it is possible to determine this value upfront, it is best
+            # to cache it in a field and just reuse the value
+            return self.current_invocation / calculate_size()
+
+
+    class CustomInfiniteParamSource:
+        def __init__(self, track, params, **kwargs):
+            self.infinite = True
+            # ...
+
+        # ...
+        # Note that we have removed the size() method
+        # ...
+
+
 Migrating to Rally 1.3.0
 ------------------------
 Races now stored by ID instead of timestamp

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -862,7 +862,7 @@ class BulkIndexParamSourceTests(TestCase):
 
         partition = source.partition(0, 1)
         # # no ingest-percentage specified, should issue all one hundred bulk requests
-        self.assertEqual(100, partition.size())
+        self.assertEqual(100, partition.total_bulks)
 
     def test_restricts_number_of_bulks_if_required(self):
         corpora = [
@@ -891,7 +891,7 @@ class BulkIndexParamSourceTests(TestCase):
 
         partition = source.partition(0, 1)
         # should issue three bulks of size 10.000
-        self.assertEqual(3, partition.size())
+        self.assertEqual(3, partition.total_bulks)
 
     def test_create_with_conflict_probability_zero(self):
         params.BulkIndexParamSource(track=track.Track(name="unit-test"), params={


### PR DESCRIPTION
There are multiple conditions how a task can be completed. Either the user
explicitly specifies a maximum number of iterations or a time-period or a task
is implicitly completed when the parameter source is exhausted (e.g. when
reading parameters from a file). In the latter case it is not necessary to
provide any indication when a task is complete because the parameter source can
determine it. However, so far this was required.

With this commit we introduce a change in the parameter source API so that it is
possible to determine this case and also provide proper progress indication.
Furthermore we adapt all parameter sources that come with Rally out of the box
and provide guidance for users how to change their own parameter sources.