### PR TITLE
Store Rally revision in metrics metadata

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1219,14 +1219,15 @@ def create_race(cfg, track, challenge, track_revision=None):
     car_params = cfg.opts("mechanic", "car.params")
     plugin_params = cfg.opts("mechanic", "plugin.params")
     rally_version = version.version()
+    rally_revision = version.revision()
 
-    return Race(rally_version, environment, race_id, race_timestamp, pipeline, user_tags, track, track_params,
-                challenge, car, car_params, plugin_params, track_revision)
+    return Race(rally_version, rally_revision, environment, race_id, race_timestamp, pipeline, user_tags, track,
+                track_params, challenge, car, car_params, plugin_params, track_revision)
 
 
 class Race:
-    def __init__(self, rally_version, environment_name, race_id, race_timestamp, pipeline, user_tags, track,
-                 track_params, challenge, car, car_params, plugin_params, track_revision=None, team_revision=None,
+    def __init__(self, rally_version, rally_revision, environment_name, race_id, race_timestamp, pipeline, user_tags,
+                 track, track_params, challenge, car, car_params, plugin_params, track_revision=None, team_revision=None,
                  distribution_version=None, distribution_flavor=None, revision=None, results=None, meta_data=None):
         if results is None:
             results = {}
@@ -1238,6 +1239,7 @@ class Race:
             if challenge:
                 meta_data.update(challenge.meta_data)
         self.rally_version = rally_version
+        self.rally_revision = rally_revision
         self.environment_name = environment_name
         self.race_id = race_id
         self.race_timestamp = race_timestamp
@@ -1278,6 +1280,7 @@ class Race:
         """
         d = {
             "rally-version": self.rally_version,
+            "rally-revision": self.rally_revision,
             "environment": self.environment_name,
             # TODO #777: Remove trial-* with a later release. They are only here for BWC
             "trial-id": self.race_id,
@@ -1315,6 +1318,7 @@ class Race:
         """
         result_template = {
             "rally-version": self.rally_version,
+            "rally-revision": self.rally_revision,
             "environment": self.environment_name,
             # TODO #777: Remove trial-* with a later release. They are only here for BWC
             "trial-id": self.race_id,
@@ -1366,7 +1370,7 @@ class Race:
         # TODO: cluster is optional for BWC. This can be removed after some grace period.
         # TODO #777: Remove the backwards-compatibility layer with trial*
         cluster = d.get("cluster", {})
-        return Race(d["rally-version"], d["environment"], d.get("race-id", d.get("trial-id")),
+        return Race(d["rally-version"], d.get("rally-revision"), d["environment"], d.get("race-id", d.get("trial-id")),
                     time.from_is8601(d.get("race-timestamp", d.get("trial-timestamp"))),
                     d["pipeline"], user_tags, d["track"], d.get("track-params"), d.get("challenge"), d["car"],
                     d.get("car-params"), d.get("plugin-params"), track_revision=d.get("track-revision"),

--- a/esrally/resources/races-template.json
+++ b/esrally/resources/races-template.json
@@ -50,6 +50,9 @@
         "rally-version": {
           "type": "keyword"
         },
+        "rally-revision": {
+          "type": "keyword"
+        },
         "environment": {
           "type": "keyword"
         },

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -53,6 +53,9 @@
         "rally-version": {
           "type": "keyword"
         },
+        "rally-revision": {
+          "type": "keyword"
+        },
         "environment": {
           "type": "keyword"
         },

--- a/esrally/version.py
+++ b/esrally/version.py
@@ -27,20 +27,31 @@ __version__ = pkg_resources.require("esrally")[0].version
 __RALLY_VERSION_PATTERN = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:.(.+))?$")
 
 
+def revision():
+    """
+    :return: The current git revision if Rally is installed in development mode or ``None``.
+    """
+    # noinspection PyBroadException
+    try:
+        if git.is_working_copy(io.normalize_path("%s/.." % paths.rally_root())):
+            raw_revision = git.head_revision(paths.rally_root())
+            return raw_revision.strip()
+    except BaseException:
+        pass
+    return None
+
+
 def version():
     """
     :return: The release version string and an optional suffix for the current git revision if Rally is installed in development mode.
     """
     release = __version__
-    # noinspection PyBroadException
-    try:
-        if git.is_working_copy(io.normalize_path("%s/.." % paths.rally_root())):
-            revision = git.head_revision(paths.rally_root())
-            return "%s (git revision: %s)" % (release, revision.strip())
-    except BaseException:
-        pass
-    # cannot determine head revision so user has probably installed Rally via pip instead of git clone
-    return release
+    rally_revision = revision()
+    if rally_revision:
+        return "%s (git revision: %s)" % (release, rally_revision.strip())
+    else:
+        # cannot determine head revision so user has probably installed Rally via pip instead of git clone
+        return release
 
 
 def release_version():

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -905,8 +905,8 @@ class EsRaceStoreTests(TestCase):
                         indices=[track.Index(name="tests", types=["_doc"])],
                         challenges=[track.Challenge(name="index", default=True, schedule=schedule)])
 
-        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", race_id=EsRaceStoreTests.RACE_ID,
-                            race_timestamp=EsRaceStoreTests.RACE_TIMESTAMP,
+        race = metrics.Race(rally_version="0.4.4", rally_revision="123abc", environment_name="unittest",
+                            race_id=EsRaceStoreTests.RACE_ID, race_timestamp=EsRaceStoreTests.RACE_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params={"shard-count": 3},
                             challenge=t.default_challenge, car="defaults", car_params={"heap_size": "512mb"}, plugin_params=None,
                             track_revision="abc1", team_revision="abc12333", distribution_version="5.0.0",
@@ -934,6 +934,7 @@ class EsRaceStoreTests(TestCase):
 
         expected_doc = {
             "rally-version": "0.4.4",
+            "rally-revision": "123abc",
             "environment": "unittest",
             "race-id": EsRaceStoreTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
@@ -1008,8 +1009,8 @@ class EsResultsStoreTests(TestCase):
                             name="index", default=True, meta_data={"saturation": "70% saturated"}, schedule=schedule)],
                         meta_data={"track-type": "saturation-degree", "saturation": "oversaturation"})
 
-        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", race_id=EsResultsStoreTests.RACE_ID,
-                            race_timestamp=EsResultsStoreTests.RACE_TIMESTAMP,
+        race = metrics.Race(rally_version="0.4.4", rally_revision="123abc", environment_name="unittest",
+                            race_id=EsResultsStoreTests.RACE_ID, race_timestamp=EsResultsStoreTests.RACE_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params=None,
                             challenge=t.default_challenge, car="4gheap", car_params=None, plugin_params={"some-param": True},
                             track_revision="abc1", team_revision="123ab", distribution_version="5.0.0",
@@ -1043,6 +1044,7 @@ class EsResultsStoreTests(TestCase):
         expected_docs = [
             {
                 "rally-version": "0.4.4",
+                "rally-revision": "123abc",
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
@@ -1074,6 +1076,7 @@ class EsResultsStoreTests(TestCase):
             },
             {
                 "rally-version": "0.4.4",
+                "rally-revision": "123abc",
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
@@ -1111,6 +1114,7 @@ class EsResultsStoreTests(TestCase):
             },
             {
                 "rally-version": "0.4.4",
+                "rally-revision": "123abc",
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
@@ -1154,8 +1158,8 @@ class EsResultsStoreTests(TestCase):
                             name="index", default=True, meta_data={"saturation": "70% saturated"}, schedule=schedule)],
                         meta_data={"track-type": "saturation-degree", "saturation": "oversaturation"})
 
-        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", race_id=EsResultsStoreTests.RACE_ID,
-                            race_timestamp=EsResultsStoreTests.RACE_TIMESTAMP,
+        race = metrics.Race(rally_version="0.4.4", rally_revision=None, environment_name="unittest",
+                            race_id=EsResultsStoreTests.RACE_ID, race_timestamp=EsResultsStoreTests.RACE_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params=None,
                             challenge=t.default_challenge, car="4gheap", car_params=None, plugin_params=None,
                             track_revision="abc1", team_revision="123ab", distribution_version=None,
@@ -1189,6 +1193,7 @@ class EsResultsStoreTests(TestCase):
         expected_docs = [
             {
                 "rally-version": "0.4.4",
+                "rally-revision": None,
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
@@ -1216,6 +1221,7 @@ class EsResultsStoreTests(TestCase):
             },
             {
                 "rally-version": "0.4.4",
+                "rally-revision": None,
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
@@ -1249,6 +1255,7 @@ class EsResultsStoreTests(TestCase):
             },
             {
                 "rally-version": "0.4.4",
+                "rally-revision": None,
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
@@ -1485,8 +1492,8 @@ class FileRaceStoreTests(TestCase):
                         indices=[track.Index(name="tests", types=["_doc"])],
                         challenges=[track.Challenge(name="index", default=True, schedule=schedule)])
 
-        race = metrics.Race(rally_version="0.4.4", environment_name="unittest", race_id=FileRaceStoreTests.RACE_ID,
-                            race_timestamp=FileRaceStoreTests.RACE_TIMESTAMP,
+        race = metrics.Race(rally_version="0.4.4", rally_revision="123abc", environment_name="unittest",
+                            race_id=FileRaceStoreTests.RACE_ID, race_timestamp=FileRaceStoreTests.RACE_TIMESTAMP,
                             pipeline="from-sources", user_tags={"os": "Linux"}, track=t, track_params={"clients": 12},
                             challenge=t.default_challenge, car="4gheap", car_params=None, plugin_params=None,
                             track_revision="abc1", team_revision="abc12333", distribution_version="5.0.0",


### PR DESCRIPTION
Rally already stores the version string as metrics metadata. However,
for unreleased versions we intermingle the version string with the git
revision making it hard to determine the revision automatically.

With this commit we store the git revision of Rally separately from the
version for race and results metadata. This allows users to derive
Rally's git revision more easily.