### PR TITLE
Honor only specified Python versions in prereq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ prereq:
 	pyenv install --skip-existing $(PY36)
 	pyenv install --skip-existing $(PY37)
 	pyenv install --skip-existing $(PY38)
-	pyenv global system $(PY35) $(PY36) $(PY37) $(PY38)
+	pyenv local $(PY35) $(PY36) $(PY37) $(PY38)
 	@# Ensure all Python versions are registered for this project
 	@ jq -r '.python_versions | [.[] | tostring] | join("\n")' .ci/variables.json > .python-version
 	-@ printf $(PYENV_PREREQ_HELP)


### PR DESCRIPTION
With this commit we set the Python versions that we use for testing only
locally for the current project. We also honor only the specified Python
versions ignoring any preinstalled version of Python that is already
installed on the system.