### PR TITLE
Don't write metrics to a closed metrics store

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -209,7 +209,8 @@ class ProcessLauncher:
         stopped_nodes = []
         for node in nodes:
             node_name = node.node_name
-            telemetry.add_metadata_for_node(metrics_store, node_name, node.host_name)
+            if metrics_store:
+                telemetry.add_metadata_for_node(metrics_store, node_name, node.host_name)
             try:
                 es = psutil.Process(pid=node.pid)
                 node.telemetry.detach_from_node(node, running=True)
@@ -239,5 +240,6 @@ class ProcessLauncher:
 
                 node.telemetry.detach_from_node(node, running=False)
             # store system metrics in any case (telemetry devices may derive system metrics while the node is running)
-            node.telemetry.store_system_metrics(node, metrics_store)
+            if metrics_store:
+                node.telemetry.store_system_metrics(node, metrics_store)
             return stopped_nodes

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -126,6 +126,7 @@ def stop(cfg):
         logging.getLogger(__name__).info("Could not find race [%s] and will thus not persist system metrics.", race_id)
         # Don't persist system metrics if we can't retrieve the race as we cannot derive the required meta-data.
         current_race = None
+        metrics_store = None
 
     node_launcher.stop(nodes, metrics_store)
     _delete_node_file(root_path)


### PR DESCRIPTION
With this commit we avoid storing any metrics on node shutdown if the
metrics store is closed. This can happen when a node is started and
stopped without any benchmark (with that race id) being run in between.