### PR TITLE
Upgrade psutil to work with newer linux kernels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ install_requires = [
     # transitive dependency urllib3: MIT
     "elasticsearch==7.0.5",
     # License: BSD
-    "psutil==5.4.0",
+    "psutil==5.6.5",
     # License: MIT
     "py-cpuinfo==3.2.0",
     # License: MIT


### PR DESCRIPTION
The 4.18 kernel introduced a number of new fields into the disk io stats
proc fileystem, and running tests on new versions of linux is causing
failures because psutil cannot interpret the new fields. This fix
updates the version such that it works w/ newer kernels.

Relates giampaolo/psutil#1354
