### PR TITLE
Allow to use the bundled JDK in Elasticsearch

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -510,6 +510,8 @@ Example::
    # Force to run with JDK 7
    esrally --distribution-version=2.4.0 --runtime-jdk=7
 
+There is also limited support to specify the JDK that is bundled with Elasticsearch with the special value ``bundled``. At the moment this only works on Linux. The JDK is bundled from Elasticsearch 7.0.0 onwards.
+
 .. _clr_revision:
 
 ``revision``

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -510,7 +510,7 @@ Example::
    # Force to run with JDK 7
    esrally --distribution-version=2.4.0 --runtime-jdk=7
 
-There is also limited support to specify the JDK that is bundled with Elasticsearch with the special value ``bundled``. At the moment this only works on Linux. The JDK is bundled from Elasticsearch 7.0.0 onwards.
+There is also limited support to specify the JDK that is bundled with Elasticsearch with the special value ``bundled``. At the moment this only works on Linux. The `JDK is bundled from Elasticsearch 7.0.0 onwards <https://www.elastic.co/guide/en/elasticsearch/reference/current/release-highlights-7.0.0.html#_bundle_jdk_in_elasticsearch_distribution>`_.
 
 .. _clr_revision:
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -362,6 +362,21 @@ Example::
 
    esrally --team-path=~/Projects/es-teams
 
+``target-os``
+~~~~~~~~~~~~~
+
+Specifies the name of the target operating system for which an artifact should be downloaded. By default this value is automatically derived based on the operating system Rally is run. This command line flag is only applicable to the ``download`` subcommand and allows to download an artifact for a different operating system. Example::
+
+    esrally download --distribution-version=7.5.1 --target-os=linux
+
+``target-arch``
+~~~~~~~~~~~~~~~
+
+Specifies the name of the target CPU architecture for which an artifact should be downloaded. By default this value is automatically derived based on the CPU architecture Rally is run. This command line flag is only applicable to the ``download`` subcommand and allows to download an artifact for a different CPU architecture. Example::
+
+    esrally download --distribution-version=7.5.1 --target-arch=x86_64
+
+
 ``car``
 ~~~~~~~
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -510,7 +510,7 @@ Example::
    # Force to run with JDK 7
    esrally --distribution-version=2.4.0 --runtime-jdk=7
 
-There is also limited support to specify the JDK that is bundled with Elasticsearch with the special value ``bundled``. At the moment this only works on Linux. The `JDK is bundled from Elasticsearch 7.0.0 onwards <https://www.elastic.co/guide/en/elasticsearch/reference/current/release-highlights-7.0.0.html#_bundle_jdk_in_elasticsearch_distribution>`_.
+It is also possible to specify the JDK that is bundled with Elasticsearch with the special value ``bundled``. The `JDK is bundled from Elasticsearch 7.0.0 onwards <https://www.elastic.co/guide/en/elasticsearch/reference/current/release-highlights-7.0.0.html#_bundle_jdk_in_elasticsearch_distribution>`_.
 
 .. _clr_revision:
 

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -165,9 +165,10 @@ class ProcessLauncher:
         env = {}
         env.update(os.environ)
         env.update(car_env)
-        self._set_env(env, "PATH", os.path.join(java_home, "bin"), separator=os.pathsep, prepend=True)
-        # Don't merge here!
-        env["JAVA_HOME"] = java_home
+        if java_home:
+            self._set_env(env, "PATH", os.path.join(java_home, "bin"), separator=os.pathsep, prepend=True)
+            # Don't merge here!
+            env["JAVA_HOME"] = java_home
         env["ES_JAVA_OPTS"] = "-XX:+ExitOnOutOfMemoryError"
         
         # we just blindly trust telemetry here...

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -342,7 +342,7 @@ class PluginInstaller:
             self.logger.info("Installing [%s] into [%s]", self.plugin_name, es_home_path)
             install_cmd = '%s install --batch "%s"' % (installer_binary_path, self.plugin_name)
 
-        return_code = process.run_subprocess_with_logging(install_cmd, env={"JAVA_HOME": self.java_home})
+        return_code = process.run_subprocess_with_logging(install_cmd, env=self.env())
         # see: https://www.elastic.co/guide/en/elasticsearch/plugins/current/_other_command_line_parameters.html
         if return_code == 0:
             self.logger.info("Successfully installed [%s].", self.plugin_name)
@@ -356,10 +356,13 @@ class PluginInstaller:
                                         (self.plugin_name, str(return_code)))
 
     def invoke_install_hook(self, phase, variables):
+        self.hook_handler.invoke(phase.name, variables=variables, env=self.env())
+
+    def env(self):
         env = {}
         if self.java_home:
             env["JAVA_HOME"] = self.java_home
-        self.hook_handler.invoke(phase.name, variables=variables, env=env)
+        return env
 
     @property
     def variables(self):

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -35,8 +35,17 @@ def create_arg_parser():
     def positive_number(v):
         value = int(v)
         if value <= 0:
-            raise argparse.ArgumentTypeError("must be positive but was %s" % value)
+            raise argparse.ArgumentTypeError("must be positive but was {}".format(value))
         return value
+
+    def runtime_jdk(v):
+        if v == "bundled":
+            return v
+        else:
+            try:
+                return positive_number(v)
+            except argparse.ArgumentTypeError:
+                raise argparse.ArgumentTypeError("must be a positive number or 'bundled' but was {}".format(v))
 
     # try to preload configurable defaults, but this does not work together with `--configuration-name` (which is undocumented anyway)
     cfg = config.Config()
@@ -303,7 +312,7 @@ def create_arg_parser():
         default="")
     start_parser.add_argument(
         "--runtime-jdk",
-        type=positive_number,
+        type=runtime_jdk,
         help="The major version of the runtime JDK to use.",
         default=None)
     start_parser.add_argument(
@@ -338,7 +347,7 @@ def create_arg_parser():
             default="")
         p.add_argument(
             "--runtime-jdk",
-            type=positive_number,
+            type=runtime_jdk,
             help="The major version of the runtime JDK to use.",
             default=None)
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -197,6 +197,9 @@ def create_arg_parser():
         help="Define the repository from where Rally will load teams and cars (default: default).",
         default="default")
     download_parser.add_argument(
+        "--team-path",
+        help="Define the path to the car and plugin configurations to use.")
+    download_parser.add_argument(
         "--distribution-version",
         help="Define the version of the Elasticsearch distribution to download. "
              "Check https://www.elastic.co/downloads/elasticsearch for released versions.",
@@ -213,6 +216,14 @@ def create_arg_parser():
         "--car-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim as variables for the car.",
         default=""
+    )
+    download_parser.add_argument(
+        "--target-os",
+        help="The name of the target operating system for which an artifact should be downloaded (default: current OS)",
+    )
+    download_parser.add_argument(
+        "--target-arch",
+        help="The name of the CPU architecture for which an artifact should be downloaded (default: current architecture)",
     )
 
     install_parser = subparsers.add_parser("install", help="Installs an Elasticsearch node locally")
@@ -859,6 +870,9 @@ def main():
             console.println("--target-hosts and --client-options must define the same keys for multi cluster setups.")
             exit(1)
     # split by component?
+    if sub_command == "download":
+        cfg.add(config.Scope.applicationOverride, "mechanic", "target.os", args.target_os)
+        cfg.add(config.Scope.applicationOverride, "mechanic", "target.arch", args.target_arch)
     if sub_command == "list":
         cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
         cfg.add(config.Scope.applicationOverride, "system", "list.races.max_results", args.limit)

--- a/tests/mechanic/java_resolver_test.py
+++ b/tests/mechanic/java_resolver_test.py
@@ -1,0 +1,61 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest.mock as mock
+from unittest import TestCase
+
+from esrally import config
+from esrally.mechanic import java_resolver
+
+
+class JavaResolverTests(TestCase):
+    @mock.patch("esrally.utils.jvm.resolve_path")
+    def test_resolves_java_home_for_default_runtime_jdk(self, resolve_jvm_path):
+        resolve_jvm_path.return_value = (12, "/opt/jdk12")
+
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "mechanic", "runtime.jdk", None)
+
+        major, java_home = java_resolver.java_home("12,11,10,9,8", cfg)
+
+        self.assertEqual(major, 12)
+        self.assertEqual(java_home, "/opt/jdk12")
+
+    @mock.patch("esrally.utils.jvm.resolve_path")
+    def test_resolves_java_home_for_specific_runtime_jdk(self, resolve_jvm_path):
+        resolve_jvm_path.return_value = (8, "/opt/jdk8")
+
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "mechanic", "runtime.jdk", 8)
+
+        major, java_home = java_resolver.java_home("12,11,10,9,8", cfg)
+
+        self.assertEqual(major, 8)
+        self.assertEqual(java_home, "/opt/jdk8")
+        resolve_jvm_path.assert_called_with([8])
+
+    def test_resolves_java_home_for_bundled_jdk(self):
+
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "mechanic", "runtime.jdk", "bundled")
+
+        major, java_home = java_resolver.java_home("12,11,10,9,8", cfg)
+
+        # assumes most recent JDK
+        self.assertEqual(major, 12)
+        # does not extract JAVA_HOME for the bundled JDK
+        self.assertEqual(java_home, None)

--- a/tests/mechanic/java_resolver_test.py
+++ b/tests/mechanic/java_resolver_test.py
@@ -57,5 +57,5 @@ class JavaResolverTests(TestCase):
 
         # assumes most recent JDK
         self.assertEqual(major, 12)
-        # does not extract JAVA_HOME for the bundled JDK
+        # does not set JAVA_HOME for the bundled JDK
         self.assertEqual(java_home, None)

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -195,6 +195,20 @@ class ProcessLauncherTests(TestCase):
                          "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath=/tmp/telemetry/profile.jfr "
                          "-XX:StartFlightRecording=defaultrecording=true", env["ES_JAVA_OPTS"])
 
+    def test_bundled_jdk_not_in_path(self):
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "mechanic", "keep.running", False)
+        cfg.add(config.Scope.application, "system", "env.name", "test")
+
+        proc_launcher = launcher.ProcessLauncher(cfg)
+
+        t = telemetry.Telemetry()
+        # no JAVA_HOME -> use the bundled JDK
+        env = proc_launcher._prepare_env(car_env={}, node_name="node0", java_home=None, t=t)
+
+        # unmodified
+        self.assertEqual(os.environ["PATH"], env["PATH"])
+
 
 class DockerLauncherTests(TestCase):
     class IterationBasedStopWatch:

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -438,6 +438,22 @@ class PluginInstallerTests(TestCase):
             env={"JAVA_HOME": "/usr/local/javas/java8"})
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
+    def test_install_plugin_with_bundled_jdk(self, installer_subprocess):
+        installer_subprocess.return_value = 0
+
+        plugin = team.PluginDescriptor(name="unit-test-plugin", config="default", variables={"active": True})
+        installer = provisioner.PluginInstaller(plugin,
+                                                # bundled JDK
+                                                java_home=None,
+                                                hook_handler_class=NoopHookHandler)
+
+        installer.install(es_home_path="/opt/elasticsearch")
+
+        installer_subprocess.assert_called_with(
+            '/opt/elasticsearch/bin/elasticsearch-plugin install --batch "unit-test-plugin"',
+            env={})
+
+    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_install_unknown_plugin(self, installer_subprocess):
         # unknown plugin
         installer_subprocess.return_value = 64


### PR DESCRIPTION
With this commit we add special handling for Elasticsearch versions that
bundle the JDK when the command line parameter `--runtime-jdk=bundled`
is set. In that case, Rally will use the bundled JDK (i.e. not set
`JAVA_HOME` when starting Elasticsearch).