### PR TITLE
Allow to override GC log parameters

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -67,6 +67,10 @@ gc
 
 The ``gc`` telemetry device enables GC logs for the benchmark candidate. You can use tools like `GCViewer <https://github.com/chewiebug/GCViewer>`_ to analyze the GC logs.
 
+If the runtime JDK is Java 9 or better, the following telemetry parameters can be specified:
+
+* ``gc-log-config`` (default: ``gc*=info,safepoint=info,age*=trace``): The GC logging configuration consisting of a list of tags and levels. Run ``java -Xlog:help`` to see the list of available levels and tags.
+
 heapdump
 --------
 

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -71,6 +71,11 @@ If the runtime JDK is Java 9 or better, the following telemetry parameters can b
 
 * ``gc-log-config`` (default: ``gc*=info,safepoint=info,age*=trace``): The GC logging configuration consisting of a list of tags and levels. Run ``java -Xlog:help`` to see the list of available levels and tags.
 
+
+.. note::
+
+    Use a JSON file for ``telemetry-params`` as the simple parameter format is not supported for the GC log configuration string. See the :ref:`command line reference <clr_telemetry_params>` for details.
+
 heapdump
 --------
 

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -67,7 +67,7 @@ gc
 
 The ``gc`` telemetry device enables GC logs for the benchmark candidate. You can use tools like `GCViewer <https://github.com/chewiebug/GCViewer>`_ to analyze the GC logs.
 
-If the runtime JDK is Java 9 or better, the following telemetry parameters can be specified:
+If the runtime JDK is Java 9 or higher, the following telemetry parameters can be specified:
 
 * ``gc-log-config`` (default: ``gc*=info,safepoint=info,age*=trace``): The GC logging configuration consisting of a list of tags and levels. Run ``java -Xlog:help`` to see the list of available levels and tags.
 

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -147,7 +147,7 @@ class ProcessLauncher:
         node_telemetry = [
             telemetry.FlightRecorder(telemetry_params, node_telemetry_dir, java_major_version),
             telemetry.JitCompiler(node_telemetry_dir),
-            telemetry.Gc(node_telemetry_dir, java_major_version),
+            telemetry.Gc(telemetry_params, node_telemetry_dir, java_major_version),
             telemetry.Heapdump(node_telemetry_dir),
             telemetry.DiskIo(node_count_on_host),
             telemetry.IndexSize(data_paths),

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -240,8 +240,9 @@ class Gc(TelemetryDevice):
     human_name = "GC log"
     help = "Enables GC logs."
 
-    def __init__(self, log_root, java_major_version):
+    def __init__(self, telemetry_params, log_root, java_major_version):
         super().__init__()
+        self.telemetry_params = telemetry_params
         self.log_root = log_root
         self.java_major_version = java_major_version
 
@@ -257,8 +258,9 @@ class Gc(TelemetryDevice):
                     "-XX:+PrintGCApplicationStoppedTime", "-XX:+PrintGCApplicationConcurrentTime",
                     "-XX:+PrintTenuringDistribution"]
         else:
+            log_config = self.telemetry_params.get("gc-log-config", "gc*=info,safepoint=info,age*=trace")
             # see https://docs.oracle.com/javase/9/tools/java.htm#JSWOR-GUID-BE93ABDC-999C-4CB5-A88B-1994AAAC74D5
-            return ["-Xlog:gc*=info,safepoint=info,age*=trace:file={}:utctime,uptimemillis,level,tags:filecount=0".format(log_file)]
+            return [f"-Xlog:{log_config}:file={log_file}:utctime,uptimemillis,level,tags:filecount=0"]
 
 
 class Heapdump(TelemetryDevice):

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -211,7 +211,7 @@ class JfrTests(TestCase):
 
 class GcTests(TestCase):
     def test_sets_options_for_pre_java_9(self):
-        gc = telemetry.Gc("/var/log", java_major_version=random.randint(0, 8))
+        gc = telemetry.Gc(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(0, 8))
         gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
         self.assertEqual(7, len(gc_java_opts))
         self.assertEqual(["-Xloggc:/var/log/defaults-node-0.gc.log", "-XX:+PrintGCDetails", "-XX:+PrintGCDateStamps",
@@ -219,11 +219,21 @@ class GcTests(TestCase):
                           "-XX:+PrintTenuringDistribution"], gc_java_opts)
 
     def test_sets_options_for_java_9_or_above(self):
-        gc = telemetry.Gc("/var/log", java_major_version=random.randint(9, 999))
+        gc = telemetry.Gc(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(9, 999))
         gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
         self.assertEqual(1, len(gc_java_opts))
         self.assertEqual(
             ["-Xlog:gc*=info,safepoint=info,age*=trace:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"],
+            gc_java_opts)
+
+    def test_can_override_options_for_java_9_or_above(self):
+        gc = telemetry.Gc(telemetry_params={"gc-log-config": "gc,safepoint"},
+                          log_root="/var/log",
+                          java_major_version=random.randint(9, 999))
+        gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
+        self.assertEqual(1, len(gc_java_opts))
+        self.assertEqual(
+            ["-Xlog:gc,safepoint:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"],
             gc_java_opts)
 
 


### PR DESCRIPTION
With this commit we expose a new telemetry parameter `gc-log-config`
that allows users to override the configuration of the GC telemetry
device. We only allow to override tags and levels but will still output
to a file.