### PR TITLE
add support for transform API's

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -134,3 +134,13 @@ Supported telemetry parameters:
 
 * ``ccr-stats-indices`` (default: all indices): An index pattern for which ccr stats should be checked.
 * ``ccr-stats-sample-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.
+
+transform-stats
+---------------
+
+The transform-stats telemetry device regularly calls the `transform stats API <https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html>` and records one metrics document per transform.
+
+Supported telemetry parameters:
+
+* ``transform-stats-transforms`` (default: all transforms): A list of transforms per cluster for which transform stats should be checked.
+* ``transform-stats-sample-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -25,7 +25,6 @@ You probably want to gain additional insights from a race. Therefore, we have ad
    node-stats       Node Stats             Regularly samples node stats
    recovery-stats   Recovery Stats         Regularly samples shard recovery stats
    ccr-stats        CCR Stats              Regularly samples Cross Cluster Replication (CCR) related stats
-   segment-stats    Segment Stats          Determines segment stats at the end of the benchmark.
    transform-stats  Transform Stats        Regularly samples transform stats
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -18,13 +18,15 @@ You probably want to gain additional insights from a race. Therefore, we have ad
 
    Command         Name                   Description
    --------------  ---------------------  --------------------------------------------------------------------
-   jit             JIT Compiler Profiler  Enables JIT compiler logs.
-   gc              GC log                 Enables GC logs.
-   jfr             Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
-   heapdump        Heap Dump              Captures a heap dump.
-   node-stats      Node Stats             Regularly samples node stats
-   recovery-stats  Recovery Stats         Regularly samples shard recovery stats
-   ccr-stats       CCR Stats              Regularly samples Cross Cluster Replication (CCR) related stats
+   jit              JIT Compiler Profiler  Enables JIT compiler logs.
+   gc               GC log                 Enables GC logs.
+   jfr              Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
+   heapdump         Heap Dump              Captures a heap dump.
+   node-stats       Node Stats             Regularly samples node stats
+   recovery-stats   Recovery Stats         Regularly samples shard recovery stats
+   ccr-stats        CCR Stats              Regularly samples Cross Cluster Replication (CCR) related stats
+   segment-stats    Segment Stats          Determines segment stats at the end of the benchmark.
+   transform-stats  Transform Stats        Regularly samples transform stats
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1209,7 +1209,7 @@ execute-transform
 With the operation ``execute-transform`` you can execute a full run of data transformation, it starts the transform and stops it once all data has been transformed. The transform must be created upfront. The ``execute-transform`` operation supports the following parameters:
 
 * ``transform-id`` (mandatory): The id of the transform to execute.
-* ``poll-interval`` (optional, defaults to `0.5`) How often transform stats are polled, used to set progress and check the state.
+* ``poll-interval`` (optional, defaults to `0.5`) How often transform stats are polled, used to set progress and check the state. You should not set this too low, because polling can skew the result.
 * ``transform-timeout`` (optional, defaults to `1800` (`1h`)) Overall runtime timeout of the batch transform in seconds.
 
 This operation requires at least Elasticsearch 7.5.0 (non-OSS).

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1151,6 +1151,69 @@ With the operation ``wait-for-recovery`` you can wait until an ongoing shard rec
 
 This operation is :ref:`retryable <track_operations>`.
 
+create-transform
+~~~~~~~~~~~~~~~~
+
+With the operation ``create-transform`` you can execute the `create transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html>`_. It supports the following parameters:
+
+* ``transform-id`` (mandatory): The id of the transform to create.
+* ``body`` (mandatory): Request body containing the configuration of the transform. Please see the `create transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html>`__ documentation for more details.
+* ``defer-validation`` (optional, defaults to false): When true, deferrable validations are not run. This behavior may be desired if the source index does not exist until after the transform is created.
+
+This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+This operation is :ref:`retryable <track_operations>`.
+
+start-transform
+~~~~~~~~~~~~~~~
+
+With the operation ``start-transform`` you can execute the `start transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html>`_. It supports the following parameters:
+
+* ``transform-id`` (mandatory): The id of the transform to start.
+* ``timeout`` (optional, defaults to empty): Amount of time to wait until a transform starts.
+
+This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+This operation is :ref:`retryable <track_operations>`.
+
+stop-transform
+~~~~~~~~~~~~~~
+
+With the operation ``stop-transform`` you can execute the `stop transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html>`_. It supports the following parameters:
+
+* ``transform-id`` (mandatory): The id of the transform to stop.
+* ``force`` (optional, defaults to false): Whether to forcefully stop the transform.
+* ``timeout`` (optional, defaults to empty): Amount of time to wait until a transform stops.
+* ``wait-for-completion`` (optional, defaults to false) If set to true, causes the API to block until the indexer state completely stops.
+* ``wait-for-checkpoint`` (optional, defaults to false) If set to true, the transform will not completely stop until the current checkpoint is completed.
+
+This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+This operation is :ref:`retryable <track_operations>`.
+
+delete-transform
+~~~~~~~~~~~~~~~~
+
+With the operation ``delete-transform`` you can execute the `delete transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html>`_. It supports the following parameters:
+
+* ``transform-id`` (mandatory): The id of the transform to delete.
+* ``force`` (optional, defaults to false): Whether to delete the transform regardless of its current state.
+
+This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+This operation is :ref:`retryable <track_operations>`.
+
+execute-transform
+~~~~~~~~~~~~~~~~~
+
+With the operation ``execute-transform`` you can execute a full run of data transformation, it starts the transform and stops it once all data has been transformed. The transform must be created upfront. The ``execute-transform`` operation supports the following parameters:
+
+* ``transform-id`` (mandatory): The id of the transform to execute.
+* ``poll-interval`` (optional, defaults to `0.5`) How often transform stats are polled, used to set progress and check the state.
+* ``transform-timeout`` (optional, defaults to `1800` (`1h`)) Overall runtime timeout of the batch transform in seconds.
+
+This operation requires at least Elasticsearch 7.5.0 (non-OSS).
+
 Examples
 ========
 

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -400,7 +400,8 @@ class Driver:
             telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
             telemetry.SegmentStats(log_root, es_default),
             telemetry.CcrStats(telemetry_params, es, self.metrics_store),
-            telemetry.RecoveryStats(telemetry_params, es, self.metrics_store)
+            telemetry.RecoveryStats(telemetry_params, es, self.metrics_store),
+            telemetry.TransformStats(telemetry_params, es, self.metrics_store)
         ])
 
     def wait_for_rest_api(self, es):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1576,7 +1576,7 @@ class CreateTransform(Runner):
     async def __call__(self, es, params):
         transform_id = mandatory(params, "transform-id", self)
         body = mandatory(params, "body", self)
-        defer_validation = params.get("defer_validation", False)
+        defer_validation = params.get("defer-validation", False)
         await es.transform.put_transform(transform_id=transform_id, body=body, defer_validation=defer_validation)
 
     def __repr__(self, *args, **kwargs):
@@ -1609,8 +1609,8 @@ class StopTransform(Runner):
         transform_id = mandatory(params, "transform-id", self)
         force = params.get("force", False)
         timeout = params.get("timeout")
-        wait_for_completion = params.get("wait_for_completion", False)
-        wait_for_checkpoint = params.get("wait_for_checkpoint", False)
+        wait_for_completion = params.get("wait-for-completion", False)
+        wait_for_checkpoint = params.get("wait-for-checkpoint", False)
 
         await es.transform.stop_transform(transform_id=transform_id,
                                           force=force,

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1682,7 +1682,7 @@ class ExecuteTransform(Runner):
                 "checkpoint_progress", {}).get("percent_complete", 0.0)
 
         if state == "failed":
-            failure_reason = stats_response["transforms'"][0].get("reason", "unknown")
+            failure_reason = stats_response["transforms"][0].get("reason", "unknown")
             raise exceptions.RallyAssertionError(
                 f"Transform [{transform_id}] failed with [{failure_reason}].")
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1672,9 +1672,8 @@ class ExecuteTransform(Runner):
         while state in ("started", "indexing"):
             if (time.time() - start_time) > transform_timeout:
                 raise exceptions.RallyAssertionError(
-                    "Transform [{}] timed out after [{}] seconds. "
-                    "Please consider increasing the timeout in the track.".format(
-                        transform_id, transform_timeout))
+                    f"Transform [{transform_id}] timed out after [{transform_timeout}] seconds. "
+                    "Please consider increasing the timeout in the track.")
             await asyncio.sleep(poll_interval)
             stats_response = await es.transform.get_transform_stats(transform_id=transform_id)
             state = stats_response["transforms"][0].get("state")
@@ -1683,9 +1682,9 @@ class ExecuteTransform(Runner):
                 "checkpoint_progress", {}).get("percent_complete", 0.0)
 
         if state == "failed":
+            failure_reason = stats_response["transforms'"][0].get("reason", "unknown")
             raise exceptions.RallyAssertionError(
-                "Transform [{}] failed with [{}].".format(transform_id,
-                                                          stats_response["transforms"][0].get("reason", "unknown")))
+                f"Transform [{transform_id}] failed with [{failure_reason}].")
 
         self._completed = True
         transform_stats = stats_response["transforms"][0].get("stats", {})

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1667,9 +1667,9 @@ class ExecuteTransform(Runner):
         await es.transform.start_transform(transform_id=transform_id)
 
         stats_response = await es.transform.get_transform_stats(transform_id=transform_id)
-        state = stats_response['transforms'][0].get("state")
+        state = stats_response["transforms"][0].get("state")
 
-        while state in ('started', 'indexing'):
+        while state in ("started", "indexing"):
             if (time.time() - start_time) > transform_timeout:
                 raise exceptions.RallyAssertionError(
                     "Transform [{}] timed out after [{}] seconds. "
@@ -1677,18 +1677,18 @@ class ExecuteTransform(Runner):
                         transform_id, transform_timeout))
             await asyncio.sleep(poll_interval)
             stats_response = await es.transform.get_transform_stats(transform_id=transform_id)
-            state = stats_response['transforms'][0].get("state")
+            state = stats_response["transforms"][0].get("state")
 
-            self._percent_completed = stats_response['transforms'][0].get("checkpointing", {}).get("next", {}).get(
+            self._percent_completed = stats_response["transforms"][0].get("checkpointing", {}).get("next", {}).get(
                 "checkpoint_progress", {}).get("percent_complete", 0.0)
 
         if state == "failed":
             raise exceptions.RallyAssertionError(
                 "Transform [{}] failed with [{}].".format(transform_id,
-                                                          stats_response['transforms'][0].get("reason", "unknown")))
+                                                          stats_response["transforms"][0].get("reason", "unknown")))
 
         self._completed = True
-        transform_stats = stats_response['transforms'][0].get("stats", {})
+        transform_stats = stats_response["transforms"][0].get("stats", {})
 
         ops = {
             "pages_processed": transform_stats.get("pages_processed", 0),

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1669,7 +1669,7 @@ class ExecuteTransform(Runner):
         stats_response = await es.transform.get_transform_stats(transform_id=transform_id)
         state = stats_response['transforms'][0].get("state")
 
-        while state == "started" or state == "indexing":
+        while state in ('started', 'indexing'):
             if (time.time() - start_time) > transform_timeout:
                 raise exceptions.RallyAssertionError(
                     "Transform [{}] timed out after [{}] seconds. "

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -65,6 +65,10 @@ def register_default_runners():
     register_runner(track.OperationType.CreateSnapshotRepository.name, Retry(CreateSnapshotRepository()), async_runner=True)
     register_runner(track.OperationType.WaitForRecovery.name, Retry(IndicesRecovery()), async_runner=True)
     register_runner(track.OperationType.PutSettings.name, Retry(PutSettings()), async_runner=True)
+    register_runner(track.OperationType.CreateTransform.name, Retry(CreateTransform()), async_runner=True)
+    register_runner(track.OperationType.StartTransform.name, Retry(StartTransform()), async_runner=True)
+    register_runner(track.OperationType.StopTransform.name, Retry(StopTransform()), async_runner=True)
+    register_runner(track.OperationType.DeleteTransform.name, Retry(DeleteTransform()), async_runner=True)
 
 
 def runner_for(operation_type):
@@ -1561,6 +1565,76 @@ class PutSettings(Runner):
 
     def __repr__(self, *args, **kwargs):
         return "put-settings"
+
+
+class CreateTransform(Runner):
+    """
+    Execute the `create transform API https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html`_.
+    """
+
+    async def __call__(self, es, params):
+        transform_id = mandatory(params, "transform-id", self)
+        body = mandatory(params, "body", self)
+        defer_validation = params.get("defer_validation", False)
+        await es.transform.put_transform(transform_id=transform_id, body=body, defer_validation=defer_validation)
+
+    def __repr__(self, *args, **kwargs):
+        return "create-transform"
+
+
+class StartTransform(Runner):
+    """
+    Execute the `start transform API
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html`_.
+    """
+
+    async def __call__(self, es, params):
+        transform_id = mandatory(params, "transform-id", self)
+        timeout = params.get("timeout")
+
+        await es.transform.start_transform(transform_id=transform_id, timeout=timeout)
+
+    def __repr__(self, *args, **kwargs):
+        return "start-transform"
+
+
+class StopTransform(Runner):
+    """
+    Execute the `stop transform API
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html`_.
+    """
+
+    async def __call__(self, es, params):
+        transform_id = mandatory(params, "transform-id", self)
+        force = params.get("force", False)
+        timeout = params.get("timeout")
+        wait_for_completion = params.get("wait_for_completion", False)
+        wait_for_checkpoint = params.get("wait_for_checkpoint", False)
+
+        await es.transform.stop_transform(transform_id=transform_id,
+                                          force=force,
+                                          timeout=timeout,
+                                          wait_for_completion=wait_for_completion,
+                                          wait_for_checkpoint=wait_for_checkpoint)
+
+    def __repr__(self, *args, **kwargs):
+        return "stop-transform"
+
+
+class DeleteTransform(Runner):
+    """
+    Execute the `delete transform API
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html`_.
+    """
+
+    async def __call__(self, es, params):
+        transform_id = mandatory(params, "transform-id", self)
+        force = params.get("force", False)
+        # we don't want to fail if a job does not exist, thus we ignore 404s.
+        await es.transform.delete_transform(transform_id=transform_id, force=force, ignore=[404])
+
+    def __repr__(self, *args, **kwargs):
+        return "delete-transform"
 
 
 # TODO: Allow to use this from (selected) regular runners and add user documentation.

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1680,7 +1680,7 @@ class ExecuteTransform(Runner):
             state = stats_response['transforms'][0].get("state")
 
             self._percent_completed = stats_response['transforms'][0].get("checkpointing", {}).get("next", {}).get(
-                "checkpoint_progress", {}).get("percent_complete",  )
+                "checkpoint_progress", {}).get("percent_complete", 0.0)
 
         if state == "failed":
             raise exceptions.RallyAssertionError(

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1703,7 +1703,8 @@ class ExecuteTransform(Runner):
             "search_time": transform_stats.get("search_time_in_ms", 0),
             "processing_time": transform_stats.get("processing_time_in_ms", 0),
             "index_time": transform_stats.get("index_time_in_ms", 0),
-            "unit": "ms",
+            "weight": transform_stats.get("documents_processed", 0),
+            "unit": "docs",
             "ops": ops
         }
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1671,6 +1671,19 @@ class GlobalStatsCalculator:
         # convert to int, fraction counts are senseless
         median_segment_count = self.median("segments_count")
         result.segment_count = int(median_segment_count) if median_segment_count is not None else median_segment_count
+
+        result.transform_pages_processed = self.max("transform_pages_processed")
+        result.transform_documents_processed = self.max("transform_documents_processed")
+        result.transform_documents_indexed = self.max("transform_documents_indexed")
+        result.transform_search_time_in_ms = self.max("transform_search_time_in_ms")
+        result.transform_index_time_in_ms = self.max("transform_index_time_in_ms")
+        result.transform_processing_time_in_ms = self.max("transform_processing_time_in_ms")
+        result.transform_index_total = self.max("transform_index_total")
+        result.transform_index_failures = self.max("transform_index_failures")
+        result.transform_search_total = self.max("transform_search_total")
+        result.transform_search_failures = self.max("transform_search_failures")
+        result.transform_processing_total = self.max("transform_processing_total")
+
         return result
 
     def merge(self, *args):
@@ -1747,6 +1760,12 @@ class GlobalStatsCalculator:
     def median(self, metric_name, task_name=None, operation_type=None, sample_type=None):
         return self.store.get_median(metric_name, task=task_name, operation_type=operation_type, sample_type=sample_type)
 
+    def max(self, metric_name, task_name=None, operation_type=None, sample_type=None):
+        stats = self.store.get_stats(metric_name, task=task_name, operation_type=operation_type, sample_type=sample_type)
+        if stats is not None:
+            return stats["max"]
+        return 0
+
     def single_latency(self, task, metric_name="latency"):
         sample_type = SampleType.Normal
         sample_size = self.store.get_count(metric_name, task=task, sample_type=sample_type)
@@ -1804,6 +1823,18 @@ class GlobalStats:
         self.store_size = self.v(d, "store_size")
         self.translog_size = self.v(d, "translog_size")
         self.segment_count = self.v(d, "segment_count")
+
+        self.transform_pages_processed = self.v(d, "transform_pages_processed")
+        self.transform_documents_processed = self.v(d, "transform_documents_processed")
+        self.transform_documents_indexed = self.v(d, "transform_documents_indexed")
+        self.transform_search_time_in_ms = self.v(d, "transform_search_time_in_ms")
+        self.transform_index_time_in_ms = self.v(d, "transform_index_time_in_ms")
+        self.transform_processing_time_in_ms = self.v(d, "transform_processing_time_in_ms")
+        self.transform_index_total = self.v(d, "transform_index_total")
+        self.transform_index_failures = self.v(d, "transform_index_failures")
+        self.transform_search_total = self.v(d, "transform_search_total")
+        self.transform_search_failures = self.v(d, "transform_search_failures")
+        self.transform_processing_total = self.v(d, "transform_processing_total")
 
     def as_dict(self):
         return self.__dict__

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -119,6 +119,8 @@ class SummaryReporter:
         metrics_table.extend(self.report_segment_memory(stats))
         metrics_table.extend(self.report_segment_counts(stats))
 
+        metrics_table.extend(self.report_transform_stats(stats))
+
         for record in stats.op_metrics:
             task = record["task"]
             metrics_table.extend(self.report_throughput(record, task))
@@ -265,6 +267,20 @@ class SummaryReporter:
     def report_segment_counts(self, stats):
         return self.join(
             self.line("Segment count", "", stats.segment_count, "")
+        )
+
+    def report_transform_stats(self, stats):
+        if stats.transform_documents_processed is None or stats.transform_documents_processed == 0:
+            return []
+
+        return self.join(
+            self.line("Transform documents_processed", "", stats.transform_documents_processed, ""),
+            self.line("Transform documents_indexed", "", stats.transform_documents_indexed, ""),
+            self.line("Transform transform_search_time", "", stats.transform_search_time_in_ms, "ms"),
+            self.line("Transform transform_index_time", "", stats.transform_index_time_in_ms, "ms"),
+            self.line("Transform transform_processing_time", "", stats.transform_processing_time_in_ms, "ms"),
+            self.line("Transform transform_index_failures", "", stats.transform_index_failures, ""),
+            self.line("Transform transform_search_failures", "", stats.transform_search_failures, "")
         )
 
     def join(self, *args):

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -799,6 +799,8 @@ class TransformStats(TelemetryDevice):
         if self.samplers:
             for sampler in self.samplers:
                 sampler.finish()
+                # record the final stats
+                sampler.recorder.record()
 
 
 class TransformStatsRecorder:

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -839,7 +839,7 @@ class TransformStatsRecorder:
         import elasticsearch
 
         try:
-            stats = self.client.transform.get_transform_stats('_all')
+            stats = self.client.transform.get_transform_stats("_all")
 
         except elasticsearch.TransportError as e:
             msg = "A transport error occurred while collecting transform stats on " \
@@ -847,9 +847,9 @@ class TransformStatsRecorder:
             self.logger.exception(msg)
             raise exceptions.RallyError(msg)
 
-        for transform in stats['transforms']:
+        for transform in stats["transforms"]:
             try:
-                if self.transforms and transform['id'] not in self.transforms:
+                if self.transforms and transform["id"] not in self.transforms:
                     # Skip metrics for transform not part of user supplied whitelist (transform-stats-transforms)
                     # in telemetry params.
                     continue

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -857,7 +857,7 @@ class TransformStatsRecorder:
 
             except KeyError:
                 self.logger.warning(
-                    f"The 'transform' key does not contain a 'transform' or 'stats' key "
+                    "The 'transform' key does not contain a 'transform' or 'stats' key "
                     "Maybe the output format has changed. Skipping."
                 )
 

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -32,7 +32,7 @@ def list_telemetry():
     console.println("Available telemetry devices:\n")
     devices = [[device.command, device.human_name, device.help] for device in [JitCompiler, Gc, FlightRecorder,
                                                                                Heapdump, NodeStats, RecoveryStats,
-                                                                               CcrStats, SegmentStats]]
+                                                                               CcrStats, SegmentStats, TransformStats]]
     console.println(tabulate.tabulate(devices, ["Command", "Name", "Description"]))
     console.println("\nKeep in mind that each telemetry device may incur a runtime overhead which can skew results.")
 
@@ -741,6 +741,144 @@ class NodeStatsRecorder:
             logging.getLogger(__name__).exception("Could not retrieve node stats.")
             return {}
         return stats["nodes"].values()
+
+
+class TransformStats(TelemetryDevice):
+    internal = False
+    command = "transform-stats"
+    human_name = "Transform Stats"
+    help = "Regularly samples transform stats"
+
+    """
+    Gathers Transform stats
+    """
+
+    def __init__(self, telemetry_params, clients, metrics_store):
+        """
+        :param telemetry_params: The configuration object for telemetry_params.
+        :param clients: A dict of clients to all clusters.
+        :param metrics_store: The configured metrics store we write to.
+        """
+        super().__init__()
+
+        self.telemetry_params = telemetry_params
+        self.clients = clients
+        self.sample_interval = telemetry_params.get("transform-stats-sample-interval", 1)
+        if self.sample_interval <= 0:
+            raise exceptions.SystemSetupError(
+                "The telemetry parameter 'transform-stats-sample-interval' must be greater than zero but was {}.".format(
+                    self.sample_interval))
+        self.specified_cluster_names = self.clients.keys()
+        self.transforms_per_cluster = self.telemetry_params.get("transform-stats-transforms", False)
+        if self.transforms_per_cluster:
+            for cluster_name in self.transforms_per_cluster.keys():
+                if cluster_name not in clients:
+                    raise exceptions.SystemSetupError(
+                        "The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys matching "
+                        "the cluster names [{}] specified in --target-hosts "
+                        "but it had [{}].".format(",".join(sorted(clients.keys())), cluster_name))
+            self.specified_cluster_names = self.transforms_per_cluster.keys()
+
+        self.metrics_store = metrics_store
+        self.samplers = []
+
+    def on_benchmark_start(self):
+        recorder = []
+        for cluster_name in self.specified_cluster_names:
+            recorder = TransformStatsRecorder(cluster_name, self.clients[cluster_name], self.metrics_store,
+                                              self.sample_interval,
+                                              self.transforms_per_cluster[
+                                                  cluster_name] if self.transforms_per_cluster else None)
+            sampler = SamplerThread(recorder)
+            self.samplers.append(sampler)
+            sampler.setDaemon(True)
+            # we don't require starting recorders precisely at the same time
+            sampler.start()
+
+    def on_benchmark_stop(self):
+        if self.samplers:
+            for sampler in self.samplers:
+                sampler.finish()
+
+
+class TransformStatsRecorder:
+    """
+    Collects and pushes Transform stats for the specified cluster to the metric store.
+    """
+
+    def __init__(self, cluster_name, client, metrics_store, sample_interval, transforms=None):
+        """
+        :param cluster_name: The cluster_name that the client connects to, as specified in target.hosts.
+        :param client: The Elasticsearch client for this cluster.
+        :param metrics_store: The configured metrics store we write to.
+        :param sample_interval: integer controlling the interval, in seconds, between collecting samples.
+        :param transforms: optional list of transforms to filter results from.
+        """
+
+        self.cluster_name = cluster_name
+        self.client = client
+        self.metrics_store = metrics_store
+        self.sample_interval = sample_interval
+        self.transforms = transforms
+        self.logger = logging.getLogger(__name__)
+
+        self.logger.info("transform stats recorder")
+
+    def __str__(self):
+        return "transform stats"
+
+    def record(self):
+        """
+        Collect Transform stats for transforms (optionally) specified in telemetry parameters and push to metrics store.
+        """
+
+        # ES returns all stats values in bytes or ms via "human: false"
+
+        import elasticsearch
+
+        try:
+            stats = self.client.transform.get_transform_stats('_all')
+
+        except elasticsearch.TransportError as e:
+            msg = "A transport error occurred while collecting transform stats on " \
+                  "cluster [{}]".format(self.cluster_name)
+            self.logger.exception(msg)
+            raise exceptions.RallyError(msg)
+
+        for transform in stats['transforms']:
+            try:
+                if self.transforms and transform['id'] not in self.transforms:
+                    # Skip metrics for transform not part of user supplied whitelist (transform-stats-transforms)
+                    # in telemetry params.
+                    continue
+                self.record_stats_per_transform(transform["id"], transform["stats"])
+
+            except KeyError:
+                self.logger.warning(
+                    "The 'transform' key in %s does not contain a 'transform' or 'stats' key "
+                    "Maybe the output format has changed. Skipping."
+                )
+
+    def record_stats_per_transform(self, name, stats):
+        """
+        :param name: The transform name.
+        :param stats: A dict with returned transform stats for the transform.
+        """
+
+        self.metrics_store.put_count_cluster_level("transform_pages_processed", stats.get("pages_processed", 0))
+        self.metrics_store.put_count_cluster_level("transform_documents_processed", stats.get("documents_processed", 0))
+        self.metrics_store.put_count_cluster_level("transform_documents_indexed", stats.get("documents_indexed", 0))
+        self.metrics_store.put_count_cluster_level("transform_index_total", stats.get("index_total", 0))
+        self.metrics_store.put_count_cluster_level("transform_index_failures", stats.get("index_failures", 0))
+        self.metrics_store.put_count_cluster_level("transform_search_total", stats.get("search_total", 0))
+        self.metrics_store.put_count_cluster_level("transform_search_failures", stats.get("search_failures", 0))
+        self.metrics_store.put_count_cluster_level("transform_processing_total", stats.get("processing_total", 0))
+
+        self.metrics_store.put_value_cluster_level("transform_search_time_in_ms", stats.get("search_time_in_ms", 0),
+                                                   "ms")
+        self.metrics_store.put_value_cluster_level("transform_index_time_in_ms", stats.get("index_time_in_ms", 0), "ms")
+        self.metrics_store.put_value_cluster_level("transform_processing_time_in_ms",
+                                                   stats.get("processing_time_in_ms", 0), "ms")
 
 
 class StartupTime(InternalTelemetryDevice):

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -766,17 +766,17 @@ class TransformStats(TelemetryDevice):
         self.sample_interval = telemetry_params.get("transform-stats-sample-interval", 1)
         if self.sample_interval <= 0:
             raise exceptions.SystemSetupError(
-                "The telemetry parameter 'transform-stats-sample-interval' must be greater than zero but was {}.".format(
-                    self.sample_interval))
+                f"The telemetry parameter 'transform-stats-sample-interval' must be greater than zero "
+                f"but was [{self.sample_interval}].")
         self.specified_cluster_names = self.clients.keys()
         self.transforms_per_cluster = self.telemetry_params.get("transform-stats-transforms", False)
         if self.transforms_per_cluster:
             for cluster_name in self.transforms_per_cluster.keys():
                 if cluster_name not in clients:
                     raise exceptions.SystemSetupError(
-                        "The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys matching "
-                        "the cluster names [{}] specified in --target-hosts "
-                        "but it had [{}].".format(",".join(sorted(clients.keys())), cluster_name))
+                        f"The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys "
+                        f"matching the cluster names [{','.join(sorted(clients.keys()))}] specified in --target-hosts "
+                        f"but it had [{cluster_name}].")
             self.specified_cluster_names = self.transforms_per_cluster.keys()
 
         self.metrics_store = metrics_store
@@ -842,8 +842,8 @@ class TransformStatsRecorder:
             stats = self.client.transform.get_transform_stats("_all")
 
         except elasticsearch.TransportError as e:
-            msg = "A transport error occurred while collecting transform stats on " \
-                  "cluster [{}]".format(self.cluster_name)
+            msg = f"A transport error occurred while collecting transform stats on " \
+                  f"cluster [{self.cluster_name}]"
             self.logger.exception(msg)
             raise exceptions.RallyError(msg)
 
@@ -857,7 +857,7 @@ class TransformStatsRecorder:
 
             except KeyError:
                 self.logger.warning(
-                    "The 'transform' key in %s does not contain a 'transform' or 'stats' key "
+                    f"The 'transform' key does not contain a 'transform' or 'stats' key "
                     "Maybe the output format has changed. Skipping."
                 )
 

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -420,6 +420,8 @@ class OperationType(Enum):
     RawRequest = 5
     WaitForRecovery = 6
     CreateSnapshot = 7
+    ExecuteTransform = 6
+
 
     # administrative actions
     ForceMerge = 1001
@@ -523,6 +525,8 @@ class OperationType(Enum):
             return OperationType.StopTransform
         elif v == "delete-transform":
             return OperationType.DeleteTransform
+        elif v == "execute-transform":
+            return OperationType.ExecuteTransform
         else:
             raise KeyError("No enum value for [%s]" % v)
 

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -444,6 +444,10 @@ class OperationType(Enum):
     CreateSnapshotRepository = 1020
     RestoreSnapshot = 1021
     PutSettings = 1022
+    CreateTransform = 1024
+    StartTransform = 1025
+    StopTransform = 1026
+    DeleteTransform = 1027
 
     @property
     def admin_op(self):
@@ -511,6 +515,14 @@ class OperationType(Enum):
             return OperationType.WaitForRecovery
         elif v == "put-settings":
             return OperationType.PutSettings
+        elif v == "create-transform":
+            return OperationType.CreateTransform
+        elif v == "start-transform":
+            return OperationType.StartTransform
+        elif v == "stop-transform":
+            return OperationType.StopTransform
+        elif v == "delete-transform":
+            return OperationType.DeleteTransform
         else:
             raise KeyError("No enum value for [%s]" % v)
 

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -420,7 +420,7 @@ class OperationType(Enum):
     RawRequest = 5
     WaitForRecovery = 6
     CreateSnapshot = 7
-    ExecuteTransform = 6
+    ExecuteTransform = 8
 
 
     # administrative actions
@@ -446,10 +446,10 @@ class OperationType(Enum):
     CreateSnapshotRepository = 1020
     RestoreSnapshot = 1021
     PutSettings = 1022
-    CreateTransform = 1024
-    StartTransform = 1025
-    StopTransform = 1026
-    DeleteTransform = 1027
+    CreateTransform = 1023
+    StartTransform = 1024
+    StopTransform = 1025
+    DeleteTransform = 1026
 
     @property
     def admin_op(self):

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -3238,6 +3238,28 @@ class DeleteTransformTests(TestCase):
                                                               ignore=[404])
 
 
+class ExecuteTransformTests(TestCase):
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_execute_transform(self, es):
+        es.transform.start_transform.return_value = as_future()
+        es.transform.stop_transform.return_value = as_future()
+
+        transform_id = "a-transform"
+        params = {
+            "transform-id": transform_id
+        }
+
+        es.transform.get_transform_stats.return_value = as_future({"transforms": [{"state": "stopped",
+                                                                                   "stats": {}}]})
+
+        r = runner.ExecuteTransform()
+        await r(es, params)
+
+        es.transform.start_transform.assert_called_once_with(transform_id=transform_id)
+        es.transform.get_transform_stats.assert_called_once_with(transform_id=transform_id)
+
+
 class RetryTests(TestCase):
     @run_async
     async def test_is_transparent_on_success_when_no_retries(self):

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -3134,6 +3134,8 @@ class PutSettingsTests(TestCase):
                 "indices.recovery.max_bytes_per_sec": "20mb"
             }
         })
+
+
 class CreateTransformTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -1859,9 +1859,9 @@ class TransformStatsRecorderTests(TestCase):
         ])
 
         metrics_store_put_value.assert_has_calls([
-            mock.call("transform_search_time_in_ms", 8, 'ms'),
-            mock.call("transform_index_time_in_ms", 5, 'ms'),
-            mock.call("transform_processing_time_in_ms", 11, 'ms')
+            mock.call("transform_search_time_in_ms", 8, "ms"),
+            mock.call("transform_index_time_in_ms", 5, "ms"),
+            mock.call("transform_processing_time_in_ms", 11, "ms")
         ])
 
 


### PR DESCRIPTION
add support for [transform](https://www.elastic.co/guide/en/elasticsearch/reference/master/transform-apis.html), consisting of the following parts:

 - create, start, stop, delete API support
 - transform-stats telemetry device to collect transform stats
 - basic command-line reporting
 - some basic documentation

Note: I will add definitions for the recorded metrics later after the 1st round of reviews.