### PR TITLE
Attach telemetry device on Docker launch

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -80,7 +80,9 @@ class DockerLauncher:
             ]
             t = telemetry.Telemetry(devices=node_telemetry)
             telemetry.add_metadata_for_node(self.metrics_store, node_name, host_name)
-            nodes.append(cluster.Node(0, host_name, node_name, t))
+            node = cluster.Node(0, host_name, node_name, t)
+            t.attach_to_node(node)
+            nodes.append(node)
         return nodes
 
     def _start_process(self, binary_path):

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -275,6 +275,16 @@ function test_distributions {
     done
 }
 
+function test_docker {
+    local cfg
+    # only test the most recent Docker distribution
+    local dist="${DISTRIBUTIONS[${#DISTRIBUTIONS[@]}-1]}"
+    random_configuration cfg
+    info "test docker [--configuration-name=${cfg}], [--distribution-version=${dist}], [--track=${track}], [--car=4gheap]"
+    kill_rally_processes
+    esrally --configuration-name="${cfg}" --on-error=abort --pipeline="docker" --distribution-version="${dist}" --track="geonames" --challenge="append-no-conflicts-index-only" --test-mode --car=4gheap
+}
+
 function test_distribution_fails_with_wrong_track_params {
     local cfg
     local distribution
@@ -508,6 +518,8 @@ function run_test {
     test_sources
     echo "**************************************** TESTING RALLY WITH ES DISTRIBUTIONS ***********************************"
     test_distributions
+    echo "**************************************** TESTING RALLY WITH ES DOCKER IMAGE ***********************************"
+    test_docker
     echo "**************************************** TESTING RALLY BENCHMARK-ONLY PIPELINE *********************************"
     test_benchmark_only
     echo "**************************************** TESTING RALLY DOCKER IMAGE ********************************************"


### PR DESCRIPTION
With this commit we ensure that telemetry devices are attached also when
Elasticsearch is launched via Docker. We also add an integration test to
test the respective pipeline.