### PR TITLE
Fix race in wait_for_pidfile.

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -101,8 +101,11 @@ def wait_for_pidfile(pidfilename, timeout=60, clock=time.Clock):
     while stop_watch.split_time() < timeout:
         try:
             with open(pidfilename, "rb") as f:
-                return int(f.read())
-        except FileNotFoundError:
+                buf = f.read()
+                if not buf:
+                    raise EOFError
+                return int(buf)
+        except (FileNotFoundError, EOFError):
             time.sleep(0.5)
 
     msg = "pid file not available after {} seconds!".format(timeout)

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -289,6 +289,8 @@ class ProcessLauncherTests(TestCase):
 
 
 class IterationBasedStopWatch:
+    __test__ = False
+
     def __init__(self, max_iterations):
         self.iterations = 0
         self.max_iterations = max_iterations
@@ -305,6 +307,8 @@ class IterationBasedStopWatch:
 
 
 class TestClock:
+    __test__ = False
+
     def __init__(self, stop_watch):
         self._stop_watch = stop_watch
 


### PR DESCRIPTION
wait_for_pidfile may open the pidfile after it is created but before it has data.
Handle empty file reads and improve testing.

Relates #899, Closes #900