### PR TITLE
Cache source artifacts by default

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -437,7 +437,7 @@ This enables the HTTP exporter of `X-Pack Monitoring <https://www.elastic.co/pro
 
 Selects the :doc:`pipeline </pipelines>` that Rally should run.
 
-Rally can autodetect the pipeline in most cases. If you specify ``--distribution-version`` it will auto-select the pipeline ``from-distribution`` otherwise it will use ``from-sources-complete``.
+Rally can autodetect the pipeline in most cases. If you specify ``--distribution-version`` it will auto-select the pipeline ``from-distribution`` otherwise it will use ``from-sources``.
 
 .. _clr_enable_driver_profiling:
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,15 @@
 Migration Guide
 ===============
 
+Migrating to Rally 2.0.1
+------------------------
+
+Pipelines from-sources-complete and from-sources-skip-build are deprecated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Rally 2.0.1 caches source artifacts automatically in ``~/.rally/benchmarks/distributions/src``. Therefore, it is not necessary anymore to explicitly skip the build with ``--pipeline=from-sources-skip-build``. Specify ``--pipeline=from-sources`` instead. See the :doc:`pipeline reference documentation </pipelines>` for more details.
+
+
 Migrating to Rally 2.0.0
 ------------------------
 

--- a/docs/pipelines.rst
+++ b/docs/pipelines.rst
@@ -11,10 +11,11 @@ You can get a list of all pipelines with ``esrally list pipelines``::
 
     Name                     Description
     -----------------------  ---------------------------------------------------------------------------------------------
+    from-sources             Builds and provisions Elasticsearch, runs a benchmark and reports results.
+    from-sources-complete    Builds and provisions Elasticsearch, runs a benchmark and reports results [deprecated].
+    from-sources-skip-build  Provisions Elasticsearch (skips the build), runs a benchmark and reports results [deprecated].
     from-distribution        Downloads an Elasticsearch distribution, provisions it, runs a benchmark and reports results.
-    from-sources-complete    Builds and provisions Elasticsearch, runs a benchmark and reports results.
     benchmark-only           Assumes an already running Elasticsearch instance, runs a benchmark and reports results
-    from-sources-skip-build  Provisions Elasticsearch (skips the build), runs a benchmark and reports results.
 
 benchmark-only
 ~~~~~~~~~~~~~~
@@ -45,16 +46,14 @@ However, this feature is mainly intended for continuous integration environments
 
    This pipeline is just mentioned for completeness but Rally will autoselect it for you. All you need to do is to define the ``--distribution-version`` flag.
 
-.. _pipelines_from-sources-complete:
-
-from-sources-complete
-~~~~~~~~~~~~~~~~~~~~~
+from-sources
+~~~~~~~~~~~~
 
 You should use this pipeline when you want to build and benchmark Elasticsearch from sources. This pipeline will only work from Elasticsearch 5.0 onwards because Elasticsearch switched from Maven to Gradle and Rally only supports one build tool in the interest of maintainability.
 
 Remember that you also need git installed. If that's not the case you'll get an error and have to run ``esrally configure`` first. An example invocation::
 
-    esrally --pipeline=from-sources-complete --revision=latest
+    esrally --pipeline=from-sources --revision=latest
 
 You have to specify a :ref:`revision <clr_revision>`.
 
@@ -62,11 +61,17 @@ You have to specify a :ref:`revision <clr_revision>`.
 
    This pipeline is just mentioned for completeness but Rally will automatically select it for you. All you need to do is to define the ``--revision`` flag.
 
-To enable artifact caching for source builds, set ``cache`` to ``true`` in the section ``source`` in the configuration file in ``~/.rally/rally.ini``. Source builds will then be cached in ``~/.rally/benchmarks/distributions`` but artifacts will not be evicted automatically.
+Artifacts are cached for seven days by default in ``~/.rally/benchmarks/distributions/src``. Artifact caching can be configured with the following sections in the section ``source`` in the configuration file in ``~/.rally/rally.ini``:
+
+* ``cache`` (default: ``True``): Set to ``False`` to disable artifact caching.
+* ``cache.days`` (default: ``7``): The maximum age in days of an artifact before it gets evicted from the artifact cache.
+
+from-sources-complete
+~~~~~~~~~~~~~~~~~~~~~
+
+This deprecated pipeline is an alias for ``from-sources`` and is only provided for backwards-compatibility. Use ``from-sources`` instead.
 
 from-sources-skip-build
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-This pipeline is similar to ``from-sources-complete`` except that it assumes you have built the binary once. It saves time if you want to run a benchmark twice for the exact same version of Elasticsearch. Obviously it doesn't make sense to provide a revision: It is always the previously built revision. An example invocation::
-
-    esrally --pipeline=from-sources-skip-build
+This deprecated pipeline is similar to ``from-sources-complete`` except that it assumes you have built the binary once. Use ``from-sources`` instead which caches built artifacts automatically.

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -353,12 +353,17 @@ class PluginLoader:
             self.logger.info("Loading plugin [%s] with default configuration.", name)
 
         root_path = self._plugin_root_path(name)
+        # used to determine whether this is a core plugin
+        core_plugin = self._core_plugin(name)
         if not config_names:
             # maybe we only have a config folder but nothing else (e.g. if there is only an install hook)
             if io.exists(root_path):
-                return PluginDescriptor(name=name, config=config_names, root_path=root_path, variables=plugin_params)
+                return PluginDescriptor(name=name,
+                                        core_plugin=core_plugin is not None,
+                                        config=config_names,
+                                        root_path=root_path,
+                                        variables=plugin_params)
             else:
-                core_plugin = self._core_plugin(name, plugin_params)
                 if core_plugin:
                     return core_plugin
                 # If we just have a plugin name then we assume that this is a community plugin and the user has specified a download URL
@@ -371,8 +376,6 @@ class PluginLoader:
             config_paths = []
             # used for deduplication
             known_config_bases = set()
-            # used to determine whether this is a core plugin
-            core_plugin = self._core_plugin(name)
 
             for config_name in config_names:
                 config_file = self._plugin_file(name, config_name)

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -273,13 +273,20 @@ def set_default_hosts(cfg, host="127.0.0.1", port=9200):
 
 
 # Poor man's curry
-def from_sources_complete(cfg):
+def from_sources(cfg):
     port = cfg.opts("provisioning", "node.http.port")
     set_default_hosts(cfg, port=port)
     return race(cfg, sources=True, build=True)
 
 
+def from_sources_complete(cfg):
+    console.warn("The pipeline from-sources-complete is deprecated. Use the pipeline \"from-sources\" instead.")
+    return from_sources(cfg)
+
+
 def from_sources_skip_build(cfg):
+    console.warn("The pipeline from-sources-skip-build is deprecated. Rally caches artifacts now automatically. "
+                 "Use the pipeline \"from-sources\" instead")
     port = cfg.opts("provisioning", "node.http.port")
     set_default_hosts(cfg, port=port)
     return race(cfg, sources=True, build=False)
@@ -303,11 +310,14 @@ def docker(cfg):
     return race(cfg, docker=True)
 
 
+Pipeline("from-sources",
+         "Builds and provisions Elasticsearch, runs a benchmark and reports results.", from_sources)
+
 Pipeline("from-sources-complete",
-         "Builds and provisions Elasticsearch, runs a benchmark and reports results.", from_sources_complete)
+         "Builds and provisions Elasticsearch, runs a benchmark and reports results [deprecated].", from_sources_complete)
 
 Pipeline("from-sources-skip-build",
-         "Provisions Elasticsearch (skips the build), runs a benchmark and reports results.", from_sources_skip_build)
+         "Provisions Elasticsearch (skips the build), runs a benchmark and reports results [deprecated].", from_sources_skip_build)
 
 Pipeline("from-distribution",
          "Downloads an Elasticsearch distribution, provisions it, runs a benchmark and reports results.", from_distribution)
@@ -338,7 +348,7 @@ def run(cfg):
         if cfg.exists("mechanic", "distribution.version"):
             name = "from-distribution"
         else:
-            name = "from-sources-complete"
+            name = "from-sources"
         logger.info("User specified no pipeline. Automatically derived pipeline [%s].", name)
         cfg.add(config.Scope.applicationOverride, "race", "pipeline", name)
     else:

--- a/tests/mechanic/data/plugins/v1/core-plugins.txt
+++ b/tests/mechanic/data/plugins/v1/core-plugins.txt
@@ -2,3 +2,4 @@
 #some-ignored-plugin
 my-analysis-plugin
 my-ingest-plugin
+my-core-plugin-with-config

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -25,8 +25,9 @@ from esrally import config, exceptions, racecontrol
 class RaceControlTests(TestCase):
     def test_finds_available_pipelines(self):
         expected = [
-            ["from-sources-complete", "Builds and provisions Elasticsearch, runs a benchmark and reports results."],
-            ["from-sources-skip-build", "Provisions Elasticsearch (skips the build), runs a benchmark and reports results."],
+            ["from-sources", "Builds and provisions Elasticsearch, runs a benchmark and reports results."],
+            ["from-sources-complete", "Builds and provisions Elasticsearch, runs a benchmark and reports results [deprecated]."],
+            ["from-sources-skip-build", "Provisions Elasticsearch (skips the build), runs a benchmark and reports results [deprecated]."],
             ["from-distribution", "Downloads an Elasticsearch distribution, provisions it, runs a benchmark and reports results."],
             ["benchmark-only", "Assumes an already running Elasticsearch instance, runs a benchmark and reports results"],
         ]


### PR DESCRIPTION
With this commit we add the artifact cache introduced by #992 also for
plugins and implement a cache cleanup mechanism that cleans up artifacts
after seven days by default (can be configured with `cache.days`). As
artifact caching can now replace the pipeline `from-sources-skip-build`
we deprecate it along with `from-sources-complete` and introduce a new
pipeline `from-sources` instead.
