### PR TITLE
Log race id on startup

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -889,6 +889,7 @@ def main():
     if sub_command in ["start", "stop"]:
         cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
 
+    logger.info("Race id [%s]", args.race_id)
     logger.info("OS [%s]", str(platform.uname()))
     logger.info("Python [%s]", str(sys.implementation))
     logger.info("Rally version [%s]", version.version())


### PR DESCRIPTION
We have introduced the race id a while ago to uniquely identify a Rally
invocation but we don't write it to logs which makes it harder than
necessary to understand to which race a certain log output belongs to.
With this commit we write the race id Rally's log file upon startup.