### PR TITLE
Store race files always as race.json

### DIFF
--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -22,11 +22,11 @@ def rally_root():
 
 
 def races_root(cfg):
-    return "%s/races" % cfg.opts("node", "root.dir")
+    return os.path.join(cfg.opts("node", "root.dir"), "races")
 
 
 def race_root(cfg=None, trial_id=None):
     if not trial_id:
         trial_id = cfg.opts("system", "trial.id")
-    return "%s/%s" % (races_root(cfg), trial_id)
+    return os.path.join(races_root(cfg), trial_id)
 

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1327,5 +1327,6 @@ class FileRaceStoreTests(TestCase):
         self.race_store.store_race(race)
 
         retrieved_race = self.race_store.find_by_trial_id(trial_id=FileRaceStoreTests.TRIAL_ID)
+        self.assertEqual(race.trial_id, retrieved_race.trial_id)
         self.assertEqual(race.trial_timestamp, retrieved_race.trial_timestamp)
         self.assertEqual(1, len(self.race_store.list()))


### PR DESCRIPTION
With this commit we store the race file always as `race.json`.
Previously Rally had a logic built-in to create a unique file name if
there was a potential for duplicate race files (with the same race
timestamp) but as we're using the race id now for the base directory
this is not possible anymore.

Relates #720