### PR TITLE
Stop all locally running nodes

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -258,4 +258,4 @@ class ProcessLauncher:
             # store system metrics in any case (telemetry devices may derive system metrics while the node is running)
             if metrics_store:
                 node.telemetry.store_system_metrics(node, metrics_store)
-            return stopped_nodes
+        return stopped_nodes

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -174,9 +174,11 @@ class ProcessLauncherTests(TestCase):
         ms = get_metrics_store(cfg)
         proc_launcher = launcher.ProcessLauncher(cfg)
 
-        node_configs = [NodeConfiguration(build_type="tar", car_env={}, car_runtime_jdks="12,11", ip="127.0.0.1",
-                                          node_name="testnode-{}".format(n), node_root_path="/tmp", binary_path="/tmp",
-                                          data_paths="/tmp") for n in range(2)]
+        node_configs = []
+        for node in range(2):
+            node_configs.append(NodeConfiguration(build_type="tar", car_env={}, car_runtime_jdks="12,11",
+                                                  ip="127.0.0.1", node_name="testnode-{}".format(node),
+                                                  node_root_path="/tmp", binary_path="/tmp", data_paths="/tmp"))
 
         nodes = proc_launcher.start(node_configs)
         self.assertEqual(len(nodes), 2)

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -174,12 +174,12 @@ class ProcessLauncherTests(TestCase):
         ms = get_metrics_store(cfg)
         proc_launcher = launcher.ProcessLauncher(cfg)
 
-        node_config = NodeConfiguration(build_type="tar", car_env={}, car_runtime_jdks="12,11", ip="127.0.0.1",
-                                        node_name="testnode", node_root_path="/tmp", binary_path="/tmp",
-                                        data_paths="/tmp")
+        node_configs = [NodeConfiguration(build_type="tar", car_env={}, car_runtime_jdks="12,11", ip="127.0.0.1",
+                                          node_name="testnode-{}".format(n), node_root_path="/tmp", binary_path="/tmp",
+                                          data_paths="/tmp") for n in range(2)]
 
-        nodes = proc_launcher.start([node_config])
-        self.assertEqual(len(nodes), 1)
+        nodes = proc_launcher.start(node_configs)
+        self.assertEqual(len(nodes), 2)
         self.assertEqual(nodes[0].pid, MOCK_PID_VALUE)
 
         stopped_nodes = proc_launcher.stop(nodes, ms)


### PR DESCRIPTION
When starting multiple nodes on one machine, Rally only stopped the
first node. With this commit we actually stop all nodes.