### PR TITLE
Add timestamps as meta-info in index recovery

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1548,7 +1548,9 @@ class IndicesRecovery(Runner):
             "unit": "byte",
             "success": True,
             "service_time": response_time_in_seconds,
-            "time_period": response_time_in_seconds
+            "time_period": response_time_in_seconds,
+            "start_time_millis": total_start_millis,
+            "stop_time_millis": total_end_millis
         }
 
     def __repr__(self, *args, **kwargs):

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -3012,6 +3012,8 @@ class IndicesRecoveryTests(TestCase):
         # 5 seconds
         self.assertEqual(5, result["service_time"])
         self.assertEqual(5, result["time_period"])
+        self.assertEqual(1393244155000, result["start_time_millis"])
+        self.assertEqual(1393244160000, result["stop_time_millis"])
 
         es.indices.recovery.assert_called_with(index="index1")
         # retries four times


### PR DESCRIPTION
With this commit we include the start and stop timestamp as meta-info in
the index recovery runner. This can be useful to correlate the
timestamps to additional diagnostic data (e.g. GC logs or system
metrics).