### PR TITLE
Remove warning about bogus results

### DIFF
--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -26,25 +26,6 @@ import thespian.actors
 from esrally import actor, config, doc_link, driver, exceptions, mechanic, metrics, reporter, track, PROGRAM_NAME
 from esrally.utils import console, opts
 
-# benchmarks with external candidates are really scary and we should warn users.
-BOGUS_RESULTS_WARNING = """
-************************************************************************
-************** WARNING: A dark dungeon lies ahead of you  **************
-************************************************************************
-
-Rally does not have control over the configuration of the benchmarked
-Elasticsearch cluster.
-
-Be aware that results may be misleading due to problems with the setup.
-Rally is also not able to gather lots of metrics at all (like CPU usage
-of the benchmarked cluster) or may even produce misleading metrics (like
-the index size).
-
-************************************************************************
-****** Use this pipeline only if you are aware of the tradeoffs.  ******
-*************************** Watch your step! ***************************
-************************************************************************
-"""
 
 pipelines = collections.OrderedDict()
 
@@ -311,7 +292,6 @@ def from_distribution(cfg):
 
 
 def benchmark_only(cfg):
-    console.println(BOGUS_RESULTS_WARNING, flush=True)
     set_default_hosts(cfg)
     # We'll use a special car name for external benchmarks.
     cfg.add(config.Scope.benchmark, "mechanic", "car.names", ["external"])


### PR DESCRIPTION
With the introduction of dedicated subcommands for cluster management it
has become more usual to use the benchmark-only pipeline. Thus, we
remove the warning about bogus results now.