### PR TITLE
Only set distribution-version if known

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -289,8 +289,8 @@ class DriverActor(actor.RallyActor):
         self.send(self.start_sender, PreparationComplete(
             # older versions (pre 6.3.0) don't expose build_flavor because the only (implicit) flavor was "oss"
             cluster_version.get("build_flavor", "oss"),
-            cluster_version.get("number", "Unknown"),
-            cluster_version.get("build_hash", "Unknown")
+            cluster_version.get("number"),
+            cluster_version.get("build_hash")
         ))
 
     def on_benchmark_complete(self, metrics):

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1323,7 +1323,6 @@ class Race:
             "race-timestamp": time.to_iso8601(self.race_timestamp),
             "distribution-version": self.distribution_version,
             "distribution-flavor": self.distribution_flavor,
-            "distribution-major-version": versions.major_version(self.distribution_version),
             "user-tags": self.user_tags,
             "track": self.track_name,
             "challenge": self.challenge_name,
@@ -1331,6 +1330,8 @@ class Race:
             # allow to logically delete records, e.g. for UI purposes when we only want to show the latest result
             "active": True
         }
+        if self.distribution_version:
+            result_template["distribution-major-version"] = versions.major_version(self.distribution_version)
         if self.team_revision:
             result_template["team-revision"] = self.team_revision
         if self.track_revision:


### PR DESCRIPTION
With this commit we don't make any attempt to set a distribution version
internally if it cannot be derived but instead keep it as `None`. When
the final results are written, we will only derive Elasticsearch's major
version if the distribution version is known, otherwise we leave it
unset.