### PR TITLE
Wait until indices are green in generated track

### DIFF
--- a/esrally/resources/track.json.j2
+++ b/esrally/resources/track.json.j2
@@ -21,22 +21,32 @@
         }
       ]
     }{% endfor %}
-  ],{% raw %}
+  ],
   "schedule": [
     {
       "operation": "delete-index"
-    },
+    },{% raw %}
     {
       "operation": {
         "operation-type": "create-index",
         "settings": {{index_settings | default({}) | tojson}}
       }
+    },{% endraw %}
+    {
+      "operation": {
+        "operation-type": "cluster-health",
+        "index": {{ indices | map(attribute='name') | list | join(',') | tojson }},{% raw %}
+        "request-params": {
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        }
+      }
     },
     {
       "operation": {
-            "operation-type": "bulk",
-            "bulk-size": {{bulk_size | default(5000)}},
-            "ingest-percentage": {{ingest_percentage | default(100)}}
+        "operation-type": "bulk",
+        "bulk-size": {{bulk_size | default(5000)}},
+        "ingest-percentage": {{ingest_percentage | default(100)}}
       },
       "clients": {{bulk_indexing_clients | default(8)}}
     }


### PR DESCRIPTION
Currently the track generated by the `create-track` sub-command starts
bulk indexing immediately after creating indices.

This may affect benchmarking results as starting indexing when indices
are still yellow may result in unwanted peer-recovery during indexing.

Wait that all indices are green before indexing in generated tracks.
