### PR TITLE
Don't invoke setup.py directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ SHELL = /bin/bash
 # We assume an active virtualenv for development
 PYENV_REGEX = .pyenv/shims
 PY_BIN = python3
+# https://github.com/pypa/pip/issues/5599
+PIP_WRAPPER = $(PY_BIN) -m pip
 PY35 = $(shell jq '.python_versions.PY35' .ci/variables.json)
 PY36 = $(shell jq '.python_versions.PY36' .ci/variables.json)
 PY37 = $(shell jq '.python_versions.PY37' .ci/variables.json)
@@ -63,10 +65,10 @@ check-venv:
 	fi
 
 install: venv-create
-	. $(VENV_ACTIVATE_FILE); pip install --upgrade pip setuptools
-	. $(VENV_ACTIVATE_FILE); pip3 install -e .
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install --upgrade pip setuptools wheel
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .
 	# Also install development dependencies
-	. $(VENV_ACTIVATE_FILE); pip3 install -e .[develop]
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .[develop]
 
 clean: nondocs-clean docs-clean
 

--- a/run.sh
+++ b/run.sh
@@ -35,9 +35,11 @@ install_esrally_with_setuptools () {
     fi
 
     if [[ ${IN_VIRTUALENV} == 0 ]]; then
-        python3 setup.py -q develop --user --upgrade
+        # https://setuptools.readthedocs.io/en/latest/setuptools.html suggests not invoking setup.py directly
+        # Also workaround system pip conflicts, https://github.com/pypa/pip/issues/5599
+        python3 -m pip install --quiet --user --upgrade --editable .[develop]
     else
-        python3 setup.py -q develop --upgrade
+        python3 -m pip install --quiet --upgrade --editable .[develop]
     fi
 }
 


### PR DESCRIPTION
Installation should always be done via pip (which is available as a
builtin Python module since 3.3) and not by calling setup.py
directly.

Also avoid conflicts with system pip packages by using the pip module
from Python.
