### PR TITLE
Allow to abort on fatal errors

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -670,7 +670,11 @@ Client certificates can be presented regardless of the ``verify_certs`` setting,
 ``on-error``
 ~~~~~~~~~~~~
 
-This option controls whether Rally will ``continue`` or ``abort`` when a request error occurs. By default, Rally will just record errors and report the error rate at the end of a race. With ``--on-error=abort``, Rally will immediately abort the race on the first error and print a detailed error message.
+This option controls how Rally behaves when a response error occurs. The following values are possible:
+
+* ``continue``: only records that an error has happened and will continue with the benchmark. At the end of a race, errors show up in the "error rate" metric.
+* ``continue-on-non-fatal`` (default): Behaves as ``continue`` but aborts the benchmark immediately on all fatal errors. At the moment a refused connection is considered fatal. All other errors are considered non-fatal.
+* ``abort``: aborts the benchmark on the first request error with a detailed error message.
 
 ``load-driver-hosts``
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -673,7 +673,7 @@ Client certificates can be presented regardless of the ``verify_certs`` setting,
 This option controls how Rally behaves when a response error occurs. The following values are possible:
 
 * ``continue``: only records that an error has happened and will continue with the benchmark. At the end of a race, errors show up in the "error rate" metric.
-* ``continue-on-non-fatal`` (default): Behaves as ``continue`` but aborts the benchmark immediately on all fatal errors. At the moment a refused connection is considered fatal. All other errors are considered non-fatal.
+* ``continue-on-non-fatal`` (default): Behaves as ``continue`` but aborts the benchmark immediately on all fatal errors. The only error that is considered fatal is "Connection Refused" (`ECONNREFUSED <http://man7.org/linux/man-pages/man2/connect.2.html>`_).
 * ``abort``: aborts the benchmark on the first request error with a detailed error message.
 
 ``load-driver-hosts``

--- a/esrally/driver/async_driver.py
+++ b/esrally/driver/async_driver.py
@@ -99,7 +99,7 @@ class AsyncDriver:
         self.quiet = self.config.opts("system", "quiet.mode", mandatory=False, default_value=False)
         # TODO: Change the default value to `False` once this implementation becomes the default
         self.debug_event_loop = self.config.opts("system", "async.debug", mandatory=False, default_value=True)
-        self.abort_on_error = self.config.opts("driver", "on.error") == "abort"
+        self.on_error = self.config.opts("driver", "on.error")
         self.profiling_enabled = self.config.opts("driver", "profiling")
         self.sampler = None
 
@@ -249,7 +249,7 @@ class AsyncDriver:
                         # used to indicate that we want to prematurely consider this completed. This is *not* due to
                         # cancellation but a regular event in a benchmark and used to model task dependency of parallel tasks.
                         complete = threading.Event()
-                        e = driver.AsyncExecutor(client_id, sub_task, schedule, es, self.sampler, cancel, complete, self.abort_on_error)
+                        e = driver.AsyncExecutor(client_id, sub_task, schedule, es, self.sampler, cancel, complete, self.on_error)
                         aws.append(e())
                 # join point
                 _ = await asyncio.gather(*aws)

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -776,7 +776,7 @@ class Worker(actor.RallyActor):
         self.client_allocations = None
         self.current_task_index = 0
         self.next_task_index = 0
-        self.abort_on_error = False
+        self.on_error = None
         self.pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         # cancellation via future does not work, hence we use our own mechanism with a shared variable and polling
         self.cancel = threading.Event()
@@ -794,7 +794,7 @@ class Worker(actor.RallyActor):
         self.master = sender
         self.worker_id = msg.worker_id
         self.config = load_local_config(msg.config)
-        self.abort_on_error = self.config.opts("driver", "on.error") == "abort"
+        self.on_error = self.config.opts("driver", "on.error")
         self.track = msg.track
         track.set_absolute_data_path(self.config, self.track)
         self.client_allocations = msg.client_allocations
@@ -907,7 +907,7 @@ class Worker(actor.RallyActor):
                 # allow to buffer more events than by default as we expect to have way more clients.
                 self.sampler = Sampler(start_timestamp=time.perf_counter(), buffer_size=65536)
                 executor = AsyncIoAdapter(self.config, self.track, task_allocations, self.sampler,
-                                          self.cancel, self.complete, self.abort_on_error)
+                                          self.cancel, self.complete, self.on_error)
 
                 self.executor_future = self.pool.submit(executor)
                 self.wakeupAfter(datetime.timedelta(seconds=self.wakeup_interval))
@@ -1224,7 +1224,7 @@ class AsyncProfiler:
 
 
 class AsyncExecutor:
-    def __init__(self, client_id, task, schedule, es, sampler, cancel, complete, abort_on_error=False):
+    def __init__(self, client_id, task, schedule, es, sampler, cancel, complete, on_error):
         """
         Executes tasks according to the schedule for a given operation.
 
@@ -1234,6 +1234,7 @@ class AsyncExecutor:
         :param sampler: A container to store raw samples.
         :param cancel: A shared boolean that indicates we need to cancel execution.
         :param complete: A shared boolean that indicates we need to prematurely complete execution.
+        :param on_error: A string specifying how the load generator should behave on errors.
         """
         self.client_id = client_id
         self.task = task
@@ -1243,7 +1244,7 @@ class AsyncExecutor:
         self.sampler = sampler
         self.cancel = cancel
         self.complete = complete
-        self.abort_on_error = abort_on_error
+        self.on_error = on_error
         self.logger = logging.getLogger(__name__)
 
     async def __call__(self, *args, **kwargs):
@@ -1267,7 +1268,7 @@ class AsyncExecutor:
                         await asyncio.sleep(rest)
                 request_context = self.es["default"].init_request_context()
                 processing_start = time.perf_counter()
-                total_ops, total_ops_unit, request_meta_data = await execute_single(runner, self.es, params, self.abort_on_error)
+                total_ops, total_ops_unit, request_meta_data = await execute_single(runner, self.es, params, self.on_error)
                 processing_end = time.perf_counter()
                 stop = request_context["request_end"]
                 service_time = request_context["request_end"] - request_context["request_start"]
@@ -1309,13 +1310,14 @@ class AsyncExecutor:
                 self.complete.set()
 
 
-async def execute_single(runner, es, params, abort_on_error=False):
+async def execute_single(runner, es, params, on_error):
     """
     Invokes the given runner once and provides the runner's return value in a uniform structure.
 
     :return: a triple of: total number of operations, unit of operations, a dict of request meta data (may be None).
     """
     import elasticsearch
+    fatal_error = False
     try:
         async with runner:
             return_value = await runner(es, params)
@@ -1333,6 +1335,10 @@ async def execute_single(runner, es, params, abort_on_error=False):
             total_ops_unit = "ops"
             request_meta_data = {"success": True}
     except elasticsearch.TransportError as e:
+        # we *specifically* want to distinguish connection refused (a node died?) from connection timeouts
+        if type(e) is elasticsearch.ConnectionError:
+            fatal_error = True
+
         total_ops = 0
         total_ops_unit = "ops"
         request_meta_data = {
@@ -1354,12 +1360,13 @@ async def execute_single(runner, es, params, abort_on_error=False):
         msg = "Cannot execute [%s]. Provided parameters are: %s. Error: [%s]." % (str(runner), list(params.keys()), str(e))
         raise exceptions.SystemSetupError(msg)
 
-    if abort_on_error and not request_meta_data["success"]:
-        msg = "Request returned an error. Error type: %s" % request_meta_data.get("error-type", "Unknown")
-        description = request_meta_data.get("error-description")
-        if description:
-            msg += ", Description: %s" % description
-        raise exceptions.RallyAssertionError(msg)
+    if not request_meta_data["success"]:
+        if on_error == "abort" or (on_error == "continue-on-non-fatal" and fatal_error):
+            msg = "Request returned an error. Error type: %s" % request_meta_data.get("error-type", "Unknown")
+            description = request_meta_data.get("error-description")
+            if description:
+                msg += ", Description: %s" % description
+            raise exceptions.RallyAssertionError(msg)
     return total_ops, total_ops_unit, request_meta_data
 
 

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1336,6 +1336,7 @@ async def execute_single(runner, es, params, on_error):
             request_meta_data = {"success": True}
     except elasticsearch.TransportError as e:
         # we *specifically* want to distinguish connection refused (a node died?) from connection timeouts
+        # pylint: disable=unidiomatic-typecheck
         if type(e) is elasticsearch.ConnectionError:
             fatal_error = True
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -484,9 +484,9 @@ def create_arg_parser():
                  "(default: {}).".format(opts.ClientOptions.DEFAULT_CLIENT_OPTIONS),
             default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS)
         p.add_argument("--on-error",
-                       choices=["continue", "abort"],
-                       help="Either 'continue' or 'abort' when Rally gets an error response (default: continue).",
-                       default="continue")
+                       choices=["continue", "continue-on-non-fatal", "abort"],
+                       help="Controls how Rally behaves on response errors (default: continue-on-non-fatal).",
+                       default="continue-on-non-fatal")
         p.add_argument(
             "--telemetry",
             help="Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry devices "


### PR DESCRIPTION
With this commit we add a third option to the command line parameter
`on-error`. So far it has been possible to either continue or abort on
error. Now we also allow to continue except for errors that indicate
that the cluster is unreachable (e.g. because it died with an OOME).