### PR TITLE
Normalize handling of --preserve-install

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -504,7 +504,8 @@ def create_arg_parser():
         p.add_argument(
             "--preserve-install",
             help="Keep the benchmark candidate and its index. (default: %s)." % str(preserve_install).lower(),
-            default=preserve_install)
+            default=preserve_install,
+            action="store_true")
         p.add_argument(
             "--test-mode",
             help="Runs the given track in 'test mode'. Meant to check a track for errors but not for real benchmarks (default: false).",


### PR DESCRIPTION
We have --preserve-install as an argument for 2 subcommands, `race` and `stop`.  In `stop`, it is an argumentless flag, but in `race` it defaults to a boolean value but expects an argument.

I normalized the argument so it is handled the same in both cases, as an argumentless flag.