### PR TITLE
Pass actor system env vars in integration test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,9 @@ passenv =
     JAVA14_HOME
     RALLY_HOME
     SSH_AUTH_SOCK
+    THESPLOG_FILE
+    THESPLOG_FILE_MAXSIZE
+    THESPLOG_THRESHOLD
 # we do not pass LANG and LC_ALL anymore in order to isolate integration tests
 # from the test environment. Rally needs to enforce UTF-8 encoding in every
 # place so we intentionally set LC_ALL to C.


### PR DESCRIPTION
With this commit we ensure that tox passes environment variables
prefixed with `THESPLOG_` that are related to the actor system. This
allows us to configure custom settings for integration tests.