### PR TITLE
Pass JAVA14_HOME in build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ passenv =
     JAVA11_HOME
     JAVA12_HOME
     JAVA13_HOME
+    JAVA14_HOME
     OVERRIDE_RALLY_HOME
     SSH_AUTH_SOCK
 # we do not pass LANG and LC_ALL anymore in order to isolate integration tests


### PR DESCRIPTION
With this commit we pass the environment variable `JAVA14_HOME` in the
build if it is defined.