### PR TITLE
Upgrade jsonschema dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ install_requires = [
     # License: MIT
     "tabulate==0.8.1",
     # License: MIT
-    "jsonschema==2.5.1",
+    "jsonschema==3.1.1",
     # License: BSD
     # transitive dependency Markupsafe: BSD
     "Jinja2==2.10.1",


### PR DESCRIPTION
So far Rally uses version 2.5.1 of `jsonschema` which is more than four
years old by now and is also not officially compatible with Python 3.7.
With this commit we upgrade to the currently latest version 3.1.1 which
is compatible with Python 3.5 - 3.7.
