### PR TITLE
Fix W1201.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -194,8 +194,7 @@ disable=print-statement,
         W0612,
         W0613,
         W0621,
-        W0631,
-        W1201
+        W0631
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -166,8 +166,8 @@ def _supply_requirements(sources, distribution, build, plugins, revisions, distr
                     if not plugin_revision or SourceRepository.is_commit_hash(plugin_revision):
                         raise exceptions.SystemSetupError("No revision specified for plugin [%s]." % plugin.name)
                     else:
-                        logging.getLogger(__name__).info("Revision for [%s] is not explicitly defined. Using catch-all revision [%s]."
-                                    % (plugin.name, plugin_revision))
+                        logging.getLogger(__name__).info("Revision for [%s] is not explicitly defined. Using catch-all revision [%s].",
+                                                         plugin.name, plugin_revision)
                 supply_requirements[plugin.name] = ("source", plugin_revision, plugin_needs_build)
             else:
                 supply_requirements[plugin.name] = (distribution, _required_version(distribution_version), False)

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -646,7 +646,7 @@ def create_readers(num_clients, client_index, corpora, batch_size, bulk_size, id
                                                  docs.includes_action_and_meta_data)
             if num_docs > 0:
                 logger.info("Task-relative client at index [%d] will bulk index [%d] docs starting from line offset [%d] for [%s/%s] "
-                            "from corpus [%s]." % (client_index, num_docs, offset, docs.target_index, docs.target_type, corpus.name))
+                            "from corpus [%s].", client_index, num_docs, offset, docs.target_index, docs.target_type, corpus.name)
                 readers.append(create_reader(docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability,
                                              on_conflict, recency))
             else:


### PR DESCRIPTION
Pass formatting arguments to log function instead of string format.

Relates #838 