### PR TITLE
Change remaining it tests to port 19200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.3.0
+### 1.3.0 DUMMY COMMIT I WILL REMOVE IN A SUBSEQUENT COMMIT
 
 #### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.3.0 DUMMY COMMIT I WILL REMOVE IN A SUBSEQUENT COMMIT
+### 1.3.0
 
 #### Enhancements
 

--- a/docker/docker-compose-tests.yml
+++ b/docker/docker-compose-tests.yml
@@ -16,15 +16,16 @@ services:
     container_name: es01
     environment:
       - discovery.type=single-node
+      - http.port=19200
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
     volumes:
       - esdata1:/usr/share/elasticsearch/data
     ports:
-      - 19200:9200
+      - 19200:19200
     networks:
       - esnet
     healthcheck:
-          test: curl -f http://localhost:9200
+          test: curl -f http://localhost:19200
           interval: 5s
           timeout: 2s
           retries: 10

--- a/docker/docker-compose-tests.yml
+++ b/docker/docker-compose-tests.yml
@@ -16,21 +16,21 @@ services:
     container_name: es01
     environment:
       - discovery.type=single-node
-      - http.port=19200
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
     volumes:
       - esdata1:/usr/share/elasticsearch/data
     ports:
-      - 19200:19200
+      - 19200:9200
     networks:
       - esnet
     healthcheck:
-          test: curl -f http://localhost:19200
+          test: curl -f http://localhost:9200
           interval: 5s
           timeout: 2s
           retries: 10
 networks:
   esnet:
+    name: rally-tests
 
 volumes:
   esdata1:

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -282,7 +282,7 @@ function test_docker {
     random_configuration cfg
     info "test docker [--configuration-name=${cfg}], [--distribution-version=${dist}], [--track=geonames], [--car=4gheap]"
     kill_rally_processes
-    esrally --configuration-name="${cfg}" --on-error=abort --pipeline="docker" --distribution-version="${dist}" --track="geonames" --challenge="append-no-conflicts-index-only" --test-mode --car=4gheap
+    esrally --configuration-name="${cfg}" --on-error=abort --pipeline="docker" --distribution-version="${dist}" --track="geonames" --challenge="append-no-conflicts-index-only" --test-mode --car=4gheap --target-hosts=127.0.0.1:19200
 }
 
 function test_distribution_fails_with_wrong_track_params {
@@ -429,7 +429,7 @@ function docker_compose {
 }
 
 function tests_for_all_docker_images {
-    export TEST_COMMAND="--pipeline=benchmark-only --test-mode --track=geonames --challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
+    export TEST_COMMAND="--pipeline=benchmark-only --test-mode --track=geonames --challenge=append-no-conflicts-index-only --target-hosts=es01:19200"
     info "Testing Rally docker image using parameters: ${TEST_COMMAND}"
     docker_compose up
     docker_compose down
@@ -447,7 +447,7 @@ function tests_for_all_docker_images {
     docker_compose down
 
     # allow overriding CMD too
-    export TEST_COMMAND="esrally --pipeline=benchmark-only --test-mode --track=geonames --challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
+    export TEST_COMMAND="esrally --pipeline=benchmark-only --test-mode --track=geonames --challenge=append-no-conflicts-index-only --target-hosts=es01:19200"
     info "Testing Rally docker image using parameters: ${TEST_COMMAND}"
     docker_compose up
     docker_compose down

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -429,7 +429,7 @@ function docker_compose {
 }
 
 function tests_for_all_docker_images {
-    export TEST_COMMAND="--pipeline=benchmark-only --test-mode --track=geonames --challenge=append-no-conflicts-index-only --target-hosts=es01:19200"
+    export TEST_COMMAND="--pipeline=benchmark-only --test-mode --track=geonames --challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
     info "Testing Rally docker image using parameters: ${TEST_COMMAND}"
     docker_compose up
     docker_compose down
@@ -447,7 +447,7 @@ function tests_for_all_docker_images {
     docker_compose down
 
     # allow overriding CMD too
-    export TEST_COMMAND="esrally --pipeline=benchmark-only --test-mode --track=geonames --challenge=append-no-conflicts-index-only --target-hosts=es01:19200"
+    export TEST_COMMAND="esrally --pipeline=benchmark-only --test-mode --track=geonames --challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
     info "Testing Rally docker image using parameters: ${TEST_COMMAND}"
     docker_compose up
     docker_compose down


### PR DESCRIPTION
The docker tests were using port 9200 because target_hosts was not
specified. Additionally the tests that were using compose were also
leaking a 9200 port on to a default bridge network that other containers
might be using, which causes a collision and failure. This commit fixes
both of these problems.

Closes #824
