### PR TITLE
Disable docstring linter check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -191,7 +191,8 @@ disable=print-statement,
         W0404,
         W0612,
         W0613,
-        W0621
+        W0621,
+        invalid-docstring-quote
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/esrally/version.py
+++ b/esrally/version.py
@@ -42,6 +42,8 @@ def revision():
 
 
 def version():
+    # Disabled not because this is an actual issue here but it is occasionally reported by pylint in CI.
+    # pylint:disable=invalid-docstring-quote
     """
     :return: The release version string and an optional suffix for the current git revision if Rally is installed in development mode.
     """

--- a/esrally/version.py
+++ b/esrally/version.py
@@ -42,8 +42,6 @@ def revision():
 
 
 def version():
-    # Disabled not because this is an actual issue here but it is occasionally reported by pylint in CI.
-    # pylint:disable=invalid-docstring-quote
     """
     :return: The release version string and an optional suffix for the current git revision if Rally is installed in development mode.
     """


### PR DESCRIPTION
With this commit we disable a linter check for invalid docstring quotes as this
causes CI failures sometimes but without being reproducible outside of CI.