### PR TITLE
Properly wait for recovery to finish

### DIFF
--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -922,6 +922,11 @@ Example (assuming Rally has been invoked specifying ``default`` and ``remote`` i
 
 For cases, where you want to provide a progress indication, you can implement the two properties ``percent_completed`` which returns a floating point value between ``0.0`` and ``1.0`` and the property ``completed`` which needs to return ``True`` if the runner has completed. This can be useful in cases when it is only possible to determine progress by calling an API, for example when waiting for a recovery to finish.
 
+.. warning::
+
+    Rally will still treat such a runner like any other. If you want to poll status at certain intervals then limit the number of calls by specifying the ``target-throughput`` property on the corresponding task.
+
+
 Custom schedulers
 ^^^^^^^^^^^^^^^^^
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -849,7 +849,25 @@ This is an administrative operation. Metrics are not reported by default. Report
 wait-for-recovery
 ~~~~~~~~~~~~~~~~~
 
-With the operation ``wait-for-recovery`` you can wait until an ongoing index recovery finishes. The ``wait-for-recovery`` operation does not support any parameters.
+With the operation ``wait-for-recovery`` you can wait until an ongoing shard recovery finishes. The ``wait-for-recovery`` operation supports the following parameters:
+
+* ``completion-recheck-attempts`` (optional, defaults to 3): It might be possible that the `index recovery API <https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html>`_ reports that there are no active shard recoveries when a new one might be scheduled shortly afterwards. Therefore, this operation will check several times whether there are still no active recoveries. In between those attempts, it will wait for a time period specified by ``completion-recheck-wait-period``.
+* ``completion-recheck-wait-period`` (optional, defaults to 2 seconds): Time in seconds to wait in between consecutive attempts.
+
+.. warning::
+
+    By default this operation will run unthrottled (like any other) but you should limit the number of calls by specifying the ``target-throughput`` property on the corresponding task::
+
+        {
+          "operation": {
+            "operation-type": "wait-for-recovery",
+            "completion-recheck-attempts": 2,
+            "completion-recheck-wait-period": 5
+          },
+          "target-throughput": 10
+        }
+
+    In this example, Rally will check the progress of shard recovery every ten seconds (as specified by ``target-throughput``). When the index recovery API reports that there are no active recoveries, it will still check this twice (``completion-recheck-attempts``), waiting for five seconds in between those calls (``completion-recheck-wait-period``).
 
 This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
 

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -613,7 +613,8 @@ class SchedulerTests(ScheduleTestCase):
                           clients=1,
                           params={"target-throughput": 1, "clients": 1})
 
-        invocations = driver.schedule_for(self.test_track, task, 0)
+        schedule_handle = driver.schedule_for(self.test_track, task, 0)
+        schedule = schedule_handle()
 
         self.assert_schedule([
             (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
@@ -621,7 +622,7 @@ class SchedulerTests(ScheduleTestCase):
             (2.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
             (3.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
             (4.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-        ], invocations, infinite_schedule=True)
+        ], schedule, infinite_schedule=True)
 
     def test_schedule_for_time_based(self):
         task = track.Task("time-based", track.Operation("time-based", track.OperationType.Bulk.name, params={"body": ["a"], "size": 11},


### PR DESCRIPTION
With this commit we ensure that a proper schedule is chosen when waiting
for shard recovery to finish. We also ensure that a short time-span where no
recoveries are active (but more might continue soon) is not mistakenly
treated as a condition where all recoveries have already finished.

Closes #796