### PR TITLE
Assume a TTY for interactive commands

### DIFF
--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -21,7 +21,7 @@ import thespian.actors
 import thespian.system.messages.status
 
 from esrally import exceptions, log
-from esrally.utils import net
+from esrally.utils import console, net
 
 
 class BenchmarkFailure:
@@ -101,6 +101,7 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
         self.status = None
         log.post_configure_actor_logging()
         self.logger = logging.getLogger(__name__)
+        console.set_assume_tty(assume_tty=False)
 
     # The method name is required by the actor framework
     # noinspection PyPep8Naming

--- a/esrally/rallyd.py
+++ b/esrally/rallyd.py
@@ -71,7 +71,7 @@ def main():
     check_python_version()
     log.install_default_log_config()
     log.configure_logging()
-    console.init()
+    console.init(assume_tty=False)
 
     parser = argparse.ArgumentParser(prog=PROGRAM_NAME,
                                      description=BANNER + "\n\n Rally daemon to support remote benchmarks",

--- a/tests/utils/console_test.py
+++ b/tests/utils/console_test.py
@@ -28,16 +28,19 @@ from esrally.utils import console
 class ConsoleFunctionTests(TestCase):
     oldconsole_quiet = None
     oldconsole_rally_running_in_docker = None
+    oldconsole_rally_assume_tty = None
 
     @classmethod
     def setUpClass(cls):
         cls.oldconsole_quiet = console.QUIET
         cls.oldconsole_rally_running_in_docker = console.RALLY_RUNNING_IN_DOCKER
+        cls.oldconsole_rally_assume_tty = console.ASSUME_TTY
 
     @classmethod
     def tearDownClass(cls):
         console.QUIET = cls.oldconsole_quiet
         console.RALLY_RUNNING_IN_DOCKER = cls.oldconsole_rally_running_in_docker
+        console.ASSUME_TTY = cls.oldconsole_rally_assume_tty
 
     @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": random.choice(["false", "False", "FALSE", ""])})
     def test_global_rally_running_in_docker_is_false(self):
@@ -57,8 +60,7 @@ class ConsoleFunctionTests(TestCase):
     @mock.patch("sys.stdout.isatty")
     @mock.patch("builtins.print")
     def test_println_randomized_dockertrue_or_istty_and_isnotquiet(self, patched_print, patched_isatty):
-        console.init()
-        console.QUIET = False
+        console.init(quiet=False, assume_tty=False)
         random_boolean = random.choice([True, False])
         patched_isatty.return_value = random_boolean
         console.RALLY_RUNNING_IN_DOCKER = not random_boolean
@@ -70,10 +72,20 @@ class ConsoleFunctionTests(TestCase):
 
     @mock.patch("sys.stdout.isatty")
     @mock.patch("builtins.print")
-    def test_println_isquiet_and_randomized_docker_or_istty(self, patched_print, patched_isatty):
-        console.init()
-        console.QUIET = True
+    def test_println_randomized_assume_tty_or_istty_and_isnotquiet(self, patched_print, patched_isatty):
         random_boolean = random.choice([True, False])
+        console.init(quiet=False, assume_tty=not random_boolean)
+        patched_isatty.return_value = random_boolean
+        console.println(msg="Unittest message")
+        patched_print.assert_called_once_with(
+            "Unittest message", end="\n", flush=False
+        )
+
+    @mock.patch("sys.stdout.isatty")
+    @mock.patch("builtins.print")
+    def test_println_isquiet_and_randomized_docker_assume_tty_or_istty(self, patched_print, patched_isatty):
+        random_boolean = random.choice([True, False])
+        console.init(quiet=True, assume_tty=not random_boolean)
         patched_isatty.return_value = random_boolean
         console.RALLY_RUNNING_IN_DOCKER = not random_boolean
         console.println(msg="Unittest message")
@@ -95,22 +107,25 @@ class ConsoleFunctionTests(TestCase):
 class TestCmdLineProgressReporter:
     oldconsole_quiet = None
     oldconsole_rally_running_in_docker = None
+    oldconsole_rally_assume_tty = None
 
     @classmethod
     def setup_class(cls):
         cls.oldconsole_quiet = console.QUIET
         cls.oldconsole_rally_running_in_docker = console.RALLY_RUNNING_IN_DOCKER
+        cls.oldconsole_rally_assume_tty = console.ASSUME_TTY
 
     @classmethod
     def teardown_class(cls):
         console.QUIET = cls.oldconsole_quiet
         console.RALLY_RUNNING_IN_DOCKER = cls.oldconsole_rally_running_in_docker
+        console.ASSUME_TTY = cls.oldconsole_rally_assume_tty
 
     @mock.patch("sys.stdout.flush")
     @mock.patch("sys.stdout.isatty")
     @pytest.mark.parametrize("seed", range(20))
     def test_print_when_isquiet_and_any_docker_or_istty(self, patched_isatty, patched_flush, seed):
-        console.QUIET = True
+        console.init(quiet=True, assume_tty=False)
         random.seed(seed)
         patched_isatty.return_value = random.choice([True, False])
         console.RALLY_RUNNING_IN_DOCKER = random.choice([True, False])
@@ -127,7 +142,7 @@ class TestCmdLineProgressReporter:
     @mock.patch("sys.stdout.flush")
     @mock.patch("sys.stdout.isatty")
     def test_prints_when_isnotquiet_and_nodocker_and_isnotty(self, patched_isatty, patched_flush):
-        console.QUIET = False
+        console.init(quiet=False, assume_tty=False)
         patched_isatty.return_value = False
         console.RALLY_RUNNING_IN_DOCKER = False
 
@@ -143,7 +158,7 @@ class TestCmdLineProgressReporter:
     @mock.patch("sys.stdout.isatty")
     @pytest.mark.parametrize("seed", range(20))
     def test_prints_when_isnotquiet_and_randomized_docker_or_istty(self, patched_isatty, patched_flush, seed):
-        console.QUIET = False
+        console.init(quiet=False, assume_tty=False)
         random.seed(seed)
         random_boolean = random.choice([True, False])
         patched_isatty.return_value = random_boolean
@@ -162,9 +177,30 @@ class TestCmdLineProgressReporter:
 
     @mock.patch("sys.stdout.flush")
     @mock.patch("sys.stdout.isatty")
+    @pytest.mark.parametrize("seed", range(20))
+    def test_prints_when_isnotquiet_and_randomized_assume_tty_or_istty(self, patched_isatty, patched_flush, seed):
+        random.seed(seed)
+        random_boolean = random.choice([True, False])
+        console.init(quiet=False, assume_tty=random_boolean)
+        console.RALLY_RUNNING_IN_DOCKER = False
+        patched_isatty.return_value = not random_boolean
+
+        message = "Unit test message"
+        width = random.randint(20, 140)
+        mock_printer = mock.Mock()
+        progress_reporter = console.CmdLineProgressReporter(width=width, printer=mock_printer)
+        progress_reporter.print(message=message, progress=".")
+        mock_printer.assert_has_calls([
+            mock.call(" " * width, end=""),
+            mock.call("\x1b[{}D{}{}.".format(width, message, " "*(width-len(message)-1)), end="")
+        ])
+        patched_flush.assert_called_once_with()
+
+    @mock.patch("sys.stdout.flush")
+    @mock.patch("sys.stdout.isatty")
     def test_noprint_when_isnotquiet_and_nodocker_and_noistty(self, patched_isatty, patched_flush):
+        console.init(quiet=False, assume_tty=False)
         patched_isatty.return_value = False
-        console.QUIET = False
         console.RALLY_RUNNING_IN_DOCKER = False
 
         message = "Unit test message"
@@ -178,7 +214,7 @@ class TestCmdLineProgressReporter:
     @mock.patch("sys.stdout.isatty")
     @pytest.mark.parametrize("seed", range(10))
     def test_finish_noprint_when_isquiet_and_randomized_docker_or_istty(self, patched_isatty, seed):
-        console.QUIET = True
+        console.init(quiet=True, assume_tty=False)
         random.seed(seed)
         patched_isatty.return_value = random.choice([True, False])
         console.RALLY_RUNNING_IN_DOCKER = random.choice([True, False])
@@ -192,11 +228,26 @@ class TestCmdLineProgressReporter:
     @mock.patch("sys.stdout.isatty")
     @pytest.mark.parametrize("seed", range(30))
     def test_finish_prints_when_isnotquiet_and_randomized_docker_or_istty(self, patched_isatty, seed):
-        console.QUIET = False
+        console.init(quiet=False, assume_tty=False)
         random.seed(seed)
         random_boolean = random.choice([True, False])
         patched_isatty.return_value = random_boolean
         console.RALLY_RUNNING_IN_DOCKER = not random_boolean
+
+        width = random.randint(20, 140)
+        mock_printer = mock.Mock()
+        progress_reporter = console.CmdLineProgressReporter(width=width, printer=mock_printer)
+        progress_reporter.finish()
+        mock_printer.assert_called_once_with("")
+
+    @mock.patch("sys.stdout.isatty")
+    @pytest.mark.parametrize("seed", range(30))
+    def test_finish_prints_when_isnotquiet_and_randomized_assume_tty_or_istty(self, patched_isatty, seed):
+        random.seed(seed)
+        random_boolean = random.choice([True, False])
+        console.init(quiet=False, assume_tty=random_boolean)
+        console.RALLY_RUNNING_IN_DOCKER = False
+        patched_isatty.return_value = not random_boolean
 
         width = random.randint(20, 140)
         mock_printer = mock.Mock()


### PR DESCRIPTION
With this commit we assume that Rally is attached to a TTY when an
interactive command is invoked and are only defensive in actors. This
change allows Rally to produce output even when it is redirected to a
file or used in shell pipelines.