### PR TITLE
Invoke pytest consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ serve-docs: check-venv
 	@. $(VENV_ACTIVATE_FILE); cd docs && $(MAKE) serve
 
 test: check-venv
-	pytest tests/
+	. $(VENV_ACTIVATE_FILE); pytest tests/
 
 precommit: lint
 
@@ -108,7 +108,7 @@ it38: check-venv python-caches-clean tox-env-clean
 	. $(VENV_ACTIVATE_FILE); tox -e py38
 
 benchmark: check-venv
-	$(VEPYTHON) setup.py pytest --addopts="-s benchmarks"
+	. $(VENV_ACTIVATE_FILE); pytest benchmarks/
 
 coverage: check-venv
 	. $(VENV_ACTIVATE_FILE); coverage run setup.py test

--- a/setup.py
+++ b/setup.py
@@ -144,9 +144,6 @@ setup(name="esrally",
       extras_require={
           "develop": tests_require + develop_require
       },
-      setup_requires=[
-          "pytest-runner==5.1",
-      ],
       entry_points={
           "console_scripts": [
               "esrally=esrally.rally:main",

--- a/tox.ini
+++ b/tox.ini
@@ -36,14 +36,17 @@ setenv =
     # applications behave identically, we also set LANG explicitly.
     LANG=C
 commands =
-    py.test --junitxml=junit-{envname}.xml
-    py.test -s it --junitxml=junit-{envname}-it.xml
+    pytest --junitxml=junit-{envname}.xml
+    pytest -s it --junitxml=junit-{envname}-it.xml
     ./integration-test.sh
 
 whitelist_externals =
-    py.test
+    pytest
 
 [testenv:docs]
 basepython=python
 changedir=docs
 commands=sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+
+whitelist_externals =
+    sphinx-build


### PR DESCRIPTION
With this commit we always invoke the `pytest` binary and eliminate the
other variations. We also remove the obsolete `pytest-runner` and fix a
small issue with the docs environment regarding a missing whitelist.