### PR TITLE
Use pbzip2/pigz to decompress corpora if available

### DIFF
--- a/docker/Dockerfiles/Dockerfile-dev
+++ b/docker/Dockerfiles/Dockerfile-dev
@@ -40,7 +40,7 @@ ARG RALLY_LICENSE
 ENV RALLY_RUNNING_IN_DOCKER True
 
 RUN apt-get -y update && \
-    apt-get install -y curl git && \
+    apt-get install -y curl git pbzip2 pigz && \
     apt-get -y upgrade && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfiles/Dockerfile-release
+++ b/docker/Dockerfiles/Dockerfile-release
@@ -5,7 +5,7 @@ ARG RALLY_LICENSE
 ENV RALLY_RUNNING_IN_DOCKER True
 
 RUN apt-get -y update && \
-    apt-get install -y curl git gcc && \
+    apt-get install -y curl git gcc pbzip2 pigz && \
     apt-get -y upgrade && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -69,6 +69,35 @@ In all other cases, Rally requires ``git 1.9`` or better. Verify with ``git --ve
 
 ``git`` is already installed on MacOS.
 
+pbzip2
+~~~~~~
+
+It is strongly recommended to install ``pbzip2`` to speed up decompressing the corpora of Rally `standard tracks <https://github.com/elastic/rally-tracks>`_.
+If you have created :doc:`custom tracks </adding_tracks>` using corpora compressed with ``gzip`` instead of ``bzip2``, it's also advisable to install ``pigz`` to speed up the process.
+
+**Debian / Ubuntu**
+
+::
+
+    sudo apt-get install pbzip2
+
+**Red Hat / CentOS / Amazon Linux**
+
+``pbzip`` is available via the `EPEL repository <https://fedoraproject.org/wiki/EPEL#Quickstart>`_.
+
+::
+
+    sudo yum install pbzip2
+
+**MacOS**
+
+Install via `Homebrew <https://brew.sh/>`_:
+
+::
+
+    brew install pbzip2
+
+
 JDK
 ~~~
 

--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -315,14 +315,13 @@ def _do_decompress_manually(target_directory, filename, decompressor_args, decom
 
 
 def _do_decompress_manually_external(target_directory, filename, base_path_without_extension, decompressor_args):
-    logger = logging.getLogger(__name__)
-
     with open(os.path.join(target_directory, base_path_without_extension), "wb") as new_file:
         try:
             subprocess.run(decompressor_args + [filename], stdout=new_file, stderr=subprocess.PIPE, check=True)
         except subprocess.CalledProcessError as err:
-            console.warn(f"Failed to decompress [{filename}] with [{err.cmd}]. Falling back to default library.")
-            logger.warning("Error [%s]", err.stderr)
+            logger = logging.getLogger(__name__)
+            console.warn(f"Failed to decompress [{filename}] with [{err.cmd}]. Error [{err.stderr}]. Falling back to standard library.",
+                         logger=logger.warning)
             return False
     return True
 

--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -309,7 +309,8 @@ def _do_decompress_manually(target_directory, filename, decompressor_args, decom
         if _do_decompress_manually_external(target_directory, filename, base_path_without_extension, decompressor_args):
             return
     else:
-        console.warn(f"{decompressor_bin} not found in PATH. Using standard library, decompression will take longer.")
+        logging.getLogger(__name__).warning("%s not found in PATH. Using standard library, decompression will take longer.",
+                                            decompressor_bin)
 
     _do_decompress_manually_with_lib(target_directory, filename, decompressor_lib(filename))
 
@@ -319,9 +320,8 @@ def _do_decompress_manually_external(target_directory, filename, base_path_witho
         try:
             subprocess.run(decompressor_args + [filename], stdout=new_file, stderr=subprocess.PIPE, check=True)
         except subprocess.CalledProcessError as err:
-            logger = logging.getLogger(__name__)
-            console.warn(f"Failed to decompress [{filename}] with [{err.cmd}]. Error [{err.stderr}]. Falling back to standard library.",
-                         logger=logger.warning)
+            logging.getLogger(__name__).warning("Failed to decompress [%s] with [%s]. Error [%s]. Falling back to standard library.",
+                                                filename, err.cmd, err.stderr)
             return False
     return True
 

--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -331,7 +331,7 @@ def _do_decompress_manually_with_lib(target_directory, filename, compressed_file
 
     ensure_dir(target_directory)
     try:
-        with open("%s/%s" % (target_directory, path_without_extension), "wb") as new_file:
+        with open(os.path.join(target_directory, path_without_extension), "wb") as new_file:
             for data in iter(lambda: compressed_file.read(100 * 1024), b""):
                 new_file.write(data)
     finally:

--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -289,11 +289,11 @@ def decompress(zip_name, target_directory):
         _do_decompress(target_directory, zipfile.ZipFile(zip_name))
     elif extension == ".bz2":
         decompressor_args = ["pbzip2", "-d", "-k", "-m10000", "-c"]
-        decompressor_lib = bz2.open(zip_name)
+        decompressor_lib = bz2.open
         _do_decompress_manually(target_directory, zip_name, decompressor_args, decompressor_lib)
     elif extension == ".gz":
         decompressor_args = ["pigz", "-d", "-k", "-c"]
-        decompressor_lib = gzip.open(zip_name)
+        decompressor_lib = gzip.open
         _do_decompress_manually(target_directory, zip_name, decompressor_args, decompressor_lib)
     elif extension in [".tar", ".tar.gz", ".tgz", ".tar.bz2"]:
         _do_decompress(target_directory, tarfile.open(zip_name))
@@ -311,7 +311,7 @@ def _do_decompress_manually(target_directory, filename, decompressor_args, decom
     else:
         console.warn(f"{decompressor_bin} not found in PATH. Using default library, decompression will take longer.")
 
-    _do_decompress_manually_with_lib(target_directory, filename, decompressor_lib)
+    _do_decompress_manually_with_lib(target_directory, filename, decompressor_lib(filename))
 
 
 def _do_decompress_manually_external(target_directory, filename, base_path_without_extension, decompressor_args):

--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -309,7 +309,7 @@ def _do_decompress_manually(target_directory, filename, decompressor_args, decom
         if _do_decompress_manually_external(target_directory, filename, base_path_without_extension, decompressor_args):
             return
     else:
-        console.warn(f"{decompressor_bin} not found in PATH. Using default library, decompression will take longer.")
+        console.warn(f"{decompressor_bin} not found in PATH. Using standard library, decompression will take longer.")
 
     _do_decompress_manually_with_lib(target_directory, filename, decompressor_lib(filename))
 


### PR DESCRIPTION
Decompressing large corpora using the standard bzip2/gzip libraries
can be a slow process as they only utilize one cpu core.  Take
advantage of pbzip2/pigz, if available, to speed up the process by
taking advantage of all cores.
