### PR TITLE
Start release process creating NOTICE

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -27,10 +27,15 @@ set -eu
 
 RELEASE_VERSION=$1
 NEXT_RELEASE="$2.dev0"
+__NOTICE_OUTPUT_FILE="NOTICE.txt"
+
 
 echo "============================="
 echo "Preparing Rally release $RELEASE_VERSION"
 echo "============================="
+
+echo "Preparing ${__NOTICE_OUTPUT_FILE}"
+source create-notice.sh
 
 echo "Updating author information"
 git log --format='%aN' | sort -u > AUTHORS
@@ -66,10 +71,6 @@ then
     echo "ERROR: Rally version string [$(esrally --version)] does not start with expected version string [esrally $RELEASE_VERSION]"
     exit 2
 fi
-
-__NOTICE_OUTPUT_FILE="NOTICE.txt"
-echo "Preparing ${__NOTICE_OUTPUT_FILE}"
-source create-notice.sh
 
 # Build new version
 python3 setup.py bdist_wheel


### PR DESCRIPTION
With this commit we move the creation of the NOTICE file to the
beginning of the release process. As this depends on pulling files from
repositories that are not under our control, it can fail. By doing this
as the first step, we can correct any errors before other tasks have
modified state.