### PR TITLE
Eliminate deprecation warnings in Python 3.7+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     "jsonschema==3.1.1",
     # License: BSD
     # transitive dependency Markupsafe: BSD
-    "Jinja2==2.10.1",
+    "Jinja2==2.10.3",
     # License: MIT
     "thespian==3.9.3",
     # recommended library for thespian to identify actors more easily with `ps`


### PR DESCRIPTION
With this commit we upgrade Jinja2 from version 2.10.1 to 2.10.3. Prior
to that version, Jinja2 has used API that has been deprecated in Python
3.7 and thus emitted warnings.