### PR TITLE
Only keep the most recent build log

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -142,25 +142,6 @@ The log file will not be rotated automatically as this is problematic due to Ral
             notifempty
     }
 
-If you are benchmarking source builds of Elasticsearch, Rally will write the log output of the build to ``~/.rally/logs/build.log``. Similarly to the configuration for ``rally.log``, you can use the following ``logrotate`` configuration as a starting point::
-
-    /home/user/.rally/logs/build.log {
-            # rotate daily
-            daily
-            # keep the last seven log files
-            rotate 7
-            # remove logs older than 14 days
-            maxage 14
-            # compress old logs ...
-            compress
-            # ... after moving them
-            delaycompress
-            # ignore missing log files
-            missingok
-            # don't attempt to rotate empty ones
-            notifempty
-    }
-
 Example
 ~~~~~~~
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -7,24 +7,7 @@ Migrating to Rally 1.4.0
 Build logs are stored in Rally's log directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you benchmark source builds of Elasticsearch, Rally has previously stored the build output log in a race-specific directory. With this release, Rally will store build logs in ``/home/user/.rally/logs/build.log``. We recommend to rotate logs with `logrotate <https://linux.die.net/man/8/logrotate>`_. See the following example as a starting point for your own ``logrotate`` configuration and ensure to replace the path ``/home/user/.rally/logs/build.log`` with the proper one::
-
-    /home/user/.rally/logs/build.log {
-            # rotate daily
-            daily
-            # keep the last seven log files
-            rotate 7
-            # remove logs older than 14 days
-            maxage 14
-            # compress old logs ...
-            compress
-            # ... after moving them
-            delaycompress
-            # ignore missing log files
-            missingok
-            # don't attempt to rotate empty ones
-            notifempty
-    }
+If you benchmark source builds of Elasticsearch, Rally has previously stored the build output log in a race-specific directory. With this release, Rally will store the most recent build log in ``/home/user/.rally/logs/build.log``.
 
 Index size and Total Written are not included in the command line report
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -472,8 +472,7 @@ class Builder:
         log_file = os.path.join(self.log_dir, "build.log")
 
         # we capture all output to a dedicated build log file
-
-        build_cmd = "export JAVA_HOME={}; cd {}; {} >> {} 2>&1".format(self.java_home, src_dir, command, log_file)
+        build_cmd = "export JAVA_HOME={}; cd {}; {} > {} 2>&1".format(self.java_home, src_dir, command, log_file)
         self.logger.info("Running build command [%s]", build_cmd)
 
         if process.run_subprocess(build_cmd):

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -142,9 +142,9 @@ class BuilderTests(TestCase):
 
         calls = [
             # Actual call
-            mock.call("export JAVA_HOME=/opt/jdk8; cd /src; ./gradlew clean >> logs/build.log 2>&1"),
+            mock.call("export JAVA_HOME=/opt/jdk8; cd /src; ./gradlew clean > logs/build.log 2>&1"),
             # Return value check
-            mock.call("export JAVA_HOME=/opt/jdk8; cd /src; ./gradlew assemble >> logs/build.log 2>&1"),
+            mock.call("export JAVA_HOME=/opt/jdk8; cd /src; ./gradlew assemble > logs/build.log 2>&1"),
         ]
 
         mock_run_subprocess.assert_has_calls(calls)
@@ -160,9 +160,9 @@ class BuilderTests(TestCase):
 
         calls = [
             # Actual call
-            mock.call("export JAVA_HOME=/opt/jdk10; cd /src; ./gradlew clean >> logs/build.log 2>&1"),
+            mock.call("export JAVA_HOME=/opt/jdk10; cd /src; ./gradlew clean > logs/build.log 2>&1"),
             # Return value check
-            mock.call("export JAVA_HOME=/opt/jdk10; cd /src; ./gradlew assemble >> logs/build.log 2>&1"),
+            mock.call("export JAVA_HOME=/opt/jdk10; cd /src; ./gradlew assemble > logs/build.log 2>&1"),
         ]
 
         mock_run_subprocess.assert_has_calls(calls)


### PR DESCRIPTION
With this commit we continously override a potentially existing
Elasticsearch build log. Keeping a history of build logs is not
necessary as it is only relevant to investigate on failures. Thus a
history only adds complexity (e.g. log rotation setup) for little value.

Relates #818