### PR TITLE
Remove MergeParts internal telemetry device

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -121,8 +121,6 @@ Rally stores the following metrics:
 * ``latency``: Time period between submission of a request and receiving the complete response. It also includes wait time, i.e. the time the request spends waiting until it is ready to be serviced by Elasticsearch.
 * ``service_time`` Time period between start of request processing and receiving the complete response. This metric can easily be mixed up with ``latency`` but does not include waiting time. This is what most load testing tools refer to as "latency" (although it is incorrect).
 * ``throughput``: Number of operations that Elasticsearch can perform within a certain time period, usually per second. See the :doc:`track reference </track>` for a definition of what is meant by one "operation" for each operation type.
-* ``merge_parts_total_time_*``: Different merge times as reported by Lucene. Only available if Lucene index writer trace logging is enabled.
-* ``merge_parts_total_docs_*``: See ``merge_parts_total_time_*``
 * ``disk_io_write_bytes``: number of bytes that have been written to disk during the benchmark. On Linux this metric reports only the bytes that have been written by Elasticsearch, on Mac OS X it reports the number of bytes written by all processes.
 * ``disk_io_read_bytes``: number of bytes that have been read from disk during the benchmark. The same caveats apply on Mac OS X as for ``disk_io_write_bytes``.
 * ``node_startup_time``: The time in seconds it took from process start until the node is up.

--- a/docs/summary_report.rst
+++ b/docs/summary_report.rst
@@ -93,22 +93,6 @@ Cumulative merge throttle time across primary shards
 * **Definition**: Minimum, median and maximum cumulative time that merges have been throttled across primary shards as reported by the indices stats API.
 * **Corresponding metrics key**: ``merges_total_throttled_time`` (property: ``per-shard``)
 
-Merge time (``X``)
-------------------
-
-Where ``X`` is one of:
-
-* postings
-* stored fields
-* doc values
-* norms
-* vectors
-* points
-
-..
-
-* **Definition**: Different merge times as reported by Lucene. Only available if Lucene index writer trace logging is enabled (use ``--car-params="verbose_iw_logging_enabled:true"`` for that).
-* **Corresponding metrics keys**: ``merge_parts_total_time_*``
 
 ML processing time
 ------------------

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -319,7 +319,6 @@ class ProcessLauncher:
             telemetry.DiskIo(self.metrics_store, node_count_on_host, node_telemetry_dir, node_name),
             telemetry.NodeEnvironmentInfo(self.metrics_store),
             telemetry.IndexSize(data_paths, self.metrics_store),
-            telemetry.MergeParts(self.metrics_store, node_configuration.log_path),
             telemetry.StartupTime(self.metrics_store),
         ]
 

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -18,7 +18,6 @@
 import collections
 import logging
 import os
-import re
 import signal
 import subprocess
 import tabulate

--- a/esrally/mechanic/telemetry.py
+++ b/esrally/mechanic/telemetry.py
@@ -712,65 +712,6 @@ class StartupTime(InternalTelemetryDevice):
         self.metrics_store.put_value_node_level(node.node_name, "node_startup_time", self.timer.total_time(), "s")
 
 
-class MergeParts(InternalTelemetryDevice):
-    """
-    Gathers merge parts time statistics. Note that you need to run a track setup which logs these data.
-    """
-    MERGE_TIME_LINE = re.compile(r": (\d+) msec to merge ([a-z ]+) \[(\d+) docs\]")
-
-    def __init__(self, metrics_store, node_log_dir):
-        super().__init__()
-        self.node_log_dir = node_log_dir
-        self.metrics_store = metrics_store
-        self._t = None
-        self.node = None
-
-    def attach_to_node(self, node):
-        self.node = node
-
-    def on_benchmark_stop(self):
-        self.logger.info("Analyzing merge times.")
-        # first decompress all logs. They have unique names so it's safe to do that. It's easier to first decompress everything
-        for log_file in os.listdir(self.node_log_dir):
-            log_path = "%s/%s" % (self.node_log_dir, log_file)
-            if io.is_archive(log_path):
-                self.logger.info("Decompressing [%s] to analyze merge times...", log_path)
-                io.decompress(log_path, self.node_log_dir)
-
-        # we need to add up times from all files
-        merge_times = {}
-        for log_file in os.listdir(self.node_log_dir):
-            log_path = "%s/%s" % (self.node_log_dir, log_file)
-            if io.is_archive(log_file):
-                self.logger.debug("Skipping archived logs in [%s].", log_path)
-            elif io.has_extension(log_file, ".json"):
-                self.logger.debug("Skipping JSON-formatted logs in [%s].", log_path)
-            else:
-                self.logger.debug("Analyzing merge times in [%s]", log_path)
-                with open(log_path, mode="rt", encoding="utf-8") as f:
-                    self._extract_merge_times(f, merge_times)
-        if merge_times:
-            self._store_merge_times(merge_times)
-        self.logger.info("Finished analyzing merge times. Extracted [%s] different merge time components.", len(merge_times))
-
-    def _extract_merge_times(self, file, merge_times):
-        for line in file.readlines():
-            match = MergeParts.MERGE_TIME_LINE.search(line)
-            if match is not None:
-                duration_ms, part, num_docs = match.groups()
-                if part not in merge_times:
-                    merge_times[part] = [0, 0]
-                l = merge_times[part]
-                l[0] += int(duration_ms)
-                l[1] += int(num_docs)
-
-    def _store_merge_times(self, merge_times):
-        for k, v in merge_times.items():
-            metric_suffix = k.replace(" ", "_")
-            self.metrics_store.put_value_node_level(self.node.node_name, "merge_parts_total_time_%s" % metric_suffix, v[0], "ms")
-            self.metrics_store.put_count_node_level(self.node.node_name, "merge_parts_total_docs_%s" % metric_suffix, v[1])
-
-
 class DiskIo(InternalTelemetryDevice):
     """
     Gathers disk I/O stats.

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -170,14 +170,6 @@ class StatsCalculator:
         result.merge_throttle_time = self.sum("merges_total_throttled_time")
         result.merge_throttle_time_per_shard = self.shard_stats("merges_total_throttled_time")
 
-        self.logger.debug("Gathering merge part metrics.")
-        result.merge_part_time_postings = self.sum("merge_parts_total_time_postings")
-        result.merge_part_time_stored_fields = self.sum("merge_parts_total_time_stored_fields")
-        result.merge_part_time_doc_values = self.sum("merge_parts_total_time_doc_values")
-        result.merge_part_time_norms = self.sum("merge_parts_total_time_norms")
-        result.merge_part_time_vectors = self.sum("merge_parts_total_time_vectors")
-        result.merge_part_time_points = self.sum("merge_parts_total_time_points")
-
         self.logger.debug("Gathering ML max processing times.")
         result.ml_processing_time = self.ml_processing_time_stats()
 


### PR DESCRIPTION
Remove the Merge Parts telemetry device, which would display different merge times as reported by Lucene only when Lucene index writer trace logging was enabled (`--car-params="verbose_iw_logging_enabled:true"`). The following metric keys will not be gathered anymore: `merge_parts_total_time_*`  where * is one of `postings, stored fields, doc values, norms, vectors, points`

Closes https://github.com/elastic/rally/issues/754