### PR TITLE
Make REST API check stricter

### DIFF
--- a/esrally/client.py
+++ b/esrally/client.py
@@ -128,7 +128,7 @@ class EsClientFactory:
         return elasticsearch.Elasticsearch(hosts=self.hosts, ssl_context=self.ssl_context, **self.client_options)
 
 
-def wait_for_rest_layer(es, max_attempts=20):
+def wait_for_rest_layer(es, max_attempts=40):
     """
     Waits for ``max_attempts`` until Elasticsearch's REST API is available.
 


### PR DESCRIPTION
So far we have used the info API to determine whether the REST API of
Elasticsearch is available. However, we might get lucky that a quorum
(but not all) of the target hosts are available yet. While certain nodes
would then respond to HTTP requests, others might not which can lead to
situations where the REST API check succeeds but we run into connection
errors later on (because we hit a different host from the connection
pool).

With this commit we make this check stricter by using the cluster health
API and blocking until  at least the number of target hosts in the
cluster is available.