### PR TITLE
Add custom probing URL

### DIFF
--- a/docs/offline.rst
+++ b/docs/offline.rst
@@ -17,11 +17,11 @@ Rally will automatically detect upon startup that no Internet connection is avai
 
 It detects this by trying to connect to ``https://github.com``. If you want it to probe against a different HTTP endpoint (e.g. a company-internal git server) you need to add a configuration property named ``probing.url`` in the ``system`` section of Rally's configuration file at ``~/.rally/rally.ini``. Specify ``--offline`` if you want to disable probing entirely.
 
-Example of `system` section with custom probing url in ``~/.rally/rally.ini``::
+Example of ``system`` section with custom probing url in ``~/.rally/rally.ini``::
 
     [system]
     env.name = local
-    probing.url = "https://www.company-internal-server.com/"
+    probing.url = https://www.company-internal-server.com/
 
 
 Using tracks

--- a/docs/offline.rst
+++ b/docs/offline.rst
@@ -15,7 +15,14 @@ Rally will automatically detect upon startup that no Internet connection is avai
 
     [WARNING] No Internet connection detected. Automatic download of track data sets etc. is disabled.
 
-It detects this by trying to connect to ``github.com``. If you want to disable this probing you can explicitly specify ``--offline``.
+It detects this by trying to connect to ``https://github.com``. If you want it to probe against a different HTTP endpoint (e.g. a company-internal git server) you need to add a configuration property named ``probing.url`` in the ``system`` section of Rally's configuration file at ``~/.rally/rally.ini``. Specify ``--offline`` if you want to disable probing entirely.
+
+Example of `system` section with custom probing url in ``~/.rally/rally.ini``::
+
+    [system]
+    env.name = local
+    probing.url = "https://www.company-internal-server.com/"
+
 
 Using tracks
 ------------

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -897,7 +897,8 @@ def main():
     # Configure networking
     net.init()
     if not args.offline:
-        if not net.has_internet_connection():
+        probing_url = cfg.opts("system", "probing.url", default_value="https://github.com", mandatory=False)
+        if not net.has_internet_connection(probing_url):
             console.warn("No Internet connection detected. Automatic download of track data sets etc. is disabled.",
                          logger=logger)
             cfg.add(config.Scope.applicationOverride, "system", "offline.mode", True)

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -169,11 +169,10 @@ def retrieve_content_as_string(url):
         return response.read().decode("utf-8")
 
 
-def has_internet_connection():
+def has_internet_connection(probing_url):
     logger = logging.getLogger(__name__)
     try:
-        # We connect to Github anyway later on so we use that to avoid touching too much different remote endpoints.
-        probing_url = "https://github.com/"
+        # We try to connect to Github by default. We use that to avoid touching too much different remote endpoints.
         logger.debug("Checking for internet connection against [%s]", probing_url)
         # We do a HTTP request here to respect the HTTP proxy setting. If we'd open a plain socket connection we circumvent the
         # proxy and erroneously conclude we don't have an Internet connection.


### PR DESCRIPTION
It makes the probing URL configurable via `rally.ini` instead of always using https://github.com/ as probing URL.

Closes #866
