### PR TITLE
Add support for OSNAME and ARCH variables in dist repo URLs.

### DIFF
--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -528,15 +528,14 @@ class DistributionRepository:
         return self._substitute_vars(url_template)
 
     def _substitute_vars(self, s):
-
         substitutions = {
             "{{VERSION}}": self.version,
             "{{OSNAME}}": sysstats.os_name().lower(),
             "{{ARCH}}": sysstats.cpu_arch().lower()
         }
         r = s
-        for k in substitutions.keys():
-            r = r.replace(k, substitutions[k])
+        for key, replacement in substitutions.items():
+            r = r.replace(key, replacement)
         return r
 
 

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -23,7 +23,7 @@ import urllib.error
 
 from esrally import exceptions, PROGRAM_NAME
 from esrally.exceptions import BuildError, SystemSetupError
-from esrally.utils import git, io, process, net, jvm, convert
+from esrally.utils import git, io, process, net, jvm, convert, sysstats
 
 # e.g. my-plugin:current - we cannot simply use String#split(":") as this would not work for timestamp-based revisions
 REVISION_PATTERN = r"(\w.*?):(.*)"
@@ -525,7 +525,20 @@ class DistributionRepository:
                 raise exceptions.SystemSetupError("Neither config key [{}] nor [{}] is defined.".format(user_defined_key, default_key))
             else:
                 return None
-        return url_template.replace("{{VERSION}}", self.version)
+        return self._substitute_vars(url_template)
+
+    def _substitute_vars(self, s):
+
+        substitutions = {
+            "{{VERSION}}": self.version,
+            "{{OSNAME}}": sysstats.os_name().lower(),
+            "{{ARCH}}": sysstats.cpu_arch().lower()
+        }
+        r = s
+        for k in substitutions.keys():
+            r = r.replace(k, substitutions[k])
+        return r
+
 
     @property
     def cache(self):

--- a/esrally/utils/sysstats.py
+++ b/esrally/utils/sysstats.py
@@ -53,6 +53,16 @@ def cpu_model():
     return "Unknown"
 
 
+def cpu_arch():
+    """
+    :return: The CPU architecture name.
+    """
+    if cpuinfo_available:
+        cpu_info = cpuinfo.get_cpu_info()
+        return cpu_info["arch"]
+    return "Unknown"
+
+
 def disks():
     # only physical partitions (no memory partitions etc)
     return psutil.disk_partitions(all=False)

--- a/esrally/utils/sysstats.py
+++ b/esrally/utils/sysstats.py
@@ -57,10 +57,7 @@ def cpu_arch():
     """
     :return: The CPU architecture name.
     """
-    if cpuinfo_available:
-        cpu_info = cpuinfo.get_cpu_info()
-        return cpu_info["arch"]
-    return "Unknown"
+    return platform.uname().machine
 
 
 def disks():

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -523,13 +523,15 @@ class CreateSupplierTests(TestCase):
 
 
 class DistributionRepositoryTests(TestCase):
-    def test_release_repo_config_with_default_url(self):
+    @mock.patch("esrally.utils.sysstats.os_name", return_value="Linux")
+    @mock.patch("esrally.utils.sysstats.cpu_arch", return_value="X86_64")
+    def test_release_repo_config_with_default_url(self, os_name, cpu_arch):
         repo = supplier.DistributionRepository(name="release", distribution_config={
-            "release_url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
+            "release_url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz",
             "release.cache": "true"
-        }, version="5.5.0")
-        self.assertEqual("https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.tar.gz", repo.download_url)
-        self.assertEqual("elasticsearch-5.5.0.tar.gz", repo.file_name)
+        }, version="7.3.2")
+        self.assertEqual("https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.3.2-linux-x86_64.tar.gz", repo.download_url)
+        self.assertEqual("elasticsearch-7.3.2-linux-x86_64.tar.gz", repo.file_name)
         self.assertTrue(repo.cache)
 
     def test_release_repo_config_with_user_url(self):


### PR DESCRIPTION
Since adding native libraries, ES download URLs now come in platform + arch-specific form.  

On the current branch 7 for config in rally_teams, we hardcode the platform and arch in the URL.  This works fine for the nightly machines but not elsewhere.  So, making these vars template parameters.