### PR TITLE
Skip setup phase in IT tests during docker release

### DIFF
--- a/integration-test.sh
+++ b/integration-test.sh
@@ -630,12 +630,16 @@ check_prerequisites
 
 trap "tear_down" EXIT
 
-# if argument is the name of a function, set up and call it
-if declare -f "$1" > /dev/null
-then
+# allow invocation from release-docker.sh
+if [[ $1 == "test-docker-release" ]]; then
+    test_docker_release_image
+    exit
+# if argument is the name of any other function, set up and call it
+elif declare -f "$1" > /dev/null; then
     set_up
     $1
     exit
+# otherwise run all functions
+else
+  main
 fi
-
-main


### PR DESCRIPTION
Commit 594b5a559f3d3119be62fff3bd7ea34a1eb8bd55 accidentally enabled
the setup phase during the docker release image tests.
Fixing by skipping the setup phase only for the
test_docker_release_image function.
