### PR TITLE
More resilient node shutdown

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -16,7 +16,6 @@
 # under the License.
 import logging
 import os
-import signal
 
 import psutil
 

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -222,16 +222,16 @@ class ProcessLauncher:
                     stop_watch = self._clock.stop_watch()
                     stop_watch.start()
                     try:
-                        os.kill(es.pid, signal.SIGTERM)
+                        es.terminate()
                         es.wait(10.0)
-                    except ProcessLookupError:
+                    except psutil.NoSuchProcess:
                         self.logger.warning("No process found with PID [%s] for node [%s].", es.pid, node_name)
                     except psutil.TimeoutExpired:
                         self.logger.info("kill -KILL node [%s]", node_name)
                         try:
                             # kill -9
                             es.kill()
-                        except ProcessLookupError:
+                        except psutil.NoSuchProcess:
                             self.logger.warning("No process found with PID [%s] for node [%s].", es.pid, node_name)
                     self.logger.info("Done shutting down node [%s] in [%.1f] s.", node_name, stop_watch.split_time())
 


### PR DESCRIPTION
With this commit we make the shutdown procedure more resilient by
handling the case that the Elasticsearch process has already terminated
and moving steps during shutdown with the `stop` subcommand so related
errors happen in related places in the code and also as early as
possible.