### PR TITLE
Migrate track param check to new IT infrastructure

### DIFF
--- a/integration-test.sh
+++ b/integration-test.sh
@@ -256,52 +256,6 @@ function test_configure {
     esrally configure --assume-defaults --configuration-name="config-integration-test"
 }
 
-function test_distribution_fails_with_wrong_track_params {
-    local cfg
-    local distribution
-    # TODO check if randomization of track is possible
-    local track="geonames" # fixed value for now, as the available track params vary between tracks
-    local track_params
-    local defined_track_params
-    local undefined_track_params
-
-    random_configuration cfg
-    random_distribution dist
-
-    undefined_track_params="number_of-replicas:0" # - simulates a typo
-
-    if [[ ${track} == "geonames" ]]; then
-        defined_track_params="conflict_probability:45,"
-    fi
-
-    local track_params="${defined_track_params}${undefined_track_params}"
-    readonly err_msg="Rally didn't fail trying to use the undefined track-param ${undefined_track_params}. Check ${RALLY_LOG}."
-
-    info "test distribution [--configuration-name=${cfg}], [--distribution-version=${dist}], [--track=${track}], [--track-params=${track_params}], [--car=4gheap]"
-    kill_rally_processes
-    wait_for_free_es_port
-
-    backup_rally_log
-    set +e
-    esrally --configuration-name="${cfg}" --on-error=abort --distribution-version="${dist}" --track="${track}" --track-params="${track_params}" --test-mode --car=4gheap
-    ret_code=$?
-    set -e
-
-    # we expect Rally to fail, with full details in its log file
-    if [[ ${ret_code} -eq 0 ]]; then
-        error "Rally didn't fail trying to use the undefined track-param ${undefined_track_params}. Check ${RALLY_LOG}."
-        error ${err_msg}
-        exit ${ret_code}
-    elif exit_if_docker_not_running && [[ ${ret_code} -ne 0 ]]; then
-        # need to use grep -P which is unavailable with macOS grep
-        if ! docker run --rm -v ${RALLY_LOG}:/rally.log:ro ubuntu:xenial grep -Pzoq '.*CRITICAL Some of your track parameter\(s\) "number_of-replicas" are not used by this track; perhaps you intend to use "number_of_replicas" instead\.\n\nAll track parameters you provided are:\n- conflict_probability\n- number_of-replicas\n\nAll parameters exposed by this track:\n*' /rally.log; then
-            error ${err_msg}
-            exit ${ret_code}
-        fi
-    fi
-    restore_rally_log
-}
-
 function test_proxy_connection {
     local cfg
 

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -453,8 +453,6 @@ function run_test {
     fi
     echo "**************************************** TESTING CONFIGURATION OF RALLY ****************************************"
     test_configure
-    echo "**************************************** TESTING RALLY FAILS WITH UNUSED TRACK-PARAMS **************************"
-    test_distribution_fails_with_wrong_track_params
     echo "**************************************** TESTING RALLY DOCKER IMAGE ********************************************"
     test_docker_dev_image
     echo "**************************************** TESTING RALLY NODE MANAGEMENT COMMANDS ********************************************"

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -67,12 +67,16 @@ def rally_es(t):
     return wrapper
 
 
+def esrally_command_line_for(cfg, command_line):
+    return f"esrally {command_line} --kill-running-processes --configuration-name='{cfg}'"
+
+
 def esrally(cfg, command_line):
     """
     This method should be used for rally invocations of the all commands besides race.
     These commands may have different CLI options than race.
     """
-    return os.system("esrally {} --kill-running-processes --configuration-name=\"{}\"".format(command_line, cfg))
+    return os.system(esrally_command_line_for(cfg, command_line))
 
 
 def race(cfg, command_line):
@@ -80,7 +84,7 @@ def race(cfg, command_line):
     This method should be used for rally invocations of the default race command.
     It sets up some defaults for how the integration tests expect to run races.
     """
-    return os.system("esrally race {} --kill-running-processes --configuration-name=\"{}\" --on-error=\"abort\"".format(command_line, cfg))
+    return esrally(cfg, f"race {command_line} --on-error='abort'")
 
 
 def wait_until_port_is_free(port_number=39200, timeout=120):

--- a/it/info_test.py
+++ b/it/info_test.py
@@ -16,18 +16,31 @@
 # under the License.
 
 import it
+from esrally.utils import process
 
 
-@it.random_rally_config
+@it.rally_in_mem
 def test_track_info_with_challenge(cfg):
     assert it.esrally(cfg, "info --track=geonames --challenge=append-no-conflicts") == 0
 
 
-@it.random_rally_config
+@it.rally_in_mem
 def test_track_info_with_track_repo(cfg):
     assert it.esrally(cfg, "info --track-repository=default --track=geonames") == 0
 
 
-@it.random_rally_config
+@it.rally_in_mem
 def test_track_info_with_task_filter(cfg):
     assert it.esrally(cfg, "info --track=geonames --challenge=append-no-conflicts --include-tasks=\"type:search\"") == 0
+
+
+@it.rally_in_mem
+def test_track_info_fails_with_wrong_track_params(cfg):
+    # simulate a typo in track parameter
+    cmd = it.esrally_command_line_for(cfg, "info --track=geonames --track-params='conflict_probability:5,number-of-replicas:1'")
+    output = process.run_subprocess_with_output(cmd)
+    expected = "Some of your track parameter(s) \"number-of-replicas\" are not used by this track; " \
+               "perhaps you intend to use \"number_of_replicas\" instead.\n\nAll track parameters you " \
+               "provided are:\n- conflict_probability\n- number-of-replicas\n\nAll parameters exposed by this track"
+
+    assert expected in "\n".join(output)


### PR DESCRIPTION
With this commit we migrate the integration test that checks for
misspelled track parameters to the new infrastructure.

Relates #975