### PR TITLE
Disable all pylint checks that we want to fix

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -165,7 +165,39 @@ disable=print-statement,
         no-member,
         too-many-instance-attributes,
         too-many-statements,
-        inconsistent-return-statements
+        inconsistent-return-statements,
+        C0121,
+        C0301,
+        C0302,
+        C0303,
+        C0326,
+        C0330,
+        C0415,
+        C4001,
+        C4002,
+        E1120,
+        R0904,
+        R0916,
+        R1704,
+        R1707,
+        R1722,
+        W0104,
+        W0105,
+        W0106,
+        W0107,
+        W0143,
+        W0201,
+        W0212,
+        W0221,
+        W0235,
+        W0311,
+        W0404,
+        W0612,
+        W0613,
+        W0621,
+        W0631,
+        W1201
+
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -606,4 +638,3 @@ min-public-methods=2
 # "BaseException, Exception".
 overgeneral-exceptions=BaseException,
                        Exception
-


### PR DESCRIPTION
This commit will allow us to make progress on the pylint issues we would
like to fix, while allowing users to commit new code that may fail some
of these. What ends up happening is that new code can be merged by other
users, and if precommit is not run in CI, we might accidentally allow a
pylint violation to sneak back in. Removing the pylint check in the
branch/PR that is removing these will allow CI to fail the check so the
user can get feedback if another person has merged code in that violates
the check in the branch/PR.

Relates #838
