### PR TITLE
Add support for a RALLY_HOME env var everywhere

### DIFF
--- a/esrally/config.py
+++ b/esrally/config.py
@@ -290,7 +290,7 @@ class ConfigFactory:
     def create_config(self, config_file, advanced_config=False, assume_defaults=False):
         """
         Either creates a new configuration file or overwrites an existing one. Will ask the user for input on configurable properties
-        and writes them to the configuration file in ${RALLY_HOME}/.rally/rally.init, where ${RALLY_HOME} is defaulted to ~.
+        and writes them to the configuration file in ${RALLY_HOME}/.rally/rally.ini, where ${RALLY_HOME} is defaulted to ~.
 
         :param config_file:
         :param advanced_config: Whether to ask for properties that are not necessary for everyday use (on a dev machine). Default: False.

--- a/esrally/config.py
+++ b/esrally/config.py
@@ -23,7 +23,7 @@ import re
 import shutil
 from enum import Enum
 
-from esrally import PROGRAM_NAME, doc_link, exceptions
+from esrally import PROGRAM_NAME, doc_link, exceptions, paths
 from esrally.utils import io, git, console, convert
 
 
@@ -72,7 +72,7 @@ class ConfigFile:
 
     @property
     def config_dir(self):
-        return os.path.join(os.path.expanduser("~"), ".rally")
+        return paths.rally_confdir()
 
     @property
     def location(self):
@@ -290,7 +290,7 @@ class ConfigFactory:
     def create_config(self, config_file, advanced_config=False, assume_defaults=False):
         """
         Either creates a new configuration file or overwrites an existing one. Will ask the user for input on configurable properties
-        and writes them to the configuration file in ~/.rally/rally.ini.
+        and writes them to the configuration file in ${RALLY_HOME}/.rally/rally.init, where ${RALLY_HOME} is defaulted to ~.
 
         :param config_file:
         :param advanced_config: Whether to ask for properties that are not necessary for everyday use (on a dev machine). Default: False.

--- a/esrally/log.py
+++ b/esrally/log.py
@@ -40,7 +40,7 @@ def log_config_path():
     """
     :return: The absolute path to Rally's log configuration file.
     """
-    return os.path.join(os.path.expanduser("~"), ".rally", "logging.json")
+    return os.path.join(paths.rally_confdir(), "logging.json")
 
 
 def install_default_log_config():

--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -42,7 +42,4 @@ def install_root(cfg=None):
 
 
 def logs():
-    """
-    :return: The absolute path to the directory that contains Rally's log file.
-    """
     return os.path.join(rally_confdir(), "logs")

--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -41,6 +41,9 @@ def install_root(cfg=None):
     return os.path.join(races_root(cfg), install_id)
 
 
+# There is a weird bug manifesting in jenkins that is somehow saying the following line has an invalid docstring
+# So to work around it, we are adding this disable, even though the docstring is perfectly fine.
+# pylint: disable=invalid-docstring-quote
 def logs():
     """
     :return: The absolute path to the directory that contains Rally's log file.

--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -17,6 +17,11 @@
 import os
 
 
+def rally_confdir():
+    default_home = os.path.expanduser("~")
+    return os.path.join(os.getenv("RALLY_HOME", default_home), ".rally")
+
+
 def rally_root():
     return os.path.dirname(os.path.realpath(__file__))
 
@@ -40,4 +45,4 @@ def logs():
     """
     :return: The absolute path to the directory that contains Rally's log file.
     """
-    return os.path.join(os.path.expanduser("~"), ".rally", "logs")
+    return os.path.join(rally_confdir(), "logs")

--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -42,4 +42,7 @@ def install_root(cfg=None):
 
 
 def logs():
+    """
+    :return: The absolute path to the directory that contains Rally's log file.
+    """
     return os.path.join(rally_confdir(), "logs")

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -33,8 +33,9 @@ readonly ES_ARTIFACT_PATH="elasticsearch-${ES_METRICS_STORE_VERSION}"
 readonly ES_ARTIFACT="${ES_ARTIFACT_PATH}.tar.gz"
 readonly MIN_CURL_VERSION=(7 12 3)
 readonly MIN_DOCKER_MEM_BYTES=$(expr 6 \* 1024 \* 1024 \* 1024)
-readonly RALLY_LOG="${HOME}/.rally/logs/rally.log"
-readonly RALLY_LOG_BACKUP="${HOME}/.rally/logs/rally.log.it.bak"
+readonly RALLY_HOME="${RALLY_HOME:-$HOME}"
+readonly RALLY_LOG="${RALLY_HOME}/.rally/logs/rally.log"
+readonly RALLY_LOG_BACKUP="${RALLY_HOME}/.rally/logs/rally.log.it.bak"
 
 ES_PID=-1
 PROXY_CONTAINER_ID=-1
@@ -145,8 +146,8 @@ function kill_related_es_processes {
 }
 
 function set_up_metrics_store {
-    local in_memory_config_file_path="${HOME}/.rally/rally-integration-test.ini"
-    local es_config_file_path="${HOME}/.rally/rally-es-integration-test.ini"
+    local in_memory_config_file_path="${RALLY_HOME}/.rally/rally-integration-test.ini"
+    local es_config_file_path="${RALLY_HOME}/.rally/rally-es-integration-test.ini"
 
     # configure Elasticsearch instead of in-memory after the fact
     # this is more portable than using sed's in-place editing which requires "-i" on GNU and "-i ''" elsewhere.
@@ -607,7 +608,7 @@ function tear_down {
         stop_and_clean_docker_container ${PROXY_CONTAINER_ID}
     fi
 
-    rm -f ~/.rally/rally*integration-test.ini
+    rm -f ${RALLY_HOME}/.rally/rally*integration-test.ini
     rm -rf .rally_it/cache/"${ES_ARTIFACT_PATH}"
     rm -rf .rally_it/proxy_tmp
     set -e

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -102,7 +102,7 @@ def check_prerequisites():
 
 class ConfigFile:
     def __init__(self, config_name):
-        self.user_home = os.path.expanduser("~")
+        self.user_home = os.getenv("RALLY_HOME", os.path.expanduser("~"))
         self.rally_home = os.path.join(self.user_home, ".rally")
         self.config_file_name = "rally-{}.ini".format(config_name)
         self.source_path = os.path.join(os.path.dirname(__file__), "resources", self.config_file_name)
@@ -127,7 +127,6 @@ class TestCluster:
                                                                      http_port=http_port,
                                                                      node_name=node_name,
                                                                      transport_port=transport_port))
-
             self.installation_id = json.loads("".join(output))["installation-id"]
         except BaseException as e:
             raise AssertionError("Failed to install Elasticsearch {}.".format(distribution_version), e)
@@ -166,8 +165,8 @@ def install_integration_test_config():
         with open(f.target_path, "w", encoding="UTF-8") as target:
             with open(f.source_path, "r", encoding="UTF-8") as src:
                 contents = src.read()
-                # optionally allow for a homedir override in integration tests
-                user_home = os.getenv("OVERRIDE_RALLY_HOME", f.user_home)
+                # Rally allows for a RALLY_HOME homedir override. This honors the change for it tests
+                user_home = os.getenv("RALLY_HOME", f.user_home)
                 target.write(Template(contents).substitute(USER_HOME=user_home))
 
     for n in CONFIG_NAMES:

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -26,7 +26,7 @@ from unittest import TestCase
 
 import elasticsearch.exceptions
 
-from esrally import config, metrics, track, exceptions
+from esrally import config, metrics, track, exceptions, paths
 
 
 class MockClientFactory:
@@ -182,7 +182,7 @@ class EsClientTests(TestCase):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             client.guarded(raise_connection_error)
         self.assertEqual("Could not connect to your Elasticsearch metrics store. Please check that it is running on host [127.0.0.1] at "
-                         "port [9200] or fix the configuration in [%s/.rally/rally.ini]." % os.path.expanduser("~"),
+                         "port [9200] or fix the configuration in [%s/rally.ini]." % paths.rally_confdir(),
                          ctx.exception.args[0])
 
     def test_raises_sytem_setup_error_on_authentication_problems(self):
@@ -194,8 +194,8 @@ class EsClientTests(TestCase):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             client.guarded(raise_authentication_error)
         self.assertEqual("The configured user could not authenticate against your Elasticsearch metrics store running on host [127.0.0.1] "
-                         "at port [9243] (wrong password?). Please fix the configuration in [%s/.rally/rally.ini]."
-                         % os.path.expanduser("~"), ctx.exception.args[0])
+                         "at port [9243] (wrong password?). Please fix the configuration in [%s/rally.ini]."
+                         % paths.rally_confdir(), ctx.exception.args[0])
 
     def test_raises_sytem_setup_error_on_authorization_problems(self):
         def raise_authorization_error():
@@ -207,8 +207,8 @@ class EsClientTests(TestCase):
             client.guarded(raise_authorization_error)
         self.assertEqual("The configured user does not have enough privileges to run the operation [raise_authorization_error] against "
                          "your Elasticsearch metrics store running on host [127.0.0.1] at port [9243]. Please adjust your x-pack "
-                         "configuration or specify a user with enough privileges in the configuration in [%s/.rally/rally.ini]."
-                         % os.path.expanduser("~"), ctx.exception.args[0])
+                         "configuration or specify a user with enough privileges in the configuration in [%s/rally.ini]."
+                         % paths.rally_confdir(), ctx.exception.args[0])
 
     def test_raises_rally_error_on_unknown_problems(self):
         def raise_unknown_error():

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ passenv =
     JAVA11_HOME
     JAVA12_HOME
     JAVA13_HOME
-    OVERRIDE_RALLY_HOME
+    RALLY_HOME
     SSH_AUTH_SOCK
 # we do not pass LANG and LC_ALL anymore in order to isolate integration tests
 # from the test environment. Rally needs to enforce UTF-8 encoding in every


### PR DESCRIPTION
Previous commits added an override for the new python tests, but this is
not enough as the rally logs and all old tests outputs do not show up in
the proper directory. This commit adds a RALLY_HOME env var that can be
set, which will move everything in rally proper as well as all tests
into that directory, rather than splitting up the data between two
places.
