### PR TITLE
Remove trial-id and trial-timestamp

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -58,6 +58,11 @@ Apply to the following changes for each custom runner:
 
 For more details please refer to the updated documentation on :ref:`custom runners <adding_tracks_custom_runners>`.
 
+``trial-id`` and ``trial-timestamp`` are removed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since Rally 1.4.0, Rally uses the properties ``race-id`` and ``race-timestamp`` when writing data to the Elasticsearch metrics store. The properties ``trial-id`` and ``trial-timestamp`` were populated but are removed in this release. Any visualizations that have still relied on these properties need to be changed to the new ones.
+
 Migrating to Rally 1.4.1
 ------------------------
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -61,7 +61,7 @@ For more details please refer to the updated documentation on :ref:`custom runne
 ``trial-id`` and ``trial-timestamp`` are removed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Since Rally 1.4.0, Rally uses the properties ``race-id`` and ``race-timestamp`` when writing data to the Elasticsearch metrics store. The properties ``trial-id`` and ``trial-timestamp`` were populated but are removed in this release. Any visualizations that have still relied on these properties need to be changed to the new ones.
+Since Rally 1.4.0, Rally uses the properties ``race-id`` and ``race-timestamp`` when writing data to the Elasticsearch metrics store. The properties ``trial-id`` and ``trial-timestamp`` were populated but are removed in this release. Any visualizations that still rely on these properties need to be changed to the new ones.
 
 Migrating to Rally 1.4.1
 ------------------------

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -590,9 +590,6 @@ class MetricsStore:
         doc = {
             "@timestamp": time.to_epoch_millis(absolute_time),
             "relative-time": int(relative_time * 1000 * 1000),
-            # TODO #777: Remove trial-* with a later release. They are only here for BWC
-            "trial-id": self._race_id,
-            "trial-timestamp": self._race_timestamp,
             "race-id": self._race_id,
             "race-timestamp": self._race_timestamp,
             "environment": self._environment_name,
@@ -650,9 +647,6 @@ class MetricsStore:
         doc.update({
             "@timestamp": time.to_epoch_millis(absolute_time),
             "relative-time": int(relative_time * 1000 * 1000),
-            # TODO #777: Remove trial-* with a later release. They are only here for BWC
-            "trial-id": self._race_id,
-            "trial-timestamp": self._race_timestamp,
             "race-id": self._race_id,
             "race-timestamp": self._race_timestamp,
             "environment": self._environment_name,
@@ -1005,8 +999,7 @@ class EsMetricsStore(MetricsStore):
                 "filter": [
                     {
                         "term": {
-                            # TODO #777: Switch to "race-id" once we remove the trial-id parameter
-                            "trial-id": self._race_id
+                            "race-id": self._race_id
                         }
                     },
                     {
@@ -1288,9 +1281,6 @@ class Race:
             "rally-version": self.rally_version,
             "rally-revision": self.rally_revision,
             "environment": self.environment_name,
-            # TODO #777: Remove trial-* with a later release. They are only here for BWC
-            "trial-id": self.race_id,
-            "trial-timestamp": time.to_iso8601(self.race_timestamp),
             "race-id": self.race_id,
             "race-timestamp": time.to_iso8601(self.race_timestamp),
             "pipeline": self.pipeline,
@@ -1326,9 +1316,6 @@ class Race:
             "rally-version": self.rally_version,
             "rally-revision": self.rally_revision,
             "environment": self.environment_name,
-            # TODO #777: Remove trial-* with a later release. They are only here for BWC
-            "trial-id": self.race_id,
-            "trial-timestamp": time.to_iso8601(self.race_timestamp),
             "race-id": self.race_id,
             "race-timestamp": time.to_iso8601(self.race_timestamp),
             "distribution-version": self.distribution_version,
@@ -1366,21 +1353,13 @@ class Race:
 
     @classmethod
     def from_dict(cls, d):
-        # for backwards compatibility with Rally < 0.9.2
-        if "user-tag" in d:
-            user_tags = extract_user_tags_from_string(d["user-tag"])
-        elif "user-tags" in d:
-            user_tags = d["user-tags"]
-        else:
-            user_tags = {}
+        user_tags = d.get("user-tags", {})
         # TODO: cluster is optional for BWC. This can be removed after some grace period.
-        # TODO #777: Remove the backwards-compatibility layer with trial*
         cluster = d.get("cluster", {})
-        return Race(d["rally-version"], d.get("rally-revision"), d["environment"], d.get("race-id", d.get("trial-id")),
-                    time.from_is8601(d.get("race-timestamp", d.get("trial-timestamp"))),
-                    d["pipeline"], user_tags, d["track"], d.get("track-params"), d.get("challenge"), d["car"],
-                    d.get("car-params"), d.get("plugin-params"), track_revision=d.get("track-revision"),
-                    team_revision=cluster.get("team-revision"),
+        return Race(d["rally-version"], d.get("rally-revision"), d["environment"], d["race-id"],
+                    time.from_is8601(d["race-timestamp"]), d["pipeline"], user_tags, d["track"], d.get("track-params"),
+                    d.get("challenge"), d["car"], d.get("car-params"), d.get("plugin-params"),
+                    track_revision=d.get("track-revision"), team_revision=cluster.get("team-revision"),
                     distribution_version=cluster.get("distribution-version"),
                     distribution_flavor=cluster.get("distribution-flavor"),
                     revision=cluster.get("revision"), results=d.get("results"), meta_data=d.get("meta", {}))
@@ -1514,8 +1493,7 @@ class EsRaceStore(RaceStore):
             "size": self._max_results(),
             "sort": [
                 {
-                    # TODO #777: Switch to "race-timestamp" once we remove the trial-timestamp parameter
-                    "trial-timestamp": {
+                    "race-timestamp": {
                         "order": "desc"
                     }
                 }
@@ -1539,8 +1517,7 @@ class EsRaceStore(RaceStore):
             },
             {
                 "term": {
-                    # TODO #777: Switch to "race-id" once we remove the trial-id parameter
-                    "trial-id": race_id
+                    "race-id": race_id
                 }
             }]
 

--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -30,18 +30,6 @@
         "relative-time": {
           "type": "long"
         },
-        "trial-id": {
-          "type": "keyword"
-        },
-        "trial-timestamp": {
-          "type": "date",
-          "format": "basic_date_time_no_millis",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
         "race-id": {
           "type": "keyword"
         },

--- a/esrally/resources/races-template.json
+++ b/esrally/resources/races-template.json
@@ -23,18 +23,6 @@
         "enabled": true
       },
       "properties": {
-        "trial-id": {
-          "type": "keyword"
-        },
-        "trial-timestamp": {
-          "type": "date",
-          "format": "basic_date_time_no_millis",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
         "race-id": {
           "type": "keyword"
         },

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -23,18 +23,6 @@
         "enabled": true
       },
       "properties": {
-        "trial-id": {
-          "type": "keyword"
-        },
-        "trial-timestamp": {
-          "type": "date",
-          "format": "basic_date_time_no_millis",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
         "race-id": {
           "type": "keyword"
         },

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -309,8 +309,6 @@ class EsMetricsTests(TestCase):
             "@timestamp": StaticClock.NOW * 1000,
             "race-id": EsMetricsTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
-            "trial-id": EsMetricsTests.RACE_ID,
-            "trial-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
             "sample-type": "normal",
@@ -340,8 +338,6 @@ class EsMetricsTests(TestCase):
             "@timestamp": 0,
             "race-id": EsMetricsTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
-            "trial-id": EsMetricsTests.RACE_ID,
-            "trial-timestamp": "20160131T000000Z",
             "relative-time": 10000000,
             "environment": "unittest",
             "sample-type": "normal",
@@ -378,8 +374,6 @@ class EsMetricsTests(TestCase):
         self.metrics_store.put_value_node_level("node0", "indexing_throughput", throughput, "docs/s")
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "trial-id": EsMetricsTests.RACE_ID,
-            "trial-timestamp": "20160131T000000Z",
             "race-id": EsMetricsTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time": 0,
@@ -420,8 +414,6 @@ class EsMetricsTests(TestCase):
             "@timestamp": StaticClock.NOW * 1000,
             "race-id": EsMetricsTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
-            "trial-id": EsMetricsTests.RACE_ID,
-            "trial-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
             "track": "test",
@@ -467,8 +459,6 @@ class EsMetricsTests(TestCase):
             "@timestamp": StaticClock.NOW * 1000,
             "race-id": EsMetricsTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
-            "trial-id": EsMetricsTests.RACE_ID,
-            "trial-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
             "track": "test",
@@ -520,7 +510,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-id": EsMetricsTests.RACE_ID
+                                "race-id": EsMetricsTests.RACE_ID
                             }
                         },
                         {
@@ -564,7 +554,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-id": EsMetricsTests.RACE_ID
+                                "race-id": EsMetricsTests.RACE_ID
                             }
                         },
                         {
@@ -614,7 +604,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-id": EsMetricsTests.RACE_ID
+                                "race-id": EsMetricsTests.RACE_ID
                             }
                         },
                         {
@@ -665,7 +655,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-id": EsMetricsTests.RACE_ID
+                                "race-id": EsMetricsTests.RACE_ID
                             }
                         },
                         {
@@ -794,7 +784,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "trial-id": EsMetricsTests.RACE_ID
+                                "race-id": EsMetricsTests.RACE_ID
                             }
                         },
                         {
@@ -862,8 +852,6 @@ class EsRaceStoreTests(TestCase):
                             "environment": "unittest",
                             "race-id": EsRaceStoreTests.RACE_ID,
                             "race-timestamp": "20160131T000000Z",
-                            "trial-id": EsRaceStoreTests.RACE_ID,
-                            "trial-timestamp": "20160131T000000Z",
                             "pipeline": "from-sources",
                             "track": "unittest",
                             "challenge": "index",
@@ -938,8 +926,6 @@ class EsRaceStoreTests(TestCase):
             "environment": "unittest",
             "race-id": EsRaceStoreTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
-            "trial-id": EsRaceStoreTests.RACE_ID,
-            "trial-timestamp": "20160131T000000Z",
             "pipeline": "from-sources",
             "user-tags": {
                 "os": "Linux"
@@ -1048,8 +1034,6 @@ class EsResultsStoreTests(TestCase):
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
-                "trial-id": EsResultsStoreTests.RACE_ID,
-                "trial-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
@@ -1080,8 +1064,6 @@ class EsResultsStoreTests(TestCase):
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
-                "trial-id": EsResultsStoreTests.RACE_ID,
-                "trial-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
@@ -1118,8 +1100,6 @@ class EsResultsStoreTests(TestCase):
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
-                "trial-id": EsResultsStoreTests.RACE_ID,
-                "trial-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
                 "distribution-major-version": 5,
@@ -1197,8 +1177,6 @@ class EsResultsStoreTests(TestCase):
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
-                "trial-id": EsResultsStoreTests.RACE_ID,
-                "trial-timestamp": "20160131T000000Z",
                 "distribution-flavor": None,
                 "distribution-version": None,
                 "user-tags": {
@@ -1225,8 +1203,6 @@ class EsResultsStoreTests(TestCase):
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
-                "trial-id": EsResultsStoreTests.RACE_ID,
-                "trial-timestamp": "20160131T000000Z",
                 "distribution-flavor": None,
                 "distribution-version": None,
                 "user-tags": {
@@ -1259,8 +1235,6 @@ class EsResultsStoreTests(TestCase):
                 "environment": "unittest",
                 "race-id": EsResultsStoreTests.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
-                "trial-id": EsResultsStoreTests.RACE_ID,
-                "trial-timestamp": "20160131T000000Z",
                 "distribution-flavor": None,
                 "distribution-version": None,
                 "user-tags": {


### PR DESCRIPTION
With this commit we remove the properties `trial-id` and
`trial-timestamp` as they have been replaced by `race-id` and
`race-timestamp` in Rally 1.4.0 and were only present for backwards
compatibility.

Closes #777