### PR TITLE
Gather cluster-level metrics in driver

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -4,6 +4,11 @@ Migration Guide
 Migrating to Rally 1.4.0
 ------------------------
 
+Node details are omitted from race metadata
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Before Rally 1.4.0, the file ``race.json`` has contained node details (such as the number of cluster nodes or details about the nodes' operating system version) if Rally has provisioned the cluster. With this release, this information is now omitted. This change also applies to the indices ``rally-races*`` in case you have setup an Elasticsearch metrics store. We recommend to use user tags in case such information is important, e.g. for visualising results.
+
 Custom Parameter Sources
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -7,7 +7,7 @@ Migrating to Rally 1.4.0
 Node details are omitted from race metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Before Rally 1.4.0, the file ``race.json`` has contained node details (such as the number of cluster nodes or details about the nodes' operating system version) if Rally has provisioned the cluster. With this release, this information is now omitted. This change also applies to the indices ``rally-races*`` in case you have setup an Elasticsearch metrics store. We recommend to use user tags in case such information is important, e.g. for visualising results.
+Before Rally 1.4.0, the file ``race.json`` contained node details (such as the number of cluster nodes or details about the nodes' operating system version) if Rally provisioned the cluster. With this release, this information is now omitted. This change also applies to the indices ``rally-races*`` in case you have setup an Elasticsearch metrics store. We recommend to use user tags in case such information is important, e.g. for visualising results.
 
 ``trial-id`` and ``trial-timestamp`` are deprecated
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/esrally/driver/__init__.py
+++ b/esrally/driver/__init__.py
@@ -16,4 +16,4 @@
 # under the License.
 
 # expose only the minimum API
-from .driver import DriverActor, StartBenchmark, BenchmarkComplete, TaskFinished
+from .driver import DriverActor, PrepareBenchmark, PreparationComplete, StartBenchmark, BenchmarkComplete, TaskFinished

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -342,7 +342,7 @@ def wait_for_rest_layer(es, max_attempts=20):
             return True
         except elasticsearch.ConnectionError as e:
             if "SSL: UNKNOWN_PROTOCOL" in str(e):
-                raise exceptions.SystemSetupError("Could not connect to cluster via https. Is this a https endpoint?", e)
+                raise exceptions.SystemSetupError("Could not connect to cluster via https. Is this an https endpoint?", e)
             else:
                 time.sleep(1)
         except elasticsearch.TransportError as e:

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -36,7 +36,7 @@ from esrally.utils import convert, console, net
 ##################################
 class PrepareBenchmark:
     """
-    Initiates preparation steps a benchmark. The benchmark should only be started after StartBenchmark is sent.
+    Initiates preparation steps for a benchmark. The benchmark should only be started after StartBenchmark is sent.
     """
 
     def __init__(self, config, track, metrics_meta_info):

--- a/esrally/mechanic/__init__.py
+++ b/esrally/mechanic/__init__.py
@@ -17,5 +17,4 @@
 
 # expose only the minimum API
 from .mechanic import NodeMetaInfo, StartEngine, EngineStarted, StopEngine, EngineStopped, \
-    OnBenchmarkStart, BenchmarkStarted, ResetRelativeTime, MechanicActor, \
-    cluster_distribution_version, download
+    ResetRelativeTime, MechanicActor, cluster_distribution_version, download

--- a/esrally/mechanic/__init__.py
+++ b/esrally/mechanic/__init__.py
@@ -17,5 +17,5 @@
 
 # expose only the minimum API
 from .mechanic import NodeMetaInfo, StartEngine, EngineStarted, StopEngine, EngineStopped, \
-    OnBenchmarkStart, BenchmarkStarted, OnBenchmarkStop, BenchmarkStopped, ResetRelativeTime, MechanicActor, \
+    OnBenchmarkStart, BenchmarkStarted, ResetRelativeTime, MechanicActor, \
     cluster_distribution_version, download

--- a/esrally/mechanic/__init__.py
+++ b/esrally/mechanic/__init__.py
@@ -16,5 +16,5 @@
 # under the License.
 
 # expose only the minimum API
-from .mechanic import NodeMetaInfo, StartEngine, EngineStarted, StopEngine, EngineStopped, \
-    ResetRelativeTime, MechanicActor, cluster_distribution_version, download
+from .mechanic import StartEngine, EngineStarted, StopEngine, EngineStopped, ResetRelativeTime, MechanicActor, \
+    cluster_distribution_version, download

--- a/esrally/mechanic/__init__.py
+++ b/esrally/mechanic/__init__.py
@@ -16,6 +16,6 @@
 # under the License.
 
 # expose only the minimum API
-from .mechanic import ClusterMetaInfo, NodeMetaInfo, StartEngine, EngineStarted, StopEngine, EngineStopped, \
+from .mechanic import NodeMetaInfo, StartEngine, EngineStarted, StopEngine, EngineStopped, \
     OnBenchmarkStart, BenchmarkStarted, OnBenchmarkStop, BenchmarkStopped, ResetRelativeTime, MechanicActor, \
     cluster_distribution_version, download

--- a/esrally/mechanic/cluster.py
+++ b/esrally/mechanic/cluster.py
@@ -43,6 +43,7 @@ class Node:
         self.fs = []
         self.plugins = []
 
+    # TODO: Uncertain whether we need this callback
     def on_benchmark_start(self):
         """
         Callback method when a benchmark is about to start.
@@ -59,67 +60,3 @@ class Node:
 
     def __repr__(self):
         return self.node_name
-
-
-class Cluster:
-    """
-    Cluster exposes APIs of the running benchmark candidate.
-    """
-    def __init__(self, hosts, nodes, telemetry, preserve=False):
-        """
-        Creates a new Elasticsearch cluster.
-
-        :param hosts: An array of host/port pairs.
-        :param nodes: The nodes of which this cluster consists of. Mandatory.
-        :param telemetry Telemetry attached to this cluster. Mandatory.
-        :param preserve Whether the cluster will be kept around after the benchmark. Optional.
-
-        """
-        self.hosts = hosts
-        self.nodes = nodes
-        self.telemetry = telemetry
-        self.distribution_version = None
-        self.distribution_flavor = None
-        self.source_revision = None
-        self.team_revision = None
-        self.preserve = preserve
-
-    def node(self, name):
-        """
-        Finds a cluster node by name.
-
-        :param name: The node's name.
-        :return: The corresponding node or ``None`` if the cluster does not contain a node with this name.
-        """
-        for n in self.nodes:
-            if n.node_name == name:
-                return n
-        return None
-
-    def has_node(self, name):
-        """
-        :param name: The node's name.
-        :return: True iff the cluster contains such a node.
-        """
-        return self.node(name) is not None
-
-    def add_node(self, host_name, node_name):
-        new_node = Node(pid=None, host_name=host_name, node_name=node_name, telemetry=None)
-        self.nodes.append(new_node)
-        return new_node
-
-    def on_benchmark_start(self):
-        """
-        Callback method when a benchmark is about to start.
-        """
-        self.telemetry.on_benchmark_start()
-        for node in self.nodes:
-            node.on_benchmark_start()
-
-    def on_benchmark_stop(self):
-        """
-        Callback method when a benchmark is about to stop.
-        """
-        self.telemetry.on_benchmark_stop()
-        for node in self.nodes:
-            node.on_benchmark_stop()

--- a/esrally/mechanic/cluster.py
+++ b/esrally/mechanic/cluster.py
@@ -43,13 +43,5 @@ class Node:
         self.fs = []
         self.plugins = []
 
-    # TODO: Uncertain whether we need this callback
-    def on_benchmark_start(self):
-        """
-        Callback method when a benchmark is about to start.
-        """
-        if self.telemetry:
-            self.telemetry.on_benchmark_start()
-
     def __repr__(self):
         return self.node_name

--- a/esrally/mechanic/cluster.py
+++ b/esrally/mechanic/cluster.py
@@ -51,12 +51,5 @@ class Node:
         if self.telemetry:
             self.telemetry.on_benchmark_start()
 
-    def on_benchmark_stop(self):
-        """
-        Callback method when a benchmark is about to stop.
-        """
-        if self.telemetry:
-            self.telemetry.on_benchmark_stop()
-
     def __repr__(self):
         return self.node_name

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -23,119 +23,9 @@ from time import monotonic as _time
 
 import psutil
 
-from esrally import time, exceptions, client
-from esrally.mechanic import telemetry, cluster, java_resolver
+from esrally import time, exceptions, telemetry
+from esrally.mechanic import cluster, java_resolver
 from esrally.utils import process
-
-
-def wait_for_rest_layer(es, max_attempts=20):
-    for attempt in range(max_attempts):
-        import elasticsearch
-        try:
-            es.info()
-            return True
-        except elasticsearch.ConnectionError as e:
-            if "SSL: UNKNOWN_PROTOCOL" in str(e):
-                raise exceptions.LaunchError("Could not connect to cluster via https. Is this a https endpoint?", e)
-            else:
-                time.sleep(1)
-        except elasticsearch.TransportError as e:
-            if e.status_code == 503:
-                time.sleep(1)
-            elif e.status_code == 401:
-                time.sleep(1)
-            else:
-                raise e
-    return False
-
-
-class ClusterLauncher:
-    """
-    The cluster launcher performs cluster-wide tasks that need to be done in the startup / shutdown phase.
-
-    """
-
-    def __init__(self, cfg, metrics_store, client_factory_class=client.EsClientFactory):
-        """
-
-        Creates a new ClusterLauncher.
-
-        :param cfg: The config object.
-        :param metrics_store: A metrics store that is configured to receive system metrics.
-        :param client_factory_class: A factory class that can create an Elasticsearch client.
-        """
-        self.cfg = cfg
-        self.metrics_store = metrics_store
-        self.client_factory = client_factory_class
-        self.logger = logging.getLogger(__name__)
-
-    def start(self):
-        """
-        Performs final startup tasks.
-
-        Precondition: All cluster nodes have been started.
-        Postcondition: The cluster is ready to receive HTTP requests or a ``LaunchError`` is raised.
-
-        :return: A representation of the launched cluster.
-        """
-        enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
-        telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
-        all_hosts = self.cfg.opts("client", "hosts").all_hosts
-        default_hosts = self.cfg.opts("client", "hosts").default
-        preserve = self.cfg.opts("mechanic", "preserve.install")
-        skip_rest_api_check = self.cfg.opts("mechanic", "skip.rest.api.check")
-
-        es = {}
-        for cluster_name, cluster_hosts in all_hosts.items():
-            all_client_options = self.cfg.opts("client", "options").all_client_options
-            cluster_client_options = dict(all_client_options[cluster_name])
-            # Use retries to avoid aborts on long living connections for telemetry devices
-            cluster_client_options["retry-on-timeout"] = True
-            es[cluster_name] = self.client_factory(cluster_hosts, cluster_client_options).create()
-
-        es_default = es["default"]
-
-        t = telemetry.Telemetry(enabled_devices, devices=[
-            telemetry.NodeStats(telemetry_params, es, self.metrics_store),
-            telemetry.ClusterMetaDataInfo(es_default),
-            # will gather node specific meta-data for all nodes
-            telemetry.ExternalEnvironmentInfo(es_default, self.metrics_store),
-            telemetry.ClusterEnvironmentInfo(es_default, self.metrics_store),
-            telemetry.JvmStatsSummary(es_default, self.metrics_store),
-            telemetry.IndexStats(es_default, self.metrics_store),
-            telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
-            telemetry.CcrStats(telemetry_params, es, self.metrics_store),
-            telemetry.RecoveryStats(telemetry_params, es, self.metrics_store)
-        ])
-
-        # The list of nodes will be populated by ClusterMetaDataInfo, so no need to do it here
-        c = cluster.Cluster(default_hosts, [], t, preserve)
-
-        if skip_rest_api_check:
-            self.logger.info("Skipping REST API check and attaching telemetry devices to cluster.")
-            t.attach_to_cluster(c)
-            self.logger.info("Telemetry devices are now attached to the cluster.")
-        else:
-            self.logger.info("All cluster nodes have successfully started. Checking if REST API is available.")
-            if wait_for_rest_layer(es_default, max_attempts=40):
-                self.logger.info("REST API is available. Attaching telemetry devices to cluster.")
-                t.attach_to_cluster(c)
-                self.logger.info("Telemetry devices are now attached to the cluster.")
-            else:
-                # Just stop the cluster here and raise. The caller is responsible for terminating individual nodes.
-                self.logger.error("REST API layer is not yet available. Forcefully terminating cluster.")
-                self.stop(c)
-                raise exceptions.LaunchError(
-                    "Elasticsearch REST API layer is not available. Forcefully terminated cluster.")
-        return c
-
-    def stop(self, c):
-        """
-        Performs cleanup tasks. This method should be called before nodes are shut down.
-
-        :param c: The cluster that is about to be stopped.
-        """
-        c.telemetry.detach_from_cluster(c)
 
 
 def _get_container_id(compose_config):
@@ -268,8 +158,8 @@ class ProcessLauncher:
 
         self.logger.info("Starting node [%s] based on car [%s].", node_name, car)
 
-        enabled_devices = self.cfg.opts("mechanic", "telemetry.devices")
-        telemetry_params = self.cfg.opts("mechanic", "telemetry.params")
+        enabled_devices = self.cfg.opts("telemetry", "devices")
+        telemetry_params = self.cfg.opts("telemetry", "params")
         node_telemetry = [
             telemetry.FlightRecorder(telemetry_params, node_telemetry_dir, java_major_version),
             telemetry.JitCompiler(node_telemetry_dir),

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -502,7 +502,7 @@ class NodeMechanicActor(actor.RallyActor):
                 self.send(sender, NodesStopped(self.metrics_store.to_externalizable(clear=True)))
                 # clear all state as the mechanic might get reused later
                 self.metrics_store.close()
-                # TODO: Run the reporter (StatsCalculator) here to calculate summary stats and safe them to the
+                # TODO: Run the reporter (StatsCalculator) here to calculate summary stats and save them to the
                 #  metrics store (no command line output though!)
                 self.running = False
                 self.config = None

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -43,22 +43,6 @@ def download(cfg):
 # Public Messages
 ##############################
 
-class NodeMetaInfo:
-    def __init__(self, n):
-        self.host_name = n.host_name
-        self.node_name = n.node_name
-        self.ip = n.ip
-        self.os = n.os
-        self.jvm = n.jvm
-        self.cpu = n.cpu
-        self.memory = n.memory
-        self.fs = n.fs
-        self.plugins = n.plugins
-
-    def as_dict(self):
-        return self.__dict__
-
-
 class StartEngine:
     def __init__(self, cfg, open_metrics_context, cluster_settings, sources, build, distribution, external, docker, ip=None, port=None,
                  node_id=None):
@@ -131,14 +115,12 @@ class StartNodes:
 
 
 class NodesStarted:
-    def __init__(self, node_meta_infos, system_meta_info):
+    def __init__(self, system_meta_info):
         """
-        Creates a new NodeStarted message.
+        Creates a new NodesStarted message.
 
-        :param node_meta_infos: A list of ``NodeMetaInfo`` instances.
         :param system_meta_info:
         """
-        self.node_meta_infos = node_meta_infos
         self.system_meta_info = system_meta_info
 
 
@@ -484,7 +466,7 @@ class NodeMechanicActor(actor.RallyActor):
             nodes = self.mechanic.start_engine()
             self.running = True
             self.wakeupAfter(METRIC_FLUSH_INTERVAL_SECONDS)
-            self.send(getattr(msg, "reply_to", sender), NodesStarted([NodeMetaInfo(node) for node in nodes], self.metrics_store.meta_info))
+            self.send(getattr(msg, "reply_to", sender), NodesStarted(self.metrics_store.meta_info))
         except Exception:
             self.logger.exception("Cannot process message [%s]", msg)
             # avoid "can't pickle traceback objects"

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -502,6 +502,8 @@ class NodeMechanicActor(actor.RallyActor):
                 self.send(sender, NodesStopped(self.metrics_store.to_externalizable(clear=True)))
                 # clear all state as the mechanic might get reused later
                 self.metrics_store.close()
+                # TODO: Run the reporter (StatsCalculator) here to calculate summary stats and safe them to the
+                #  metrics store (no command line output though!)
                 self.running = False
                 self.config = None
                 self.mechanic = None

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -98,7 +98,7 @@ def plain_text(file):
 def cleanup(preserve, install_dir, data_paths):
     logger = logging.getLogger(__name__)
     if preserve:
-        console.info("Preserving benchmark candidate installation at [%s].", install_dir)
+        console.info("Preserving benchmark candidate installation at [{}].".format(install_dir), logger=logger)
     else:
         logger.info("Wiping benchmark candidate installation at [%s].", install_dir)
         for path in data_paths:

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -45,10 +45,6 @@ def local_provisioner(cfg, car, plugins, cluster_settings, all_node_ips, target_
     return BareProvisioner(cluster_settings, es_installer, plugin_installers, preserve, distribution_version=distribution_version)
 
 
-def no_op_provisioner():
-    return NoOpProvisioner()
-
-
 def docker_provisioner(cfg, car, cluster_settings, target_root, node_id):
     distribution_version = cfg.opts("mechanic", "distribution.version", mandatory=False)
     ip = cfg.opts("provisioning", "node.ip")
@@ -358,17 +354,6 @@ class PluginInstaller:
     def sub_plugin_name(self):
         # if a plugin consists of multiple plugins (e.g. x-pack) we're interested in that name
         return self.variables.get("plugin_name", self.plugin_name)
-
-
-class NoOpProvisioner:
-    def __init__(self, *args):
-        pass
-
-    def prepare(self, *args):
-        return None
-
-    def cleanup(self):
-        pass
 
 
 class DockerProvisioner:

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -24,7 +24,7 @@ import jinja2
 
 from esrally import exceptions
 from esrally.mechanic import team, java_resolver
-from esrally.utils import io, process, versions
+from esrally.utils import console, io, process, versions
 
 
 def local_provisioner(cfg, car, plugins, cluster_settings, all_node_ips, target_root, node_id):
@@ -98,7 +98,7 @@ def plain_text(file):
 def cleanup(preserve, install_dir, data_paths):
     logger = logging.getLogger(__name__)
     if preserve:
-        logger.info("Preserving benchmark candidate installation at [%s].", install_dir)
+        console.info("Preserving benchmark candidate installation at [%s].", install_dir)
     else:
         logger.info("Wiping benchmark candidate installation at [%s].", install_dir)
         for path in data_paths:

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -330,12 +330,14 @@ class MetricsStore:
         self._environment_name = cfg.opts("system", "env.name")
         self.opened = False
         if meta_info is None:
-            self._meta_info = {
-                MetaInfoScope.cluster: {},
-                MetaInfoScope.node: {}
-            }
+            self._meta_info = {}
         else:
             self._meta_info = meta_info
+        # ensure mandatory keys are always present
+        if MetaInfoScope.cluster not in self._meta_info:
+            self._meta_info[MetaInfoScope.cluster] = {}
+        if MetaInfoScope.node not in self._meta_info:
+            self._meta_info[MetaInfoScope.node] = {}
         self._clock = clock
         self._stop_watch = self._clock.stop_watch()
         self.logger = logging.getLogger(__name__)
@@ -596,7 +598,6 @@ class MetricsStore:
             doc["operation-type"] = operation_type
         if self._track_params:
             doc["track-params"] = self._track_params
-
         self._add(doc)
 
     def put_doc(self, doc, level=None, node_name=None, meta_data=None, absolute_time=None, relative_time=None):
@@ -1162,7 +1163,7 @@ def list_races(cfg):
     races = []
     for race in race_store(cfg).list():
         races.append([race.trial_id, time.to_iso8601(race.trial_timestamp), race.track, format_dict(race.track_params), race.challenge_name, race.car_name,
-                      format_dict(race.user_tags), race.track_revision, race.cluster.get("team-revision")])
+                      format_dict(race.user_tags), race.track_revision, race.team_revision])
 
     if len(races) > 0:
         console.println("\nRecent races:\n")
@@ -1184,13 +1185,14 @@ def create_race(cfg, track, challenge, track_revision=None):
     plugin_params = cfg.opts("mechanic", "plugin.params")
     rally_version = version.version()
 
-    return Race(rally_version, environment, trial_id, trial_timestamp, pipeline, user_tags, track, track_params, challenge, car,
-                car_params, plugin_params, track_revision)
+    return Race(rally_version, environment, trial_id, trial_timestamp, pipeline, user_tags, track, track_params,
+                challenge, car, car_params, plugin_params, track_revision)
 
 
 class Race:
-    def __init__(self, rally_version, environment_name, trial_id, trial_timestamp, pipeline, user_tags, track, track_params, challenge, car,
-                 car_params, plugin_params, track_revision=None, cluster=None, results=None):
+    def __init__(self, rally_version, environment_name, trial_id, trial_timestamp, pipeline, user_tags, track,
+                 track_params, challenge, car, car_params, plugin_params, track_revision=None, team_revision=None,
+                 distribution_version=None, distribution_flavor=None, revision=None, results=None):
         if results is None:
             results = {}
         self.rally_version = rally_version
@@ -1205,10 +1207,12 @@ class Race:
         self.car = car
         self.car_params = car_params
         self.plugin_params = plugin_params
-        # will be set later - contains hosts, revision, distribution_version, ...
-        self.cluster = cluster
-        self.results = results
         self.track_revision = track_revision
+        self.team_revision = team_revision
+        self.distribution_version = distribution_version
+        self.distribution_flavor = distribution_flavor
+        self.revision = revision
+        self.results = results
 
     @property
     def track_name(self):
@@ -1221,11 +1225,6 @@ class Race:
     @property
     def car_name(self):
         return "+".join(self.car) if isinstance(self.car, list) else self.car
-
-    @property
-    def revision(self):
-        # minor simplification for reporter
-        return self.cluster.revision
 
     @property
     def meta_data(self):
@@ -1251,7 +1250,12 @@ class Race:
             "user-tags": self.user_tags,
             "track": self.track_name,
             "car": self.car,
-            "cluster": self.cluster.as_dict(),
+            "cluster": {
+                "revision": self.revision,
+                "distribution-version": self.distribution_version,
+                "distribution-flavor": self.distribution_flavor,
+                "team-revision": self.team_revision,
+            },
             "results": self.results.as_dict()
         }
         if self.track_revision:
@@ -1275,25 +1279,17 @@ class Race:
             "environment": self.environment_name,
             "trial-id": self.trial_id,
             "trial-timestamp": time.to_iso8601(self.trial_timestamp),
-            "distribution-version": self.cluster.distribution_version,
-            "distribution-flavor": self.cluster.distribution_flavor,
-            "distribution-major-version": versions.major_version(self.cluster.distribution_version),
+            "distribution-version": self.distribution_version,
+            "distribution-flavor": self.distribution_flavor,
+            "distribution-major-version": versions.major_version(self.distribution_version),
             "user-tags": self.user_tags,
             "track": self.track_name,
             "car": self.car_name,
-            "node-count": len(self.cluster.nodes),
-            # allow to logically delete records, e.g. for UI purposes when we only want to show the latest result on graphs
+            # allow to logically delete records, e.g. for UI purposes when we only want to show the latest result
             "active": True
         }
-        plugins = set()
-        for node in self.cluster.nodes:
-            plugins.update(node.plugins)
-
-        if plugins:
-            result_template["plugins"] = list(plugins)
-
-        if self.cluster.team_revision:
-            result_template["team-revision"] = self.cluster.team_revision
+        if self.team_revision:
+            result_template["team-revision"] = self.team_revision
         if self.track_revision:
             result_template["track-revision"] = self.track_revision
         if not self.challenge.auto_generated:
@@ -1325,16 +1321,15 @@ class Race:
             user_tags = d["user-tags"]
         else:
             user_tags = {}
-
-        team_revision = None
-        if "cluster" in d:
-            team_revision = d.get("cluster").get("team-revision")
-
-        # Don't restore a few properties like some cluster properties because they (a) cannot be reconstructed easily without knowledge of other modules
-        # and (b) it is not necessary for this use case.
-        return Race(d["rally-version"], d["environment"], d["trial-id"], time.from_is8601(d["trial-timestamp"]), d["pipeline"], user_tags,
-                    d["track"], d.get("track-params"), d.get("challenge"), d["car"], d.get("car-params"), d.get("plugin-params"),
-                    track_revision=d.get("track-revision"), cluster={"team-revision": team_revision}, results=d["results"])
+        # TODO: cluster is optional for BWC. This can be removed after some grace period.
+        cluster = d.get("cluster", {})
+        return Race(d["rally-version"], d["environment"], d["trial-id"], time.from_is8601(d["trial-timestamp"]),
+                    d["pipeline"], user_tags, d["track"], d.get("track-params"), d.get("challenge"), d["car"],
+                    d.get("car-params"), d.get("plugin-params"), track_revision=d.get("track-revision"),
+                    team_revision=cluster.get("team-revision"),
+                    distribution_version=cluster.get("distribution-version"),
+                    distribution_flavor=cluster.get("distribution-flavor"),
+                    revision=cluster.get("revision"), results=d["results"])
 
 
 class RaceStore:

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -226,8 +226,6 @@ class BenchmarkActor(actor.RallyActor):
                                                       msg.distribution, msg.external, msg.docker))
 
     def run(self):
-        self.logger.info("Telling mechanic of benchmark start.")
-        self.send(self.mechanic, mechanic.OnBenchmarkStart())
         self.logger.info("Telling driver to start benchmark.")
         self.send(self.main_driver, driver.StartBenchmark())
 

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -170,15 +170,6 @@ class BenchmarkActor(actor.RallyActor):
         self.metrics_store.bulk_add(msg.metrics)
         self.send(self.main_driver, thespian.actors.ActorExitRequest())
         self.main_driver = None
-        self.send(self.mechanic, mechanic.OnBenchmarkStop())
-
-    @actor.no_retry("race control")
-    def receiveMsg_BenchmarkStopped(self, msg, sender):
-        self.logger.info("Bulk adding system metrics to metrics store.")
-        self.metrics_store.bulk_add(msg.system_metrics)
-        self.logger.debug("Flushing metrics data...")
-        self.metrics_store.flush()
-        self.logger.debug("Flushing done")
         self.teardown()
 
     @actor.no_retry("race control")

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -123,14 +123,22 @@ class BenchmarkActor(actor.RallyActor):
     def receiveMsg_EngineStarted(self, msg, sender):
         self.logger.info("Mechanic has started engine successfully.")
         self.metrics_store.meta_info = msg.system_meta_info
-        cluster = msg.cluster_meta_info
-        self.race.cluster = cluster
+        self.race.team_revision = msg.team_revision
+        self.main_driver = self.createActor(driver.DriverActor, targetActorRequirements={"coordinator": True})
+        self.logger.info("Telling driver to prepare for benchmarking.")
+        self.send(self.main_driver, driver.PrepareBenchmark(self.cfg, self.race.track, self.metrics_store.meta_info))
+
+    @actor.no_retry("race control")
+    def receiveMsg_PreparationComplete(self, msg, sender):
+        self.race.distribution_flavor = msg.distribution_flavor
+        self.race.distribution_version = msg.distribution_version
+        self.race.revision = msg.revision
         if self.race.challenge.auto_generated:
             console.info("Racing on track [{}] and car {} with version [{}].\n"
-                         .format(self.race.track_name, self.race.car, self.race.cluster.distribution_version))
+                         .format(self.race.track_name, self.race.car, self.race.distribution_version))
         else:
             console.info("Racing on track [{}], challenge [{}] and car {} with version [{}].\n"
-                         .format(self.race.track_name, self.race.challenge_name, self.race.car, self.race.cluster.distribution_version))
+                         .format(self.race.track_name, self.race.challenge_name, self.race.car, self.race.distribution_version))
         self.run()
 
     @actor.no_retry("race control")
@@ -229,9 +237,8 @@ class BenchmarkActor(actor.RallyActor):
     def run(self):
         self.logger.info("Telling mechanic of benchmark start.")
         self.send(self.mechanic, mechanic.OnBenchmarkStart())
-        self.main_driver = self.createActor(driver.DriverActor, targetActorRequirements={"coordinator": True})
         self.logger.info("Telling driver to start benchmark.")
-        self.send(self.main_driver, driver.StartBenchmark(self.cfg, self.race.track, self.metrics_store.meta_info))
+        self.send(self.main_driver, driver.StartBenchmark())
 
     def teardown(self):
         self.logger.info("Asking mechanic to stop the engine.")

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -23,10 +23,10 @@ import sys
 import time
 import uuid
 
-from esrally import PROGRAM_NAME, BANNER, SKULL, check_python_version, doc_link
+from esrally import PROGRAM_NAME, BANNER, SKULL, check_python_version, doc_link, telemetry
 from esrally import version, actor, config, paths, racecontrol, reporter, metrics, track, chart_generator, exceptions, \
     log
-from esrally.mechanic import team, telemetry, mechanic
+from esrally.mechanic import team, mechanic
 from esrally.utils import io, convert, process, console, net, opts
 
 
@@ -603,8 +603,8 @@ def main():
         cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
     cfg.add(config.Scope.applicationOverride, "mechanic", "skip.rest.api.check", convert.to_bool(args.skip_rest_api_check))
     cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
-    cfg.add(config.Scope.applicationOverride, "mechanic", "telemetry.devices", opts.csv_to_list(args.telemetry))
-    cfg.add(config.Scope.applicationOverride, "mechanic", "telemetry.params", opts.to_dict(args.telemetry_params))
+    cfg.add(config.Scope.applicationOverride, "telemetry", "devices", opts.csv_to_list(args.telemetry))
+    cfg.add(config.Scope.applicationOverride, "telemetry", "params", opts.to_dict(args.telemetry_params))
 
     cfg.add(config.Scope.applicationOverride, "race", "pipeline", args.pipeline)
     cfg.add(config.Scope.applicationOverride, "race", "user.tag", args.user_tag)

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -191,6 +191,7 @@ class StatsCalculator:
         result.memory_points = self.median("segments_points_memory_in_bytes")
         result.memory_stored_fields = self.median("segments_stored_fields_memory_in_bytes")
 
+        # TODO: This cannot be done in the reporter anymore!
         self.logger.debug("Gathering disk metrics.")
         # This metric will only be written for the last iteration (as it can only be determined after the cluster has been shut down)
         result.index_size = self.sum("final_index_size_bytes")

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -54,11 +54,6 @@ class Telemetry:
                 opts.extend(additional_opts)
         return opts
 
-    def attach_to_cluster(self, cluster):
-        for device in self.devices:
-            if self._enabled(device):
-                device.attach_to_cluster(cluster)
-
     def on_pre_node_start(self, node_name):
         for device in self.devices:
             if self._enabled(device):
@@ -84,11 +79,6 @@ class Telemetry:
             if self._enabled(device):
                 device.on_benchmark_stop()
 
-    def detach_from_cluster(self, cluster):
-        for device in self.devices:
-            if self._enabled(device):
-                device.detach_from_cluster(cluster)
-
     def _enabled(self, device):
         return device.internal or device.command in self.enabled_devices
 
@@ -106,9 +96,6 @@ class TelemetryDevice:
     def instrument_java_opts(self, car, candidate_id):
         return {}
 
-    def attach_to_cluster(self, cluster):
-        pass
-
     def on_pre_node_start(self, node_name):
         pass
 
@@ -116,9 +103,6 @@ class TelemetryDevice:
         pass
 
     def detach_from_node(self, node, running):
-        pass
-
-    def detach_from_cluster(self, cluster):
         pass
 
     def on_benchmark_start(self):
@@ -302,10 +286,6 @@ class CcrStats(TelemetryDevice):
 
         self.metrics_store = metrics_store
         self.samplers = []
-
-    def attach_to_cluster(self, cluster):
-        # This cluster parameter does not correspond to the cluster names passed in target.hosts, see on_benchmark_start()
-        super().attach_to_cluster(cluster)
 
     def on_benchmark_start(self):
         recorder = []
@@ -841,7 +821,7 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
         self.metrics_store = metrics_store
         self.client = client
 
-    def attach_to_cluster(self, cluster):
+    def on_benchmark_start(self):
         # noinspection PyBroadException
         try:
             client_info = self.client.info()
@@ -892,7 +872,7 @@ class ExternalEnvironmentInfo(InternalTelemetryDevice):
         self.client = client
 
     # noinspection PyBroadException
-    def attach_to_cluster(self, cluster):
+    def on_benchmark_start(self):
         try:
             nodes_stats = self.client.nodes.stats(metric="_all")["nodes"].values()
         except BaseException:
@@ -925,95 +905,6 @@ class ExternalEnvironmentInfo(InternalTelemetryDevice):
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, metric_key, extract_value(node, path))
 
 
-class ClusterMetaDataInfo(InternalTelemetryDevice):
-    """
-    Enriches the cluster with meta-data about it and its nodes.
-    """
-    def __init__(self, client):
-        super().__init__()
-        self.client = client
-
-    def attach_to_cluster(self, cluster):
-        self.cluster_metadata(cluster)
-        self.nodes_metadata(cluster)
-
-    def cluster_metadata(self, cluster):
-        # noinspection PyBroadException
-        try:
-            client_info = self.client.info()
-        except BaseException:
-            self.logger.exception("Could not retrieve cluster version info")
-            return
-        revision = client_info["version"]["build_hash"]
-        distribution_version = client_info["version"]["number"]
-        # older versions (pre 6.3.0) don't expose a build_flavor property because the only (implicit) flavor was "oss".
-        distribution_flavor = client_info["version"].get("build_flavor", "oss")
-
-        cluster.distribution_version = distribution_version
-        cluster.distribution_flavor = distribution_flavor
-        cluster.source_revision = revision
-
-    # noinspection PyBroadException
-    def nodes_metadata(self, cluster):
-        try:
-            nodes_stats = self.client.nodes.stats(metric="_all")["nodes"]
-        except BaseException:
-            self.logger.exception("Could not retrieve nodes stats")
-            nodes_stats = {}
-        try:
-            nodes_info = self.client.nodes.info(node_id="_all")["nodes"]
-        except BaseException:
-            self.logger.exception("Could not retrieve nodes info")
-            nodes_info = {}
-
-        for node_stats in nodes_stats.values():
-            node_name = node_stats["name"]
-            if cluster.has_node(node_name):
-                cluster_node = cluster.node(node_name)
-            else:
-                host = node_stats.get("host", "unknown")
-                cluster_node = cluster.add_node(host, node_name)
-            self.add_node_stats(cluster_node, node_stats)
-
-        for node_info in nodes_info.values():
-            self.add_node_info(cluster, node_info)
-
-    def add_node_info(self, cluster, node_info):
-        node_name = node_info["name"]
-        cluster_node = cluster.node(node_name)
-        if cluster_node:
-            cluster_node.ip = extract_value(node_info, ["ip"])
-            cluster_node.os = {
-                "name": extract_value(node_info, ["os", "name"]),
-                "version": extract_value(node_info, ["os", "version"])
-            }
-            cluster_node.jvm = {
-                "vendor": extract_value(node_info, ["jvm", "vm_vendor"]),
-                "version": extract_value(node_info, ["jvm", "version"])
-            }
-            cluster_node.cpu = {
-                "available_processors": extract_value(node_info, ["os", "available_processors"]),
-                "allocated_processors": extract_value(node_info, ["os", "allocated_processors"], fallback=None),
-            }
-            for plugin in extract_value(node_info, ["plugins"], fallback=[]):
-                if "name" in plugin:
-                    cluster_node.plugins.append(plugin["name"])
-
-    def add_node_stats(self, cluster_node, stats):
-        if cluster_node:
-            data_dirs = extract_value(stats, ["fs", "data"], fallback=[])
-            for data_dir in data_dirs:
-                fs_meta_data = {
-                    "mount": data_dir.get("mount", "unknown"),
-                    "type": data_dir.get("type", "unknown"),
-                    "spins": data_dir.get("spins", "unknown")
-                }
-                cluster_node.fs.append(fs_meta_data)
-            cluster_node.memory = {
-                "total_bytes": extract_value(stats, ["os", "mem", "total_in_bytes"], fallback=None)
-            }
-
-
 class JvmStatsSummary(InternalTelemetryDevice):
     """
     Gathers a summary of various JVM statistics during the whole race.
@@ -1025,6 +916,7 @@ class JvmStatsSummary(InternalTelemetryDevice):
         self.jvm_stats_per_node = {}
 
     def on_benchmark_start(self):
+        self.logger.info("JvmStatsSummary on benchmark start")
         self.jvm_stats_per_node = self.jvm_stats()
 
     def on_benchmark_stop(self):
@@ -1223,7 +1115,7 @@ class MlBucketProcessingTime(InternalTelemetryDevice):
         self.client = client
         self.metrics_store = metrics_store
 
-    def detach_from_cluster(self, cluster):
+    def on_benchmark_stop(self):
         import elasticsearch
         try:
             results = self.client.search(index=".ml-anomalies-*", body={

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -54,10 +54,30 @@ class DriverTestParamSource:
 
 
 class DriverTests(TestCase):
+    class Holder:
+        def __init__(self, all_hosts=None, all_client_options=None):
+            self.all_hosts = all_hosts
+            self.all_client_options = all_client_options
+
     def __init__(self, methodName='runTest'):
         super().__init__(methodName)
         self.cfg = None
         self.track = None
+
+    class StaticClientFactory:
+        PATCHER = None
+
+        def __init__(self, *args, **kwargs):
+            DriverTests.StaticClientFactory.PATCHER = mock.patch("elasticsearch.Elasticsearch")
+            self.es = DriverTests.StaticClientFactory.PATCHER.start()
+            self.es.indices.stats.return_value = {"mocked": True}
+
+        def create(self):
+            return self.es
+
+        @classmethod
+        def close(cls):
+            DriverTests.StaticClientFactory.PATCHER.stop()
 
     def setUp(self):
         self.cfg = config.Config()
@@ -67,9 +87,13 @@ class DriverTests(TestCase):
         self.cfg.add(config.Scope.application, "track", "challenge.name", "default")
         self.cfg.add(config.Scope.application, "track", "params", {})
         self.cfg.add(config.Scope.application, "track", "test.mode.enabled", True)
+        self.cfg.add(config.Scope.application, "telemetry", "devices", [])
+        self.cfg.add(config.Scope.application, "telemetry", "params", {})
         self.cfg.add(config.Scope.application, "mechanic", "car.names", ["default"])
-        self.cfg.add(config.Scope.application, "client", "hosts", ["localhost:9200"])
-        self.cfg.add(config.Scope.application, "client", "options", {})
+        self.cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", True)
+        self.cfg.add(config.Scope.application, "client", "hosts",
+                     DriverTests.Holder(all_hosts={"default": ["localhost:9200"]}))
+        self.cfg.add(config.Scope.application, "client", "options", DriverTests.Holder(all_client_options={"default": {}}))
         self.cfg.add(config.Scope.application, "driver", "load_driver_hosts", ["localhost"])
         self.cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")
 
@@ -78,6 +102,9 @@ class DriverTests(TestCase):
         ])
         another_challenge = track.Challenge("other", default=False)
         self.track = track.Track(name="unittest", description="unittest track", challenges=[another_challenge, default_challenge])
+
+    def tearDown(self):
+        DriverTests.StaticClientFactory.close()
 
     def create_test_driver_target(self):
         track_preparator = "track_preparator_marker"
@@ -95,9 +122,8 @@ class DriverTests(TestCase):
         resolve.side_effect = ["10.5.5.1", "10.5.5.2"]
 
         target = self.create_test_driver_target()
-        d = driver.Driver(target, self.cfg)
-
-        d.start_benchmark(t=self.track, metrics_meta_info={})
+        d = driver.Driver(target, self.cfg, es_client_factory_class=DriverTests.StaticClientFactory)
+        d.prepare_benchmark(t=self.track, metrics_meta_info={})
 
         target.create_track_preparator.assert_has_calls(calls=[
             mock.call("10.5.5.1"),
@@ -105,8 +131,7 @@ class DriverTests(TestCase):
         ])
 
         target.on_prepare_track.assert_called_once_with(["track_preparator_marker", "track_preparator_marker"], self.cfg, self.track)
-
-        d.after_track_prepared()
+        d.start_benchmark()
 
         target.create_client.assert_has_calls(calls=[
             mock.call(0, "10.5.5.1"),
@@ -120,14 +145,14 @@ class DriverTests(TestCase):
 
     def test_assign_drivers_round_robin(self):
         target = self.create_test_driver_target()
-        d = driver.Driver(target, self.cfg)
+        d = driver.Driver(target, self.cfg, es_client_factory_class=DriverTests.StaticClientFactory)
 
-        d.start_benchmark(t=self.track, metrics_meta_info={})
+        d.prepare_benchmark(t=self.track, metrics_meta_info={})
 
         target.create_track_preparator.assert_called_once_with("localhost")
         target.on_prepare_track.assert_called_once_with(["track_preparator_marker"], self.cfg, self.track)
 
-        d.after_track_prepared()
+        d.start_benchmark()
 
         target.create_client.assert_has_calls(calls=[
             mock.call(0, "localhost"),
@@ -141,10 +166,10 @@ class DriverTests(TestCase):
 
     def test_client_reaches_join_point_others_still_executing(self):
         target = self.create_test_driver_target()
-        d = driver.Driver(target, self.cfg)
+        d = driver.Driver(target, self.cfg, es_client_factory_class=DriverTests.StaticClientFactory)
 
-        d.start_benchmark(t=self.track, metrics_meta_info={})
-        d.after_track_prepared()
+        d.prepare_benchmark(t=self.track, metrics_meta_info={})
+        d.start_benchmark()
 
         self.assertEqual(0, len(d.clients_completed_current_step))
 
@@ -157,10 +182,10 @@ class DriverTests(TestCase):
 
     def test_client_reaches_join_point_which_completes_parent(self):
         target = self.create_test_driver_target()
-        d = driver.Driver(target, self.cfg)
+        d = driver.Driver(target, self.cfg, es_client_factory_class=DriverTests.StaticClientFactory)
 
-        d.start_benchmark(t=self.track, metrics_meta_info={})
-        d.after_track_prepared()
+        d.prepare_benchmark(t=self.track, metrics_meta_info={})
+        d.start_benchmark()
 
         self.assertEqual(0, len(d.clients_completed_current_step))
 
@@ -869,3 +894,49 @@ class ProfilerTests(TestCase):
         self.assertEqual(2, return_value)
         duration = end - start
         self.assertTrue(0.9 <= duration <= 1.2, "Should sleep for roughly 1 second but took [%.2f] seconds." % duration)
+
+
+class RestLayerTests(TestCase):
+    @mock.patch("elasticsearch.Elasticsearch", autospec=True)
+    def test_successfully_waits_for_rest_layer(self, es):
+        self.assertTrue(driver.wait_for_rest_layer(es, max_attempts=3))
+
+    # don't sleep in realtime
+    @mock.patch("time.sleep")
+    @mock.patch("elasticsearch.Elasticsearch", autospec=True)
+    def test_retries_on_transport_errors(self, es, sleep):
+        import elasticsearch
+
+        es.info.side_effect = [
+            elasticsearch.TransportError(503, "Service Unavailable"),
+            elasticsearch.TransportError(401, "Unauthorized"),
+            {
+                "version": {
+                    "number": "5.0.0",
+                    "build_hash": "abc123"
+                }
+            }
+        ]
+        self.assertTrue(driver.wait_for_rest_layer(es, max_attempts=3))
+
+    # don't sleep in realtime
+    @mock.patch("time.sleep")
+    @mock.patch("elasticsearch.Elasticsearch", autospec=True)
+    def test_dont_retries_eternally_on_transport_errors(self, es, sleep):
+        import elasticsearch
+
+        es.info.side_effect = elasticsearch.TransportError(401, "Unauthorized")
+        self.assertFalse(driver.wait_for_rest_layer(es, max_attempts=3))
+
+    @mock.patch("elasticsearch.Elasticsearch", autospec=True)
+    def test_ssl_error(self, es):
+        import elasticsearch
+        import urllib3.exceptions
+
+        es.info.side_effect = elasticsearch.ConnectionError("N/A",
+                                                            "[SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:719)",
+                                                            urllib3.exceptions.SSLError(
+                                                                "[SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:719)"))
+        with self.assertRaisesRegex(expected_exception=exceptions.SystemSetupError,
+                                    expected_regex="Could not connect to cluster via https. Is this a https endpoint?"):
+            driver.wait_for_rest_layer(es, max_attempts=3)

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -198,59 +198,6 @@ class ProcessLauncherTests(TestCase):
                          "-XX:StartFlightRecording=defaultrecording=true", env["ES_JAVA_OPTS"])
 
 
-class ExternalLauncherTests(TestCase):
-    test_host = opts.TargetHosts("127.0.0.1:9200,10.17.0.5:19200")
-    client_options = opts.ClientOptions("timeout:60")
-
-    def test_setup_external_cluster_single_node(self):
-        cfg = config.Config()
-
-        cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
-        cfg.add(config.Scope.application, "client", "hosts", self.test_host)
-        cfg.add(config.Scope.application, "client", "options", self.client_options)
-        cfg.add(config.Scope.application, "system", "env.name", "test")
-
-        ms = get_metrics_store(cfg)
-
-        m = launcher.ExternalLauncher(cfg, ms, client_factory_class=MockClientFactory)
-        m.start()
-
-        # automatically determined by launcher on attach
-        self.assertEqual(cfg.opts("mechanic", "distribution.version"), "5.0.0")
-
-    def test_setup_external_cluster_multiple_nodes(self):
-        cfg = config.Config()
-        cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
-        cfg.add(config.Scope.application, "client", "hosts", self.test_host)
-        cfg.add(config.Scope.application, "client", "options", self.client_options)
-        cfg.add(config.Scope.application, "mechanic", "distribution.version", "2.3.3")
-        cfg.add(config.Scope.application, "system", "env.name", "test")
-
-        ms = get_metrics_store(cfg)
-
-        m = launcher.ExternalLauncher(cfg, ms, client_factory_class=MockClientFactory)
-        m.start()
-        # did not change user defined value
-        self.assertEqual(cfg.opts("mechanic", "distribution.version"), "2.3.3")
-
-    def test_setup_external_cluster_cannot_determine_version(self):
-        client_options = opts.ClientOptions("timeout:60,raise-error-on-info:true")
-        cfg = config.Config()
-
-        cfg.add(config.Scope.application, "mechanic", "telemetry.devices", [])
-        cfg.add(config.Scope.application, "client", "hosts", self.test_host)
-        cfg.add(config.Scope.application, "client", "options", client_options)
-        cfg.add(config.Scope.application, "system", "env.name", "test")
-
-        ms = get_metrics_store(cfg)
-
-        m = launcher.ExternalLauncher(cfg, ms, client_factory_class=MockClientFactory)
-        m.start()
-
-        # automatically determined by launcher on attach
-        self.assertIsNone(cfg.opts("mechanic", "distribution.version"))
-
-
 class ClusterLauncherTests(TestCase):
     test_host = opts.TargetHosts("10.0.0.10:9200,10.0.0.11:9200")
     client_options = opts.ClientOptions('timeout:60')

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -847,14 +847,8 @@ class EsRaceStoreTests(TestCase):
                             trial_timestamp=EsRaceStoreTests.TRIAL_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params={"shard-count": 3},
                             challenge=t.default_challenge, car="defaults", car_params={"heap_size": "512mb"}, plugin_params=None,
-                            track_revision="abc1",
-                            cluster=EsRaceStoreTests.DictHolder(
-                                {
-                                    "distribution-version": "5.0.0",
-                                    "nodes": [
-                                        {"node_name": "node0", "ip": "127.0.0.1", "plugins": ["analysis-icu", "x-pack"]}
-                                    ]
-                                }),
+                            track_revision="abc1", team_revision="abc12333", distribution_version="5.0.0",
+                            distribution_flavor="default", revision="aaaeeef",
                             results=EsRaceStoreTests.DictHolder(
                                 {
                                     "young_gc_time": 100,
@@ -896,14 +890,10 @@ class EsRaceStoreTests(TestCase):
                 "heap_size": "512mb"
             },
             "cluster": {
+                "revision": "aaaeeef",
                 "distribution-version": "5.0.0",
-                "nodes": [
-                    {
-                        "node_name": "node0",
-                        "ip": "127.0.0.1",
-                        "plugins": ["analysis-icu", "x-pack"]
-                    }
-                ]
+                "distribution-flavor": "default",
+                "team-revision": "abc12333",
             },
             "results": {
                 "young_gc_time": 100,
@@ -955,20 +945,12 @@ class EsResultsStoreTests(TestCase):
                             name="index", default=True, meta_data={"saturation": "70% saturated"}, schedule=schedule)],
                         meta_data={"track-type": "saturation-degree", "saturation": "oversaturation"})
 
-        c = cluster.Cluster([], [], None)
-        c.distribution_version = "5.0.0"
-        c.distribution_flavor = "oss"
-        c.team_revision = "123ab"
-        node = c.add_node("localhost", "rally-node-0")
-        node.plugins.append("x-pack")
-
         race = metrics.Race(rally_version="0.4.4", environment_name="unittest", trial_id=EsResultsStoreTests.TRIAL_ID,
                             trial_timestamp=EsResultsStoreTests.TRIAL_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params=None,
                             challenge=t.default_challenge, car="4gheap", car_params=None, plugin_params={"some-param": True},
-                            track_revision="abc1",
-                            cluster=c,
-                            results=reporter.Stats(
+                            track_revision="abc1", team_revision="123ab", distribution_version="5.0.0",
+                            distribution_flavor="oss", results=reporter.Stats(
                                 {
                                     "young_gc_time": 100,
                                     "old_gc_time": 5,
@@ -1021,8 +1003,6 @@ class EsResultsStoreTests(TestCase):
                 "plugin-params": {
                     "some-param": True
                 },
-                "node-count": 1,
-                "plugins": ["x-pack"],
                 "active": True,
                 "name": "old_gc_time",
                 "value": {
@@ -1052,8 +1032,6 @@ class EsResultsStoreTests(TestCase):
                 "plugin-params": {
                     "some-param": True
                 },
-                "node-count": 1,
-                "plugins": ["x-pack"],
                 "active": True,
                 "node": "rally-node-0",
                 "name": "startup_time",
@@ -1084,8 +1062,6 @@ class EsResultsStoreTests(TestCase):
                 "plugin-params": {
                     "some-param": True
                 },
-                "node-count": 1,
-                "plugins": ["x-pack"],
                 "active": True,
                 "name": "throughput",
                 "task": "index #1",
@@ -1121,8 +1097,6 @@ class EsResultsStoreTests(TestCase):
                 "plugin-params": {
                     "some-param": True
                 },
-                "node-count": 1,
-                "plugins": ["x-pack"],
                 "active": True,
                 "name": "young_gc_time",
                 "value": {
@@ -1348,14 +1322,8 @@ class FileRaceStoreTests(TestCase):
                             trial_timestamp=FileRaceStoreTests.TRIAL_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params={"clients": 12},
                             challenge=t.default_challenge, car="4gheap", car_params=None, plugin_params=None,
-                            track_revision="abc1",
-                            cluster=FileRaceStoreTests.DictHolder(
-                                {
-                                    "distribution-version": "5.0.0",
-                                    "nodes": [
-                                        {"node_name": "node0", "ip": "127.0.0.1"}
-                                    ]
-                                }),
+                            track_revision="abc1", team_revision="abc12333", distribution_version="5.0.0",
+                            distribution_flavor="default", revision="aaaeeef",
                             results=FileRaceStoreTests.DictHolder(
                                 {
                                     "young_gc_time": 100,


### PR DESCRIPTION
With this commit we gather cluster-level metrics in the driver instead of the
mechanic. As these metrics are gathered via API calls there is no need to gather
them on the very same machine were an Elasticsearch node is running. Instead, it
defines clearer boundaries in between these two components.

Relates #697
