### PR TITLE
Remove os environment variables from env prep

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -13,7 +13,7 @@ JAVA_HOME and the bundled runtime JDK
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Rally can optionally use the bundled runtime JDK by setting ``--runtime-jdk="bundled"``. This setting will use the JDK that is bundled with
-elasticsearch and not honor any ``JAVA_HOME`` settings you may have set.
+Elasticsearch and not honor any ``JAVA_HOME`` settings you may have set.
 
 Meta-Data for queries are omitted
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,16 @@
 Migration Guide
 ===============
 
+
+Migrating to Rally 2.0.0
+------------------------
+
+JAVA_HOME and the bundled runtime JDK
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Rally can optionally use the bundled runtime JDK by setting ``--runtime-jdk="bundled"``. This setting will use the JDK that is bundled with
+elasticsearch and not honor any ``JAVA_HOME`` settings you may have set.
+
 Migrating to Rally 1.5.0
 ------------------------
 

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -169,7 +169,7 @@ class ProcessLauncher:
         return node
 
     def _prepare_env(self, car_env, node_name, java_home, t):
-        env = {k: v for k, v in os.environ.items() if k in self.pass_env_vars or k == "PATH"}
+        env = {k: v for k, v in os.environ.items() if k in self.pass_env_vars}
         env.update(car_env)
         if java_home:
             self._set_env(env, "PATH", os.path.join(java_home, "bin"), separator=os.pathsep, prepend=True)

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -175,6 +175,9 @@ class ProcessLauncher:
             self._set_env(env, "PATH", os.path.join(java_home, "bin"), separator=os.pathsep, prepend=True)
             # Don't merge here!
             env["JAVA_HOME"] = java_home
+        elif env.get("JAVA_HOME"):
+            # Assume that since java_home was not passed in, it should be unset in the environment if it exists
+            del env["JAVA_HOME"]
         env["ES_JAVA_OPTS"] = "-XX:+ExitOnOutOfMemoryError"
 
         # we just blindly trust telemetry here...
@@ -189,9 +192,9 @@ class ProcessLauncher:
             if k not in env:
                 env[k] = v
             elif prepend:
-                    env[k] = v + separator + env[k]
+                env[k] = v + separator + env[k]
             else:
-                    env[k] = env[k] + separator + v
+                env[k] = env[k] + separator + v
 
     @staticmethod
     def _run_subprocess(command_line, env):

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -265,7 +265,6 @@ class ProcessLauncherTests(TestCase):
         env = proc_launcher._prepare_env(car_env={}, node_name="node0", java_home=None, t=t)
 
         # unmodified
-        self.assertEqual(os.environ["PATH"], env["PATH"])
         self.assertEqual(os.environ["JAVA_HOME"], env["JAVA_HOME"])
         self.assertEqual(os.environ["FOO1"], env["FOO1"])
         self.assertEqual(env["ES_JAVA_OPTS"], "-XX:+ExitOnOutOfMemoryError")
@@ -284,7 +283,6 @@ class ProcessLauncherTests(TestCase):
         env = proc_launcher._prepare_env(car_env={}, node_name="node0", java_home=None, t=t)
 
         # unmodified
-        self.assertEqual(os.environ["PATH"], env["PATH"])
         self.assertEqual(os.environ["ES_JAVA_OPTS"], env["ES_JAVA_OPTS"])
 
     @mock.patch("esrally.time.sleep")


### PR DESCRIPTION
The launcher pulls in local environment variables from the OS prior to
launching Elasticsearch. This can be problematic if the $JAVA_HOME
variable is locally set, but explicitly not set by the Rally
launcher. For the case of the bundled JDK, a variable java_home is
explicitly unset, which should be reconciled with the local env by also
unsetting $JAVA_HOME if it exists before launching. This commit ensures
that if java_home is unset in the code, that the local env's $JAVA_HOME
variable is also unset.

Closes #976
