### PR TITLE
Allow to disable HTTP compression for all queries

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -402,10 +402,10 @@ With the operation type ``search`` you can execute `request body searches <http:
         2. Rally will not attempt to serialize the parameters and pass them as is. Always use "true" / "false" strings for boolean parameters (see example below).
 
 * ``body`` (mandatory): The query body.
+* ``response-compression-enabled`` (optional, defaults to ``true``): Allows to disable HTTP compression of responses. As these responses are sometimes large and decompression may be a bottleneck on the client, it is possible to turn off response compression.
 * ``detailed-results`` (optional, defaults to ``false``): Records more detailed meta-data about queries. As it analyzes the corresponding response in more detail, this might incur additional overhead which can skew measurement results. This flag is ineffective for scroll queries.
 * ``pages`` (optional): Number of pages to retrieve. If this parameter is present, a scroll query will be executed. If you want to retrieve all result pages, use the value "all".
 * ``results-per-page`` (optional):  Number of documents to retrieve per page for scroll queries.
-* ``response-compression-enabled`` (optional, defaults to ``true``): Allows to disable HTTP compression of scroll responses. As these responses are sometimes large and decompression may be a bottleneck on the client, it is possible to turn off response compression. This option is ineffective for regular queries.
 
 If ``detailed-results`` is set to ``true``, the following meta-data properties will be determined and stored:
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1085,7 +1085,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.search.return_value = as_future(io.StringIO(json.dumps(search_response)))
+        es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1110,10 +1110,12 @@ class QueryRunnerTests(TestCase):
         self.assertEqual(5, result["took"])
         self.assertFalse("error-type" in result)
 
-        es.search.assert_called_once_with(
-            index="_all",
+        es.transport.perform_request.assert_called_once_with(
+            "GET",
+            "/_all/_search",
+            params={"request_cache": "true"},
             body=params["body"],
-            params={"request_cache": "true"}
+            headers=None
         )
         es.clear_scroll.assert_not_called()
 
@@ -1139,7 +1141,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.search.return_value = as_future(io.StringIO(json.dumps(response)))
+        es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(response)))
 
         query_runner = runner.Query()
         params = {
@@ -1162,13 +1164,15 @@ class QueryRunnerTests(TestCase):
         self.assertEqual(62, result["took"])
         self.assertFalse("error-type" in result)
 
-        es.search.assert_called_once_with(
-            index="_all",
-            body=params["body"],
+        es.transport.perform_request.assert_called_once_with(
+            "GET",
+            "/_all/_search",
             params={
                 "request_cache": "false",
                 "q": "user:kimchy"
-            }
+            },
+            body=params["body"],
+            headers=None
         )
         es.clear_scroll.assert_not_called()
 
@@ -1194,7 +1198,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.search.return_value = as_future(io.StringIO(json.dumps(response)))
+        es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(response)))
 
         query_runner = runner.Query()
         params = {
@@ -1216,10 +1220,12 @@ class QueryRunnerTests(TestCase):
         self.assertNotIn("took", result)
         self.assertNotIn("error-type", result)
 
-        es.search.assert_called_once_with(
-            index="_all",
+        es.transport.perform_request.assert_called_once_with(
+            "GET",
+            "/_all/_search",
+            params={"q": "user:kimchy"},
             body=params["body"],
-            params={"q": "user:kimchy"}
+            headers=None
         )
         es.clear_scroll.assert_not_called()
 
@@ -1241,7 +1247,7 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.search.return_value = as_future(io.StringIO(json.dumps(search_response)))
+        es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1266,12 +1272,14 @@ class QueryRunnerTests(TestCase):
         self.assertEqual(5, result["took"])
         self.assertFalse("error-type" in result)
 
-        es.search.assert_called_once_with(
-            index="_all",
-            body=params["body"],
+        es.transport.perform_request.assert_called_once_with(
+            "GET",
+            "/_all/_search",
             params={
                 "request_cache": "true"
-            }
+            },
+            body=params["body"],
+            headers=None
         )
         es.clear_scroll.assert_not_called()
 
@@ -1296,14 +1304,14 @@ class QueryRunnerTests(TestCase):
                 ]
             }
         }
-        es.search.return_value = as_future(io.StringIO(json.dumps(search_response)))
+        es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
         params = {
             "index": "unittest",
             "detailed-results": True,
-            "cache": None,
+            "response-compression-enabled": False,
             "body": {
                 "query": {
                     "match_all": {}
@@ -1322,10 +1330,12 @@ class QueryRunnerTests(TestCase):
         self.assertEqual(5, result["took"])
         self.assertFalse("error-type" in result)
 
-        es.search.assert_called_once_with(
-            index="unittest",
+        es.transport.perform_request.assert_called_once_with(
+            "GET",
+            "/unittest/_search",
+            params={},
             body=params["body"],
-            params={}
+            headers={"Accept-Encoding": "identity"}
         )
         es.clear_scroll.assert_not_called()
 


### PR DESCRIPTION
With this commit we expand the support added in #941 so that not only
scroll queries can take advantage but also regular queries.

Relates #941