### PR TITLE
Remove duplicate integration test

### DIFF
--- a/integration-test.sh
+++ b/integration-test.sh
@@ -302,24 +302,6 @@ function test_distribution_fails_with_wrong_track_params {
     restore_rally_log
 }
 
-function test_benchmark_only {
-    # we just use our metrics cluster for these benchmarks. It's not ideal but simpler.
-    local cfg
-    local dist
-    random_configuration cfg
-
-    info "test benchmark-only [--configuration-name=${cfg}]"
-    kill_rally_processes
-    esrally --target-host="localhost:${ES_METRICS_STORE_HTTP_PORT}" \
-            --configuration-name="${cfg}" \
-            --on-error=abort \
-            --pipeline=benchmark-only \
-            --track=geonames \
-            --test-mode \
-            --challenge=append-no-conflicts-index-only \
-            --track-params="cluster_health:'yellow'"
-}
-
 function test_proxy_connection {
     local cfg
 
@@ -519,8 +501,6 @@ function run_test {
     test_configure
     echo "**************************************** TESTING RALLY FAILS WITH UNUSED TRACK-PARAMS **************************"
     test_distribution_fails_with_wrong_track_params
-    echo "**************************************** TESTING RALLY BENCHMARK-ONLY PIPELINE *********************************"
-    test_benchmark_only
     echo "**************************************** TESTING RALLY DOCKER IMAGE ********************************************"
     test_docker_dev_image
     echo "**************************************** TESTING RALLY NODE MANAGEMENT COMMANDS ********************************************"


### PR DESCRIPTION
With this commit we remove an integration test for the `benchmark-only`
pipeline that exists in the old integration test script but is also
already tested in `distribution_test` in any of `test_eventdata*`.