### PR TITLE
Add fallbacks for ML APIs

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -23,8 +23,6 @@ import types
 from collections import Counter, OrderedDict
 from copy import deepcopy
 
-import elasticsearch
-
 from esrally import exceptions, track
 
 # Mapping from operation type to specific runner
@@ -1027,6 +1025,7 @@ class CreateMlDatafeed(Runner):
     """
 
     def __call__(self, es, params):
+        import elasticsearch
         datafeed_id = mandatory(params, "datafeed-id", self)
         body = mandatory(params, "body", self)
         try:
@@ -1036,7 +1035,7 @@ class CreateMlDatafeed(Runner):
             if e.status_code == 400:
                 es.transport.perform_request(
                     "PUT",
-                    "/_xpack/ml/datafeeds/" + datafeed_id,
+                    "/_xpack/ml/datafeeds/%s" % datafeed_id,
                     params=params,
                     body=body,
                 )
@@ -1053,6 +1052,7 @@ class DeleteMlDatafeed(Runner):
     """
 
     def __call__(self, es, params):
+        import elasticsearch
         datafeed_id = mandatory(params, "datafeed-id", self)
         force = params.get("force", False)
         try:
@@ -1063,7 +1063,7 @@ class DeleteMlDatafeed(Runner):
             if e.status_code == 400:
                 es.transport.perform_request(
                     "DELETE",
-                    "/_xpack/ml/datafeeds/" + datafeed_id,
+                    "/_xpack/ml/datafeeds/%s" %datafeed_id,
                     params=params,
                 )
             else:
@@ -1079,6 +1079,7 @@ class StartMlDatafeed(Runner):
     """
 
     def __call__(self, es, params):
+        import elasticsearch
         datafeed_id = mandatory(params, "datafeed-id", self)
         body = params.get("body")
         start = params.get("start")
@@ -1108,6 +1109,7 @@ class StopMlDatafeed(Runner):
     """
 
     def __call__(self, es, params):
+        import elasticsearch
         datafeed_id = mandatory(params, "datafeed-id", self)
         force = params.get("force", False)
         timeout = params.get("timeout")
@@ -1134,6 +1136,7 @@ class CreateMlJob(Runner):
     """
 
     def __call__(self, es, params):
+        import elasticsearch
         job_id = mandatory(params, "job-id", self)
         body = mandatory(params, "body", self)
         try:
@@ -1143,7 +1146,7 @@ class CreateMlJob(Runner):
             if e.status_code == 400:
                 es.transport.perform_request(
                     "PUT",
-                    "/_xpack/ml/anomaly_detectors/" + job_id,
+                    "/_xpack/ml/anomaly_detectors/%s" % job_id,
                     params=params,
                     body=body,
                 )
@@ -1160,6 +1163,7 @@ class DeleteMlJob(Runner):
     """
 
     def __call__(self, es, params):
+        import elasticsearch
         job_id = mandatory(params, "job-id", self)
         force = params.get("force", False)
         # we don't want to fail if a job does not exist, thus we ignore 404s.
@@ -1170,7 +1174,7 @@ class DeleteMlJob(Runner):
             if e.status_code == 400:
                 es.transport.perform_request(
                     "DELETE",
-                    "/_xpack/ml/anomaly_detectors/" + job_id,
+                    "/_xpack/ml/anomaly_detectors/%s" % job_id,
                     params=params,
                 )
             else:
@@ -1186,6 +1190,7 @@ class OpenMlJob(Runner):
     """
 
     def __call__(self, es, params):
+        import elasticsearch
         job_id = mandatory(params, "job-id", self)
         try:
             es.xpack.ml.open_job(job_id=job_id)
@@ -1210,6 +1215,7 @@ class CloseMlJob(Runner):
     """
 
     def __call__(self, es, params):
+        import elasticsearch
         job_id = mandatory(params, "job-id", self)
         force = params.get("force", False)
         timeout = params.get("timeout")

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1769,7 +1769,7 @@ class CreateMlDatafeedTests(TestCase):
         r(es, params)
 
         es.transport.perform_request.assert_called_once_with("PUT",
-                                                             "/_xpack/ml/datafeeds/" + datafeed_id,
+                                                             "/_xpack/ml/datafeeds/%s" % datafeed_id,
                                                              body=body,
                                                              params=params)
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -21,6 +21,7 @@ import unittest.mock as mock
 from unittest import TestCase
 
 import elasticsearch
+import pytest
 
 from esrally import exceptions
 from esrally.driver import runner
@@ -1859,9 +1860,11 @@ class StartMlDatafeedTests(TestCase):
                                                            timeout=params["timeout"])
 
 
-class StopMlDatafeedTests(TestCase):
+class StopMlDatafeedTests:
     @mock.patch("elasticsearch.Elasticsearch")
-    def test_stop_ml_datafeed(self, es):
+    @pytest.mark.parametrize("seed", range(20))
+    def test_stop_ml_datafeed(self, es, seed):
+        random.seed(seed)
         params = {
             "datafeed-id": "some-data-feed",
             "force": random.choice([False, True]),
@@ -1876,7 +1879,9 @@ class StopMlDatafeedTests(TestCase):
                                                           timeout=params["timeout"])
 
     @mock.patch("elasticsearch.Elasticsearch")
-    def test_stop_ml_datafeed_fallback(self, es):
+    @pytest.mark.parametrize("seed", range(20))
+    def test_stop_ml_datafeed_fallback(self, es, seed):
+        random.seed(seed)
         es.xpack.ml.stop_datafeed.side_effect = elasticsearch.TransportError(400, "Bad Request")
         params = {
             "datafeed-id": "some-data-feed",
@@ -2015,9 +2020,11 @@ class OpenMlJobTests(TestCase):
                                                              params=params)
 
 
-class CloseMlJobTests(TestCase):
+class CloseMlJobTests:
     @mock.patch("elasticsearch.Elasticsearch")
-    def test_close_ml_job(self, es):
+    @pytest.mark.parametrize("seed", range(20))
+    def test_close_ml_job(self, es, seed):
+        random.seed(seed)
         params = {
             "job-id": "an-ml-job",
             "force": random.choice([False, True]),
@@ -2030,7 +2037,9 @@ class CloseMlJobTests(TestCase):
         es.xpack.ml.close_job.assert_called_once_with(job_id=params["job-id"], force=params["force"], timeout=params["timeout"])
 
     @mock.patch("elasticsearch.Elasticsearch")
-    def test_close_ml_job_fallback(self, es):
+    @pytest.mark.parametrize("seed", range(20))
+    def test_close_ml_job_fallback(self, es, seed):
+        random.seed(seed)
         es.xpack.ml.close_job.side_effect = elasticsearch.TransportError(400, "Bad Request")
 
         params = {


### PR DESCRIPTION
In older ES, "xpack" was still required in the URL, so the newer client in Rally would have issues.  Add fallback functionality to handle this case.

Closes #787 