### PR TITLE
Expose race-id as command line parameter

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -159,6 +159,11 @@ Note that the default values are not recorded or shown (Rally does not know abou
 
 A track consists of one or more challenges. With this flag you can specify which challenge should be run. If you don't specify a challenge, Rally derives the default challenge itself. To see the default challenge of a track, run ``esrally list tracks``.
 
+``race-id``
+~~~~~~~~~~~
+
+A unique identifier for this race. By default a random UUID is automatically chosen by Rally.
+
 .. _clr_include_tasks:
 
 ``include-tasks``

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -142,7 +142,7 @@ To further examine the contents we can bind mount it from another image e.g.::
     {
      "rally-version": "1.2.1.dev0",
      "environment": "local",
-     "trial-id": "1d81930a-4ebe-4640-a09b-3055174bce43",
+     "race-id": "1d81930a-4ebe-4640-a09b-3055174bce43",
 
 Specifics about the image
 -------------------------

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -11,8 +11,8 @@ Here is a typical metrics record::
 
     {
           "environment": "nightly",
-          "trial-timestamp": "20160421T042749Z",
-          "trial-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
+          "race-timestamp": "20160421T042749Z",
+          "race-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
           "@timestamp": 1461213093093,
           "relative-time": 10507328,
           "track": "geonames",
@@ -61,17 +61,17 @@ If you specify a car with mixins, it will be stored as one string separated with
 sample-type
 ~~~~~~~~~~~
 
-Rally runs warmup trials but records all samples. Normally, we are just interested in "normal" samples but for a full picture we might want to look also at "warmup" samples.
+Rally can be configured to run for a certain period in warmup mode. In this mode samples will be collected with the ``sample-type`` "warmup" but only "normal" samples are considered for the results that reported.
 
-trial-timestamp
-~~~~~~~~~~~~~~~
+race-timestamp
+~~~~~~~~~~~~~~
 
 A constant timestamp (always in UTC) that is determined when Rally is invoked.
 
-trial-id
-~~~~~~~~
+race-id
+~~~~~~~
 
-A UUID that changes on every invocation of Rally. It is intended to group all samples of a benchmark trial.
+A UUID that changes on every invocation of Rally. It is intended to group all samples of a benchmarking run.
 
 @timestamp
 ~~~~~~~~~~
@@ -81,7 +81,7 @@ The timestamp in milliseconds since epoch determined when the sample was taken.
 relative-time
 ~~~~~~~~~~~~~
 
-The relative time in microseconds since the start of the benchmark. This is useful for comparing time-series graphs over multiple trials, e.g. you might want to compare the indexing throughput over time across multiple benchmark trials. Obviously, they should always start at the same (relative) point in time and absolute timestamps are useless for that.
+The relative time in microseconds since the start of the benchmark. This is useful for comparing time-series graphs over multiple races, e.g. you might want to compare the indexing throughput over time across multiple races. Obviously, they should always start at the same (relative) point in time and absolute timestamps are useless for that.
 
 name, value, unit
 ~~~~~~~~~~~~~~~~~

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -4,6 +4,11 @@ Migration Guide
 Migrating to Rally 1.4.0
 ------------------------
 
+``trial-id`` and ``trial-timestamp`` are deprecated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With Rally 1.4.0, Rally will use the properties ``race-id`` and ``race-timestamp`` when writing data to the Elasticsearch metrics store. The properties ``trial-id`` and ``trial-timestamp`` are still populated but will be removed in a future release. Any visualizations that rely on these properties should be changed to the new ones.
+
 Custom Parameter Sources
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -876,7 +876,7 @@ class TimeSeriesCharts:
                 "show_legend": 1,
                 "show_grid": 1,
                 "drop_last_bucket": 0,
-                "time_field": "trial-timestamp",
+                "time_field": "race-timestamp",
                 "type": "timeseries",
                 "filter": TimeSeriesCharts.filter_string(environment, race_config),
                 "annotations": [
@@ -888,7 +888,7 @@ class TimeSeriesCharts:
                                         "AND environment:\"%s\"" % (race_config.track, environment),
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
-                        "time_field": "trial-timestamp",
+                        "time_field": "race-timestamp",
                         "icon": "fa-tag",
                         "ignore_panel_filters": 1
                     }
@@ -968,7 +968,7 @@ class TimeSeriesCharts:
                 "show_legend": 1,
                 "show_grid": 1,
                 "drop_last_bucket": 0,
-                "time_field": "trial-timestamp",
+                "time_field": "race-timestamp",
                 "type": "timeseries",
                 "filter": TimeSeriesCharts.filter_string(environment, race_config),
                 "annotations": [
@@ -980,7 +980,7 @@ class TimeSeriesCharts:
                                         "AND environment:\"%s\"" % (race_config.track, environment),
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
-                        "time_field": "trial-timestamp",
+                        "time_field": "race-timestamp",
                         "icon": "fa-tag",
                         "ignore_panel_filters": 1
                     }
@@ -1082,7 +1082,7 @@ class TimeSeriesCharts:
                     }
                 ],
                 "show_legend": 1,
-                "time_field": "trial-timestamp",
+                "time_field": "race-timestamp",
                 "type": "timeseries",
                 "filter": TimeSeriesCharts.filter_string(environment, race_config),
                 "annotations": [
@@ -1094,7 +1094,7 @@ class TimeSeriesCharts:
                                         "AND environment:\"%s\"" % (race_config.track, environment),
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
-                        "time_field": "trial-timestamp",
+                        "time_field": "race-timestamp",
                         "icon": "fa-tag",
                         "ignore_panel_filters": 1
                     }
@@ -1226,7 +1226,7 @@ class TimeSeriesCharts:
                         "series_drop_last_bucket": 0
                     }
                 ],
-                "time_field": "trial-timestamp",
+                "time_field": "race-timestamp",
                 "index_pattern": "rally-results-*",
                 "interval": "1d",
                 "axis_position": "left",
@@ -1250,7 +1250,7 @@ class TimeSeriesCharts:
                                         "AND environment:\"%s\"" % (race_config.track, environment),
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
-                        "time_field": "trial-timestamp",
+                        "time_field": "race-timestamp",
                         "icon": "fa-tag",
                         "ignore_panel_filters": 1
                     }
@@ -1332,7 +1332,7 @@ class TimeSeriesCharts:
                 "show_legend": 1,
                 "show_grid": 1,
                 "drop_last_bucket": 0,
-                "time_field": "trial-timestamp",
+                "time_field": "race-timestamp",
                 "type": "timeseries",
                 "filter": "environment:\"%s\" AND track:\"%s\" AND name:\"throughput\" AND active:true" % (environment, t),
                 "annotations": [
@@ -1344,7 +1344,7 @@ class TimeSeriesCharts:
                                         "AND environment:\"%s\"" % (t, environment),
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
-                        "time_field": "trial-timestamp",
+                        "time_field": "race-timestamp",
                         "icon": "fa-tag",
                         "ignore_panel_filters": 1
                     }

--- a/esrally/config.py
+++ b/esrally/config.py
@@ -359,7 +359,7 @@ class ConfigFactory:
                 env_name = self._ask_env_name()
 
             preserve_install = convert.to_bool(self._ask_property("Do you want Rally to keep the Elasticsearch benchmark candidate "
-                                                                  "installation including the index (will use several GB per trial run)?",
+                                                                  "installation including the index (will use several GB per race)?",
                                                                   default_value=False))
         else:
             # Does not matter for an in-memory store

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -459,7 +459,7 @@ class DockerProvisioner:
         # do not attempt to cleanup data paths. It does not work due to different permissions. As:
         #
         # (a) Docker is unsupported and not meant to be used by everybody, and
-        # (b) the volume is recreated before each trial run
+        # (b) the volume is recreated before each race
         #
         # this is not a major problem.
         cleanup(self.preserve, self.install_dir, [])

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -255,11 +255,11 @@ def metrics_store(cfg, read_only=True, track=None, challenge=None, car=None, met
     store = cls(cfg=cfg, meta_info=meta_info)
     logging.getLogger(__name__).info("Creating %s", str(store))
 
-    trial_id = cfg.opts("system", "trial.id")
-    trial_timestamp = cfg.opts("system", "time.start")
+    race_id = cfg.opts("system", "race.id")
+    race_timestamp = cfg.opts("system", "time.start")
     selected_car = cfg.opts("mechanic", "car.names") if car is None else car
 
-    store.open(trial_id, trial_timestamp, track, challenge, selected_car, create=not read_only)
+    store.open(race_id, race_timestamp, track, challenge, selected_car, create=not read_only)
     return store
 
 
@@ -320,8 +320,8 @@ class MetricsStore:
         :param meta_info: This parameter is optional and intended for creating a metrics store with a previously serialized meta-info.
         """
         self._config = cfg
-        self._trial_id = None
-        self._trial_timestamp = None
+        self._race_id = None
+        self._race_timestamp = None
         self._track = None
         self._track_params = cfg.opts("track", "params", default_value={}, mandatory=False)
         self._challenge = None
@@ -340,12 +340,12 @@ class MetricsStore:
         self._stop_watch = self._clock.stop_watch()
         self.logger = logging.getLogger(__name__)
 
-    def open(self, trial_id=None, trial_timestamp=None, track_name=None, challenge_name=None, car_name=None, ctx=None, create=False):
+    def open(self, race_id=None, race_timestamp=None, track_name=None, challenge_name=None, car_name=None, ctx=None, create=False):
         """
-        Opens a metrics store for a specific trial, track, challenge and car.
+        Opens a metrics store for a specific race, track, challenge and car.
 
-        :param trial_id: The trial id. This attribute is sufficient to uniquely identify a race.
-        :param trial_timestamp: The trial timestamp as a datetime.
+        :param race_id: The race id. This attribute is sufficient to uniquely identify a race.
+        :param race_timestamp: The race timestamp as a datetime.
         :param track_name: Track name.
         :param challenge_name: Challenge name.
         :param car_name: Car name.
@@ -354,27 +354,27 @@ class MetricsStore:
         False when it is just opened for reading (as we can assume all necessary indices exist at this point).
         """
         if ctx:
-            self._trial_id = ctx["trial-id"]
-            self._trial_timestamp = ctx["trial-timestamp"]
+            self._race_id = ctx["race-id"]
+            self._race_timestamp = ctx["race-timestamp"]
             self._track = ctx["track"]
             self._challenge = ctx["challenge"]
             self._car = ctx["car"]
         else:
-            self._trial_id = trial_id
-            self._trial_timestamp = time.to_iso8601(trial_timestamp)
+            self._race_id = race_id
+            self._race_timestamp = time.to_iso8601(race_timestamp)
             self._track = track_name
             self._challenge = challenge_name
             self._car = car_name
-        assert self._trial_id is not None, "Attempting to open metrics store without a trial id"
-        assert self._trial_timestamp is not None, "Attempting to open metrics store without a trial timestamp"
+        assert self._race_id is not None, "Attempting to open metrics store without a race id"
+        assert self._race_timestamp is not None, "Attempting to open metrics store without a race timestamp"
         assert self._track is not None, "Attempting to open metrics store without a track"
         assert self._challenge is not None, "Attempting to open metrics store without a challenge"
         assert self._car is not None, "Attempting to open metrics store without a car"
 
         self._car_name = "+".join(self._car) if isinstance(self._car, list) else self._car
 
-        self.logger.info("Opening metrics store for trial timestamp=[%s], track=[%s], challenge=[%s], car=[%s]",
-                         self._trial_timestamp, self._track, self._challenge, self._car)
+        self.logger.info("Opening metrics store for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s]",
+                         self._race_timestamp, self._track, self._challenge, self._car)
 
         user_tags = extract_user_tags_from_config(self._config)
         for k, v in user_tags.items():
@@ -461,8 +461,8 @@ class MetricsStore:
     @property
     def open_context(self):
         return {
-            "trial-id": self._trial_id,
-            "trial-timestamp": self._trial_timestamp,
+            "race-id": self._race_id,
+            "race-timestamp": self._race_timestamp,
             "track": self._track,
             "challenge": self._challenge,
             "car": self._car
@@ -576,8 +576,11 @@ class MetricsStore:
         doc = {
             "@timestamp": time.to_epoch_millis(absolute_time),
             "relative-time": int(relative_time * 1000 * 1000),
-            "trial-id": self._trial_id,
-            "trial-timestamp": self._trial_timestamp,
+            # TODO #777: Remove trial-* with a later release. They are only here for BWC
+            "trial-id": self._race_id,
+            "trial-timestamp": self._race_timestamp,
+            "race-id": self._race_id,
+            "race-timestamp": self._race_timestamp,
             "environment": self._environment_name,
             "track": self._track,
             "challenge": self._challenge,
@@ -634,8 +637,11 @@ class MetricsStore:
         doc.update({
             "@timestamp": time.to_epoch_millis(absolute_time),
             "relative-time": int(relative_time * 1000 * 1000),
-            "trial-id": self._trial_id,
-            "trial-timestamp": self._trial_timestamp,
+            # TODO #777: Remove trial-* with a later release. They are only here for BWC
+            "trial-id": self._race_id,
+            "trial-timestamp": self._race_timestamp,
+            "race-id": self._race_id,
+            "race-timestamp": self._race_timestamp,
             "environment": self._environment_name,
             "track": self._track,
             "challenge": self._challenge,
@@ -832,9 +838,9 @@ class EsMetricsStore(MetricsStore):
         self._index_template_provider = index_template_provider_class(cfg)
         self._docs = None
 
-    def open(self, trial_id=None, trial_timestamp=None, track_name=None, challenge_name=None, car_name=None, ctx=None, create=False):
+    def open(self, race_id=None, race_timestamp=None, track_name=None, challenge_name=None, car_name=None, ctx=None, create=False):
         self._docs = []
-        MetricsStore.open(self, trial_id, trial_timestamp, track_name, challenge_name, car_name, ctx, create)
+        MetricsStore.open(self, race_id, race_timestamp, track_name, challenge_name, car_name, ctx, create)
         self._index = self.index_name()
         # reduce a bit of noise in the metrics cluster log
         if create:
@@ -865,7 +871,7 @@ class EsMetricsStore(MetricsStore):
         self._client.refresh(index=self._index)
 
     def index_name(self):
-        ts = time.from_is8601(self._trial_timestamp)
+        ts = time.from_is8601(self._race_timestamp)
         return "rally-metrics-%04d-%02d" % (ts.year, ts.month)
 
     def _migrated_index_name(self, original_name):
@@ -877,8 +883,8 @@ class EsMetricsStore(MetricsStore):
     def flush(self, refresh=True):
         if self._docs:
             self._client.bulk_index(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, items=self._docs)
-            self.logger.info("Successfully added %d metrics documents for trial timestamp=[%s], track=[%s], challenge=[%s], car=[%s].",
-                             len(self._docs), self._trial_timestamp, self._track, self._challenge, self._car)
+            self.logger.info("Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s].",
+                             len(self._docs), self._race_timestamp, self._track, self._challenge, self._car)
         self._docs = []
         # ensure we can search immediately after flushing
         if refresh:
@@ -988,7 +994,8 @@ class EsMetricsStore(MetricsStore):
                 "filter": [
                     {
                         "term": {
-                            "trial-id": self._trial_id
+                            # TODO #777: Switch to "race-id" once we remove the trial-id parameter
+                            "trial-id": self._race_id
                         }
                     },
                     {
@@ -1161,7 +1168,7 @@ def list_races(cfg):
 
     races = []
     for race in race_store(cfg).list():
-        races.append([race.trial_id, time.to_iso8601(race.trial_timestamp), race.track, format_dict(race.track_params), race.challenge_name, race.car_name,
+        races.append([race.race_id, time.to_iso8601(race.race_timestamp), race.track, format_dict(race.track_params), race.challenge_name, race.car_name,
                       format_dict(race.user_tags), race.track_revision, race.cluster.get("team-revision")])
 
     if len(races) > 0:
@@ -1175,8 +1182,8 @@ def list_races(cfg):
 def create_race(cfg, track, challenge, track_revision=None):
     car = cfg.opts("mechanic", "car.names")
     environment = cfg.opts("system", "env.name")
-    trial_id = cfg.opts("system", "trial.id")
-    trial_timestamp = cfg.opts("system", "time.start")
+    race_id = cfg.opts("system", "race.id")
+    race_timestamp = cfg.opts("system", "time.start")
     user_tags = extract_user_tags_from_config(cfg)
     pipeline = cfg.opts("race", "pipeline")
     track_params = cfg.opts("track", "params")
@@ -1184,19 +1191,20 @@ def create_race(cfg, track, challenge, track_revision=None):
     plugin_params = cfg.opts("mechanic", "plugin.params")
     rally_version = version.version()
 
-    return Race(rally_version, environment, trial_id, trial_timestamp, pipeline, user_tags, track, track_params, challenge, car,
-                car_params, plugin_params, track_revision)
+    return Race(rally_version, environment, race_id, race_timestamp, pipeline, user_tags, track, track_params,
+                challenge, car, car_params, plugin_params, track_revision)
 
 
 class Race:
-    def __init__(self, rally_version, environment_name, trial_id, trial_timestamp, pipeline, user_tags, track, track_params, challenge, car,
-                 car_params, plugin_params, track_revision=None, cluster=None, results=None):
+    def __init__(self, rally_version, environment_name, race_id, race_timestamp, pipeline, user_tags, track,
+                 track_params, challenge, car, car_params, plugin_params, track_revision=None, cluster=None,
+                 results=None):
         if results is None:
             results = {}
         self.rally_version = rally_version
         self.environment_name = environment_name
-        self.trial_id = trial_id
-        self.trial_timestamp = trial_timestamp
+        self.race_id = race_id
+        self.race_timestamp = race_timestamp
         self.pipeline = pipeline
         self.user_tags = user_tags
         self.track = track
@@ -1245,8 +1253,11 @@ class Race:
         d = {
             "rally-version": self.rally_version,
             "environment": self.environment_name,
-            "trial-id": self.trial_id,
-            "trial-timestamp": time.to_iso8601(self.trial_timestamp),
+            # TODO #777: Remove trial-* with a later release. They are only here for BWC
+            "trial-id": self.race_id,
+            "trial-timestamp": time.to_iso8601(self.race_timestamp),
+            "race-id": self.race_id,
+            "race-timestamp": time.to_iso8601(self.race_timestamp),
             "pipeline": self.pipeline,
             "user-tags": self.user_tags,
             "track": self.track_name,
@@ -1273,8 +1284,11 @@ class Race:
         result_template = {
             "rally-version": self.rally_version,
             "environment": self.environment_name,
-            "trial-id": self.trial_id,
-            "trial-timestamp": time.to_iso8601(self.trial_timestamp),
+            # TODO #777: Remove trial-* with a later release. They are only here for BWC
+            "trial-id": self.race_id,
+            "trial-timestamp": time.to_iso8601(self.race_timestamp),
+            "race-id": self.race_id,
+            "race-timestamp": time.to_iso8601(self.race_timestamp),
             "distribution-version": self.cluster.distribution_version,
             "distribution-flavor": self.cluster.distribution_flavor,
             "distribution-major-version": versions.major_version(self.cluster.distribution_version),
@@ -1332,20 +1346,23 @@ class Race:
 
         # Don't restore a few properties like some cluster properties because they (a) cannot be reconstructed easily without knowledge of other modules
         # and (b) it is not necessary for this use case.
-        return Race(d["rally-version"], d["environment"], d["trial-id"], time.from_is8601(d["trial-timestamp"]), d["pipeline"], user_tags,
-                    d["track"], d.get("track-params"), d.get("challenge"), d["car"], d.get("car-params"), d.get("plugin-params"),
-                    track_revision=d.get("track-revision"), cluster={"team-revision": team_revision}, results=d["results"])
+        # TODO #777: Remove the backwards-compatibility layer with trial*
+        return Race(d["rally-version"], d["environment"], d.get("race-id", d.get("trial-id")),
+                    time.from_is8601(d.get("race-timestamp", d.get("trial-timestamp"))), d["pipeline"], user_tags,
+                    d["track"], d.get("track-params"), d.get("challenge"), d["car"], d.get("car-params"),
+                    d.get("plugin-params"), track_revision=d.get("track-revision"),
+                    cluster={"team-revision": team_revision}, results=d["results"])
 
 
 class RaceStore:
     def __init__(self, cfg):
         self.cfg = cfg
         self.environment_name = cfg.opts("system", "env.name")
-        self.trial_timestamp = cfg.opts("system", "time.start")
-        self.trial_id = cfg.opts("system", "trial.id")
+        self.race_timestamp = cfg.opts("system", "time.start")
+        self.race_id = cfg.opts("system", "race.id")
         self.current_race = None
 
-    def find_by_trial_id(self, uid):
+    def find_by_race_id(self, race_id):
         raise NotImplementedError("abstract method")
 
     def list(self):
@@ -1373,8 +1390,8 @@ class CompositeRaceStore:
         self.es_results_store = es_results_store
         self.file_store = file_store
 
-    def find_by_trial_id(self, trial_id):
-        return self.es_store.find_by_trial_id(trial_id)
+    def find_by_race_id(self, race_id):
+        return self.es_store.find_by_race_id(race_id)
 
     def store_race(self, race):
         self.file_store.store_race(race)
@@ -1397,22 +1414,22 @@ class FileRaceStore(RaceStore):
         with open(self._race_file(), mode="wt", encoding="utf-8") as f:
             f.write(json.dumps(doc, indent=True, ensure_ascii=False))
 
-    def _race_file(self, trial_id=None):
-        return os.path.join(paths.race_root(cfg=self.cfg, trial_id=trial_id), "race.json")
+    def _race_file(self, race_id=None):
+        return os.path.join(paths.race_root(cfg=self.cfg, race_id=race_id), "race.json")
 
     def list(self):
         import glob
-        results = glob.glob(self._race_file(trial_id="*"))
+        results = glob.glob(self._race_file(race_id="*"))
         all_races = self._to_races(results)
         return all_races[:self._max_results()]
 
-    def find_by_trial_id(self, trial_id):
-        race_file = self._race_file(trial_id=trial_id)
+    def find_by_race_id(self, race_id):
+        race_file = self._race_file(race_id=race_id)
         if io.exists(race_file):
             races = self._to_races([race_file])
             if races:
                 return races[0]
-        raise exceptions.NotFound("No race with trial id [{}]".format(trial_id))
+        raise exceptions.NotFound("No race with race id [{}]".format(race_id))
 
     def _to_races(self, results):
         import json
@@ -1424,7 +1441,7 @@ class FileRaceStore(RaceStore):
                     races.append(Race.from_dict(json.loads(f.read())))
             except BaseException:
                 logging.getLogger(__name__).exception("Could not load race file [%s] (incompatible format?) Skipping...", result)
-        return sorted(races, key=lambda r: r.trial_timestamp, reverse=True)
+        return sorted(races, key=lambda r: r.race_timestamp, reverse=True)
 
 
 class EsRaceStore(RaceStore):
@@ -1456,7 +1473,7 @@ class EsRaceStore(RaceStore):
         self.client.index(index=idx, doc_type=EsRaceStore.RACE_DOC_TYPE, item=doc)
 
     def index_name(self):
-        return "%s%04d-%02d" % (EsRaceStore.INDEX_PREFIX, self.trial_timestamp.year, self.trial_timestamp.month)
+        return "%s%04d-%02d" % (EsRaceStore.INDEX_PREFIX, self.race_timestamp.year, self.race_timestamp.month)
 
     def list(self):
         filters = [{
@@ -1474,6 +1491,7 @@ class EsRaceStore(RaceStore):
             "size": self._max_results(),
             "sort": [
                 {
+                    # TODO #777: Switch to "race-timestamp" once we remove the trial-timestamp parameter
                     "trial-timestamp": {
                         "order": "desc"
                     }
@@ -1490,7 +1508,7 @@ class EsRaceStore(RaceStore):
         else:
             return []
 
-    def find_by_trial_id(self, trial_id):
+    def find_by_race_id(self, race_id):
         filters = [{
                 "term": {
                     "environment": self.environment_name
@@ -1498,7 +1516,8 @@ class EsRaceStore(RaceStore):
             },
             {
                 "term": {
-                    "trial-id": trial_id
+                    # TODO #777: Switch to "race-id" once we remove the trial-id parameter
+                    "trial-id": race_id
                 }
             }]
 
@@ -1518,9 +1537,9 @@ class EsRaceStore(RaceStore):
             return Race.from_dict(result["hits"]["hits"][0]["_source"])
         elif hits > 1:
             raise exceptions.RallyAssertionError(
-                "Expected exactly one race to match trial id [{}] but there were [{}] matches.".format(trial_id, hits))
+                "Expected exactly one race to match race id [{}] but there were [{}] matches.".format(race_id, hits))
         else:
-            raise exceptions.NotFound("No race with trial id [{}]".format(trial_id))
+            raise exceptions.NotFound("No race with race id [{}]".format(race_id))
 
 
 class EsResultsStore:
@@ -1539,7 +1558,7 @@ class EsResultsStore:
         :param index_template_provider_class: This parameter is optional and needed for testing.
         """
         self.cfg = cfg
-        self.trial_timestamp = cfg.opts("system", "time.start")
+        self.race_timestamp = cfg.opts("system", "time.start")
         self.client = client_factory_class(cfg).create()
         self.index_template_provider = index_template_provider_class(cfg)
 
@@ -1556,4 +1575,4 @@ class EsResultsStore:
         self.client.bulk_index(index=idx, doc_type=EsResultsStore.RESULTS_DOC_TYPE, items=race.to_result_dicts())
 
     def index_name(self):
-        return "%s%04d-%02d" % (EsResultsStore.INDEX_PREFIX, self.trial_timestamp.year, self.trial_timestamp.month)
+        return "%s%04d-%02d" % (EsResultsStore.INDEX_PREFIX, self.race_timestamp.year, self.race_timestamp.month)

--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -25,8 +25,8 @@ def races_root(cfg):
     return os.path.join(cfg.opts("node", "root.dir"), "races")
 
 
-def race_root(cfg=None, trial_id=None):
-    if not trial_id:
-        trial_id = cfg.opts("system", "trial.id")
-    return os.path.join(races_root(cfg), trial_id)
+def race_root(cfg=None, race_id=None):
+    if not race_id:
+        race_id = cfg.opts("system", "race.id")
+    return os.path.join(races_root(cfg), race_id)
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -212,6 +212,10 @@ def create_arg_parser():
 
     for p in [parser, race_parser]:
         p.add_argument(
+            "--race-id",
+            help="Define a unique id for this race.",
+            default=str(uuid.uuid4()))
+        p.add_argument(
             "--pipeline",
             help="Select the pipeline to run.",
             # the default will be dynamically derived by racecontrol based on the presence / absence of other command line options
@@ -571,7 +575,7 @@ def main():
         cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.utcnow())
         cfg.add(config.Scope.application, "system", "time.start.user_provided", False)
 
-    cfg.add(config.Scope.applicationOverride, "system", "trial.id", str(uuid.uuid4()))
+    cfg.add(config.Scope.applicationOverride, "system", "race.id", args.race_id)
     cfg.add(config.Scope.applicationOverride, "system", "quiet.mode", args.quiet)
     cfg.add(config.Scope.applicationOverride, "system", "offline.mode", args.offline)
 

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -56,8 +56,8 @@ def compare(cfg):
         raise exceptions.SystemSetupError("compare needs baseline and a contender")
     race_store = metrics.race_store(cfg)
     ComparisonReporter(cfg).report(
-        race_store.find_by_trial_id(baseline_id),
-        race_store.find_by_trial_id(contender_id))
+        race_store.find_by_race_id(baseline_id),
+        race_store.find_by_race_id(contender_id))
 
 
 def print_internal(message):
@@ -629,8 +629,8 @@ class ComparisonReporter:
 
         print_internal("")
         print_internal("Comparing baseline")
-        print_internal("  Race ID: %s" % r1.trial_id)
-        print_internal("  Race timestamp: %s" % r1.trial_timestamp)
+        print_internal("  Race ID: %s" % r1.race_id)
+        print_internal("  Race timestamp: %s" % r1.race_timestamp)
         if r1.challenge_name:
             print_internal("  Challenge: %s" % r1.challenge_name)
         print_internal("  Car: %s" % r1.car_name)
@@ -639,8 +639,8 @@ class ComparisonReporter:
             print_internal("  User tags: %s" % r1_user_tags)
         print_internal("")
         print_internal("with contender")
-        print_internal("  Race ID: %s" % r2.trial_id)
-        print_internal("  Race timestamp: %s" % r2.trial_timestamp)
+        print_internal("  Race ID: %s" % r2.race_id)
+        print_internal("  Race timestamp: %s" % r2.race_timestamp)
         if r2.challenge_name:
             print_internal("  Challenge: %s" % r2.challenge_name)
         print_internal("  Car: %s" % r2.car_name)

--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -42,6 +42,18 @@
             }
           }
         },
+        "race-id": {
+          "type": "keyword"
+        },
+        "race-timestamp": {
+          "type": "date",
+          "format": "basic_date_time_no_millis",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
         "environment": {
           "type": "keyword"
         },

--- a/esrally/resources/races-template.json
+++ b/esrally/resources/races-template.json
@@ -35,6 +35,18 @@
             }
           }
         },
+        "race-id": {
+          "type": "keyword"
+        },
+        "race-timestamp": {
+          "type": "date",
+          "format": "basic_date_time_no_millis",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
         "rally-version": {
           "type": "keyword"
         },

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -35,6 +35,18 @@
             }
           }
         },
+        "race-id": {
+          "type": "keyword"
+        },
+        "race-timestamp": {
+          "type": "date",
+          "format": "basic_date_time_no_millis",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
         "active": {
           "type": "boolean"
         },

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -215,9 +215,9 @@ def parse_args():
 
     parser.add_argument(
         "--label",
-        help="defines which attribute to use for labelling data series (default: trial-timestamp).",
-        # choices=["environment", "trial-timestamp", "user-tags", "challenge", "car"],
-        default="trial-timestamp")
+        help="defines which attribute to use for labelling data series (default: race-timestamp).",
+        # choices=["environment", "race-timestamp", "user-tags", "challenge", "car"],
+        default="race-timestamp")
 
     parser.add_argument("path",
                         nargs="+",

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -63,7 +63,7 @@ class DriverTests(TestCase):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
         self.cfg.add(config.Scope.application, "system", "time.start", datetime(year=2017, month=8, day=20, hour=1, minute=0, second=0))
-        self.cfg.add(config.Scope.application, "system", "trial.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
+        self.cfg.add(config.Scope.application, "system", "race.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
         self.cfg.add(config.Scope.application, "track", "challenge.name", "default")
         self.cfg.add(config.Scope.application, "track", "params", {})
         self.cfg.add(config.Scope.application, "track", "test.mode.enabled", True)

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -135,8 +135,8 @@ class MockProcess:
 
 def get_metrics_store(cfg):
     ms = InMemoryMetricsStore(cfg)
-    ms.open(trial_id=str(uuid.uuid4()),
-            trial_timestamp=datetime.now(),
+    ms.open(race_id=str(uuid.uuid4()),
+            race_timestamp=datetime.now(),
             track_name="test",
             challenge_name="test",
             car_name="test")

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -284,8 +284,8 @@ class EsClientTests(TestCase):
 
 
 class EsMetricsTests(TestCase):
-    TRIAL_TIMESTAMP = datetime.datetime(2016, 1, 31)
-    TRIAL_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
+    RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
+    RACE_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
     def setUp(self):
         self.cfg = config.Config()
@@ -301,12 +301,14 @@ class EsMetricsTests(TestCase):
 
     def test_put_value_without_meta_info(self):
         throughput = 5000
-        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         self.metrics_store.put_count_cluster_level("indexing_throughput", throughput, "docs/s")
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "trial-id": EsMetricsTests.TRIAL_ID,
+            "race-id": EsMetricsTests.RACE_ID,
+            "race-timestamp": "20160131T000000Z",
+            "trial-id": EsMetricsTests.RACE_ID,
             "trial-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
@@ -329,13 +331,15 @@ class EsMetricsTests(TestCase):
 
     def test_put_value_with_explicit_timestamps(self):
         throughput = 5000
-        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         self.metrics_store.put_count_cluster_level(name="indexing_throughput", count=throughput, unit="docs/s",
                                                    absolute_time=0, relative_time=10)
         expected_doc = {
             "@timestamp": 0,
-            "trial-id": EsMetricsTests.TRIAL_ID,
+            "race-id": EsMetricsTests.RACE_ID,
+            "race-timestamp": "20160131T000000Z",
+            "trial-id": EsMetricsTests.RACE_ID,
             "trial-timestamp": "20160131T000000Z",
             "relative-time": 10000000,
             "environment": "unittest",
@@ -360,7 +364,7 @@ class EsMetricsTests(TestCase):
         throughput = 5000
         # add a user-defined tag
         self.cfg.add(config.Scope.application, "race", "user.tag", "intention:testing,disk_type:hdd")
-        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         # Ensure we also merge in cluster level meta info
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "source_revision", "abc123")
@@ -373,8 +377,10 @@ class EsMetricsTests(TestCase):
         self.metrics_store.put_value_node_level("node0", "indexing_throughput", throughput, "docs/s")
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "trial-id": EsMetricsTests.TRIAL_ID,
+            "trial-id": EsMetricsTests.RACE_ID,
             "trial-timestamp": "20160131T000000Z",
+            "race-id": EsMetricsTests.RACE_ID,
+            "race-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
             "sample-type": "normal",
@@ -401,7 +407,7 @@ class EsMetricsTests(TestCase):
         self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", doc_type="_doc", items=[expected_doc])
 
     def test_put_doc_no_meta_data(self):
-        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         self.metrics_store.put_doc(doc={
             "name": "custom_metric",
@@ -411,7 +417,9 @@ class EsMetricsTests(TestCase):
         })
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "trial-id": EsMetricsTests.TRIAL_ID,
+            "race-id": EsMetricsTests.RACE_ID,
+            "race-timestamp": "20160131T000000Z",
+            "trial-id": EsMetricsTests.RACE_ID,
             "trial-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
@@ -434,7 +442,7 @@ class EsMetricsTests(TestCase):
     def test_put_doc_with_metadata(self):
         # add a user-defined tag
         self.cfg.add(config.Scope.application, "race", "user.tag", "intention:testing,disk_type:hdd")
-        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         # Ensure we also merge in cluster level meta info
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "source_revision", "abc123")
@@ -456,7 +464,9 @@ class EsMetricsTests(TestCase):
             })
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "trial-id": EsMetricsTests.TRIAL_ID,
+            "race-id": EsMetricsTests.RACE_ID,
+            "race-timestamp": "20160131T000000Z",
+            "trial-id": EsMetricsTests.RACE_ID,
             "trial-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
@@ -501,7 +511,7 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
@@ -509,7 +519,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-id": EsMetricsTests.TRIAL_ID
+                                "trial-id": EsMetricsTests.RACE_ID
                             }
                         },
                         {
@@ -546,7 +556,7 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
@@ -554,7 +564,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-id": EsMetricsTests.TRIAL_ID
+                                "trial-id": EsMetricsTests.RACE_ID
                             }
                         },
                         {
@@ -597,7 +607,7 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
@@ -605,7 +615,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-id": EsMetricsTests.TRIAL_ID
+                                "trial-id": EsMetricsTests.RACE_ID
                             }
                         },
                         {
@@ -726,7 +736,7 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.TRIAL_ID, EsMetricsTests.TRIAL_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
@@ -734,7 +744,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-id": EsMetricsTests.TRIAL_ID
+                                "trial-id": EsMetricsTests.RACE_ID
                             }
                         },
                         {
@@ -766,8 +776,8 @@ class EsMetricsTests(TestCase):
 
 
 class EsRaceStoreTests(TestCase):
-    TRIAL_TIMESTAMP = datetime.datetime(2016, 1, 31)
-    TRIAL_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
+    RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
+    RACE_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
     class DictHolder:
         def __init__(self, d):
@@ -779,8 +789,8 @@ class EsRaceStoreTests(TestCase):
     def setUp(self):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
-        self.cfg.add(config.Scope.application, "system", "time.start", EsRaceStoreTests.TRIAL_TIMESTAMP)
-        self.cfg.add(config.Scope.application, "system", "trial.id", FileRaceStoreTests.TRIAL_ID)
+        self.cfg.add(config.Scope.application, "system", "time.start", EsRaceStoreTests.RACE_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "race.id", FileRaceStoreTests.RACE_ID)
         self.race_store = metrics.EsRaceStore(self.cfg,
                                               client_factory_class=MockClientFactory,
                                               index_template_provider_class=DummyIndexTemplateProvider,
@@ -788,7 +798,7 @@ class EsRaceStoreTests(TestCase):
         # get hold of the mocked client...
         self.es_mock = self.race_store.client
 
-    def test_find_existing_race_by_trial_id(self):
+    def test_find_existing_race_by_race_id(self):
         self.es_mock.search.return_value = {
             "hits": {
                 "total": {
@@ -800,7 +810,9 @@ class EsRaceStoreTests(TestCase):
                         "_source": {
                             "rally-version": "0.4.4",
                             "environment": "unittest",
-                            "trial-id": EsRaceStoreTests.TRIAL_ID,
+                            "race-id": EsRaceStoreTests.RACE_ID,
+                            "race-timestamp": "20160131T000000Z",
+                            "trial-id": EsRaceStoreTests.RACE_ID,
                             "trial-timestamp": "20160131T000000Z",
                             "pipeline": "from-sources",
                             "track": "unittest",
@@ -817,10 +829,10 @@ class EsRaceStoreTests(TestCase):
             }
         }
 
-        race = self.race_store.find_by_trial_id(trial_id=EsRaceStoreTests.TRIAL_ID)
-        self.assertEqual(race.trial_id, EsRaceStoreTests.TRIAL_ID)
+        race = self.race_store.find_by_race_id(race_id=EsRaceStoreTests.RACE_ID)
+        self.assertEqual(race.race_id, EsRaceStoreTests.RACE_ID)
 
-    def test_does_not_find_missing_race_by_trial_id(self):
+    def test_does_not_find_missing_race_by_race_id(self):
         self.es_mock.search.return_value = {
             "hits": {
                 "total": {
@@ -831,8 +843,8 @@ class EsRaceStoreTests(TestCase):
             }
         }
 
-        with self.assertRaisesRegex(exceptions.NotFound, r"No race with trial id \[.*\]"):
-            self.race_store.find_by_trial_id(trial_id="some invalid trial id")
+        with self.assertRaisesRegex(exceptions.NotFound, r"No race with race id \[.*\]"):
+            self.race_store.find_by_race_id(race_id="some invalid race id")
 
     def test_store_race(self):
         schedule = [
@@ -843,8 +855,8 @@ class EsRaceStoreTests(TestCase):
                         indices=[track.Index(name="tests", types=["_doc"])],
                         challenges=[track.Challenge(name="index", default=True, schedule=schedule)])
 
-        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", trial_id=EsRaceStoreTests.TRIAL_ID,
-                            trial_timestamp=EsRaceStoreTests.TRIAL_TIMESTAMP,
+        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", race_id=EsRaceStoreTests.RACE_ID,
+                            race_timestamp=EsRaceStoreTests.RACE_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params={"shard-count": 3},
                             challenge=t.default_challenge, car="defaults", car_params={"heap_size": "512mb"}, plugin_params=None,
                             track_revision="abc1",
@@ -879,7 +891,9 @@ class EsRaceStoreTests(TestCase):
         expected_doc = {
             "rally-version": "0.4.4",
             "environment": "unittest",
-            "trial-id": EsRaceStoreTests.TRIAL_ID,
+            "race-id": EsRaceStoreTests.RACE_ID,
+            "race-timestamp": "20160131T000000Z",
+            "trial-id": EsRaceStoreTests.RACE_ID,
             "trial-timestamp": "20160131T000000Z",
             "pipeline": "from-sources",
             "user-tags": {
@@ -926,13 +940,13 @@ class EsRaceStoreTests(TestCase):
 
 
 class EsResultsStoreTests(TestCase):
-    TRIAL_TIMESTAMP = datetime.datetime(2016, 1, 31)
-    TRIAL_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
+    RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
+    RACE_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
     def setUp(self):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
-        self.cfg.add(config.Scope.application, "system", "time.start", EsRaceStoreTests.TRIAL_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "time.start", EsRaceStoreTests.RACE_TIMESTAMP)
         self.race_store = metrics.EsResultsStore(self.cfg,
                                                  client_factory_class=MockClientFactory,
                                                  index_template_provider_class=DummyIndexTemplateProvider,
@@ -962,8 +976,8 @@ class EsResultsStoreTests(TestCase):
         node = c.add_node("localhost", "rally-node-0")
         node.plugins.append("x-pack")
 
-        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", trial_id=EsResultsStoreTests.TRIAL_ID,
-                            trial_timestamp=EsResultsStoreTests.TRIAL_TIMESTAMP,
+        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", race_id=EsResultsStoreTests.RACE_ID,
+                            race_timestamp=EsResultsStoreTests.RACE_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params=None,
                             challenge=t.default_challenge, car="4gheap", car_params=None, plugin_params={"some-param": True},
                             track_revision="abc1",
@@ -1005,7 +1019,9 @@ class EsResultsStoreTests(TestCase):
             {
                 "rally-version": "0.4.4",
                 "environment": "unittest",
-                "trial-id": EsResultsStoreTests.TRIAL_ID,
+                "race-id": EsResultsStoreTests.RACE_ID,
+                "race-timestamp": "20160131T000000Z",
+                "trial-id": EsResultsStoreTests.RACE_ID,
                 "trial-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
@@ -1036,7 +1052,9 @@ class EsResultsStoreTests(TestCase):
             {
                 "rally-version": "0.4.4",
                 "environment": "unittest",
-                "trial-id": EsResultsStoreTests.TRIAL_ID,
+                "race-id": EsResultsStoreTests.RACE_ID,
+                "race-timestamp": "20160131T000000Z",
+                "trial-id": EsResultsStoreTests.RACE_ID,
                 "trial-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
@@ -1068,7 +1086,9 @@ class EsResultsStoreTests(TestCase):
             {
                 "rally-version": "0.4.4",
                 "environment": "unittest",
-                "trial-id": EsResultsStoreTests.TRIAL_ID,
+                "race-id": EsResultsStoreTests.RACE_ID,
+                "race-timestamp": "20160131T000000Z",
+                "trial-id": EsResultsStoreTests.RACE_ID,
                 "trial-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
@@ -1105,7 +1125,9 @@ class EsResultsStoreTests(TestCase):
             {
                 "rally-version": "0.4.4",
                 "environment": "unittest",
-                "trial-id": EsResultsStoreTests.TRIAL_ID,
+                "race-id": EsResultsStoreTests.RACE_ID,
+                "race-timestamp": "20160131T000000Z",
+                "trial-id": EsResultsStoreTests.RACE_ID,
                 "trial-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
@@ -1138,8 +1160,8 @@ class EsResultsStoreTests(TestCase):
 
 
 class InMemoryMetricsStoreTests(TestCase):
-    TRIAL_TIMESTAMP = datetime.datetime(2016, 1, 31)
-    TRIAL_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
+    RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
+    RACE_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
     def setUp(self):
         self.cfg = config.Config()
@@ -1153,7 +1175,7 @@ class InMemoryMetricsStoreTests(TestCase):
 
     def test_get_value(self):
         throughput = 5000
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.put_count_cluster_level("indexing_throughput", 1, "docs/s", sample_type=metrics.SampleType.Warmup)
         self.metrics_store.put_count_cluster_level("indexing_throughput", throughput, "docs/s")
@@ -1161,21 +1183,21 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults")
 
         self.assertEqual(1, self.metrics_store.get_one("indexing_throughput", sample_type=metrics.SampleType.Warmup))
         self.assertEqual(throughput, self.metrics_store.get_one("indexing_throughput", sample_type=metrics.SampleType.Normal))
 
     def test_get_percentile(self):
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults", create=True)
         for i in range(1, 1001):
             self.metrics_store.put_value_cluster_level("query_latency", float(i), "ms")
 
         self.metrics_store.close()
 
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults")
 
         self.assert_equal_percentiles("query_latency", [100.0], {100.0: 1000.0})
@@ -1186,27 +1208,27 @@ class InMemoryMetricsStoreTests(TestCase):
         self.assert_equal_percentiles("query_latency", [99, 99.9, 100], {99: 990.0, 99.9: 999.0, 100: 1000.0})
 
     def test_get_mean(self):
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults", create=True)
         for i in range(1, 100):
             self.metrics_store.put_value_cluster_level("query_latency", float(i), "ms")
 
         self.metrics_store.close()
 
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults")
 
         self.assertAlmostEqual(50, self.metrics_store.get_mean("query_latency"))
 
     def test_get_median(self):
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults", create=True)
         for i in range(1, 1001):
             self.metrics_store.put_value_cluster_level("query_latency", float(i), "ms")
 
         self.metrics_store.close()
 
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults")
 
         self.assertAlmostEqual(500.5, self.metrics_store.get_median("query_latency"))
@@ -1219,7 +1241,7 @@ class InMemoryMetricsStoreTests(TestCase):
                                    msg=str(percentile) + "th percentile differs")
 
     def test_externalize_and_bulk_add(self):
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.put_count_cluster_level("final_index_size", 1000, "GB")
 
@@ -1237,7 +1259,7 @@ class InMemoryMetricsStoreTests(TestCase):
         self.assertEqual(1000, self.metrics_store.get_one("final_index_size"))
 
     def test_meta_data_per_document(self):
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "cluster-name", "test")
 
@@ -1260,17 +1282,17 @@ class InMemoryMetricsStoreTests(TestCase):
         }, self.metrics_store.docs[1]["meta"])
 
     def test_get_error_rate_zero_without_samples(self):
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.close()
 
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults")
 
         self.assertEqual(0.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal))
 
     def test_get_error_rate_by_sample_type(self):
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.put_value_cluster_level("service_time", 3.0, "ms", task="term-query", sample_type=metrics.SampleType.Warmup,
                                                    meta_data={"success": False})
@@ -1279,14 +1301,14 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults")
 
         self.assertEqual(1.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Warmup))
         self.assertEqual(0.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal))
 
     def test_get_error_rate_mixed(self):
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults", create=True)
         self.metrics_store.put_value_cluster_level("service_time", 3.0, "ms", task="term-query", sample_type=metrics.SampleType.Normal,
                                                    meta_data={"success": True})
@@ -1301,7 +1323,7 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(InMemoryMetricsStoreTests.TRIAL_ID, InMemoryMetricsStoreTests.TRIAL_TIMESTAMP,
+        self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults")
 
         self.assertEqual(0.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Warmup))
@@ -1309,8 +1331,8 @@ class InMemoryMetricsStoreTests(TestCase):
 
 
 class FileRaceStoreTests(TestCase):
-    TRIAL_TIMESTAMP = datetime.datetime(2016, 1, 31)
-    TRIAL_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
+    RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
+    RACE_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
     class DictHolder:
         def __init__(self, d):
@@ -1326,14 +1348,14 @@ class FileRaceStoreTests(TestCase):
         self.cfg.add(config.Scope.application, "node", "root.dir", os.path.join(tempfile.gettempdir(), str(uuid.uuid4())))
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
         self.cfg.add(config.Scope.application, "system", "list.races.max_results", 100)
-        self.cfg.add(config.Scope.application, "system", "time.start", FileRaceStoreTests.TRIAL_TIMESTAMP)
-        self.cfg.add(config.Scope.application, "system", "trial.id", FileRaceStoreTests.TRIAL_ID)
+        self.cfg.add(config.Scope.application, "system", "time.start", FileRaceStoreTests.RACE_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "race.id", FileRaceStoreTests.RACE_ID)
         self.race_store = metrics.FileRaceStore(self.cfg)
 
     def test_race_not_found(self):
-        with self.assertRaisesRegex(exceptions.NotFound, r"No race with trial id \[.*\]"):
+        with self.assertRaisesRegex(exceptions.NotFound, r"No race with race id \[.*\]"):
             # did not store anything yet
-            self.race_store.find_by_trial_id(FileRaceStoreTests.TRIAL_ID)
+            self.race_store.find_by_race_id(FileRaceStoreTests.RACE_ID)
 
     def test_store_race(self):
         schedule = [
@@ -1344,8 +1366,8 @@ class FileRaceStoreTests(TestCase):
                         indices=[track.Index(name="tests", types=["_doc"])],
                         challenges=[track.Challenge(name="index", default=True, schedule=schedule)])
 
-        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", trial_id=FileRaceStoreTests.TRIAL_ID,
-                            trial_timestamp=FileRaceStoreTests.TRIAL_TIMESTAMP,
+        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", race_id=FileRaceStoreTests.RACE_ID,
+                            race_timestamp=FileRaceStoreTests.RACE_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params={"clients": 12},
                             challenge=t.default_challenge, car="4gheap", car_params=None, plugin_params=None,
                             track_revision="abc1",
@@ -1377,7 +1399,7 @@ class FileRaceStoreTests(TestCase):
 
         self.race_store.store_race(race)
 
-        retrieved_race = self.race_store.find_by_trial_id(trial_id=FileRaceStoreTests.TRIAL_ID)
-        self.assertEqual(race.trial_id, retrieved_race.trial_id)
-        self.assertEqual(race.trial_timestamp, retrieved_race.trial_timestamp)
+        retrieved_race = self.race_store.find_by_race_id(race_id=FileRaceStoreTests.RACE_ID)
+        self.assertEqual(race.race_id, retrieved_race.race_id)
+        self.assertEqual(race.race_timestamp, retrieved_race.race_timestamp)
         self.assertEqual(1, len(self.race_store.list()))

--- a/tests/reporter_test.py
+++ b/tests/reporter_test.py
@@ -27,7 +27,7 @@ class StatsCalculatorTests(TestCase):
         cfg = config.Config()
         cfg.add(config.Scope.application, "system", "env.name", "unittest")
         cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.now())
-        cfg.add(config.Scope.application, "system", "trial.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
+        cfg.add(config.Scope.application, "system", "race.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
         cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")
         cfg.add(config.Scope.application, "mechanic", "car.names", ["unittest_car"])
         cfg.add(config.Scope.application, "mechanic", "car.params", {})


### PR DESCRIPTION
With this commit we expose the race id as command line parameter. As the
internal name "trial id" and the related name "trial timestamp" are
inconsistent with this terminology we rename them to "race id" and "race
timestamp" respectively and add a backwards-compatibility layer that
will be removed again in #777.
