### PR TITLE
Allow to use significantly more clients

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -436,8 +436,8 @@ class Driver:
         for host in self.config.opts("driver", "load_driver_hosts"):
             host_config = {
                 # for simplicity we assume that all benchmark machines have the same specs
-                "cores": self.config.opts("system", "available.cores", mandatory=False,
-                                          default_value=multiprocessing.cpu_count())
+                "cores": int(self.config.opts("system", "available.cores", mandatory=False,
+                                              default_value=multiprocessing.cpu_count()))
             }
             if host != "localhost":
                 host_config["host"] = net.resolve(host)

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1153,14 +1153,14 @@ class AsyncIoAdapter:
             _ = await asyncio.gather(*aws)
         finally:
             run_end = time.perf_counter()
-            self.logger.info(f"Total run duration: {run_end - run_start} seconds.")
+            self.logger.info("Total run duration: %f seconds.", (run_end - run_start))
             await asyncio.get_event_loop().shutdown_asyncgens()
             shutdown_asyncgens_end = time.perf_counter()
-            self.logger.info(f"Total time to shutdown asyncgens: {run_end - shutdown_asyncgens_end} seconds.")
+            self.logger.info("Total time to shutdown asyncgens: %f seconds.", (shutdown_asyncgens_end - run_end))
             for e in es.values():
                 await e.transport.close()
             transport_close_end = time.perf_counter()
-            self.logger.info(f"Total time to close transports: {shutdown_asyncgens_end - transport_close_end} seconds.")
+            self.logger.info("Total time to close transports: %f seconds.", (shutdown_asyncgens_end - transport_close_end))
 
 
 class AsyncProfiler:

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -883,7 +883,8 @@ class Worker(actor.RallyActor):
                 self.logger.info("Worker[%d] is executing tasks at index [%d].", self.worker_id, self.current_task_index)
                 # allow to buffer more events than by default as we expect to have way more clients.
                 self.sampler = Sampler(start_timestamp=time.perf_counter(), buffer_size=65536)
-                executor = AsyncIoAdapter(self.config, self.track, task_allocations, self.sampler, self.cancel, self.complete, self.abort_on_error)
+                executor = AsyncIoAdapter(self.config, self.track, task_allocations, self.sampler,
+                                          self.cancel, self.complete, self.abort_on_error)
 
                 self.executor_future = self.pool.submit(executor)
                 self.wakeupAfter(datetime.timedelta(seconds=self.wakeup_interval))

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -436,7 +436,8 @@ class Driver:
         for host in self.config.opts("driver", "load_driver_hosts"):
             host_config = {
                 # for simplicity we assume that all benchmark machines have the same specs
-                "cores": multiprocessing.cpu_count()
+                "cores": self.config.opts("system", "available.cores", mandatory=False,
+                                          default_value=multiprocessing.cpu_count())
             }
             if host != "localhost":
                 host_config["host"] = net.resolve(host)

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -889,9 +889,11 @@ class EsMetricsStore(MetricsStore):
 
     def flush(self, refresh=True):
         if self._docs:
+            start = time.perf_counter()
             self._client.bulk_index(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, items=self._docs)
-            self.logger.info("Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s].",
-                             len(self._docs), self._race_timestamp, self._track, self._challenge, self._car)
+            end = time.perf_counter()
+            self.logger.info("Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",
+                             len(self._docs), self._race_timestamp, self._track, self._challenge, self._car, (end - start))
         self._docs = []
         # ensure we can search immediately after flushing
         if refresh:

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -889,11 +889,12 @@ class EsMetricsStore(MetricsStore):
 
     def flush(self, refresh=True):
         if self._docs:
-            start = time.perf_counter()
+            sw = time.StopWatch()
+            sw.start()
             self._client.bulk_index(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, items=self._docs)
-            end = time.perf_counter()
+            sw.stop()
             self.logger.info("Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",
-                             len(self._docs), self._race_timestamp, self._track, self._challenge, self._car, (end - start))
+                             len(self._docs), self._race_timestamp, self._track, self._challenge, self._car, sw.total_time())
         self._docs = []
         # ensure we can search immediately after flushing
         if refresh:

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -893,8 +893,9 @@ class EsMetricsStore(MetricsStore):
             sw.start()
             self._client.bulk_index(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, items=self._docs)
             sw.stop()
-            self.logger.info("Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",
-                             len(self._docs), self._race_timestamp, self._track, self._challenge, self._car, sw.total_time())
+            self.logger.info("Successfully added %d metrics documents for race timestamp=[%s], track=[%s], "
+                             "challenge=[%s], car=[%s] in [%f] seconds.", len(self._docs), self._race_timestamp,
+                             self._track, self._challenge, self._car, sw.total_time())
         self._docs = []
         # ensure we can search immediately after flushing
         if refresh:

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -248,6 +248,145 @@ def op(name, operation_type):
     return track.Operation(name, operation_type, param_source="driver-test-param-source")
 
 
+class WorkerAssignmentTests(TestCase):
+    def test_single_host_assignment_clients_matches_cores(self):
+        host_configs = [{
+            "host": "localhost",
+            "cores": 4
+        }]
+
+        assignments = driver.calculate_worker_assignments(host_configs, client_count=4)
+
+        self.assertEqual([
+            {
+                "host": "localhost",
+                "workers": [
+                    [0],
+                    [1],
+                    [2],
+                    [3]
+                ],
+                "worker": 4
+            }
+        ], assignments)
+
+    def test_single_host_assignment_more_clients_than_cores(self):
+        host_configs = [{
+            "host": "localhost",
+            "cores": 4
+        }]
+
+        assignments = driver.calculate_worker_assignments(host_configs, client_count=6)
+
+        self.assertEqual([
+            {
+                "host": "localhost",
+                "workers": [
+                    [0, 4],
+                    [1, 5],
+                    [2],
+                    [3]
+                ],
+                "worker": 6
+            }
+        ], assignments)
+
+    def test_single_host_assignment_less_clients_than_cores(self):
+        host_configs = [{
+            "host": "localhost",
+            "cores": 4
+        }]
+
+        assignments = driver.calculate_worker_assignments(host_configs, client_count=2)
+
+        self.assertEqual([
+            {
+                "host": "localhost",
+                "workers": [
+                    [0],
+                    [1],
+                    [],
+                    []
+                ],
+                "worker": 2
+            }
+        ], assignments)
+
+    def test_multiple_host_assignment_more_clients_than_cores(self):
+        host_configs = [
+            {
+                "host": "host-a",
+                "cores": 4
+            },
+            {
+                "host": "host-b",
+                "cores": 4
+            }
+        ]
+
+        assignments = driver.calculate_worker_assignments(host_configs, client_count=16)
+
+        self.assertEqual([
+            {
+                "host": "host-a",
+                "workers": [
+                    [0, 8],
+                    [2, 10],
+                    [4, 12],
+                    [6, 14]
+                ],
+                "worker": 8
+            },
+            {
+                "host": "host-b",
+                "workers": [
+                    [1, 9],
+                    [3, 11],
+                    [5, 13],
+                    [7, 15]
+                ],
+                "worker": 8
+            }
+        ], assignments)
+
+    def test_multiple_host_assignment_less_clients_than_cores(self):
+        host_configs = [
+            {
+                "host": "host-a",
+                "cores": 4
+            },
+            {
+                "host": "host-b",
+                "cores": 4
+            }
+        ]
+
+        assignments = driver.calculate_worker_assignments(host_configs, client_count=4)
+
+        self.assertEqual([
+            {
+                "host": "host-a",
+                "workers": [
+                    [0],
+                    [2],
+                    [],
+                    []
+                ],
+                "worker": 2
+            },
+            {
+                "host": "host-b",
+                "workers": [
+                    [1],
+                    [3],
+                    [],
+                    []
+                ],
+                "worker": 2
+            }
+        ], assignments)
+
+
 class AllocatorTests(TestCase):
     def setUp(self):
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -87,6 +87,7 @@ class DriverTests(TestCase):
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
         self.cfg.add(config.Scope.application, "system", "time.start", datetime(year=2017, month=8, day=20, hour=1, minute=0, second=0))
         self.cfg.add(config.Scope.application, "system", "race.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
+        self.cfg.add(config.Scope.application, "system", "available.cores", 8)
         self.cfg.add(config.Scope.application, "track", "challenge.name", "default")
         self.cfg.add(config.Scope.application, "track", "params", {})
         self.cfg.add(config.Scope.application, "track", "test.mode.enabled", True)
@@ -137,10 +138,10 @@ class DriverTests(TestCase):
         d.start_benchmark()
 
         target.create_client.assert_has_calls(calls=[
-            mock.call(0, "10.5.5.1"),
-            mock.call(1, "10.5.5.2"),
-            mock.call(2, "10.5.5.1"),
-            mock.call(3, "10.5.5.2"),
+            mock.call("10.5.5.1"),
+            mock.call("10.5.5.1"),
+            mock.call("10.5.5.2"),
+            mock.call("10.5.5.2"),
         ])
 
         # Did we start all load generators? There is no specific mock assert for this...
@@ -158,10 +159,10 @@ class DriverTests(TestCase):
         d.start_benchmark()
 
         target.create_client.assert_has_calls(calls=[
-            mock.call(0, "localhost"),
-            mock.call(1, "localhost"),
-            mock.call(2, "localhost"),
-            mock.call(3, "localhost"),
+            mock.call("localhost"),
+            mock.call("localhost"),
+            mock.call("localhost"),
+            mock.call("localhost"),
         ])
 
         # Did we start all load generators? There is no specific mock assert for this...
@@ -176,7 +177,9 @@ class DriverTests(TestCase):
 
         self.assertEqual(0, len(d.workers_completed_current_step))
 
-        d.joinpoint_reached(worker_id=0, worker_local_timestamp=10, task=driver.JoinPoint(id=0))
+        d.joinpoint_reached(worker_id=0,
+                            worker_local_timestamp=10,
+                            task_allocations=[driver.ClientAllocation(client_id=0, task=driver.JoinPoint(id=0))])
 
         self.assertEqual(1, len(d.workers_completed_current_step))
 
@@ -192,8 +195,12 @@ class DriverTests(TestCase):
 
         self.assertEqual(0, len(d.workers_completed_current_step))
 
-        # it does not matter what we put into `clients_executing_completing_task` We choose to put the client id into it.
-        d.joinpoint_reached(worker_id=0, worker_local_timestamp=10, task=driver.JoinPoint(id=0, clients_executing_completing_task=[0]))
+        d.joinpoint_reached(worker_id=0,
+                            worker_local_timestamp=10,
+                            task_allocations=[
+                                driver.ClientAllocation(client_id=0,
+                                                        task=driver.JoinPoint(id=0,
+                                                                              clients_executing_completing_task=[0]))])
 
         self.assertEqual(-1, d.current_step)
         self.assertEqual(1, len(d.workers_completed_current_step))
@@ -201,15 +208,31 @@ class DriverTests(TestCase):
         self.assertEqual(4, target.complete_current_task.call_count)
 
         # awaiting responses of other clients
-        d.joinpoint_reached(worker_id=1, worker_local_timestamp=11, task=driver.JoinPoint(id=0, clients_executing_completing_task=[0]))
+        d.joinpoint_reached(worker_id=1,
+                            worker_local_timestamp=11,
+                            task_allocations=[
+                                driver.ClientAllocation(client_id=1,
+                                                        task=driver.JoinPoint(id=0,
+                                                                              clients_executing_completing_task=[0]))])
+
         self.assertEqual(-1, d.current_step)
         self.assertEqual(2, len(d.workers_completed_current_step))
 
-        d.joinpoint_reached(worker_id=2, worker_local_timestamp=12, task=driver.JoinPoint(id=0, clients_executing_completing_task=[0]))
+        d.joinpoint_reached(worker_id=2,
+                            worker_local_timestamp=12,
+                            task_allocations=[
+                                driver.ClientAllocation(client_id=2,
+                                                        task=driver.JoinPoint(id=0,
+                                                                              clients_executing_completing_task=[0]))])
         self.assertEqual(-1, d.current_step)
         self.assertEqual(3, len(d.workers_completed_current_step))
 
-        d.joinpoint_reached(worker_id=3, worker_local_timestamp=13, task=driver.JoinPoint(id=0, clients_executing_completing_task=[0]))
+        d.joinpoint_reached(worker_id=3,
+                            worker_local_timestamp=13,
+                            task_allocations=[
+                                driver.ClientAllocation(client_id=3,
+                                                        task=driver.JoinPoint(id=0,
+                                                                              clients_executing_completing_task=[0]))])
 
         # by now the previous step should be considered completed and we are at the next one
         self.assertEqual(0, d.current_step)


### PR DESCRIPTION
With this commit we change how clients are assigned to worker processes in the
load generator. While historically Rally has assigned one worker (process) to
one client, with the changes done in #935 we can assign multiple clients to a
single worker process now and run the clients in an asyncio event loop. This
allows us to simulate many more clients than what is possible the process-based
approach which is very heavy-weight.

By default Rally will only create as many workers as there are CPUs available on
the system. This choice can be overridden in Rally's config file with the
configuration setting `available.cores` in the section `system` to allocate more
or less workers. If multiple load generator machines note that we assume that
all of them have the same hardware specifications and only take the coordinating
machine's CPU count into account.