### PR TITLE
Don't read from stdout/stderr on ES startup

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -196,7 +196,6 @@ class ProcessLauncher:
         with subprocess.Popen(command_line_args,
                               stdout=subprocess.DEVNULL,
                               stderr=subprocess.DEVNULL,
-                              universal_newlines=True,
                               env=env,
                               preexec_fn=os.setpgrp) as command_line_process:
             # wait for it to finish

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -106,6 +106,9 @@ class MockPopen:
     def communicate(self, input=None, timeout=None):
         return [b"", b""]
 
+    def poll(self):
+        pass
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
With this commit we avoid reading from stdout/stderr which might have
been closed by the application and rely solely on the process' return
code.

Relates elastic/elasticsearch#50259