### PR TITLE
Add integration tests with eventdata

### DIFF
--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import uuid
+
+import pytest
+
 import it
 
 
@@ -35,3 +39,58 @@ def test_docker_distribution(cfg):
     assert it.esrally(cfg, f"--on-error=abort --pipeline=\"docker\" --distribution-version=\"{dist}\" "
                            f"--track=\"geonames\" --challenge=\"append-no-conflicts-index-only\" --test-mode "
                            f"--car=4gheap --target-hosts=127.0.0.1:19200") == 0
+
+
+@pytest.fixture(scope="module")
+def test_cluster():
+    cluster = it.TestCluster("in-memory-it")
+    # test with a recent distribution as eventdata is not available for all versions
+    dist = it.DISTRIBUTIONS[-1]
+    port = 49200
+    race_id = str(uuid.uuid4())
+
+    it.wait_until_port_is_free(port_number=port)
+    cluster.install(distribution_version=dist, node_name="rally-node", car="4gheap", http_port=port)
+    cluster.start(race_id=race_id)
+    yield cluster
+    cluster.stop()
+
+
+@it.random_rally_config
+def test_eventdata_frozen(cfg, test_cluster):
+    challenges = ["frozen-data-generation", "frozen-querying"]
+    track_params = "number_of_replicas:0"
+    execute_eventdata(cfg, test_cluster, challenges, track_params)
+
+
+@it.random_rally_config
+def test_eventdata_indexing_and_querying(cfg, test_cluster):
+    challenges = ["elasticlogs-1bn-load",
+                  "elasticlogs-continuous-index-and-query",
+                  "combined-indexing-and-querying",
+                  "elasticlogs-querying"]
+    track_params = "bulk_indexing_clients:1,number_of_replicas:0,rate_limit_max:2,rate_limit_duration_secs:5," \
+                   "p1_bulk_indexing_clients:1,p2_bulk_indexing_clients:1,p1_duration_secs:5,p2_duration_secs:5"
+    execute_eventdata(cfg, test_cluster, challenges, track_params)
+
+
+@it.random_rally_config
+def test_eventdata_update(cfg, test_cluster):
+    challenges = ["bulk-update"]
+    track_params = "bulk_indexing_clients:1,number_of_replicas:0"
+    execute_eventdata(cfg, test_cluster, challenges, track_params)
+
+
+@it.random_rally_config
+def test_eventdata_daily_volume(cfg, test_cluster):
+    challenges = ["index-logs-fixed-daily-volume", "index-and-query-logs-fixed-daily-volume"]
+    track_params = "bulk_indexing_clients:1,number_of_replicas:0,daily_logging_volume:1MB"
+    execute_eventdata(cfg, test_cluster, challenges, track_params)
+
+
+def execute_eventdata(cfg, test_cluster, challenges, track_params):
+    for challenge in challenges:
+        cmd = f"--test-mode --pipeline=benchmark-only --target-host=127.0.0.1:{test_cluster.http_port} " \
+              f"--track-repository=eventdata --track=eventdata --track-params=\"{track_params}\" " \
+              f"--challenge={challenge} --on-error=abort"
+        assert it.esrally(cfg, cmd) == 0

--- a/it/list_test.py
+++ b/it/list_test.py
@@ -36,6 +36,7 @@ def test_list_elasticsearch_plugins(cfg):
 @it.rally_in_mem
 def test_list_tracks(cfg):
     assert it.esrally(cfg, "list tracks") == 0
+    assert it.esrally(cfg, "list tracks --track-repository=eventdata") == 0
     assert it.esrally(cfg, "list tracks --track-repository=default "
                            "--track-revision=4080dc9850d07e23b6fc7cfcdc7cf57b14e5168d") == 0
 


### PR DESCRIPTION
With this commit we add integration tests with the eventdata track. As
it is not included in the regular Rally tracks, it uses many features of
Rally and we often use it for benchmarks, it makes sense to integrate
testing more tightly.

Note that we do not add tests for all challenges of the eventdata track
as elastic/rally-eventdata-track#82 will remove some of them.