### PR TITLE
Store track-related meta-data in results

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1226,6 +1226,14 @@ class Race:
         # minor simplification for reporter
         return self.cluster.revision
 
+    @property
+    def meta_data(self):
+        meta = {}
+        meta.update(self.track.meta_data)
+        if self.challenge:
+            meta.update(self.challenge.meta_data)
+        return meta
+
     def add_results(self, results):
         self.results = results
 
@@ -1295,6 +1303,8 @@ class Race:
             result_template["car-params"] = self.car_params
         if self.plugin_params:
             result_template["plugin-params"] = self.plugin_params
+        if self.meta_data:
+            result_template["meta"] = self.meta_data
 
         all_results = []
 

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -39,7 +39,7 @@ FINAL_SCORE = r"""
 
 
 def calculate_results(metrics_store, race):
-    calc = StatsCalculator(metrics_store, race.challenge)
+    calc = StatsCalculator(metrics_store, race.track, race.challenge)
     return calc()
 
 
@@ -124,8 +124,9 @@ def percentiles_for_sample_size(sample_size):
 
 
 class StatsCalculator:
-    def __init__(self, store, challenge):
+    def __init__(self, store, track, challenge):
         self.store = store
+        self.track = track
         self.challenge = challenge
         self.logger = logging.getLogger(__name__)
 
@@ -143,7 +144,12 @@ class StatsCalculator:
                         self.summary_stats("throughput", t),
                         self.single_latency(t),
                         self.single_latency(t, metric_name="service_time"),
-                        self.error_rate(t)
+                        self.error_rate(t),
+                        self.merge(
+                                self.track.meta_data,
+                                self.challenge.meta_data,
+                                task.operation.meta_data,
+                                task.meta_data)
                     )
         self.logger.debug("Gathering node startup time metrics.")
         startup_times = self.store.get_raw("node_startup_time")
@@ -196,6 +202,13 @@ class StatsCalculator:
         # convert to int, fraction counts are senseless
         median_segment_count = self.median("segments_count")
         result.segment_count = int(median_segment_count) if median_segment_count is not None else median_segment_count
+        return result
+
+    def merge(self, *args):
+        result = {}
+        for arg in args:
+            if arg is not None:
+                result.update(arg)
         return result
 
     def sum(self, metric_name):
@@ -327,23 +340,32 @@ class Stats:
         return self.__dict__
 
     def as_flat_list(self):
+        def op_metrics(op_item, key, single_value=False):
+            doc = {
+                "task": op_item["task"],
+                "operation": op_item["operation"],
+                "name": key
+            }
+            if single_value:
+                doc["value"] = {"single":  op_item[key]}
+            else:
+                doc["value"] = op_item[key]
+            if "meta" in op_item:
+                doc["meta"] = op_item["meta"]
+            return doc
+
         all_results = []
         for metric, value in self.as_dict().items():
             if metric == "op_metrics":
                 for item in value:
                     if "throughput" in item:
-                        all_results.append(
-                            {"task": item["task"], "operation": item["operation"], "name": "throughput", "value": item["throughput"]})
+                        all_results.append(op_metrics(item, "throughput"))
                     if "latency" in item:
-                        all_results.append(
-                            {"task": item["task"], "operation": item["operation"], "name": "latency", "value": item["latency"]})
+                        all_results.append(op_metrics(item, "latency"))
                     if "service_time" in item:
-                        all_results.append(
-                            {"task": item["task"], "operation": item["operation"], "name": "service_time", "value": item["service_time"]})
+                        all_results.append(op_metrics(item, "service_time"))
                     if "error_rate" in item:
-                        all_results.append(
-                            {"task": item["task"], "operation": item["operation"], "name": "error_rate",
-                             "value": {"single": item["error_rate"]}})
+                        all_results.append(op_metrics(item, "error_rate", single_value=True))
             elif metric == "ml_processing_time":
                 for item in value:
                     all_results.append({
@@ -377,15 +399,18 @@ class Stats:
     def v(self, d, k, default=None):
         return d.get(k, default) if d else default
 
-    def add_op_metrics(self, task, operation, throughput, latency, service_time, error_rate):
-        self.op_metrics.append({
+    def add_op_metrics(self, task, operation, throughput, latency, service_time, error_rate, meta):
+        doc = {
             "task": task,
             "operation": operation,
             "throughput": throughput,
             "latency": latency,
             "service_time": service_time,
-            "error_rate": error_rate
-        })
+            "error_rate": error_rate,
+        }
+        if meta:
+            doc["meta"] = meta
+        self.op_metrics.append(doc)
 
     def add_node_metrics(self, node, startup_time):
         self.node_metrics.append({

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -905,7 +905,9 @@ class EsResultsStoreTests(TestCase):
 
         t = track.Track(name="unittest-track",
                         indices=[track.Index(name="tests", types=["_doc"])],
-                        challenges=[track.Challenge(name="index", default=True, schedule=schedule)])
+                        challenges=[track.Challenge(
+                            name="index", default=True, meta_data={"saturation": "70% saturated"}, schedule=schedule)],
+                        meta_data={"track-type": "saturation-degree", "saturation": "oversaturation"})
 
         c = cluster.Cluster([], [], None)
         c.distribution_version = "5.0.0"
@@ -928,6 +930,12 @@ class EsResultsStoreTests(TestCase):
                                         {
                                             "task": "index #1",
                                             "operation": "index",
+                                            # custom op-metric which will override the defaults provided by the race
+                                            "meta": {
+                                                "track-type": "saturation-degree",
+                                                "saturation": "70% saturated",
+                                                "op-type": "bulk"
+                                            },
                                             "throughput": {
                                                 "min": 1000,
                                                 "median": 1250,
@@ -973,6 +981,10 @@ class EsResultsStoreTests(TestCase):
                 "name": "old_gc_time",
                 "value": {
                     "single": 5
+                },
+                "meta": {
+                    "track-type": "saturation-degree",
+                    "saturation": "70% saturated"
                 }
             },
             {
@@ -1002,6 +1014,10 @@ class EsResultsStoreTests(TestCase):
                 "value": {
                     "single": 3.4
                 },
+                "meta": {
+                    "track-type": "saturation-degree",
+                    "saturation": "70% saturated"
+                }
             },
             {
                 "rally-version": "0.4.4",
@@ -1033,6 +1049,11 @@ class EsResultsStoreTests(TestCase):
                     "median": 1250,
                     "max": 1500,
                     "unit": "docs/s"
+                },
+                "meta": {
+                    "track-type": "saturation-degree",
+                    "saturation": "70% saturated",
+                    "op-type": "bulk"
                 }
             },
             {
@@ -1060,6 +1081,10 @@ class EsResultsStoreTests(TestCase):
                 "name": "young_gc_time",
                 "value": {
                     "single": 100
+                },
+                "meta": {
+                    "track-type": "saturation-degree",
+                    "saturation": "70% saturated"
                 }
             }
         ]

--- a/tests/reporter_test.py
+++ b/tests/reporter_test.py
@@ -122,7 +122,30 @@ class StatsTests(TestCase):
                         "50": 341,
                         "100": 376
                     },
-                    "error_rate": 0.0
+                    "error_rate": 0.0,
+                    "meta": {
+                        "clients": 8,
+                        "phase": "idx"
+                    }
+                },
+                {
+                    "task": "search #2",
+                    "operation": "search",
+                    "throughput": {
+                        "min": 9,
+                        "median": 10,
+                        "max": 12,
+                        "unit": "ops/s"
+                    },
+                    "latency": {
+                        "50": 99,
+                        "100": 111,
+                    },
+                    "service_time": {
+                        "50": 98,
+                        "100": 110
+                    },
+                    "error_rate": 0.1
                 }
             ],
             "node_metrics": [
@@ -185,6 +208,10 @@ class StatsTests(TestCase):
                 "median": 450,
                 "max": 452,
                 "unit": "docs/s"
+            },
+            "meta": {
+                "clients": 8,
+                "phase": "idx"
             }
         }, select(metric_list, "throughput", operation="index"))
 
@@ -195,6 +222,10 @@ class StatsTests(TestCase):
             "value": {
                 "50": 341,
                 "100": 376
+            },
+            "meta": {
+                "clients": 8,
+                "phase": "idx"
             }
         }, select(metric_list, "service_time", operation="index"))
 
@@ -205,6 +236,10 @@ class StatsTests(TestCase):
             "value": {
                 "50": 340,
                 "100": 376
+            },
+            "meta": {
+                "clients": 8,
+                "phase": "idx"
             }
         }, select(metric_list, "latency", operation="index"))
 
@@ -214,8 +249,53 @@ class StatsTests(TestCase):
             "operation": "index",
             "value": {
                 "single": 0.0
+            },
+            "meta": {
+                "clients": 8,
+                "phase": "idx"
             }
         }, select(metric_list, "error_rate", operation="index"))
+
+        self.assertEqual({
+            "name": "throughput",
+            "task": "search #2",
+            "operation": "search",
+            "value": {
+                "min": 9,
+                "median": 10,
+                "max": 12,
+                "unit": "ops/s"
+            }
+        }, select(metric_list, "throughput", operation="search"))
+
+        self.assertEqual({
+            "name": "service_time",
+            "task": "search #2",
+            "operation": "search",
+            "value": {
+                "50": 98,
+                "100": 110
+            }
+        }, select(metric_list, "service_time", operation="search"))
+
+        self.assertEqual({
+            "name": "latency",
+            "task": "search #2",
+            "operation": "search",
+            "value": {
+                "50": 99,
+                "100": 111
+            }
+        }, select(metric_list, "latency", operation="search"))
+
+        self.assertEqual({
+            "name": "error_rate",
+            "task": "search #2",
+            "operation": "search",
+            "value": {
+                "single": 0.1
+            }
+        }, select(metric_list, "error_rate", operation="search"))
 
         self.assertEqual({
             "node": "rally-node-0",


### PR DESCRIPTION
Rally allows to specify meta-data on track, challenge, task and
operation level. This information is stored for raw metrics records but
not for results. With this commit we ensure that any meta-data are
properly set also on the respective results documents. This allows to
use this information also e.g. in Kibana visualizations.
