### PR TITLE
Upgrade pytest to 5.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ check-venv:
 	fi
 
 install: venv-create
-	. $(VENV_ACTIVATE_FILE); pip install --upgrade pip
+	. $(VENV_ACTIVATE_FILE); pip install --upgrade pip setuptools
 	. $(VENV_ACTIVATE_FILE); pip3 install -e .
 	# install tox for it tests
 	. $(VENV_ACTIVATE_FILE); pip3 install tox

--- a/setup.py
+++ b/setup.py
@@ -74,14 +74,8 @@ install_requires = [
 ]
 
 tests_require = [
-    # transitive dependency of pytest but pinned to that version to avoid:
-    #
-    # TypeError: attrib() got an unexpected keyword argument 'convert'
-    #
-    # see also https://stackoverflow.com/questions/58189683/typeerror-attrib-got-an-unexpected-keyword-argument-convert
-    "attrs==19.1.0",
-    "pytest==3.4.2",
-    "pytest-benchmark==3.1.1"
+    "pytest==5.2.0",
+    "pytest-benchmark==3.2.2"
 ]
 
 # we call the tool rally, but it will be published as esrally on pypi
@@ -103,7 +97,7 @@ setup(name="esrally",
       test_suite="tests",
       tests_require=tests_require,
       setup_requires=[
-          "pytest-runner==2.10.1",
+          "pytest-runner==5.1",
       ],
       entry_points={
           "console_scripts": [

--- a/tox.ini
+++ b/tox.ini
@@ -29,12 +29,8 @@ platform =
 
 [testenv]
 deps =
-# transitive dependency of pytest but pinned to that version to avoid:
-#
-# TypeError: attrib() got an unexpected keyword argument 'convert'
-    attrs==19.1.0
-    pytest==3.4.2
-    pytest-benchmark==3.1.1
+    pytest==5.2.0
+    pytest-benchmark==3.2.2
 passenv =
     HOME
     JAVA8_HOME


### PR DESCRIPTION
With this commit we upgrade pytest to 5.2.0 and also upgrade related
dependencies. This version make pytest compatible with recent versions
of its dependency `attrs`.