### PR TITLE
Reduce mapped memory with many bulk clients

### DIFF
--- a/esrally/driver/async_driver.py
+++ b/esrally/driver/async_driver.py
@@ -240,8 +240,10 @@ class AsyncDriver:
                 for sub_task in task:
                     self.current_tasks.append(sub_task)
                     self.logger.info("Running task [%s] with [%d] clients...", sub_task.name, sub_task.clients)
+                    # A parameter source should only be created once per task - it is partitioned later on per client.
+                    param_source = track.operation_parameters(self.track, task)
                     for client_id in range(sub_task.clients):
-                        schedule = driver.schedule_for(self.track, sub_task, client_id)
+                        schedule = driver.schedule_for(param_source, sub_task, client_id)
                         # used to indicate that we want to prematurely consider this completed. This is *not* due to
                         # cancellation but a regular event in a benchmark and used to model task dependency of parallel tasks.
                         complete = threading.Event()

--- a/esrally/driver/async_driver.py
+++ b/esrally/driver/async_driver.py
@@ -243,7 +243,7 @@ class AsyncDriver:
                     # A parameter source should only be created once per task - it is partitioned later on per client.
                     param_source = track.operation_parameters(self.track, task)
                     for client_id in range(sub_task.clients):
-                        schedule = driver.schedule_for(param_source, sub_task, client_id)
+                        schedule = driver.schedule_for(sub_task, client_id, param_source)
                         # used to indicate that we want to prematurely consider this completed. This is *not* due to
                         # cancellation but a regular event in a benchmark and used to model task dependency of parallel tasks.
                         complete = threading.Event()

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1167,7 +1167,7 @@ class AsyncIoAdapter:
             #
             # Now we need to ensure that we start partitioning parameters correctly in both cases. And that means we
             # need to start from (client) index 0 in both cases instead of 0 for indexA and 4 for indexB.
-            schedule = schedule_for(params_per_task[task], task, task_allocation.client_index_in_task)
+            schedule = schedule_for(task, task_allocation.client_index_in_task, params_per_task[task])
             async_executor = AsyncExecutor(
                 client_id, task, schedule, es, self.sampler, self.cancel, self.complete, self.abort_on_error)
             final_executor = AsyncProfiler(async_executor) if self.profiling_enabled else async_executor
@@ -1519,13 +1519,13 @@ class Allocator:
 
 # Runs a concrete schedule on one worker client
 # Needs to determine the runners and concrete iterations per client.
-def schedule_for(parameter_source, task, client_index):
+def schedule_for(task, client_index, parameter_source):
     """
     Calculates a client's schedule for a given task.
 
-    :param parameter_source: The current track.
     :param task: The task that should be executed.
     :param client_index: The current client index.  Must be in the range [0, `task.clients').
+    :param parameter_source: The parameter source that should be used for this task.
     :return: A generator for the operations the given client needs to perform for this task.
     """
     logger = logging.getLogger(__name__)

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -20,6 +20,7 @@ import collections
 import concurrent.futures
 import datetime
 import logging
+import math
 import multiprocessing
 import queue
 import threading
@@ -692,21 +693,38 @@ def calculate_worker_assignments(host_configs, client_count):
              in that list contains another list with the clients that should be assigned to these workers.
     """
     assignments = []
-
+    client_idx = 0
+    host_count = len(host_configs)
+    clients_per_host = math.ceil(client_count / host_count)
+    remaining_clients = client_count
     for host_config in host_configs:
-        assignments.append({
+        # the last host might not need to simulate as many clients as the rest of the hosts as we eagerly
+        # assign clients to hosts.
+        clients_on_this_host = min(clients_per_host, remaining_clients)
+        assignment = {
             "host": host_config["host"],
-            "workers": [[] for _ in range(host_config["cores"])],
-            "worker": 0
-        })
+            "workers": [],
+        }
+        assignments.append(assignment)
 
-    for client_idx in range(client_count):
-        host = assignments[client_idx % len(assignments)]
-        workers = host["workers"]
-        worker_idx = host["worker"]
-        worker = host["workers"][worker_idx % len(workers)]
-        worker.append(client_idx)
-        host["worker"] = worker_idx + 1
+        workers_on_this_host = host_config["cores"]
+        clients_per_worker = [0] * workers_on_this_host
+
+        # determine how many clients each worker should simulate
+        for c in range(clients_on_this_host):
+            clients_per_worker[c % workers_on_this_host] += 1
+
+        # assign client ids to workers
+        for worker_idx, client_count in enumerate(clients_per_worker):
+            worker_assignment = []
+            assignment["workers"].append(worker_assignment)
+            for c in range(client_idx, client_idx + client_count):
+                worker_assignment.append(c)
+            client_idx += client_count
+
+        remaining_clients -= clients_on_this_host
+
+    assert remaining_clients == 0
 
     return assignments
 
@@ -1134,7 +1152,13 @@ class AsyncIoAdapter:
         es = es_clients(self.cfg.opts("client", "hosts").all_hosts, self.cfg.opts("client", "options").all_client_options)
 
         aws = []
-        for client_id, task in self.task_allocations:
+        # A parameter source should only be created once per task - it is partitioned later on per client.
+        params_per_task = {}
+        for client_id, task_allocation in self.task_allocations:
+            task = task_allocation.task
+            if task not in params_per_task:
+                param_source = track.operation_parameters(self.track, task)
+                params_per_task[task] = param_source
             # We cannot use the global client index here because we need to support parallel execution of tasks
             # with multiple clients. Consider the following scenario:
             #
@@ -1143,9 +1167,9 @@ class AsyncIoAdapter:
             #
             # Now we need to ensure that we start partitioning parameters correctly in both cases. And that means we
             # need to start from (client) index 0 in both cases instead of 0 for indexA and 4 for indexB.
-            schedule = schedule_for(self.track, task.task, task.client_index_in_task)
+            schedule = schedule_for(params_per_task[task], task, task_allocation.client_index_in_task)
             async_executor = AsyncExecutor(
-                client_id, task.task, schedule, es, self.sampler, self.cancel, self.complete, self.abort_on_error)
+                client_id, task, schedule, es, self.sampler, self.cancel, self.complete, self.abort_on_error)
             final_executor = AsyncProfiler(async_executor) if self.profiling_enabled else async_executor
             aws.append(final_executor())
         run_start = time.perf_counter()
@@ -1495,11 +1519,11 @@ class Allocator:
 
 # Runs a concrete schedule on one worker client
 # Needs to determine the runners and concrete iterations per client.
-def schedule_for(current_track, task, client_index):
+def schedule_for(parameter_source, task, client_index):
     """
     Calculates a client's schedule for a given task.
 
-    :param current_track: The current track.
+    :param parameter_source: The current track.
     :param task: The task that should be executed.
     :param client_index: The current client index.  Must be in the range [0, `task.clients').
     :return: A generator for the operations the given client needs to perform for this task.
@@ -1510,7 +1534,7 @@ def schedule_for(current_track, task, client_index):
     sched = scheduler.scheduler_for(task.schedule, task.params)
     logger.info("Choosing [%s] for [%s].", sched, task)
     runner_for_op = runner.runner_for(op.type)
-    params_for_op = track.operation_parameters(current_track, task).partition(client_index, num_clients)
+    params_for_op = parameter_source.partition(client_index, num_clients)
 
     if requires_time_period_schedule(task, runner_for_op, params_for_op):
         warmup_time_period = task.warmup_time_period if task.warmup_time_period else 0

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -488,6 +488,10 @@ class BulkIndexParamSource(ParamSource):
             raise exceptions.InvalidSyntax("'batch-size' must be numeric")
 
         self.ingest_percentage = self.float_param(params, name="ingest-percentage", default_value=100, min_value=0, max_value=100)
+        self.param_source = PartitionBulkIndexParamSource(self.corpora, self.batch_size, self.bulk_size,
+                                                          self.ingest_percentage, self.id_conflicts,
+                                                          self.conflict_probability, self.on_conflict,
+                                                          self.recency, self.pipeline, self._params)
 
     def float_param(self, params, name, default_value, min_value, max_value, min_operator=operator.le):
         try:
@@ -521,22 +525,20 @@ class BulkIndexParamSource(ParamSource):
         return corpora
 
     def partition(self, partition_index, total_partitions):
-        return PartitionBulkIndexParamSource(self.corpora, partition_index, total_partitions, self.batch_size, self.bulk_size,
-                                             self.ingest_percentage, self.id_conflicts, self.conflict_probability, self.on_conflict,
-                                             self.recency, self.pipeline, self._params)
+        # register the new partition internally
+        self.param_source.partition(partition_index, total_partitions)
+        return self.param_source
 
     def params(self):
         raise exceptions.RallyError("Do not use a BulkIndexParamSource without partitioning")
 
 
 class PartitionBulkIndexParamSource:
-    def __init__(self, corpora, partition_index, total_partitions, batch_size, bulk_size, ingest_percentage,
-                 id_conflicts, conflict_probability, on_conflict, recency, pipeline=None, original_params=None):
+    def __init__(self, corpora, batch_size, bulk_size, ingest_percentage, id_conflicts, conflict_probability,
+                 on_conflict, recency, pipeline=None, original_params=None):
         """
 
         :param corpora: Specification of affected document corpora.
-        :param partition_index: The current partition index.  Must be in the range [0, `total_partitions`).
-        :param total_partitions: The total number of partitions (i.e. clients) for bulk index operations.
         :param batch_size: The number of documents to read in one go.
         :param bulk_size: The size of bulk index operations (number of documents per bulk).
         :param ingest_percentage: A number between (0.0, 100.0] that defines how much of the whole corpus should be ingested.
@@ -549,33 +551,55 @@ class PartitionBulkIndexParamSource:
         :param original_params: The original dict passed to the parent parameter source.
         """
         self.corpora = corpora
-        self.partition_index = partition_index
-        self.total_partitions = total_partitions
+        self.partitions = []
+        self.total_partitions = None
         self.batch_size = batch_size
         self.bulk_size = bulk_size
         self.ingest_percentage = ingest_percentage
         self.id_conflicts = id_conflicts
+        self.conflict_probability = conflict_probability
+        self.on_conflict = on_conflict
+        self.recency = recency
         self.pipeline = pipeline
+        self.original_params = original_params
         # this is only intended for unit-testing
-        create_reader = original_params.pop("__create_reader", create_default_reader)
-        self.internal_params = bulk_data_based(total_partitions, partition_index, corpora, batch_size,
-                                               bulk_size, id_conflicts, conflict_probability, on_conflict, recency,
-                                               pipeline, original_params, create_reader)
+        self.create_reader = original_params.pop("__create_reader", create_default_reader)
         self.current_bulk = 0
-        all_bulks = number_of_bulks(self.corpora, self.partition_index, self.total_partitions, self.bulk_size)
-        self.total_bulks = math.ceil((all_bulks * self.ingest_percentage) / 100)
+        # use a value > 0 so percent_completed returns a sensible value
+        self.total_bulks = 1
         self.infinite = False
 
     def partition(self, partition_index, total_partitions):
-        raise exceptions.RallyError("Cannot partition a PartitionBulkIndexParamSource further")
+        if self.total_partitions is None:
+            self.total_partitions = total_partitions
+        elif self.total_partitions != total_partitions:
+            raise exceptions.RallyAssertionError(
+                f"Total partitions is expected to be [{self.total_partitions}] but was [{total_partitions}]")
+        self.partitions.append(partition_index)
 
     def params(self):
+        if self.current_bulk == 0:
+            self._init_internal_params()
         # self.internal_params always reads all files. This is necessary to ensure we terminate early in case
         # the user has specified ingest percentage.
         if self.current_bulk == self.total_bulks:
             raise StopIteration()
         self.current_bulk += 1
         return next(self.internal_params)
+
+    def _init_internal_params(self):
+        # contains a continuous range of client ids
+        self.partitions = sorted(self.partitions)
+        start_index = self.partitions[0]
+        end_index = self.partitions[-1]
+
+        self.internal_params = bulk_data_based(self.total_partitions, start_index, end_index, self.corpora,
+                                               self.batch_size, self.bulk_size, self.id_conflicts,
+                                               self.conflict_probability, self.on_conflict, self.recency,
+                                               self.pipeline, self.original_params, self.create_reader)
+
+        all_bulks = number_of_bulks(self.corpora, start_index, end_index, self.total_partitions, self.bulk_size)
+        self.total_bulks = math.ceil((all_bulks * self.ingest_percentage) / 100)
 
     @property
     def percent_completed(self):
@@ -602,15 +626,15 @@ class ForceMergeParamSource(ParamSource):
         }
 
 
-def number_of_bulks(corpora, partition_index, total_partitions, bulk_size):
+def number_of_bulks(corpora, start_partition_index, end_partition_index, total_partitions, bulk_size):
     """
     :return: The number of bulk operations that the given client will issue.
     """
     bulks = 0
     for corpus in corpora:
         for docs in corpus.documents:
-            _, num_docs, _ = bounds(docs.number_of_documents, partition_index, total_partitions,
-                                    docs.includes_action_and_meta_data)
+            _, num_docs, _ = bounds(docs.number_of_documents, start_partition_index, end_partition_index,
+                                    total_partitions, docs.includes_action_and_meta_data)
             complete_bulks, rest = (num_docs // bulk_size, num_docs % bulk_size)
             bulks += complete_bulks
             if rest > 0:
@@ -657,42 +681,45 @@ def create_default_reader(docs, offset, num_lines, num_docs, batch_size, bulk_si
         return MetadataIndexDataReader(docs.document_file, batch_size, bulk_size, source, am_handler, docs.target_index, docs.target_type)
 
 
-def create_readers(num_clients, client_index, corpora, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict, recency,
-                   create_reader):
+def create_readers(num_clients, start_client_index, end_client_index, corpora, batch_size, bulk_size, id_conflicts,
+                   conflict_probability, on_conflict, recency, create_reader):
     logger = logging.getLogger(__name__)
     readers = []
     for corpus in corpora:
         for docs in corpus.documents:
-            offset, num_docs, num_lines = bounds(docs.number_of_documents, client_index, num_clients,
-                                                 docs.includes_action_and_meta_data)
+            offset, num_docs, num_lines = bounds(docs.number_of_documents, start_client_index, end_client_index,
+                                                 num_clients, docs.includes_action_and_meta_data)
             if num_docs > 0:
-                logger.info("Task-relative client at index [%d] will bulk index [%d] docs starting from line offset [%d] for [%s/%s] "
-                            "from corpus [%s].", client_index, num_docs, offset, docs.target_index, docs.target_type, corpus.name)
-                readers.append(create_reader(docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability,
-                                             on_conflict, recency))
+                logger.info("Task-relative clients at index [%d-%d] will bulk index [%d] docs starting from line offset [%d] for [%s/%s] "
+                            "from corpus [%s].", start_client_index, end_client_index, num_docs, offset,
+                            docs.target_index, docs.target_type, corpus.name)
+                readers.append(create_reader(docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts,
+                                             conflict_probability, on_conflict, recency))
             else:
-                logger.info("Task-relative client at index [%d] skips [%s] (no documents to read).", client_index, corpus.name)
+                logger.info("Task-relative clients at index [%d-%d] skip [%s] (no documents to read).",
+                            start_client_index, end_client_index, corpus.name)
     return readers
 
 
-def bounds(total_docs, client_index, num_clients, includes_action_and_meta_data):
+def bounds(total_docs, start_client_index, end_client_index, num_clients, includes_action_and_meta_data):
     """
 
-    Calculates the start offset and number of documents for each client.
+    Calculates the start offset and number of documents for a range of clients.
 
     :param total_docs: The total number of documents to index.
-    :param client_index: The current client index.  Must be in the range [0, `num_clients').
+    :param start_client_index: The first client index.  Must be in the range [0, `num_clients').
+    :param end_client_index: The last client index.  Must be in the range [0, `num_clients').
     :param num_clients: The total number of clients that will run bulk index operations.
     :param includes_action_and_meta_data: Whether the source file already includes the action and meta-data line.
-    :return: A tuple containing: the start offset (in lines) for the document corpus, the number documents that the client should index,
-    and the number of lines that the client should read.
+    :return: A tuple containing: the start offset (in lines) for the document corpus, the number documents that the
+             clients should index, and the number of lines that the clients should read.
     """
     source_lines_per_doc = 2 if includes_action_and_meta_data else 1
 
     docs_per_client = total_docs / num_clients
 
-    start_offset_docs = round(docs_per_client * client_index)
-    end_offset_docs = round(docs_per_client * (client_index + 1))
+    start_offset_docs = round(docs_per_client * start_client_index)
+    end_offset_docs = round(docs_per_client * (end_client_index + 1))
 
     offset_lines = start_offset_docs * source_lines_per_doc
     docs = end_offset_docs - start_offset_docs
@@ -701,7 +728,7 @@ def bounds(total_docs, client_index, num_clients, includes_action_and_meta_data)
     return offset_lines, docs, lines
 
 
-def bulk_generator(readers, client_index, pipeline, original_params):
+def bulk_generator(readers, pipeline, original_params):
     bulk_id = 0
     for index, type, batch in readers:
         # each batch can contain of one or more bulks
@@ -715,9 +742,7 @@ def bulk_generator(readers, client_index, pipeline, original_params):
                 "action-metadata-present": True,
                 "body": bulk,
                 # This is not always equal to the bulk_size we get as parameter. The last bulk may be less than the bulk size.
-                "bulk-size": docs_in_bulk,
-                # a globally unique id for this bulk
-                "bulk-id": "%d-%d" % (client_index, bulk_id)
+                "bulk-size": docs_in_bulk
             }
             if pipeline:
                 bulk_params["pipeline"] = pipeline
@@ -727,13 +752,14 @@ def bulk_generator(readers, client_index, pipeline, original_params):
             yield params
 
 
-def bulk_data_based(num_clients, client_index, corpora, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict, recency,
-                    pipeline, original_params, create_reader=create_default_reader):
+def bulk_data_based(num_clients, start_client_index, end_client_index, corpora, batch_size, bulk_size, id_conflicts,
+                    conflict_probability, on_conflict, recency, pipeline, original_params, create_reader=create_default_reader):
     """
     Calculates the necessary schedule for bulk operations.
 
     :param num_clients: The total number of clients that will run the bulk operation.
-    :param client_index: The current client for which we calculated the schedule. Must be in the range [0, `num_clients').
+    :param start_client_index: The first client for which we calculated the schedule. Must be in the range [0, `num_clients').
+    :param end_client_index: The last client for which we calculated the schedule. Must be in the range [0, `num_clients').
     :param corpora: Specification of affected document corpora.
     :param batch_size: The number of documents to read in one go.
     :param bulk_size: The size of bulk index operations (number of documents per bulk).
@@ -748,9 +774,9 @@ def bulk_data_based(num_clients, client_index, corpora, batch_size, bulk_size, i
                       intended for testing only.
     :return: A generator for the bulk operations of the given client.
     """
-    readers = create_readers(num_clients, client_index, corpora, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict,
+    readers = create_readers(num_clients, start_client_index, end_client_index, corpora, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict,
                              recency, create_reader)
-    return bulk_generator(chain(*readers), client_index, pipeline, original_params)
+    return bulk_generator(chain(*readers), pipeline, original_params)
 
 
 class GenerateActionMetaData:

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -774,8 +774,8 @@ def bulk_data_based(num_clients, start_client_index, end_client_index, corpora, 
                       intended for testing only.
     :return: A generator for the bulk operations of the given client.
     """
-    readers = create_readers(num_clients, start_client_index, end_client_index, corpora, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict,
-                             recency, create_reader)
+    readers = create_readers(num_clients, start_client_index, end_client_index, corpora, batch_size, bulk_size,
+                             id_conflicts, conflict_probability, on_conflict, recency, create_reader)
     return bulk_generator(chain(*readers), pipeline, original_params)
 
 

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -265,8 +265,7 @@ class WorkerAssignmentTests(TestCase):
                     [1],
                     [2],
                     [3]
-                ],
-                "worker": 4
+                ]
             }
         ], assignments)
 
@@ -282,12 +281,11 @@ class WorkerAssignmentTests(TestCase):
             {
                 "host": "localhost",
                 "workers": [
-                    [0, 4],
-                    [1, 5],
-                    [2],
-                    [3]
-                ],
-                "worker": 6
+                    [0, 1],
+                    [2, 3],
+                    [4],
+                    [5]
+                ]
             }
         ], assignments)
 
@@ -307,8 +305,7 @@ class WorkerAssignmentTests(TestCase):
                     [1],
                     [],
                     []
-                ],
-                "worker": 2
+                ]
             }
         ], assignments)
 
@@ -330,22 +327,20 @@ class WorkerAssignmentTests(TestCase):
             {
                 "host": "host-a",
                 "workers": [
-                    [0, 8],
-                    [2, 10],
-                    [4, 12],
-                    [6, 14]
-                ],
-                "worker": 8
+                    [0, 1],
+                    [2, 3],
+                    [4, 5],
+                    [6, 7]
+                ]
             },
             {
                 "host": "host-b",
                 "workers": [
-                    [1, 9],
-                    [3, 11],
-                    [5, 13],
-                    [7, 15]
-                ],
-                "worker": 8
+                    [8, 9],
+                    [10, 11],
+                    [12, 13],
+                    [14, 15]
+                ]
             }
         ], assignments)
 
@@ -368,23 +363,70 @@ class WorkerAssignmentTests(TestCase):
                 "host": "host-a",
                 "workers": [
                     [0],
-                    [2],
+                    [1],
                     [],
                     []
-                ],
-                "worker": 2
+                ]
             },
             {
                 "host": "host-b",
                 "workers": [
-                    [1],
+                    [2],
                     [3],
                     [],
                     []
-                ],
-                "worker": 2
+                ]
             }
         ], assignments)
+
+    def test_uneven_assignment_across_hosts(self):
+        host_configs = [
+            {
+                "host": "host-a",
+                "cores": 4
+            },
+            {
+                "host": "host-b",
+                "cores": 4
+            },
+            {
+                "host": "host-c",
+                "cores": 4
+            }
+        ]
+
+        assignments = driver.calculate_worker_assignments(host_configs, client_count=17)
+
+        self.assertEqual([
+            {
+                "host": "host-a",
+                "workers": [
+                    [0, 1],
+                    [2, 3],
+                    [4],
+                    [5]
+                ]
+            },
+            {
+                "host": "host-b",
+                "workers": [
+                    [6, 7],
+                    [8, 9],
+                    [10],
+                    [11]
+                ]
+            },
+            {
+                "host": "host-c",
+                "workers": [
+                    [12, 13],
+                    [14],
+                    [15],
+                    [16]
+                ]
+            }
+        ], assignments)
+
 
 
 class AllocatorTests(TestCase):
@@ -640,7 +682,8 @@ class SchedulerTests(TestCase):
     async def test_search_task_one_client(self):
         task = track.Task("search", track.Operation("search", track.OperationType.Search.name, param_source="driver-test-param-source"),
                           warmup_iterations=3, iterations=5, clients=1, params={"target-throughput": 10, "clients": 1})
-        schedule = driver.schedule_for(self.test_track, task, 0)
+        param_source = track.operation_parameters(self.test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         expected_schedule = [
             (0, metrics.SampleType.Warmup, 1 / 8, {}),
@@ -658,7 +701,8 @@ class SchedulerTests(TestCase):
     async def test_search_task_two_clients(self):
         task = track.Task("search", track.Operation("search", track.OperationType.Search.name, param_source="driver-test-param-source"),
                           warmup_iterations=1, iterations=5, clients=2, params={"target-throughput": 10, "clients": 2})
-        schedule = driver.schedule_for(self.test_track, task, 0)
+        param_source = track.operation_parameters(self.test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         expected_schedule = [
             (0, metrics.SampleType.Warmup, 1 / 6, {}),
@@ -677,7 +721,8 @@ class SchedulerTests(TestCase):
                                                         param_source="driver-test-param-source"),
                           clients=1, params={"target-throughput": 4, "clients": 4})
 
-        schedule = driver.schedule_for(self.test_track, task, 0)
+        param_source = track.operation_parameters(self.test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, 1 / 3, {"body": ["a"], "size": 3}),
@@ -691,7 +736,8 @@ class SchedulerTests(TestCase):
                                                         param_source="driver-test-param-source"),
                           warmup_iterations=2, clients=1, params={"target-throughput": 4, "clients": 4})
 
-        schedule = driver.schedule_for(self.test_track, task, 0)
+        param_source = track.operation_parameters(self.test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Warmup, 1 / 5, {"body": ["a"], "size": 5}),
@@ -708,7 +754,8 @@ class SchedulerTests(TestCase):
                                                         param_source="driver-test-param-source"),
                           clients=1, params={"target-throughput": 4, "clients": 4})
 
-        schedule = driver.schedule_for(self.test_track, task, 0)
+        param_source = track.operation_parameters(self.test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, 1 / 1, {"body": ["a"]}),
@@ -720,7 +767,8 @@ class SchedulerTests(TestCase):
                                                         param_source="driver-test-param-source"),
                           warmup_time_period=0, clients=4, params={"target-throughput": 4, "clients": 4})
 
-        schedule = driver.schedule_for(self.test_track, task, 0)
+        param_source = track.operation_parameters(self.test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, 1 / 11, {"body": ["a"], "size": 11}),
@@ -742,7 +790,8 @@ class SchedulerTests(TestCase):
                                                         param_source="driver-test-param-source"),
                           warmup_time_period=0, clients=4, params={"target-throughput": 4, "clients": 4})
 
-        schedule = driver.schedule_for(self.test_track, task, 0)
+        param_source = track.operation_parameters(self.test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
@@ -758,7 +807,8 @@ class SchedulerTests(TestCase):
                                                         param_source="driver-test-param-source"),
                           warmup_time_period=0, clients=4, params={"target-throughput": 4, "clients": 4})
 
-        schedule = driver.schedule_for(self.test_track, task, 0)
+        param_source = track.operation_parameters(self.test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, 1 / 5, {"body": ["a"], "size": 5}),
@@ -776,7 +826,8 @@ class SchedulerTests(TestCase):
                           clients=1,
                           params={"target-throughput": 1, "clients": 1})
 
-        schedule = driver.schedule_for(self.test_track, task, 0)
+        param_source = track.operation_parameters(self.test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
@@ -792,7 +843,8 @@ class SchedulerTests(TestCase):
                                                         param_source="driver-test-param-source"), warmup_time_period=0.1, time_period=0.1,
                           clients=1)
 
-        schedule_handle = driver.schedule_for(self.test_track, task, 0)
+        param_source = track.operation_parameters(self.test_track, task)
+        schedule_handle = driver.schedule_for(param_source, task, 0)
         schedule = schedule_handle()
 
         last_progress = -1
@@ -880,7 +932,8 @@ class AsyncExecutorTests(TestCase):
         },
                                                         param_source="driver-test-param-source"),
                           warmup_time_period=0, clients=4)
-        schedule = driver.schedule_for(test_track, task, 0)
+        param_source = track.operation_parameters(test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         sampler = driver.Sampler(start_timestamp=time.perf_counter())
         cancel = threading.Event()
@@ -937,7 +990,8 @@ class AsyncExecutorTests(TestCase):
             # The runner will determine progress
             "size": None
         }, param_source="driver-test-param-source"), warmup_time_period=0, clients=4)
-        schedule = driver.schedule_for(test_track, task, 0)
+        param_source = track.operation_parameters(test_track, task)
+        schedule = driver.schedule_for(param_source, task, 0)
 
         sampler = driver.Sampler(start_timestamp=time.perf_counter())
         cancel = threading.Event()
@@ -1011,7 +1065,8 @@ class AsyncExecutorTests(TestCase):
             cancel = threading.Event()
             complete = threading.Event()
 
-            schedule = driver.schedule_for(test_track, task, 0)
+            param_source = track.operation_parameters(test_track, task)
+            schedule = driver.schedule_for(param_source, task, 0)
             execute_schedule = driver.AsyncExecutor(client_id=0,
                                                     task=task,
                                                     schedule=schedule,
@@ -1056,7 +1111,9 @@ class AsyncExecutorTests(TestCase):
                                                             param_source="driver-test-param-source"),
                               warmup_time_period=0.5, time_period=0.5, clients=4,
                               params={"target-throughput": target_throughput, "clients": 4})
-            schedule = driver.schedule_for(test_track, task, 0)
+
+            param_source = track.operation_parameters(test_track, task)
+            schedule = driver.schedule_for(param_source, task, 0)
             sampler = driver.Sampler(start_timestamp=0)
 
             cancel = threading.Event()

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -683,7 +683,7 @@ class SchedulerTests(TestCase):
         task = track.Task("search", track.Operation("search", track.OperationType.Search.name, param_source="driver-test-param-source"),
                           warmup_iterations=3, iterations=5, clients=1, params={"target-throughput": 10, "clients": 1})
         param_source = track.operation_parameters(self.test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         expected_schedule = [
             (0, metrics.SampleType.Warmup, 1 / 8, {}),
@@ -702,7 +702,7 @@ class SchedulerTests(TestCase):
         task = track.Task("search", track.Operation("search", track.OperationType.Search.name, param_source="driver-test-param-source"),
                           warmup_iterations=1, iterations=5, clients=2, params={"target-throughput": 10, "clients": 2})
         param_source = track.operation_parameters(self.test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         expected_schedule = [
             (0, metrics.SampleType.Warmup, 1 / 6, {}),
@@ -722,7 +722,7 @@ class SchedulerTests(TestCase):
                           clients=1, params={"target-throughput": 4, "clients": 4})
 
         param_source = track.operation_parameters(self.test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, 1 / 3, {"body": ["a"], "size": 3}),
@@ -737,7 +737,7 @@ class SchedulerTests(TestCase):
                           warmup_iterations=2, clients=1, params={"target-throughput": 4, "clients": 4})
 
         param_source = track.operation_parameters(self.test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Warmup, 1 / 5, {"body": ["a"], "size": 5}),
@@ -755,7 +755,7 @@ class SchedulerTests(TestCase):
                           clients=1, params={"target-throughput": 4, "clients": 4})
 
         param_source = track.operation_parameters(self.test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, 1 / 1, {"body": ["a"]}),
@@ -768,7 +768,7 @@ class SchedulerTests(TestCase):
                           warmup_time_period=0, clients=4, params={"target-throughput": 4, "clients": 4})
 
         param_source = track.operation_parameters(self.test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, 1 / 11, {"body": ["a"], "size": 11}),
@@ -791,7 +791,7 @@ class SchedulerTests(TestCase):
                           warmup_time_period=0, clients=4, params={"target-throughput": 4, "clients": 4})
 
         param_source = track.operation_parameters(self.test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
@@ -808,7 +808,7 @@ class SchedulerTests(TestCase):
                           warmup_time_period=0, clients=4, params={"target-throughput": 4, "clients": 4})
 
         param_source = track.operation_parameters(self.test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, 1 / 5, {"body": ["a"], "size": 5}),
@@ -827,7 +827,7 @@ class SchedulerTests(TestCase):
                           params={"target-throughput": 1, "clients": 1})
 
         param_source = track.operation_parameters(self.test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         await self.assert_schedule([
             (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
@@ -844,7 +844,7 @@ class SchedulerTests(TestCase):
                           clients=1)
 
         param_source = track.operation_parameters(self.test_track, task)
-        schedule_handle = driver.schedule_for(param_source, task, 0)
+        schedule_handle = driver.schedule_for(task, 0, param_source)
         schedule = schedule_handle()
 
         last_progress = -1
@@ -933,7 +933,7 @@ class AsyncExecutorTests(TestCase):
                                                         param_source="driver-test-param-source"),
                           warmup_time_period=0, clients=4)
         param_source = track.operation_parameters(test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         sampler = driver.Sampler(start_timestamp=time.perf_counter())
         cancel = threading.Event()
@@ -991,7 +991,7 @@ class AsyncExecutorTests(TestCase):
             "size": None
         }, param_source="driver-test-param-source"), warmup_time_period=0, clients=4)
         param_source = track.operation_parameters(test_track, task)
-        schedule = driver.schedule_for(param_source, task, 0)
+        schedule = driver.schedule_for(task, 0, param_source)
 
         sampler = driver.Sampler(start_timestamp=time.perf_counter())
         cancel = threading.Event()
@@ -1066,7 +1066,7 @@ class AsyncExecutorTests(TestCase):
             complete = threading.Event()
 
             param_source = track.operation_parameters(test_track, task)
-            schedule = driver.schedule_for(param_source, task, 0)
+            schedule = driver.schedule_for(task, 0, param_source)
             execute_schedule = driver.AsyncExecutor(client_id=0,
                                                     task=task,
                                                     schedule=schedule,
@@ -1113,7 +1113,7 @@ class AsyncExecutorTests(TestCase):
                               params={"target-throughput": target_throughput, "clients": 4})
 
             param_source = track.operation_parameters(test_track, task)
-            schedule = driver.schedule_for(param_source, task, 0)
+            schedule = driver.schedule_for(task, 0, param_source)
             sampler = driver.Sampler(start_timestamp=0)
 
             cancel = threading.Event()

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -581,50 +581,74 @@ class InvocationGeneratorTests(TestCase):
         self.assertEqual(1, i1.exit_count)
 
     def test_calculate_bounds(self):
-        self.assertEqual((0, 1000, 1000), params.bounds(1000, 0, 0, 1, includes_action_and_meta_data=False))
-        self.assertEqual((0, 1000, 2000), params.bounds(1000, 0, 0, 1, includes_action_and_meta_data=True))
+        num_docs = 1000
+        clients = 1
+        self.assertEqual((0, 1000, 1000), params.bounds(num_docs, 0, 0, clients, includes_action_and_meta_data=False))
+        self.assertEqual((0, 1000, 2000), params.bounds(num_docs, 0, 0, clients, includes_action_and_meta_data=True))
 
-        self.assertEqual((  0, 500, 500), params.bounds(1000, 0, 0, 2, includes_action_and_meta_data=False))
-        self.assertEqual((500, 500, 500), params.bounds(1000, 1, 1, 2, includes_action_and_meta_data=False))
+        num_docs = 1000
+        clients = 2
+        self.assertEqual((  0, 500, 500), params.bounds(num_docs, 0, 0, clients, includes_action_and_meta_data=False))
+        self.assertEqual((500, 500, 500), params.bounds(num_docs, 1, 1, clients, includes_action_and_meta_data=False))
 
-        self.assertEqual((   0, 200, 400), params.bounds(800, 0, 0, 4, includes_action_and_meta_data=True))
-        self.assertEqual(( 400, 200, 400), params.bounds(800, 1, 1, 4, includes_action_and_meta_data=True))
-        self.assertEqual(( 800, 200, 400), params.bounds(800, 2, 2, 4, includes_action_and_meta_data=True))
-        self.assertEqual((1200, 200, 400), params.bounds(800, 3, 3, 4, includes_action_and_meta_data=True))
+        num_docs = 800
+        clients = 4
+        self.assertEqual((   0, 200, 400), params.bounds(num_docs, 0, 0, clients, includes_action_and_meta_data=True))
+        self.assertEqual(( 400, 200, 400), params.bounds(num_docs, 1, 1, clients, includes_action_and_meta_data=True))
+        self.assertEqual(( 800, 200, 400), params.bounds(num_docs, 2, 2, clients, includes_action_and_meta_data=True))
+        self.assertEqual((1200, 200, 400), params.bounds(num_docs, 3, 3, clients, includes_action_and_meta_data=True))
 
-        self.assertEqual((   0, 250, 250), params.bounds(2000, 0, 0, 8, includes_action_and_meta_data=False))
-        self.assertEqual(( 250, 250, 250), params.bounds(2000, 1, 1, 8, includes_action_and_meta_data=False))
-        self.assertEqual(( 500, 250, 250), params.bounds(2000, 2, 2, 8, includes_action_and_meta_data=False))
-        self.assertEqual(( 750, 250, 250), params.bounds(2000, 3, 3, 8, includes_action_and_meta_data=False))
-        self.assertEqual((1000, 250, 250), params.bounds(2000, 4, 4, 8, includes_action_and_meta_data=False))
-        self.assertEqual((1250, 250, 250), params.bounds(2000, 5, 5, 8, includes_action_and_meta_data=False))
-        self.assertEqual((1500, 250, 250), params.bounds(2000, 6, 6, 8, includes_action_and_meta_data=False))
-        self.assertEqual((1750, 250, 250), params.bounds(2000, 7, 7, 8, includes_action_and_meta_data=False))
+        num_docs = 2000
+        clients = 8
+        self.assertEqual((   0, 250, 250), params.bounds(num_docs, 0, 0, clients, includes_action_and_meta_data=False))
+        self.assertEqual(( 250, 250, 250), params.bounds(num_docs, 1, 1, clients, includes_action_and_meta_data=False))
+        self.assertEqual(( 500, 250, 250), params.bounds(num_docs, 2, 2, clients, includes_action_and_meta_data=False))
+        self.assertEqual(( 750, 250, 250), params.bounds(num_docs, 3, 3, clients, includes_action_and_meta_data=False))
+        self.assertEqual((1000, 250, 250), params.bounds(num_docs, 4, 4, clients, includes_action_and_meta_data=False))
+        self.assertEqual((1250, 250, 250), params.bounds(num_docs, 5, 5, clients, includes_action_and_meta_data=False))
+        self.assertEqual((1500, 250, 250), params.bounds(num_docs, 6, 6, clients, includes_action_and_meta_data=False))
+        self.assertEqual((1750, 250, 250), params.bounds(num_docs, 7, 7, clients, includes_action_and_meta_data=False))
 
-    def test_calculate_non_multiple_bounds(self):
+    def test_calculate_non_multiple_bounds_16_clients(self):
         # in this test case, each client would need to read 1333.3333 lines. Instead we let most clients read 1333
         # lines and every third client, one line more (1334).
-        self.assertEqual((    0, 1333, 1333), params.bounds(16000,  0,  0, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 1333, 1334, 1334), params.bounds(16000,  1,  1, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 2667, 1333, 1333), params.bounds(16000,  2,  2, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 4000, 1333, 1333), params.bounds(16000,  3,  3, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 5333, 1334, 1334), params.bounds(16000,  4,  4, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 6667, 1333, 1333), params.bounds(16000,  5,  5, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 8000, 1333, 1333), params.bounds(16000,  6,  6, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 9333, 1334, 1334), params.bounds(16000,  7,  7, 12, includes_action_and_meta_data=False))
-        self.assertEqual((10667, 1333, 1333), params.bounds(16000,  8,  8, 12, includes_action_and_meta_data=False))
-        self.assertEqual((12000, 1333, 1333), params.bounds(16000,  9,  9, 12, includes_action_and_meta_data=False))
-        self.assertEqual((13333, 1334, 1334), params.bounds(16000, 10, 10, 12, includes_action_and_meta_data=False))
-        self.assertEqual((14667, 1333, 1333), params.bounds(16000, 11, 11, 12, includes_action_and_meta_data=False))
+        num_docs = 16000
+        clients = 12
+        self.assertEqual((    0, 1333, 1333), params.bounds(num_docs, 0, 0, clients, includes_action_and_meta_data=False))
+        self.assertEqual(( 1333, 1334, 1334), params.bounds(num_docs, 1, 1, clients, includes_action_and_meta_data=False))
+        self.assertEqual(( 2667, 1333, 1333), params.bounds(num_docs, 2, 2, clients, includes_action_and_meta_data=False))
+        self.assertEqual(( 4000, 1333, 1333), params.bounds(num_docs, 3, 3, clients, includes_action_and_meta_data=False))
+        self.assertEqual(( 5333, 1334, 1334), params.bounds(num_docs, 4, 4, clients, includes_action_and_meta_data=False))
+        self.assertEqual(( 6667, 1333, 1333), params.bounds(num_docs, 5, 5, clients, includes_action_and_meta_data=False))
+        self.assertEqual(( 8000, 1333, 1333), params.bounds(num_docs, 6, 6, clients, includes_action_and_meta_data=False))
+        self.assertEqual(( 9333, 1334, 1334), params.bounds(num_docs, 7, 7, clients, includes_action_and_meta_data=False))
+        self.assertEqual((10667, 1333, 1333), params.bounds(num_docs, 8, 8, clients, includes_action_and_meta_data=False))
+        self.assertEqual((12000, 1333, 1333), params.bounds(num_docs, 9, 9, clients, includes_action_and_meta_data=False))
+        self.assertEqual((13333, 1334, 1334), params.bounds(num_docs, 10, 10, clients, includes_action_and_meta_data=False))
+        self.assertEqual((14667, 1333, 1333), params.bounds(num_docs, 11, 11, clients, includes_action_and_meta_data=False))
 
+    def test_calculate_non_multiple_bounds_6_clients(self):
         # With 3500 docs and 6 clients, every client needs to read 583.33 docs. We have two lines per doc, which makes it
         # 2 * 583.333 docs = 1166.6666 lines per client. We let them read 1166 and 1168 lines respectively (583 and 584 docs).
-        self.assertEqual((   0, 583, 1166), params.bounds(3500, 0, 0, 6, includes_action_and_meta_data=True))
-        self.assertEqual((1166, 584, 1168), params.bounds(3500, 1, 1, 6, includes_action_and_meta_data=True))
-        self.assertEqual((2334, 583, 1166), params.bounds(3500, 2, 2, 6, includes_action_and_meta_data=True))
-        self.assertEqual((3500, 583, 1166), params.bounds(3500, 3, 3, 6, includes_action_and_meta_data=True))
-        self.assertEqual((4666, 584, 1168), params.bounds(3500, 4, 4, 6, includes_action_and_meta_data=True))
-        self.assertEqual((5834, 583, 1166), params.bounds(3500, 5, 5, 6, includes_action_and_meta_data=True))
+        num_docs = 3500
+        clients = 6
+        self.assertEqual((   0, 583, 1166), params.bounds(num_docs, 0, 0, clients, includes_action_and_meta_data=True))
+        self.assertEqual((1166, 584, 1168), params.bounds(num_docs, 1, 1, clients, includes_action_and_meta_data=True))
+        self.assertEqual((2334, 583, 1166), params.bounds(num_docs, 2, 2, clients, includes_action_and_meta_data=True))
+        self.assertEqual((3500, 583, 1166), params.bounds(num_docs, 3, 3, clients, includes_action_and_meta_data=True))
+        self.assertEqual((4666, 584, 1168), params.bounds(num_docs, 4, 4, clients, includes_action_and_meta_data=True))
+        self.assertEqual((5834, 583, 1166), params.bounds(num_docs, 5, 5, clients, includes_action_and_meta_data=True))
+
+    def test_calculate_bounds_for_multiple_clients_per_worker(self):
+        num_docs = 2000
+        clients = 8
+        # four clients per worker, each reads 250 lines
+        self.assertEqual((   0, 1000, 1000), params.bounds(num_docs, 0, 3, clients, includes_action_and_meta_data=False))
+        self.assertEqual((1000, 1000, 1000), params.bounds(num_docs, 4, 7, clients, includes_action_and_meta_data=False))
+
+        # four clients per worker, each reads 500 lines (includes action and metadata)
+        self.assertEqual((   0, 1000, 2000), params.bounds(num_docs, 0, 3, clients, includes_action_and_meta_data=True))
+        self.assertEqual((2000, 1000, 2000), params.bounds(num_docs, 4, 7, clients, includes_action_and_meta_data=True))
 
     def test_calculate_number_of_bulks(self):
         docs1 = self.docs(1)

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -581,76 +581,76 @@ class InvocationGeneratorTests(TestCase):
         self.assertEqual(1, i1.exit_count)
 
     def test_calculate_bounds(self):
-        self.assertEqual((0, 1000, 1000), params.bounds(1000, 0, 1, includes_action_and_meta_data=False))
-        self.assertEqual((0, 1000, 2000), params.bounds(1000, 0, 1, includes_action_and_meta_data=True))
+        self.assertEqual((0, 1000, 1000), params.bounds(1000, 0, 0, 1, includes_action_and_meta_data=False))
+        self.assertEqual((0, 1000, 2000), params.bounds(1000, 0, 0, 1, includes_action_and_meta_data=True))
 
-        self.assertEqual((  0, 500, 500), params.bounds(1000, 0, 2, includes_action_and_meta_data=False))
-        self.assertEqual((500, 500, 500), params.bounds(1000, 1, 2, includes_action_and_meta_data=False))
+        self.assertEqual((  0, 500, 500), params.bounds(1000, 0, 0, 2, includes_action_and_meta_data=False))
+        self.assertEqual((500, 500, 500), params.bounds(1000, 1, 1, 2, includes_action_and_meta_data=False))
 
-        self.assertEqual((   0, 200, 400), params.bounds(800, 0, 4, includes_action_and_meta_data=True))
-        self.assertEqual(( 400, 200, 400), params.bounds(800, 1, 4, includes_action_and_meta_data=True))
-        self.assertEqual(( 800, 200, 400), params.bounds(800, 2, 4, includes_action_and_meta_data=True))
-        self.assertEqual((1200, 200, 400), params.bounds(800, 3, 4, includes_action_and_meta_data=True))
+        self.assertEqual((   0, 200, 400), params.bounds(800, 0, 0, 4, includes_action_and_meta_data=True))
+        self.assertEqual(( 400, 200, 400), params.bounds(800, 1, 1, 4, includes_action_and_meta_data=True))
+        self.assertEqual(( 800, 200, 400), params.bounds(800, 2, 2, 4, includes_action_and_meta_data=True))
+        self.assertEqual((1200, 200, 400), params.bounds(800, 3, 3, 4, includes_action_and_meta_data=True))
 
-        self.assertEqual((   0, 250, 250), params.bounds(2000, 0, 8, includes_action_and_meta_data=False))
-        self.assertEqual(( 250, 250, 250), params.bounds(2000, 1, 8, includes_action_and_meta_data=False))
-        self.assertEqual(( 500, 250, 250), params.bounds(2000, 2, 8, includes_action_and_meta_data=False))
-        self.assertEqual(( 750, 250, 250), params.bounds(2000, 3, 8, includes_action_and_meta_data=False))
-        self.assertEqual((1000, 250, 250), params.bounds(2000, 4, 8, includes_action_and_meta_data=False))
-        self.assertEqual((1250, 250, 250), params.bounds(2000, 5, 8, includes_action_and_meta_data=False))
-        self.assertEqual((1500, 250, 250), params.bounds(2000, 6, 8, includes_action_and_meta_data=False))
-        self.assertEqual((1750, 250, 250), params.bounds(2000, 7, 8, includes_action_and_meta_data=False))
+        self.assertEqual((   0, 250, 250), params.bounds(2000, 0, 0, 8, includes_action_and_meta_data=False))
+        self.assertEqual(( 250, 250, 250), params.bounds(2000, 1, 1, 8, includes_action_and_meta_data=False))
+        self.assertEqual(( 500, 250, 250), params.bounds(2000, 2, 2, 8, includes_action_and_meta_data=False))
+        self.assertEqual(( 750, 250, 250), params.bounds(2000, 3, 3, 8, includes_action_and_meta_data=False))
+        self.assertEqual((1000, 250, 250), params.bounds(2000, 4, 4, 8, includes_action_and_meta_data=False))
+        self.assertEqual((1250, 250, 250), params.bounds(2000, 5, 5, 8, includes_action_and_meta_data=False))
+        self.assertEqual((1500, 250, 250), params.bounds(2000, 6, 6, 8, includes_action_and_meta_data=False))
+        self.assertEqual((1750, 250, 250), params.bounds(2000, 7, 7, 8, includes_action_and_meta_data=False))
 
     def test_calculate_non_multiple_bounds(self):
         # in this test case, each client would need to read 1333.3333 lines. Instead we let most clients read 1333
         # lines and every third client, one line more (1334).
-        self.assertEqual((    0, 1333, 1333), params.bounds(16000,  0, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 1333, 1334, 1334), params.bounds(16000,  1, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 2667, 1333, 1333), params.bounds(16000,  2, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 4000, 1333, 1333), params.bounds(16000,  3, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 5333, 1334, 1334), params.bounds(16000,  4, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 6667, 1333, 1333), params.bounds(16000,  5, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 8000, 1333, 1333), params.bounds(16000,  6, 12, includes_action_and_meta_data=False))
-        self.assertEqual(( 9333, 1334, 1334), params.bounds(16000,  7, 12, includes_action_and_meta_data=False))
-        self.assertEqual((10667, 1333, 1333), params.bounds(16000,  8, 12, includes_action_and_meta_data=False))
-        self.assertEqual((12000, 1333, 1333), params.bounds(16000,  9, 12, includes_action_and_meta_data=False))
-        self.assertEqual((13333, 1334, 1334), params.bounds(16000, 10, 12, includes_action_and_meta_data=False))
-        self.assertEqual((14667, 1333, 1333), params.bounds(16000, 11, 12, includes_action_and_meta_data=False))
+        self.assertEqual((    0, 1333, 1333), params.bounds(16000,  0,  0, 12, includes_action_and_meta_data=False))
+        self.assertEqual(( 1333, 1334, 1334), params.bounds(16000,  1,  1, 12, includes_action_and_meta_data=False))
+        self.assertEqual(( 2667, 1333, 1333), params.bounds(16000,  2,  2, 12, includes_action_and_meta_data=False))
+        self.assertEqual(( 4000, 1333, 1333), params.bounds(16000,  3,  3, 12, includes_action_and_meta_data=False))
+        self.assertEqual(( 5333, 1334, 1334), params.bounds(16000,  4,  4, 12, includes_action_and_meta_data=False))
+        self.assertEqual(( 6667, 1333, 1333), params.bounds(16000,  5,  5, 12, includes_action_and_meta_data=False))
+        self.assertEqual(( 8000, 1333, 1333), params.bounds(16000,  6,  6, 12, includes_action_and_meta_data=False))
+        self.assertEqual(( 9333, 1334, 1334), params.bounds(16000,  7,  7, 12, includes_action_and_meta_data=False))
+        self.assertEqual((10667, 1333, 1333), params.bounds(16000,  8,  8, 12, includes_action_and_meta_data=False))
+        self.assertEqual((12000, 1333, 1333), params.bounds(16000,  9,  9, 12, includes_action_and_meta_data=False))
+        self.assertEqual((13333, 1334, 1334), params.bounds(16000, 10, 10, 12, includes_action_and_meta_data=False))
+        self.assertEqual((14667, 1333, 1333), params.bounds(16000, 11, 11, 12, includes_action_and_meta_data=False))
 
         # With 3500 docs and 6 clients, every client needs to read 583.33 docs. We have two lines per doc, which makes it
         # 2 * 583.333 docs = 1166.6666 lines per client. We let them read 1166 and 1168 lines respectively (583 and 584 docs).
-        self.assertEqual((   0, 583, 1166), params.bounds(3500, 0, 6, includes_action_and_meta_data=True))
-        self.assertEqual((1166, 584, 1168), params.bounds(3500, 1, 6, includes_action_and_meta_data=True))
-        self.assertEqual((2334, 583, 1166), params.bounds(3500, 2, 6, includes_action_and_meta_data=True))
-        self.assertEqual((3500, 583, 1166), params.bounds(3500, 3, 6, includes_action_and_meta_data=True))
-        self.assertEqual((4666, 584, 1168), params.bounds(3500, 4, 6, includes_action_and_meta_data=True))
-        self.assertEqual((5834, 583, 1166), params.bounds(3500, 5, 6, includes_action_and_meta_data=True))
+        self.assertEqual((   0, 583, 1166), params.bounds(3500, 0, 0, 6, includes_action_and_meta_data=True))
+        self.assertEqual((1166, 584, 1168), params.bounds(3500, 1, 1, 6, includes_action_and_meta_data=True))
+        self.assertEqual((2334, 583, 1166), params.bounds(3500, 2, 2, 6, includes_action_and_meta_data=True))
+        self.assertEqual((3500, 583, 1166), params.bounds(3500, 3, 3, 6, includes_action_and_meta_data=True))
+        self.assertEqual((4666, 584, 1168), params.bounds(3500, 4, 4, 6, includes_action_and_meta_data=True))
+        self.assertEqual((5834, 583, 1166), params.bounds(3500, 5, 5, 6, includes_action_and_meta_data=True))
 
     def test_calculate_number_of_bulks(self):
         docs1 = self.docs(1)
         docs2 = self.docs(2)
 
-        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [docs1])], 0, 1, 1))
-        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [docs1])], 0, 1, 2))
+        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [docs1])], 0, 0, 1, 1))
+        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [docs1])], 0, 0, 1, 2))
         self.assertEqual(20, self.number_of_bulks(
             [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]),
-             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 1, 1))
+             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 0, 1, 1))
         self.assertEqual(11, self.number_of_bulks(
             [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]),
-             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 1, 2))
+             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 0, 1, 2))
         self.assertEqual(11, self.number_of_bulks(
             [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]),
-             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 1, 3))
+             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 0, 1, 3))
         self.assertEqual(11, self.number_of_bulks(
             [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]),
-             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 1, 100))
+             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 0, 1, 100))
 
-        self.assertEqual(2, self.number_of_bulks([self.corpus("a", [self.docs(800)])], 0, 3, 250))
-        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [self.docs(800)])], 0, 3, 267))
-        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [self.docs(80)])], 0, 3, 267))
+        self.assertEqual(2, self.number_of_bulks([self.corpus("a", [self.docs(800)])], 0, 0, 3, 250))
+        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [self.docs(800)])], 0, 0, 3, 267))
+        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [self.docs(80)])], 0, 0, 3, 267))
         # this looks odd at first but we are prioritizing number of clients above bulk size
-        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [self.docs(80)])], 1, 3, 267))
-        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [self.docs(80)])], 2, 3, 267))
+        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [self.docs(80)])], 1, 1, 3, 267))
+        self.assertEqual(1, self.number_of_bulks([self.corpus("a", [self.docs(80)])], 2, 2, 3, 267))
 
     @staticmethod
     def corpus(name, docs):
@@ -661,8 +661,8 @@ class InvocationGeneratorTests(TestCase):
         return track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=num_docs)
 
     @staticmethod
-    def number_of_bulks(corpora, partition_index, total_partitions, bulk_size):
-        return params.number_of_bulks(corpora, partition_index, total_partitions, bulk_size)
+    def number_of_bulks(corpora, first_partition_index, last_partition_index, total_partitions, bulk_size):
+        return params.number_of_bulks(corpora, first_partition_index, last_partition_index, total_partitions, bulk_size)
 
     def test_build_conflicting_ids(self):
         self.assertIsNone(params.build_conflicting_ids(params.IndexIdConflict.NoConflicts, 3, 0))
@@ -890,6 +890,7 @@ class BulkIndexParamSourceTests(TestCase):
             })
 
         partition = source.partition(0, 1)
+        partition._init_internal_params()
         # # no ingest-percentage specified, should issue all one hundred bulk requests
         self.assertEqual(100, partition.total_bulks)
 
@@ -941,6 +942,7 @@ class BulkIndexParamSourceTests(TestCase):
             })
 
         partition = source.partition(0, 1)
+        partition._init_internal_params()
         # should issue three bulks of size 10.000
         self.assertEqual(3, partition.total_bulks)
         self.assertEqual(3, len(list(schedule(partition))))
@@ -1001,7 +1003,7 @@ class BulkDataGeneratorTests(TestCase):
                             )
         ])
 
-        bulks = params.bulk_data_based(num_clients=1, client_index=0, corpora=[corpus],
+        bulks = params.bulk_data_based(num_clients=1, start_client_index=0, end_client_index=0, corpora=[corpus],
                                        batch_size=5, bulk_size=5,
                                        id_conflicts=params.IndexIdConflict.NoConflicts, conflict_probability=None, on_conflict=None,
                                        recency=None, pipeline=None,
@@ -1015,7 +1017,6 @@ class BulkDataGeneratorTests(TestCase):
         self.assertEqual({
             "action-metadata-present": True,
             "body": ["1", "2", "3", "4", "5"],
-            "bulk-id": "0-1",
             "bulk-size": 5,
             "index": "test-idx",
             "type": "test-type",
@@ -1026,7 +1027,6 @@ class BulkDataGeneratorTests(TestCase):
         self.assertEqual({
             "action-metadata-present": True,
             "body": ["6", "7", "8"],
-            "bulk-id": "0-2",
             "bulk-size": 3,
             "index": "test-idx",
             "type": "test-type",
@@ -1059,7 +1059,7 @@ class BulkDataGeneratorTests(TestCase):
 
             ]
 
-        bulks = params.bulk_data_based(num_clients=1, client_index=0, corpora=corpora,
+        bulks = params.bulk_data_based(num_clients=1, start_client_index=0, end_client_index=0, corpora=corpora,
                                        batch_size=5, bulk_size=5,
                                        id_conflicts=params.IndexIdConflict.NoConflicts, conflict_probability=None, on_conflict=None,
                                        recency=None, pipeline=None,
@@ -1073,7 +1073,6 @@ class BulkDataGeneratorTests(TestCase):
         self.assertEqual({
             "action-metadata-present": True,
             "body": ["1", "2", "3", "4", "5"],
-            "bulk-id": "0-1",
             "bulk-size": 5,
             "index": "logs-2018-01",
             "type": "docs",
@@ -1084,7 +1083,6 @@ class BulkDataGeneratorTests(TestCase):
         self.assertEqual({
             "action-metadata-present": True,
             "body": ["1", "2", "3", "4", "5"],
-            "bulk-id": "0-2",
             "bulk-size": 5,
             "index": "logs-2018-02",
             "type": "docs",
@@ -1095,7 +1093,6 @@ class BulkDataGeneratorTests(TestCase):
         self.assertEqual({
             "action-metadata-present": True,
             "body": ["1", "2", "3", "4", "5"],
-            "bulk-id": "0-3",
             "bulk-size": 5,
             "index": "logs-2017-01",
             "type": "docs",
@@ -1112,8 +1109,9 @@ class BulkDataGeneratorTests(TestCase):
                             )
         ])
 
-        bulks = params.bulk_data_based(num_clients=1, client_index=0, corpora=[corpus], batch_size=3, bulk_size=3,
-                                       id_conflicts=params.IndexIdConflict.NoConflicts, conflict_probability=None, on_conflict=None,
+        bulks = params.bulk_data_based(num_clients=1, start_client_index=0, end_client_index=0, corpora=[corpus],
+                                       batch_size=3, bulk_size=3, id_conflicts=params.IndexIdConflict.NoConflicts,
+                                       conflict_probability=None, on_conflict=None,
                                        recency=None, pipeline=None,
                                        original_params={
                                            "body": "foo",
@@ -1126,7 +1124,6 @@ class BulkDataGeneratorTests(TestCase):
         self.assertEqual({
             "action-metadata-present": True,
             "body": ["1", "2", "3"],
-            "bulk-id": "0-1",
             "bulk-size": 3,
             "index": "test-idx",
             "type": "test-type",


### PR DESCRIPTION
With this commit we share a parameter source for all bulk indexing
clients per Rally worker. As all clients run in the same asyncio event
loop they can also share a parameter source. This reduces the number of
mmap system calls and thus virtual memory usage significantly: we only
map the bulk data file(s) now only once per process instead of once per
client. We can also better take advantage of prefetching as multiple
clients within a process read now linearly from the mapped file. We have
also changed the assignment rules slightly so successive client ids get
assigned to a worker in order to read a continuous range of data.