### PR TITLE
Allow to specify an indices stats condition

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -32,7 +32,7 @@ __RUNNERS = {}
 def register_default_runners():
     register_runner(track.OperationType.Bulk.name, BulkIndex())
     register_runner(track.OperationType.ForceMerge.name, ForceMerge())
-    register_runner(track.OperationType.IndicesStats.name, IndicesStats())
+    register_runner(track.OperationType.IndicesStats.name, Retry(IndicesStats()))
     register_runner(track.OperationType.NodesStats.name, NodeStats())
     register_runner(track.OperationType.Search.name, Query())
     register_runner(track.OperationType.RawRequest.name, RawRequest())
@@ -607,8 +607,39 @@ class IndicesStats(Runner):
     Gather index stats for all indices.
     """
 
+    def _get(self, v, path):
+        if len(path) == 1:
+            return v[path[0]]
+        else:
+            return self._get(v[path[0]], path[1:])
+
     def __call__(self, es, params):
-        es.indices.stats(metric="_all")
+        index = params.get("index", "_all")
+        condition = params.get("condition")
+
+        response = es.indices.stats(index=index, metric="_all")
+        if condition:
+            path = mandatory(condition, "path", repr(self))
+            expected_value = mandatory(condition, "expected-value", repr(self))
+            actual_value = self._get(response, path.split("."))
+            return {
+                "weight": 1,
+                "unit": "ops",
+                "condition": {
+                    "path": path,
+                    # avoid mapping issues in the ES metrics store by always rendering values as strings
+                    "actual-value": str(actual_value),
+                    "expected-value": str(expected_value)
+                },
+                # currently we only support "==" as a predicate but that might change in the future
+                "success": actual_value == expected_value
+            }
+        else:
+            return {
+                "weight": 1,
+                "unit": "ops",
+                "success": True
+            }
 
     def __repr__(self, *args, **kwargs):
         return "indices-stats"
@@ -1433,8 +1464,10 @@ class Retry(Runner, Delegator):
                 # we can determine success if and only if the runner returns a dict. Otherwise, we have to assume it was fine.
                 elif isinstance(return_value, dict):
                     if return_value.get("success", True):
+                        self.logger.debug("%s has returned successfully", repr(self.delegate))
                         return return_value
                     else:
+                        self.logger.debug("%s has returned with an error: %s.", repr(self.delegate), return_value)
                         time.sleep(sleep_time)
                 else:
                     return return_value

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -830,6 +830,84 @@ class ForceMergeRunnerTests(TestCase):
                                                              params={"request_timeout": 17000})
 
 
+class IndicesStatsRunnerTests(TestCase):
+    @mock.patch("elasticsearch.Elasticsearch")
+    def test_indices_stats_without_parameters(self, es):
+        indices_stats = runner.IndicesStats()
+        result = indices_stats(es, params={})
+        self.assertEqual(1, result["weight"])
+        self.assertEqual("ops", result["unit"])
+        self.assertTrue(result["success"])
+
+        es.indices.stats.assert_called_once_with(index="_all", metric="_all")
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    def test_indices_stats_with_failed_condition(self, es):
+        es.indices.stats.return_value = {
+            "_all": {
+                "total": {
+                    "merges": {
+                        "current": 2,
+                        "current_docs": 292698,
+                    }
+                }
+            }
+        }
+
+        indices_stats = runner.IndicesStats()
+
+        result = indices_stats(es, params={
+            "index": "logs-*",
+            "condition": {
+                "path": "_all.total.merges.current",
+                "expected-value": 0
+            }
+        })
+        self.assertEqual(1, result["weight"])
+        self.assertEqual("ops", result["unit"])
+        self.assertFalse(result["success"])
+        self.assertDictEqual({
+            "path": "_all.total.merges.current",
+            "actual-value": "2",
+            "expected-value": "0"
+        }, result["condition"])
+
+        es.indices.stats.assert_called_once_with(index="logs-*", metric="_all")
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    def test_indices_stats_with_successful_condition(self, es):
+        es.indices.stats.return_value = {
+            "_all": {
+                "total": {
+                    "merges": {
+                        "current": 0,
+                        "current_docs": 292698,
+                    }
+                }
+            }
+        }
+
+        indices_stats = runner.IndicesStats()
+
+        result = indices_stats(es, params={
+            "index": "logs-*",
+            "condition": {
+                "path": "_all.total.merges.current",
+                "expected-value": 0
+            }
+        })
+        self.assertEqual(1, result["weight"])
+        self.assertEqual("ops", result["unit"])
+        self.assertTrue(result["success"])
+        self.assertDictEqual({
+            "path": "_all.total.merges.current",
+            "actual-value": "0",
+            "expected-value": "0"
+        }, result["condition"])
+
+        es.indices.stats.assert_called_once_with(index="logs-*", metric="_all")
+
+
 class QueryRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     def test_query_match_only_request_body_defined(self, es):


### PR DESCRIPTION
With this commit we expand the existing `indices-stats` operation and
allow to pass a condition based on a path and an expected value. This
has a variety of use cases:

* Verify that the number of documents in an index matches the expected
number of documents
* Wait until an operation has finished (e.g. no ongoing segment merges)
by specifying additional retry properties.