### PR TITLE
Manage dev dependencies in setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,14 +59,8 @@ check-venv:
 install: venv-create
 	. $(VENV_ACTIVATE_FILE); pip install --upgrade pip setuptools
 	. $(VENV_ACTIVATE_FILE); pip3 install -e .
-	# install tox for it tests
-	. $(VENV_ACTIVATE_FILE); pip3 install tox
-	# install coverage
-	. $(VENV_ACTIVATE_FILE); pip3 install coverage
-	# also install development/release dependencies
-	# workaround for https://github.com/elastic/rally/issues/439
-	. $(VENV_ACTIVATE_FILE); pip3 install -q sphinx sphinx_rtd_theme twine wheel
-	. $(VENV_ACTIVATE_FILE); pip3 install --pre github3.py
+	# Also install development dependencies
+	. $(VENV_ACTIVATE_FILE); pip3 install -e .[develop]
 
 clean: nondocs-clean docs-clean
 
@@ -100,10 +94,6 @@ test: check-venv
 it: check-venv python-caches-clean tox-env-clean
 	. $(VENV_ACTIVATE_FILE); tox
 
-# Temporarily disable Python 3.4 builds
-#it34: check-venv python-caches-clean
-#	. $(VENV_ACTIVATE_FILE); tox -e py34
-#
 it35: check-venv python-caches-clean tox-env-clean
 	. $(VENV_ACTIVATE_FILE); tox -e py35
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,17 @@ tests_require = [
     "pytest-benchmark==3.2.2"
 ]
 
+# These packages are only required when developing Rally
+develop_require = [
+    "tox==3.14.0",
+    "coverage==4.5.4",
+    "sphinx==2.2.0",
+    "sphinx_rtd_theme==0.4.3",
+    "twine==1.15.0",
+    "wheel==0.33.6",
+    "github3.py==1.3.0"
+]
+
 # we call the tool rally, but it will be published as esrally on pypi
 setup(name="esrally",
       maintainer="Daniel Mitterdorfer",
@@ -96,6 +107,9 @@ setup(name="esrally",
       install_requires=install_requires,
       test_suite="tests",
       tests_require=tests_require,
+      extras_require={
+          "develop": tests_require + develop_require
+      },
       setup_requires=[
           "pytest-runner==5.1",
       ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,23 +2,7 @@
 #
 # tox configuration for Rally.
 #
-# Invocation: Just run "tox" from the project root.
-#
-# Prerequisites
-# ==============
-#
-# * Tox (pip3 install tox)
-# * Python 3.5, 3.6 and 3.7 available (pyenv: https://github.com/yyuu/pyenv)
-#
-# Hint: When using pyenv, new Python interpreters can be installed with:
-#
-# pyenv install 3.5.2
-# pyenv install 3.6.0
-# pyenv install 3.7.0
-#
-# pyenv global system 3.7.0 3.6.0 3.5.2
-#
-# For details see https://github.com/yyuu/pyenv#choosing-the-python-version
+# Invocation: Run `make it`
 #
 ###############################################################################
 [tox]
@@ -28,9 +12,6 @@ platform =
     linux|darwin
 
 [testenv]
-deps =
-    pytest==5.2.0
-    pytest-benchmark==3.2.2
 passenv =
     HOME
     JAVA8_HOME
@@ -55,7 +36,4 @@ commands =
 [testenv:docs]
 basepython=python
 changedir=docs
-deps=
-    sphinx
-    sphinx_rtd_theme
 commands=sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
With this commit we define development dependencies as extra
requirements and set them up in the `make install` target. This
simplifies setup and also removes duplication from our tox
configuration.

Closes #439