### PR TITLE
Only clear  metrics store on benchmark end

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -492,7 +492,7 @@ class Driver:
                 self.logger.debug("Closing metrics store...")
                 self.metrics_store.close()
                 # immediately clear as we don't need it anymore and it can consume a significant amount of memory
-                del self.metrics_store
+                self.metrics_store = None
                 self.logger.debug("Sending benchmark results...")
                 self.target.on_benchmark_complete(m)
             else:


### PR DESCRIPTION
With this commit we only reset the `metrics_store` field in the driver
instead of completely removing the field from its class. This makes
Rally more resilient in failure scenarios, e.g. when failure happens
upon shutdown of Elasticsearch, which leads to the driver's `#close()`
method being invoked, which in turn attempts to access the already
removed field again.