### PR TITLE
Update Elasticsearch version of targets and metricstore in CCR recipe

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -161,11 +161,11 @@ Running the ``start.sh`` script requires Docker locally installed and performs t
 
 1. Starts a single node (512MB heap) Elasticsearch cluster locally, to serve as a :ref:`metrics store <configuration_options>`. It also starts Kibana attached to the Elasticsearch metric store cluster.
 2. Creates a new configuration file for Rally under ``~/.rally/rally-metricstore.ini`` referencing Elasticsearch from step 1.
-3. Starts two additional local Elasticsearch clusters with 1 node each, (version ``7.0.0`` by default) called ``leader`` and ``follower`` listening at ports 32901 and 32902 respectively. Each node uses 1GB heap.
+3. Starts two additional local Elasticsearch clusters with 1 node each, (version ``7.3.2`` by default) called ``leader`` and ``follower`` listening at ports 32901 and 32902 respectively. Each node uses 1GB heap.
 4. Accepts the trial license.
 5. Configures ``leader`` on the ``follower`` as a `remote cluster <https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-remote-clusters.html#configuring-remote-clusters>`_.
 6. Sets an `auto-follow pattern <https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html#ccr-put-auto-follow-pattern>`_ on the follower for every index on the leader to be replicated as ``<leader-index-name>-copy``.
-7. Runs the `geonames track <https://github.com/elastic/rally-tracks/tree/master/geonames>`_, `append-no-conflicts-index-only challenge <https://github.com/elastic/rally-tracks/blob/d4814aa7bf54a9dafd4c77be076d54500c3f2dd4/geonames/challenges/default.json#L188-L222>`_ challenge, ingesting only 20% of the corpus. It also enables the ``ccr-stats`` :doc:`telemetry device </telemetry>` with a sample rate interval of ``1s``.
+7. Runs the `geonames track <https://github.com/elastic/rally-tracks/tree/master/geonames>`_, `append-no-conflicts-index-only challenge <https://github.com/elastic/rally-tracks/blob/d4814aa7bf54a9dafd4c77be076d54500c3f2dd4/geonames/challenges/default.json#L188-L222>`_ challenge, ingesting only 20% of the corpus using 3 primary shards. It also enables the ``ccr-stats`` :doc:`telemetry device </telemetry>` with a sample rate interval of ``1s``.
 
 Rally will push metrics to the metric store configured in 1. and they can be visualized by accessing Kibana at `http://locahost:5601 <http://localhost:5601>`_.
 

--- a/recipes/ccr/.elastic-version
+++ b/recipes/ccr/.elastic-version
@@ -1,2 +1,2 @@
-export ES_VERSION=${ES_VERSION:-7.0.0}
+export ES_VERSION=${ES_VERSION:-7.3.2}
 

--- a/recipes/ccr/metricstore-docker-compose.yml
+++ b/recipes/ccr/metricstore-docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.2'
 services:
   metricsstore:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.7.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.2
     container_name: es01
     environment:
       - cluster.name=es01
@@ -25,7 +25,7 @@ services:
       retries: 5
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:6.7.1
+    image: docker.elastic.co/kibana/kibana:7.3.2
     ports:
       - 5601:5601
     environment:

--- a/recipes/ccr/start.sh
+++ b/recipes/ccr/start.sh
@@ -106,4 +106,4 @@ release.cache = true
 EOF
 
 # Start Rally
-esrally --configuration-name=metricstore --target-hosts=./ccr-target-hosts.json --pipeline=benchmark-only --on-error=abort --track=geonames --challenge=append-no-conflicts-index-only --track-params="ingest_percentage:20" --telemetry="ccr-stats" --telemetry-params="ccr-stats-sample-interval:1"
+esrally --configuration-name=metricstore --target-hosts=./ccr-target-hosts.json --pipeline=benchmark-only --on-error=abort --track=geonames --challenge=append-no-conflicts-index-only --track-params="ingest_percentage:20,number_of_shards:3" --telemetry="ccr-stats" --telemetry-params="ccr-stats-sample-interval:1"


### PR DESCRIPTION
Bump Elasticsearch version used for target clusters and metricstore to `7.3.2` in CCR recipe.
Also decrease number of primary shards to `3` to reduce amount of docs collected by the ccr-stats telemetry device.