### PR TITLE
Move CI script to the rally repository

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -43,12 +43,12 @@ function archive {
   if [[ -d ${RALLY_DIR} ]]; then
     find ${RALLY_DIR} -name "*.log" -printf "%P\\0" | tar -cvjf ${RALLY_DIR}/${BUILD_NUMBER}.tar.bz2 -C ${RALLY_DIR} --transform "s,^,ci-${BUILD_NUMBER}/," --null -T -
   else
-    echo "Rally directory not present, this should not happen"
+    echo "Rally directory [${RALLY_DIR}] not present. Ensure the RALLY_DIR environment variable is correct"
     exit 1
   fi
 }
 
-if declare -f "$1" > /dev/null; then
+if declare -F "$1" > /dev/null; then
     $1
     exit
 else

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,0 +1,32 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eo pipefail
+export PATH="$HOME/.pyenv/bin:$PATH"
+export TERM=dumb
+export LC_ALL=en_US.UTF-8
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+make prereq
+make install
+make precommit
+make it
+
+# this will only be done if the build number variable is present
+if [ ! -z "$BUILD_NUMBER" ] && [ -d ".rally" ]; then
+  tar -cvjf .rally/$BUILD_NUMBER.tar.bzip $( find .rally/ -name "*.log" )
+fi

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Licensed to Elasticsearch B.V. under one or more contributor
 # license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright
@@ -15,7 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -eo pipefail
+# fail this script immediately if any command fails with a non-zero exit code
+set -e
+# fail on pipeline errors, e.g. when grepping
+set -o pipefail
+
 export PATH="$HOME/.pyenv/bin:$PATH"
 export TERM=dumb
 export LC_ALL=en_US.UTF-8
@@ -26,7 +32,11 @@ make install
 make precommit
 make it
 
+# Treat unset env variables as an error, but only after the make targets have completed
+set -u
+
 # this will only be done if the build number variable is present
-if [ ! -z "$BUILD_NUMBER" ] && [ -d ".rally" ]; then
-  tar -cvjf .rally/$BUILD_NUMBER.tar.bzip $( find .rally/ -name "*.log" )
+RALLY_DIR=${RALLY_HOME}/.rally
+if [ ! -z "${BUILD_NUMBER}" ] && [ -d ${RALLY_DIR} ]; then
+  tar -cvjf ${RALLY_DIR}/${BUILD_NUMBER}.tar.bzip $( find ${RALLY_DIR} -name "*.log" )
 fi


### PR DESCRIPTION
This script was previously in a repository that did not allow the rally
team to quickly iterate on, and instead relied on a team that is not
responsible for rally related functionality to approve changes
therein. This commit moves the script into the rally repository so that
it can be iterated on by the rally team.