### PR TITLE
Clarify uses of distribution-version

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -375,7 +375,11 @@ Note that it is still required to provide the parameter ``--elasticsearch-plugin
 ``distribution-version``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to benchmark a binary distribution, you can specify the version here.
+If you want Rally to launch and benchmark a cluster using a binary distribution, you can specify the version here.
+
+.. note::
+
+    Do not use ``distribution-version`` when benchmarking a cluster that hasn't been setup by Rally (i.e. together with ``pipeline=benchmark-only``); Rally automatically derives and stores the version of the cluster in the metrics store regardless of the ``pipeline`` used.
 
 **Example**
 


### PR DESCRIPTION
Enhance docs to clarify that the distribution-version cli arg
only influences launching nodes and that it shouldn't be used
together with the benchmark-only pipeline.

Closes #833
