### PR TITLE
Show more user-friendly track loader errors

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -862,8 +862,9 @@ class TrackFileReader:
             raise TrackSyntaxError(msg)
         except Exception as e:
             self.logger.exception("Could not load [%s].", track_spec_file)
+            msg = "Could not load '{}'. The complete track has been written to '{}' for diagnosis.".format(track_spec_file, tmp.name)
             # Convert to string early on to avoid serialization errors with Jinja exceptions.
-            raise TrackSyntaxError("Could not load '{}'. The complete track has been written to '{}' for diagnosis.".format(track_spec_file, tmp.name), str(e))
+            raise TrackSyntaxError(msg, str(e))
         # check the track version before even attempting to validate the JSON format to avoid bogus errors.
         raw_version = track_spec.get("version", TrackFileReader.MAXIMUM_SUPPORTED_TRACK_VERSION)
         try:


### PR DESCRIPTION
With this commit we add more details when Rally cannot load a track. In
all cases we include the path to the completely rendered track file. We
also detect syntax errors separately and provide the specific context in
which the error happens.