### PR TITLE
Upgrade tabulate dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ install_requires = [
     # License: MIT
     "py-cpuinfo==3.2.0",
     # License: MIT
-    "tabulate==0.8.1",
+    "tabulate==0.8.5",
     # License: MIT
     "jsonschema==2.5.1",
     # License: BSD


### PR DESCRIPTION
So far Rally uses version 0.8.1 of `tabulate` which is not fully
compatible with Python 3.7 (see
https://bitbucket.org/astanin/python-tabulate/commits/3bfe29401e0f32ba4cff374d234ba37331a472a1).
Compatibility issues have been fixed in the most recent version 0.8.5
hence we upgrade to it.