### PR TITLE
Detach ES using Python standard mechanism

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -192,12 +192,11 @@ class ProcessLauncher:
     def _run_subprocess(command_line, env):
         command_line_args = shlex.split(command_line)
 
-        # pylint: disable=subprocess-popen-preexec-fn
         with subprocess.Popen(command_line_args,
                               stdout=subprocess.DEVNULL,
                               stderr=subprocess.DEVNULL,
                               env=env,
-                              preexec_fn=os.setpgrp) as command_line_process:
+                              start_new_session=True) as command_line_process:
             # wait for it to finish
             command_line_process.wait()
         return command_line_process.returncode


### PR DESCRIPTION
With this commit we use the parameter `start_new_session` to detach
Elasticsearch from its parent process group (Rally) instead of the
problematic (and low-level) `preexec_fn`. Under the hood this will use
the `setsid` system call instead of `setpgrp`.

See also:

* https://linux.die.net/man/2/setsid
* https://linux.die.net/man/2/setpgrp

Relates #859