### PR TITLE
Upgrade Elasticsearch client to 7.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ supported_python_versions = [(3, 8)]
 install_requires = [
     # License: Apache 2.0
     # transitive dependency urllib3: MIT
-    "elasticsearch==7.0.5",
+    "elasticsearch==7.6.0",
     # License: Apache 2.0
     # transitive dependencies:
     #   aiohttp: Apache 2.0


### PR DESCRIPTION
With this commit we upgrade the Elasticsearch client to the most recent
version 7.6.0.