### PR TITLE
Change next Rally version in migration docs

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,18 +1,18 @@
 Migration Guide
 ===============
 
-Migrating to Rally 1.5.0
+Migrating to Rally 2.0.0
 ------------------------
 
 Minimum Python version is 3.8.0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Rally 1.5.0 requires Python 3.8.0. Check the :ref:`updated installation instructions <install_python>` for more details.
+Rally 2.0.0 requires Python 3.8.0. Check the :ref:`updated installation instructions <install_python>` for more details.
 
 Meta-Data for queries are omitted
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Rally 1.5.0 does not determine query meta-data anymore by default to reduce the risk of client-side bottlenecks. The following meta-data fields are affected:
+Rally 2.0.0 does not determine query meta-data anymore by default to reduce the risk of client-side bottlenecks. The following meta-data fields are affected:
 
 * ``hits``
 * ``hits_relation``
@@ -24,9 +24,9 @@ If you still want to retrieve them (risking skewed results due to additional ove
 Runner API uses asyncio
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-In order to support more concurrent clients in the future, Rally is moving from a synchronous model to an asynchronous model internally. With Rally 1.5.0 all custom runners need to be implemented using async APIs and a new bool argument ``async_runner=True`` needs to be provided upon registration. Below is an example how to migrate a custom runner function.
+In order to support more concurrent clients in the future, Rally is moving from a synchronous model to an asynchronous model internally. With Rally 2.0.0 all custom runners need to be implemented using async APIs and a new bool argument ``async_runner=True`` needs to be provided upon registration. Below is an example how to migrate a custom runner function.
 
-A custom runner prior to Rally 1.5.0::
+A custom runner prior to Rally 2.0.0::
 
     def percolate(es, params):
         es.percolate(
@@ -38,7 +38,7 @@ A custom runner prior to Rally 1.5.0::
     def register(registry):
         registry.register_runner("percolate", percolate)
 
-With Rally 1.5.0, the implementation changes as follows::
+With Rally 2.0.0, the implementation changes as follows::
 
     async def percolate(es, params):
         await es.percolate(


### PR DESCRIPTION
With this commit we change any references from Rally 1.5.0 to Rally
2.0.0 to align it with the next release version.