### PR TITLE
Improve response processing

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -405,6 +405,7 @@ With the operation type ``search`` you can execute `request body searches <http:
 * ``detailed-results`` (optional, defaults to ``false``): Records more detailed meta-data about queries. As it analyzes the corresponding response in more detail, this might incur additional overhead which can skew measurement results. This flag is ineffective for scroll queries.
 * ``pages`` (optional): Number of pages to retrieve. If this parameter is present, a scroll query will be executed. If you want to retrieve all result pages, use the value "all".
 * ``results-per-page`` (optional):  Number of documents to retrieve per page for scroll queries.
+* ``response-compression-enabled`` (optional, defaults to ``true``): Allows to disable HTTP compression of scroll responses. As these responses are sometimes large and decompression may be a bottleneck on the client, it is possible to turn off response compression. This option is ineffective for regular queries.
 
 If ``detailed-results`` is set to ``true``, the following meta-data properties will be determined and stored:
 

--- a/esrally/client.py
+++ b/esrally/client.py
@@ -144,7 +144,7 @@ class EsClientFactory:
             def loads(self, s):
                 meta = RallyAsyncElasticsearch.request_context.get()
                 if "raw_response" in meta:
-                    return io.StringIO(s)
+                    return io.BytesIO(s)
                 else:
                     return super().loads(s)
 


### PR DESCRIPTION
With this commit we improve response processing speed by taking the following
measures:

1. We use the raw bytes for JSON parsing instead of first converting them into a
string.
2. We expose an additional option for scroll queries to disable HTTP response
compression as we have seen that this can cause significant overhead for very
large responses (large documents). The default is (still) to have response
compression enabled.

Our experiments have shown the following changes to the 50th percentile service
time for the PMC track:

* Baseline: 3203 ms
* With measure 1: 3014 ms
* With measure 1 and measure 2: 774 ms

Relates #935