### PR TITLE
Add an it method for rally race

### DIFF
--- a/it/__init__.py
+++ b/it/__init__.py
@@ -68,7 +68,19 @@ def rally_es(t):
 
 
 def esrally(cfg, command_line):
+    """
+    This method should be used for rally invocations of the all commands besides race.
+    These commands may have different CLI options than race.
+    """
     return os.system("esrally {} --kill-running-processes --configuration-name=\"{}\"".format(command_line, cfg))
+
+
+def race(cfg, command_line):
+    """
+    This method should be used for rally invocations of the default race command.
+    It sets up some defaults for how the integration tests expect to run races.
+    """
+    return os.system("esrally race {} --kill-running-processes --configuration-name=\"{}\" --on-error=\"abort\"".format(command_line, cfg))
 
 
 def wait_until_port_is_free(port_number=39200, timeout=120):

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -27,7 +27,7 @@ def test_tar_distributions(cfg):
     for dist in it.DISTRIBUTIONS:
         for track in it.TRACKS:
             it.wait_until_port_is_free()
-            assert it.esrally(cfg, f"--on-error=abort --distribution-version=\"{dist}\" --track=\"{track}\" "
+            assert it.race(cfg, f"--distribution-version=\"{dist}\" --track=\"{track}\" "
                                    f"--test-mode --car=4gheap") == 0
 
 
@@ -36,7 +36,7 @@ def test_docker_distribution(cfg):
     # only test the most recent Docker distribution
     dist = it.DISTRIBUTIONS[-1]
     it.wait_until_port_is_free(port_number=19200)
-    assert it.esrally(cfg, f"--on-error=abort --pipeline=\"docker\" --distribution-version=\"{dist}\" "
+    assert it.race(cfg, f"--pipeline=\"docker\" --distribution-version=\"{dist}\" "
                            f"--track=\"geonames\" --challenge=\"append-no-conflicts-index-only\" --test-mode "
                            f"--car=4gheap --target-hosts=127.0.0.1:19200") == 0
 
@@ -92,5 +92,5 @@ def execute_eventdata(cfg, test_cluster, challenges, track_params):
     for challenge in challenges:
         cmd = f"--test-mode --pipeline=benchmark-only --target-host=127.0.0.1:{test_cluster.http_port} " \
               f"--track-repository=eventdata --track=eventdata --track-params=\"{track_params}\" " \
-              f"--challenge={challenge} --on-error=abort"
-        assert it.esrally(cfg, cmd) == 0
+              f"--challenge={challenge}"
+        assert it.race(cfg, cmd) == 0

--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -21,9 +21,9 @@ import it
 @it.random_rally_config
 def test_sources(cfg):
     it.wait_until_port_is_free()
-    assert it.esrally(cfg, "--on-error=abort --revision=latest --track=geonames --test-mode "
-                           "--challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu") == 0
+    assert it.race(cfg, "--revision=latest --track=geonames --test-mode "
+                        "--challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu") == 0
 
     it.wait_until_port_is_free()
-    assert it.esrally(cfg, "--on-error=abort --pipeline=from-sources-skip-build --track=geonames --test-mode "
-                           "--challenge=append-no-conflicts-index-only --car=\"4gheap,ea\"") == 0
+    assert it.race(cfg, "--pipeline=from-sources-skip-build --track=geonames --test-mode "
+                        "--challenge=append-no-conflicts-index-only --car=\"4gheap,ea\"") == 0


### PR DESCRIPTION
All of the commands that relied on the default rally race command were
manually adding the --on-error flag to the cli. This is something that
can be missed by a developer or reviewer. This commit adds a race()
command so that the it tests can take advantage of any defaults added to
every race in the tests.

Relates #968
