### PR TITLE
Whitelist py.test in tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,9 @@ commands =
     py.test --junitxml=junit-{envname}.xml
     ./integration-test.sh
 
+whitelist_externals =
+    py.test
+
 [testenv:docs]
 basepython=python
 changedir=docs


### PR DESCRIPTION
When a binary is not installed via tox, it will emit the following
warning:

```
WARNING: test command found but not installed in testenv
  cmd: /Users/daniel/Projects/rally/.venv/bin/py.test
  env: /Users/daniel/Projects/rally/.tox/py37
Maybe you forgot to specify a dependency? See also the
whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
```

With this commit we exclude `py.test` from this check by specifying it
in `whitelist_externals`. This is ok since we ensure that this binary is
installed via our configuration in `setup.py` and thus we can avoid this
warning.