### PR TITLE
Store Disk I/O metrics if available

### DIFF
--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -783,8 +783,9 @@ class DiskIo(InternalTelemetryDevice):
                 self.write_bytes = None
 
     def store_system_metrics(self, node, metrics_store):
-        if self.write_bytes and self.read_bytes:
+        if self.write_bytes is not None:
             metrics_store.put_count_node_level(node.node_name, "disk_io_write_bytes", self.write_bytes, "byte")
+        if self.read_bytes is not None:
             metrics_store.put_count_node_level(node.node_name, "disk_io_read_bytes", self.read_bytes, "byte")
 
 

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -2058,8 +2058,6 @@ class DiskIoTests(TestCase):
         t.detach_from_node(node, running=False)
         t.store_system_metrics(node, metrics_store)
 
-        # expected result is 1 byte because there are two nodes on the machine. Result is calculated
-        # with total_bytes / node_count
         metrics_store_node_count.assert_has_calls([
             mock.call("rally0", "disk_io_write_bytes", 3, "byte"),
             mock.call("rally0", "disk_io_read_bytes", 0, "byte"),

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -2032,7 +2032,37 @@ class DiskIoTests(TestCase):
         metrics_store_node_count.assert_has_calls([
             mock.call("rally0", "disk_io_write_bytes", 1, "byte"),
             mock.call("rally0", "disk_io_read_bytes", 1, "byte")
-            
+        ])
+
+    @mock.patch("esrally.utils.sysstats.disk_io_counters")
+    @mock.patch("esrally.utils.sysstats.process_io_counters")
+    @mock.patch("esrally.metrics.EsMetricsStore.put_count_node_level")
+    def test_diskio_writes_metrics_if_available(self, metrics_store_node_count, process_io_counters, disk_io_counters):
+        Diskio = namedtuple("Diskio", "read_bytes write_bytes")
+        process_start = Diskio(10, 10)
+        process_stop = Diskio(10, 13)
+        disk_io_counters.side_effect = [process_start, process_stop]
+        process_io_counters.side_effect = [None, None]
+
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+
+        device = telemetry.DiskIo(node_count_on_host=1)
+        t = telemetry.Telemetry(enabled_devices=[], devices=[device])
+        node = cluster.Node(pid=None, binary_path="/bin", host_name="localhost", node_name="rally0", telemetry=t)
+        t.attach_to_node(node)
+        t.on_benchmark_start()
+        # we assume that serializing and deserializing the telemetry device produces the same state
+        t.on_benchmark_stop()
+        t.detach_from_node(node, running=True)
+        t.detach_from_node(node, running=False)
+        t.store_system_metrics(node, metrics_store)
+
+        # expected result is 1 byte because there are two nodes on the machine. Result is calculated
+        # with total_bytes / node_count
+        metrics_store_node_count.assert_has_calls([
+            mock.call("rally0", "disk_io_write_bytes", 3, "byte"),
+            mock.call("rally0", "disk_io_read_bytes", 0, "byte"),
         ])
 
 


### PR DESCRIPTION
With this commit we split the check for disk I/O metrics for reads and
writes. This avoids the case when one of these metrics is either `None`
or `0`, the other metric is still added to the metrics store (this
scenario might happen if data is only written but never read so the read
counter is zero). We also change the check to test for `None` explicitly
because we even want to add metrics to the metrics store if the value is
zero.