### PR TITLE
Detach Elasticsearch on startup

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -194,7 +194,7 @@ class ProcessLauncher:
         os.chdir(binary_path)
         cmd = [io.escape_path(os.path.join(".", "bin", "elasticsearch"))]
         cmd.extend(["-d", "-p", "pid"])
-        ret = process.run_subprocess_with_logging(command_line=" ".join(cmd), env=env)
+        ret = process.run_subprocess_with_logging(command_line=" ".join(cmd), env=env, detach=True)
         if ret != 0:
             msg = "Daemon startup failed with exit code [{}]".format(ret)
             logging.error(msg)


### PR DESCRIPTION
With this commit we detach Elasticsearch on startup from its controlling
process via the [setpgrp](http://man7.org/linux/man-pages/man3/setpgrp.3p.html) system call. Although we start Elasticsearch 
with the `-d` flag, this is necessary to ensure it does not receive signals
like `SIGHUP` from its original parent process (Rally).