### PR TITLE
Add experimental segment stats telemetry device

### DIFF
--- a/esrally/driver/async_driver.py
+++ b/esrally/driver/async_driver.py
@@ -22,7 +22,7 @@ import logging
 import threading
 import time
 
-from esrally import exceptions, metrics, track, client, telemetry
+from esrally import exceptions, metrics, paths, track, client, telemetry
 from esrally.driver import driver, runner, scheduler
 from esrally.utils import console
 
@@ -122,6 +122,7 @@ class AsyncDriver:
     def prepare_telemetry(self):
         enabled_devices = self.config.opts("telemetry", "devices")
         telemetry_params = self.config.opts("telemetry", "params")
+        log_root = paths.race_root(self.config)
 
         es = self.es_clients
         es_default = self.es_clients["default"]
@@ -132,6 +133,7 @@ class AsyncDriver:
             telemetry.JvmStatsSummary(es_default, self.metrics_store),
             telemetry.IndexStats(es_default, self.metrics_store),
             telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
+            telemetry.SegmentStats(log_root, es_default),
             telemetry.CcrStats(telemetry_params, es, self.metrics_store),
             telemetry.RecoveryStats(telemetry_params, es, self.metrics_store)
         ])

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -388,6 +388,7 @@ class Driver:
     def prepare_telemetry(self, es):
         enabled_devices = self.config.opts("telemetry", "devices")
         telemetry_params = self.config.opts("telemetry", "params")
+        log_root = paths.race_root(self.config)
 
         es_default = es["default"]
         self.telemetry = telemetry.Telemetry(enabled_devices, devices=[
@@ -397,6 +398,7 @@ class Driver:
             telemetry.JvmStatsSummary(es_default, self.metrics_store),
             telemetry.IndexStats(es_default, self.metrics_store),
             telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
+            telemetry.SegmentStats(log_root, es_default),
             telemetry.CcrStats(telemetry_params, es, self.metrics_store),
             telemetry.RecoveryStats(telemetry_params, es, self.metrics_store)
         ])

--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -30,7 +30,7 @@ def races_root(cfg):
     return os.path.join(cfg.opts("node", "root.dir"), "races")
 
 
-def race_root(cfg=None, race_id=None):
+def race_root(cfg, race_id=None):
     if not race_id:
         race_id = cfg.opts("system", "race.id")
     return os.path.join(races_root(cfg), race_id)

--- a/tests/driver/async_driver_test.py
+++ b/tests/driver/async_driver_test.py
@@ -151,6 +151,7 @@ class AsyncDriverTests(TestCase):
                 datetime(year=2017, month=8, day=20, hour=1, minute=0, second=0))
         cfg.add(config.Scope.application, "system", "race.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
         cfg.add(config.Scope.application, "system", "offline.mode", False)
+        cfg.add(config.Scope.application, "node", "root.dir", "/tmp")
         cfg.add(config.Scope.application, "driver", "on.error", "abort")
         cfg.add(config.Scope.application, "driver", "profiling", False)
         cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -88,6 +88,7 @@ class DriverTests(TestCase):
         self.cfg.add(config.Scope.application, "system", "time.start", datetime(year=2017, month=8, day=20, hour=1, minute=0, second=0))
         self.cfg.add(config.Scope.application, "system", "race.id", "6ebc6e53-ee20-4b0c-99b4-09697987e9f4")
         self.cfg.add(config.Scope.application, "system", "available.cores", 8)
+        self.cfg.add(config.Scope.application, "node", "root.dir", "/tmp")
         self.cfg.add(config.Scope.application, "track", "challenge.name", "default")
         self.cfg.add(config.Scope.application, "track", "params", {})
         self.cfg.add(config.Scope.application, "track", "test.mode.enabled", True)


### PR DESCRIPTION
With this commit we add a new telemetry device that writes segments
stats at the end of a benchmark to a log file. This telemetry device is
currently considered experimental (i.e. it may be removed at any time)
and is thus also intentionally undocumented.