### PR TITLE
Don't attach telemetry devices for Docker

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -70,13 +70,10 @@ class DockerLauncher:
             node_name = node_configuration.node_name
             host_name = node_configuration.ip
             binary_path = node_configuration.binary_path
-            node_telemetry_dir = os.path.join(node_configuration.node_root_path, "telemetry")
             self.binary_paths[node_name] = binary_path
             self._start_process(binary_path)
-            # only support a subset of telemetry for Docker hosts
-            # (specifically, we do not allow users to enable any devices)
             node_telemetry = [
-                telemetry.DiskIo(self.metrics_store, len(node_configurations), node_telemetry_dir, node_name),
+                # Don't attach any telemetry devices for now but keep the infrastructure in place
             ]
             t = telemetry.Telemetry(devices=node_telemetry)
             telemetry.add_metadata_for_node(self.metrics_store, node_name, host_name)

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -280,7 +280,7 @@ function test_docker {
     # only test the most recent Docker distribution
     local dist="${DISTRIBUTIONS[${#DISTRIBUTIONS[@]}-1]}"
     random_configuration cfg
-    info "test docker [--configuration-name=${cfg}], [--distribution-version=${dist}], [--track=${track}], [--car=4gheap]"
+    info "test docker [--configuration-name=${cfg}], [--distribution-version=${dist}], [--track=geonames], [--car=4gheap]"
     kill_rally_processes
     esrally --configuration-name="${cfg}" --on-error=abort --pipeline="docker" --distribution-version="${dist}" --track="geonames" --challenge="append-no-conflicts-index-only" --test-mode --car=4gheap
 }


### PR DESCRIPTION
With this commit we don't attach any telemetry devices for Docker
because this is not easily possible to measure properly without
considering we're running in a container. We keep the underlying
infrastructure in place so we can easily add new telemetry devices if
needed.