### PR TITLE
Cache source artifacts

### DIFF
--- a/docs/pipelines.rst
+++ b/docs/pipelines.rst
@@ -62,6 +62,7 @@ You have to specify a :ref:`revision <clr_revision>`.
 
    This pipeline is just mentioned for completeness but Rally will automatically select it for you. All you need to do is to define the ``--revision`` flag.
 
+To enable artifact caching for source builds, set ``cache`` to ``true`` in the section ``source`` in the configuration file in ``~/.rally/rally.ini``. Source builds will then be cached in ``~/.rally/benchmarks/distributions`` but artifacts will not be evicted automatically.
 
 from-sources-skip-build
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -276,12 +276,11 @@ class CachedElasticsearchSourceSupplier:
             # this can be None if the Elasticsearch does not reside in a git repo and the user has only
             # copied all source files. In that case, we cannot resolve a revision hash and thus we cannot cache.
             if self.cached_path:
-                # noinspection PyBroadException
                 try:
                     shutil.copy(original_path, self.cached_path)
                     self.logger.info("Caching artifact in [%s]", self.cached_path)
                     binaries["elasticsearch"] = self.cached_path
-                except BaseException:
+                except OSError:
                     self.logger.exception("Not caching [%s].", original_path)
             else:
                 self.logger.info("Not caching [%s] (no revision info).", original_path)

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -276,9 +276,13 @@ class CachedElasticsearchSourceSupplier:
             # this can be None if the Elasticsearch does not reside in a git repo and the user has only
             # copied all source files. In that case, we cannot resolve a revision hash and thus we cannot cache.
             if self.cached_path:
-                shutil.copy(original_path, self.cached_path)
-                self.logger.info("Caching artifact in [%s]", self.cached_path)
-                binaries["elasticsearch"] = self.cached_path
+                # noinspection PyBroadException
+                try:
+                    shutil.copy(original_path, self.cached_path)
+                    self.logger.info("Caching artifact in [%s]", self.cached_path)
+                    binaries["elasticsearch"] = self.cached_path
+                except BaseException:
+                    self.logger.exception("Not caching [%s].", original_path)
             else:
                 self.logger.info("Not caching [%s] (no revision info).", original_path)
 

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -260,6 +260,45 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
         self.assertTrue(cached_supplier.cached)
 
 
+    @mock.patch("os.path.exists")
+    @mock.patch("shutil.copy")
+    @mock.patch("esrally.mechanic.supplier.ElasticsearchSourceSupplier")
+    def test_does_not_cache_on_copy_error(self, es, copy, path_exists):
+        def add_es_artifact(binaries):
+            binaries["elasticsearch"] = "/path/to/artifact.tar.gz"
+
+        path_exists.return_value = False
+
+        es.fetch.return_value = "abc123"
+        es.add.side_effect = add_es_artifact
+        copy.side_effect = OSError("no space left on device")
+
+        renderer = supplier.TemplateRenderer(version="abc123", os_name="linux", arch="x86_64")
+
+        dist_cfg = {
+            "runtime.jdk.bundled": "true",
+            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz"
+        }
+
+        cached_supplier = supplier.CachedElasticsearchSourceSupplier(distributions_root="/tmp",
+                                                                     source_supplier=es,
+                                                                     distribution_config=dist_cfg,
+                                                                     template_renderer=renderer)
+        cached_supplier.fetch()
+        cached_supplier.prepare()
+
+        binaries = {}
+
+        cached_supplier.add(binaries)
+
+        self.assertEqual(1, copy.call_count, "artifact has been copied")
+        self.assertEqual(1, es.add.call_count, "artifact has been added by internal supplier")
+        self.assertFalse(cached_supplier.cached)
+        self.assertIn("elasticsearch", binaries)
+        # still the uncached artifact
+        self.assertEqual("/path/to/artifact.tar.gz", binaries["elasticsearch"])
+
+
 class ElasticsearchSourceSupplierTests(TestCase):
     def test_no_build(self):
         car = team.Car("default", root_path=None, config_paths=[], variables={


### PR DESCRIPTION
With this commit we add a cache for source artifacts. It can be enabled
by setting `cache = true` in the `source` section of `rally.ini`.
Caching works based on the specified revision. We don't implement an
eviction policy for now but assume that an external process cleans up
cached artifacts.