### PR TITLE
Upgrade Elasticsearch client to latest (7.0.5).

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -641,7 +641,6 @@ class Query(Runner):
         request_params = self._default_request_params(params)
         r = es.search(
             index=params.get("index", "_all"),
-            doc_type=params.get("type"),
             body=mandatory(params, "body", self),
             params=request_params)
         hits = r["hits"]["total"]
@@ -675,7 +674,6 @@ class Query(Runner):
             if page == 0:
                 r = es.search(
                     index=params.get("index", "_all"),
-                    doc_type=params.get("type"),
                     body=mandatory(params, "body", self),
                     sort="_doc",
                     scroll="10s",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ long_description = str_from_file("README.rst")
 install_requires = [
     # License: Apache 2.0
     # transitive dependency urllib3: MIT
-    "elasticsearch==6.2.0",
+    "elasticsearch==7.0.5",
     # License: BSD
     "psutil==5.4.0",
     # License: MIT

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -774,7 +774,6 @@ class QueryRunnerTests(TestCase):
 
         es.search.assert_called_once_with(
             index="_all",
-            doc_type=None,
             body=params["body"],
             params={"request_cache": "true"}
         )
@@ -823,7 +822,6 @@ class QueryRunnerTests(TestCase):
 
         es.search.assert_called_once_with(
             index="_all",
-            doc_type=None,
             body=params["body"],
             params={
                 "request_cache": "false",
@@ -873,7 +871,6 @@ class QueryRunnerTests(TestCase):
 
         es.search.assert_called_once_with(
             index="_all",
-            doc_type=None,
             body=params["body"],
             params={
                 "request_cache": "true"
@@ -927,7 +924,6 @@ class QueryRunnerTests(TestCase):
 
         es.search.assert_called_once_with(
             index="unittest",
-            doc_type="type",
             body=params["body"],
             params={}
         )
@@ -986,7 +982,6 @@ class QueryRunnerTests(TestCase):
 
         es.search.assert_called_once_with(
             index="unittest",
-            doc_type="type",
             body=params["body"],
             scroll="10s",
             size=100,
@@ -1049,7 +1044,6 @@ class QueryRunnerTests(TestCase):
 
         es.search.assert_called_once_with(
             index="unittest",
-            doc_type="type",
             body=params["body"],
             scroll="10s",
             size=100,


### PR DESCRIPTION
Upgrade to latest Elasticsearch Python client with fallback for older versions.

Relates #787 