### PR TITLE
Allow to specify a runtime-jdk during installation

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -283,6 +283,11 @@ def create_arg_parser():
         "--team-path",
         help="Define the path to the car and plugin configurations to use.")
     install_parser.add_argument(
+        "--runtime-jdk",
+        type=runtime_jdk,
+        help="The major version of the runtime JDK to use during installation.",
+        default=None)
+    install_parser.add_argument(
         "--distribution-repository",
         help="Define the repository from where the Elasticsearch distribution should be downloaded (default: release).",
         default="release")


### PR DESCRIPTION
The `install` subcommand sometimes requires to run so called install
hooks, for example to install plugins. These are installed with
Elasticsearch's `plugin` script which requires Java. Yet, if we rely on
the bundled JDK and no other JDK is installed on the system, the `java`
binary cannot be resolved because no runtime JDK is specified at all.
With this commit we expose the command line option `--runtime-jdk` so
users can provide `bundled` in the installation phase.