### PR TITLE
Adjust IT tests for elastic/rally-eventdata-track#67

### DIFF
--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -102,7 +102,6 @@ class GenericHelperFunctionTests(TestCase):
             "rolledover_indices_suffix_separator",
             "rollover_max_age",
             "rollover_max_size",
-            "shard_count",
             "shard_sizing_iterations",
             "shard_sizing_queries",
             "source_enabled",


### PR DESCRIPTION
In https://github.com/elastic/rally-eventdata-track/pull/67 we
consistently switch to number_of_shards from shard_count, so adjust the
IT tests accordingly.
