### PR TITLE
add transform support

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -18,13 +18,14 @@ You probably want to gain additional insights from a race. Therefore, we have ad
 
    Command         Name                   Description
    --------------  ---------------------  --------------------------------------------------------------------
-   jit             JIT Compiler Profiler  Enables JIT compiler logs.
-   gc              GC log                 Enables GC logs.
-   jfr             Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
-   heapdump        Heap Dump              Captures a heap dump.
-   node-stats      Node Stats             Regularly samples node stats
-   recovery-stats  Recovery Stats         Regularly samples shard recovery stats
-   ccr-stats       CCR Stats              Regularly samples Cross Cluster Replication (CCR) related stats
+   jit              JIT Compiler Profiler  Enables JIT compiler logs.
+   gc               GC log                 Enables GC logs.
+   jfr              Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
+   heapdump         Heap Dump              Captures a heap dump.
+   node-stats       Node Stats             Regularly samples node stats
+   recovery-stats   Recovery Stats         Regularly samples shard recovery stats
+   ccr-stats        CCR Stats              Regularly samples Cross Cluster Replication (CCR) related stats
+   transform-stats  Transform Stats        Regularly samples transform stats
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 
@@ -134,3 +135,13 @@ Supported telemetry parameters:
 
 * ``ccr-stats-indices`` (default: all indices): An index pattern for which ccr stats should be checked.
 * ``ccr-stats-sample-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.
+
+transform-stats
+---------------
+
+The transform-stats telemetry device regularly calls the `transform stats API <https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html>` and records one metrics document per transform.
+
+Supported telemetry parameters:
+
+* ``transform-stats-transforms`` (default: all transforms): A list of transforms per cluster for which transform stats should be checked.
+* ``transform-stats-sample-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1151,6 +1151,59 @@ With the operation ``wait-for-recovery`` you can wait until an ongoing shard rec
 
 This operation is :ref:`retryable <track_operations>`.
 
+create-transform
+~~~~~~~~~~~~~~~~
+
+With the operation ``create-transform`` you can execute the `create transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html>`_. It supports the following parameters:
+
+* ``transform-id`` (mandatory): The id of the transform to create.
+* ``body`` (mandatory): Request body containing the configuration of the transform. Please see the `create transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html>`__ documentation for more details.
+* ``defer-validation`` (optional, defaults to false): When true, deferrable validations are not run. This behavior may be desired if the source index does not exist until after the transform is created.
+
+This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+This operation is :ref:`retryable <track_operations>`.
+
+start-transform
+~~~~~~~~~~~~~~~
+
+With the operation ``start-transform`` you can execute the `start transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html>`_. It supports the following parameters:
+
+* ``transform-id`` (mandatory): The id of the transform to start.
+* ``timeout`` (optional, defaults to empty): Amount of time to wait until a transform starts.
+
+This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+This operation is :ref:`retryable <track_operations>`.
+
+stop-transform
+~~~~~~~~~~~~~~
+
+With the operation ``stop-transform`` you can execute the `stop transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html>`_. It supports the following parameters:
+
+* ``transform-id`` (mandatory): The id of the transform to stop.
+* ``force`` (optional, defaults to false): Whether to forcefully stop the transform.
+* ``timeout`` (optional, defaults to empty): Amount of time to wait until a transform stops.
+* ``wait-for-completion`` (optional, defaults to true) If set to true, causes the API to block until the indexer state completely stops.
+* ``wait-for-checkpoint`` (optional, defaults to true) If set to true, the transform will not completely stop until the current checkpoint is completed.
+* ``transform-timeout`` (optional, defaults to `1800` (`1h`)) Overall runtime timeout of the batch transform in seconds.
+
+This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+This operation is :ref:`retryable <track_operations>`.
+
+delete-transform
+~~~~~~~~~~~~~~~~
+
+With the operation ``delete-transform`` you can execute the `delete transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html>`_. It supports the following parameters:
+
+* ``transform-id`` (mandatory): The id of the transform to delete.
+* ``force`` (optional, defaults to false): Whether to delete the transform regardless of its current state.
+
+This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+This operation is :ref:`retryable <track_operations>`.
+
 Examples
 ========
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1178,7 +1178,6 @@ This operation is :ref:`retryable <track_operations>`.
 
 stop-transform
 ~~~~~~~~~~~~~~
-
 With the operation ``stop-transform`` you can execute the `stop transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html>`_. It supports the following parameters:
 
 * ``transform-id`` (mandatory): The id of the transform to stop.
@@ -1186,7 +1185,23 @@ With the operation ``stop-transform`` you can execute the `stop transform API <h
 * ``timeout`` (optional, defaults to empty): Amount of time to wait until a transform stops.
 * ``wait-for-completion`` (optional, defaults to true) If set to true, causes the API to block until the indexer state completely stops.
 * ``wait-for-checkpoint`` (optional, defaults to true) If set to true, the transform will not completely stop until the current checkpoint is completed.
+
+This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
+This operation is :ref:`retryable <track_operations>`.
+
+wait-for-transform
+~~~~~~~~~~~~~~
+
+With the operation ``wait-for-transform`` you can stop a transform after a certain amount of work is done. Use this operation for measuring performance. It supports the following parameters:
+
+* ``transform-id`` (mandatory): The id of the transform to stop.
+* ``force`` (optional, defaults to false): Whether to forcefully stop the transform.
+* ``timeout`` (optional, defaults to empty): Amount of time to wait until a transform stops.
+* ``wait-for-completion`` (optional, defaults to true) If set to true, causes the API to block until the indexer state completely stops.
+* ``wait-for-checkpoint`` (optional, defaults to true) If set to true, the transform will not completely stop until the current checkpoint is completed.
 * ``transform-timeout`` (optional, defaults to `1800` (`1h`)) Overall runtime timeout of the batch transform in seconds.
+* ``poll-interval`` (optional, defaults to `0.5`) How often transform stats are polled, used to set progress and check the state. You should not set this too low, because polling can skew the result.
 
 This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1176,22 +1176,8 @@ This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an admin
 
 This operation is :ref:`retryable <track_operations>`.
 
-stop-transform
-~~~~~~~~~~~~~~
-With the operation ``stop-transform`` you can execute the `stop transform API <https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html>`_. It supports the following parameters:
-
-* ``transform-id`` (mandatory): The id of the transform to stop.
-* ``force`` (optional, defaults to false): Whether to forcefully stop the transform.
-* ``timeout`` (optional, defaults to empty): Amount of time to wait until a transform stops.
-* ``wait-for-completion`` (optional, defaults to true) If set to true, causes the API to block until the indexer state completely stops.
-* ``wait-for-checkpoint`` (optional, defaults to true) If set to true, the transform will not completely stop until the current checkpoint is completed.
-
-This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
-
-This operation is :ref:`retryable <track_operations>`.
-
 wait-for-transform
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 With the operation ``wait-for-transform`` you can stop a transform after a certain amount of work is done. Use this operation for measuring performance. It supports the following parameters:
 
@@ -1200,7 +1186,7 @@ With the operation ``wait-for-transform`` you can stop a transform after a certa
 * ``timeout`` (optional, defaults to empty): Amount of time to wait until a transform stops.
 * ``wait-for-completion`` (optional, defaults to true) If set to true, causes the API to block until the indexer state completely stops.
 * ``wait-for-checkpoint`` (optional, defaults to true) If set to true, the transform will not completely stop until the current checkpoint is completed.
-* ``transform-timeout`` (optional, defaults to `1800` (`1h`)) Overall runtime timeout of the batch transform in seconds.
+* ``transform-timeout`` (optional, defaults to `3600` (`1h`)) Overall runtime timeout of the batch transform in seconds.
 * ``poll-interval`` (optional, defaults to `0.5`) How often transform stats are polled, used to set progress and check the state. You should not set this too low, because polling can skew the result.
 
 This operation requires at least Elasticsearch 7.5.0 (non-OSS). This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -400,7 +400,8 @@ class Driver:
             telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
             telemetry.SegmentStats(log_root, es_default),
             telemetry.CcrStats(telemetry_params, es, self.metrics_store),
-            telemetry.RecoveryStats(telemetry_params, es, self.metrics_store)
+            telemetry.RecoveryStats(telemetry_params, es, self.metrics_store),
+            telemetry.TransformStats(telemetry_params, es, self.metrics_store)
         ])
 
     def wait_for_rest_api(self, es):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1756,7 +1756,7 @@ class WaitForTransform(Runner):
             processing_time_delta = processing_time - self._last_processing_time
 
             # only report if we have enough data or transform has completed
-            if self._completed or documents_processed_delta > 5000 or processing_time_delta > 500:
+            if self._completed or (documents_processed_delta > 5000 and processing_time_delta > 500):
                 stats = {
                     "transform-id": transform_id,
                     "search-time-ms": transform_stats.get("search_time_in_ms", 0),
@@ -1767,9 +1767,11 @@ class WaitForTransform(Runner):
                     "ops": ops
                 }
 
+                throughput = 0
                 if self._completed:
                     # take the overall throughput
-                    throughput = documents_processed / processing_time * 1000
+                    if processing_time > 0:
+                        throughput = documents_processed / processing_time * 1000
                 else:
                     throughput = documents_processed_delta / processing_time_delta * 1000
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -67,7 +67,6 @@ def register_default_runners():
     register_runner(track.OperationType.PutSettings.name, Retry(PutSettings()), async_runner=True)
     register_runner(track.OperationType.CreateTransform.name, Retry(CreateTransform()), async_runner=True)
     register_runner(track.OperationType.StartTransform.name, Retry(StartTransform()), async_runner=True)
-    register_runner(track.OperationType.StopTransform.name, Retry(StopTransform()), async_runner=True)
     register_runner(track.OperationType.WaitForTransform.name, Retry(WaitForTransform()), async_runner=True)
     register_runner(track.OperationType.DeleteTransform.name, Retry(DeleteTransform()), async_runner=True)
 
@@ -1604,29 +1603,6 @@ class StartTransform(Runner):
         return "start-transform"
 
 
-class StopTransform(Runner):
-    """
-    Execute the `stop transform API
-    https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html`_.
-    """
-
-    async def __call__(self, es, params):
-        transform_id = mandatory(params, "transform-id", self)
-        force = params.get("force", False)
-        timeout = params.get("timeout")
-        wait_for_completion = params.get("wait-for-completion", False)
-        wait_for_checkpoint = params.get("wait-for-checkpoint", False)
-
-        await es.transform.stop_transform(transform_id=transform_id,
-                                          force=force,
-                                          timeout=timeout,
-                                          wait_for_completion=wait_for_completion,
-                                          wait_for_checkpoint=wait_for_checkpoint)
-
-    def __repr__(self, *args, **kwargs):
-        return "stop-transform"
-
-
 class WaitForTransform(Runner):
     """
     Wait for the transform until it reaches a certain checkpoint.
@@ -1650,7 +1626,7 @@ class WaitForTransform(Runner):
 
     async def __call__(self, es, params):
         """
-        stop the transform and return stats
+        stop the transform and wait until transform has finished return stats
 
         :param es: The Elasticsearch client.
         :param params: A hash with all parameters. See below for details.

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1757,7 +1757,7 @@ class GlobalStatsCalculator:
                 if transform_id is not None:
                     result.append({
                         "id": transform_id,
-                        "value": v["value"],
+                        "mean": v["value"],
                         "unit": v["unit"]
                     })
         return result
@@ -1875,13 +1875,13 @@ class GlobalStats:
                             "max": item["max"]
                         }
                     })
-            elif metric.startswith("total_transform_"):
+            elif metric.startswith("total_transform_") and value is not None:
                 for item in value:
                     all_results.append({
                         "id": item["id"],
                         "name": metric,
                         "value": {
-                            "single": item["value"]
+                            "single": item["mean"]
                         }
                     })
             elif metric.endswith("_time_per_shard"):

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -271,16 +271,19 @@ class SummaryReporter:
 
     def report_transform_stats(self, stats):
         lines = []
-        for processing_time in stats.transform_processing_times:
-            transform_id = processing_time["id"]
-            unit = processing_time["unit"]
-            lines.append(self.line("Transform search processing time", transform_id, processing_time["search"], unit))
-            lines.append(self.line("Transform indexing processing time", transform_id, processing_time["index"], unit))
-            lines.append(self.line("Transform task processing time", transform_id, processing_time["processing"], unit))
-
-        for throughput in stats.transform_throughput:
+        for processing_time in stats.total_transform_processing_times:
             lines.append(
-                self.line("Transform throughput", throughput["id"], throughput["throughput"], throughput["unit"]))
+                self.line("Transform processing time", processing_time["id"], processing_time["value"],
+                          processing_time["unit"]))
+        for index_time in stats.total_transform_index_times:
+            lines.append(
+                self.line("Transform indexing time", index_time["id"], index_time["value"], index_time["unit"]))
+        for search_time in stats.total_transform_search_times:
+            lines.append(
+                self.line("Transform search time", search_time["id"], search_time["value"], search_time["unit"]))
+        for throughput in stats.total_transform_throughput:
+            lines.append(
+                self.line("Transform throughput", throughput["id"], throughput["value"], throughput["unit"]))
 
         return lines
 
@@ -428,29 +431,34 @@ class ComparisonReporter:
 
     def report_transform_processing_times(self, baseline_stats, contender_stats):
         lines = []
-        for baseline in baseline_stats.transform_processing_times:
+        for baseline in baseline_stats.total_transform_processing_times:
             transform_id = baseline["id"]
-            unit = baseline["unit"]
-            # O(n^2) but we assume here only a *very* limited number of jobs (usually just one)
-            for contender in contender_stats.transform_processing_times:
+            for contender in contender_stats.total_transform_processing_times:
                 if contender["id"] == transform_id:
                     lines.append(
-                        self.line("Transform search processing time", baseline["search"], contender["search"],
-                                  transform_id, unit, treat_increase_as_improvement=False))
-                    lines.append(
-                        self.line("Transform indexing processing time", baseline["index"], contender["index"],
-                                  transform_id, unit, treat_increase_as_improvement=False))
-                    lines.append(
-                        self.line("Transform task processing time", baseline["processing"], contender["processing"],
-                                  transform_id, unit, treat_increase_as_improvement=False))
-        for baseline in baseline_stats.transform_throughput:
+                        self.line("Transform processing time", baseline["value"], contender["value"],
+                                  transform_id, baseline["unit"], treat_increase_as_improvement=True))
+        for baseline in baseline_stats.total_transform_index_times:
             transform_id = baseline["id"]
-            unit = baseline["unit"]
-            for contender in contender_stats.transform_throughput:
+            for contender in contender_stats.total_transform_index_times:
                 if contender["id"] == transform_id:
                     lines.append(
-                        self.line("Transform throughput", baseline["throughput"], contender["throughput"],
-                                  transform_id, unit, treat_increase_as_improvement=True))
+                        self.line("Transform indexing time", baseline["value"], contender["value"],
+                                  transform_id, baseline["unit"], treat_increase_as_improvement=True))
+        for baseline in baseline_stats.total_transform_search_times:
+            transform_id = baseline["id"]
+            for contender in contender_stats.total_transform_search_times:
+                if contender["id"] == transform_id:
+                    lines.append(
+                        self.line("Transform search time", baseline["value"], contender["value"],
+                                  transform_id, baseline["unit"], treat_increase_as_improvement=True))
+        for baseline in baseline_stats.total_transform_throughput:
+            transform_id = baseline["id"]
+            for contender in contender_stats.total_transform_throughput:
+                if contender["id"] == transform_id:
+                    lines.append(
+                        self.line("Transform throughput", baseline["value"], contender["value"],
+                                  transform_id, baseline["unit"], treat_increase_as_improvement=True))
         return lines
 
     def report_total_times(self, baseline_stats, contender_stats):

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -273,17 +273,17 @@ class SummaryReporter:
         lines = []
         for processing_time in stats.total_transform_processing_times:
             lines.append(
-                self.line("Transform processing time", processing_time["id"], processing_time["value"],
+                self.line("Transform processing time", processing_time["id"], processing_time["mean"],
                           processing_time["unit"]))
         for index_time in stats.total_transform_index_times:
             lines.append(
-                self.line("Transform indexing time", index_time["id"], index_time["value"], index_time["unit"]))
+                self.line("Transform indexing time", index_time["id"], index_time["mean"], index_time["unit"]))
         for search_time in stats.total_transform_search_times:
             lines.append(
-                self.line("Transform search time", search_time["id"], search_time["value"], search_time["unit"]))
+                self.line("Transform search time", search_time["id"], search_time["mean"], search_time["unit"]))
         for throughput in stats.total_transform_throughput:
             lines.append(
-                self.line("Transform throughput", throughput["id"], throughput["value"], throughput["unit"]))
+                self.line("Transform throughput", throughput["id"], throughput["mean"], throughput["unit"]))
 
         return lines
 
@@ -436,28 +436,28 @@ class ComparisonReporter:
             for contender in contender_stats.total_transform_processing_times:
                 if contender["id"] == transform_id:
                     lines.append(
-                        self.line("Transform processing time", baseline["value"], contender["value"],
+                        self.line("Transform processing time", baseline["mean"], contender["mean"],
                                   transform_id, baseline["unit"], treat_increase_as_improvement=True))
         for baseline in baseline_stats.total_transform_index_times:
             transform_id = baseline["id"]
             for contender in contender_stats.total_transform_index_times:
                 if contender["id"] == transform_id:
                     lines.append(
-                        self.line("Transform indexing time", baseline["value"], contender["value"],
+                        self.line("Transform indexing time", baseline["mean"], contender["mean"],
                                   transform_id, baseline["unit"], treat_increase_as_improvement=True))
         for baseline in baseline_stats.total_transform_search_times:
             transform_id = baseline["id"]
             for contender in contender_stats.total_transform_search_times:
                 if contender["id"] == transform_id:
                     lines.append(
-                        self.line("Transform search time", baseline["value"], contender["value"],
+                        self.line("Transform search time", baseline["mean"], contender["mean"],
                                   transform_id, baseline["unit"], treat_increase_as_improvement=True))
         for baseline in baseline_stats.total_transform_throughput:
             transform_id = baseline["id"]
             for contender in contender_stats.total_transform_throughput:
                 if contender["id"] == transform_id:
                     lines.append(
-                        self.line("Transform throughput", baseline["value"], contender["value"],
+                        self.line("Transform throughput", baseline["mean"], contender["mean"],
                                   transform_id, baseline["unit"], treat_increase_as_improvement=True))
         return lines
 

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -274,9 +274,13 @@ class SummaryReporter:
         for processing_time in stats.transform_processing_times:
             transform_id = processing_time["id"]
             unit = processing_time["unit"]
-            lines.append(self.line("Search processing time", transform_id, processing_time["search"], unit))
-            lines.append(self.line("Indexing processing time", transform_id, processing_time["index"], unit))
-            lines.append(self.line("Task processing time", transform_id, processing_time["processing"], unit))
+            lines.append(self.line("Transform search processing time", transform_id, processing_time["search"], unit))
+            lines.append(self.line("Transform indexing processing time", transform_id, processing_time["index"], unit))
+            lines.append(self.line("Transform task processing time", transform_id, processing_time["processing"], unit))
+
+        for throughput in stats.transform_throughput:
+            lines.append(
+                self.line("Transform throughput", throughput["id"], throughput["throughput"], throughput["unit"]))
 
         return lines
 
@@ -431,14 +435,22 @@ class ComparisonReporter:
             for contender in contender_stats.transform_processing_times:
                 if contender["id"] == transform_id:
                     lines.append(
-                        self.line("Search processing time", baseline["search"], contender["search"],
+                        self.line("Transform search processing time", baseline["search"], contender["search"],
                                   transform_id, unit, treat_increase_as_improvement=False))
                     lines.append(
-                        self.line("Indexing processing time", baseline["index"], contender["index"],
+                        self.line("Transform indexing processing time", baseline["index"], contender["index"],
                                   transform_id, unit, treat_increase_as_improvement=False))
                     lines.append(
-                        self.line("Task processing time", baseline["processing"], contender["processing"],
+                        self.line("Transform task processing time", baseline["processing"], contender["processing"],
                                   transform_id, unit, treat_increase_as_improvement=False))
+        for baseline in baseline_stats.transform_throughput:
+            transform_id = baseline["id"]
+            unit = baseline["unit"]
+            for contender in contender_stats.transform_throughput:
+                if contender["id"] == transform_id:
+                    lines.append(
+                        self.line("Transform throughput", baseline["throughput"], contender["throughput"],
+                                  transform_id, unit, treat_increase_as_improvement=True))
         return lines
 
     def report_total_times(self, baseline_stats, contender_stats):

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -907,6 +907,17 @@ class TransformStatsRecorder:
                                                    stats.get("processing_time_in_ms", 0), "ms", sample_type=sample_type,
                                                    meta_data=meta_data)
 
+        documents_processed = stats.get("documents_processed", 0)
+        processing_time = stats.get("search_time_in_ms", 0)
+        processing_time += stats.get("processing_time_in_ms", 0)
+        processing_time += stats.get("index_time_in_ms", 0)
+
+        if processing_time > 0:
+            throughput = documents_processed / processing_time * 1000
+
+        self.metrics_store.put_value_cluster_level("transform_throughput", throughput,
+                                                   "docs/s", sample_type=sample_type, meta_data=meta_data)
+
 
 class StartupTime(InternalTelemetryDevice):
     def __init__(self, stopwatch=time.StopWatch):

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -914,9 +914,8 @@ class TransformStatsRecorder:
 
         if processing_time > 0:
             throughput = documents_processed / processing_time * 1000
-
-        self.metrics_store.put_value_cluster_level("transform_throughput", throughput,
-                                                   "docs/s", sample_type=sample_type, meta_data=meta_data)
+            self.metrics_store.put_value_cluster_level("transform_throughput", throughput,
+                                                       "docs/s", sample_type=sample_type, meta_data=meta_data)
 
 
 class StartupTime(InternalTelemetryDevice):

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -420,7 +420,6 @@ class OperationType(Enum):
     RawRequest = 5
     WaitForRecovery = 6
     CreateSnapshot = 7
-    WaitForTransform = 8
 
 
     # administrative actions
@@ -448,7 +447,7 @@ class OperationType(Enum):
     PutSettings = 1022
     CreateTransform = 1023
     StartTransform = 1024
-    StopTransform = 1025
+    WaitForTransform = 1025
     DeleteTransform = 1026
 
     @property
@@ -521,8 +520,6 @@ class OperationType(Enum):
             return OperationType.CreateTransform
         elif v == "start-transform":
             return OperationType.StartTransform
-        elif v == "stop-transform":
-            return OperationType.StopTransform
         elif v == "wait-for-transform":
             return OperationType.WaitForTransform
         elif v == "delete-transform":

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -420,7 +420,7 @@ class OperationType(Enum):
     RawRequest = 5
     WaitForRecovery = 6
     CreateSnapshot = 7
-    StopTransform = 8
+    WaitForTransform = 8
 
 
     # administrative actions
@@ -448,7 +448,8 @@ class OperationType(Enum):
     PutSettings = 1022
     CreateTransform = 1023
     StartTransform = 1024
-    DeleteTransform = 1025
+    StopTransform = 1025
+    DeleteTransform = 1026
 
     @property
     def admin_op(self):
@@ -522,6 +523,8 @@ class OperationType(Enum):
             return OperationType.StartTransform
         elif v == "stop-transform":
             return OperationType.StopTransform
+        elif v == "wait-for-transform":
+            return OperationType.WaitForTransform
         elif v == "delete-transform":
             return OperationType.DeleteTransform
         else:

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -420,6 +420,8 @@ class OperationType(Enum):
     RawRequest = 5
     WaitForRecovery = 6
     CreateSnapshot = 7
+    StopTransform = 8
+
 
     # administrative actions
     ForceMerge = 1001
@@ -444,6 +446,9 @@ class OperationType(Enum):
     CreateSnapshotRepository = 1020
     RestoreSnapshot = 1021
     PutSettings = 1022
+    CreateTransform = 1023
+    StartTransform = 1024
+    DeleteTransform = 1025
 
     @property
     def admin_op(self):
@@ -511,6 +516,14 @@ class OperationType(Enum):
             return OperationType.WaitForRecovery
         elif v == "put-settings":
             return OperationType.PutSettings
+        elif v == "create-transform":
+            return OperationType.CreateTransform
+        elif v == "start-transform":
+            return OperationType.StartTransform
+        elif v == "stop-transform":
+            return OperationType.StopTransform
+        elif v == "delete-transform":
+            return OperationType.DeleteTransform
         else:
             raise KeyError("No enum value for [%s]" % v)
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -3237,31 +3237,6 @@ class StartTransformTests(TestCase):
         es.transform.start_transform.assert_called_once_with(transform_id=transform_id, timeout=params["timeout"])
 
 
-class StopTransformTests(TestCase):
-    @mock.patch("elasticsearch.Elasticsearch")
-    @run_async
-    async def test_stop_transform(self, es):
-        es.transform.stop_transform.return_value = as_future()
-
-        transform_id = "a-transform"
-        params = {
-            "transform-id": transform_id,
-            "force": random.choice([False, True]),
-            "timeout": "5s",
-            "wait-for-completion": random.choice([False, True]),
-            "wait-for-checkpoint": random.choice([False, True]),
-        }
-
-        r = runner.StopTransform()
-        await r(es, params)
-
-        es.transform.stop_transform.assert_called_once_with(transform_id=transform_id, force=params["force"],
-                                                            timeout=params["timeout"],
-                                                            wait_for_completion=params["wait-for-completion"],
-                                                            wait_for_checkpoint=params["wait-for-checkpoint"]
-                                                            )
-
-
 class WaitForTransformTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -3293,19 +3293,6 @@ class WaitForTransformTests(TestCase):
 
         self.assertTrue(r.completed)
         self.assertEqual(r.percent_completed, 1.0)
-
-        self.assertEqual(result["ops"]["pages-processed"], 1)
-        self.assertEqual(result["ops"]["documents-processed"], 2)
-        self.assertEqual(result["ops"]["documents-indexed"], 3)
-        self.assertEqual(result["ops"]["index-total"], 6)
-        self.assertEqual(result["ops"]["index-failures"], 7)
-        self.assertEqual(result["ops"]["search-total"], 9)
-        self.assertEqual(result["ops"]["search-failures"], 10)
-        self.assertEqual(result["ops"]["processing-total"], 12)
-
-        self.assertEqual(result["search-time-ms"], 8)
-        self.assertEqual(11, result["processing-time-ms"], 11)
-        self.assertEqual(5, result["index-time-ms"], 5)
         self.assertEqual(2, result["weight"], 2)
         self.assertEqual(result["unit"], "docs")
 
@@ -3488,19 +3475,6 @@ class WaitForTransformTests(TestCase):
         self.assertEqual(total_calls, 4)
         self.assertTrue(r.completed)
         self.assertEqual(r.percent_completed, 1.0)
-
-        self.assertEqual(result["ops"]["pages-processed"], 1)
-        self.assertEqual(result["ops"]["documents-processed"], 60000)
-        self.assertEqual(result["ops"]["documents-indexed"], 3)
-        self.assertEqual(result["ops"]["index-total"], 6)
-        self.assertEqual(result["ops"]["index-failures"], 7)
-        self.assertEqual(result["ops"]["search-total"], 9)
-        self.assertEqual(result["ops"]["search-failures"], 10)
-        self.assertEqual(result["ops"]["processing-total"], 12)
-
-        self.assertEqual(result["search-time-ms"], 3000)
-        self.assertEqual(result["processing-time-ms"], 1000)
-        self.assertEqual(result["index-time-ms"], 1500)
         self.assertEqual(result["weight"], 60000)
         self.assertEqual(result["unit"], "docs")
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -3176,6 +3176,312 @@ class PutSettingsTests(TestCase):
         })
 
 
+class CreateTransformTests(TestCase):
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_create_transform(self, es):
+        es.transform.put_transform.return_value = as_future()
+
+        params = {
+            "transform-id": "a-transform",
+            "body": {
+                "source": {
+                    "index": "source"
+                },
+                "pivot": {
+                    "group_by": {
+                        "event_id": {
+                            "terms": {
+                                "field": "event_id"
+                            }
+                        }
+                    },
+                    "aggregations": {
+                        "max_metric": {
+                            "max": {
+                                "field": "metric"
+                            }
+                        }
+                    }
+                },
+                "description": "an example transform",
+                "dest": {
+                    "index": "dest"
+                }
+            },
+            "defer-validation": random.choice([False, True])
+        }
+
+        r = runner.CreateTransform()
+        await r(es, params)
+
+        es.transform.put_transform.assert_called_once_with(transform_id=params["transform-id"], body=params["body"],
+                                                           defer_validation=params["defer-validation"])
+
+
+class StartTransformTests(TestCase):
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_start_transform(self, es):
+        es.transform.start_transform.return_value = as_future()
+
+        transform_id = "a-transform"
+        params = {
+            "transform-id": transform_id,
+            "timeout": "5s"
+        }
+
+        r = runner.StartTransform()
+        await r(es, params)
+
+        es.transform.start_transform.assert_called_once_with(transform_id=transform_id, timeout=params["timeout"])
+
+
+class StopTransformTests(TestCase):
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_stop_transform(self, es):
+        es.transform.stop_transform.return_value = as_future()
+        transform_id = "a-transform"
+        params = {
+            "transform-id": transform_id,
+            "force": random.choice([False, True]),
+            "timeout": "5s",
+            "wait-for-completion": random.choice([False, True]),
+            "wait-for-checkpoint": random.choice([False, True]),
+        }
+
+        es.transform.get_transform_stats.return_value = as_future({
+            "count": 1,
+            "transforms": [
+                {
+                    "id": "a-transform",
+                    "state": "stopped",
+                    "stats": {
+                        "pages_processed": 1,
+                        "documents_processed": 2,
+                        "documents_indexed": 3,
+                        "trigger_count": 4,
+                        "index_time_in_ms": 5,
+                        "index_total": 6,
+                        "index_failures": 7,
+                        "search_time_in_ms": 8,
+                        "search_total": 9,
+                        "search_failures": 10,
+                        "processing_time_in_ms": 11,
+                        "processing_total": 12,
+                        "exponential_avg_checkpoint_duration_ms": 13.13,
+                        "exponential_avg_documents_indexed": 14.14,
+                        "exponential_avg_documents_processed": 15.15
+                    },
+                    "checkpointing": {
+                        "last": {
+                            "checkpoint": 1,
+                            "timestamp_millis": 16
+                        },
+                        "changes_last_detected_at": 16
+                    }
+                }
+            ]
+        })
+
+        r = runner.StopTransform()
+        self.assertFalse(r.completed)
+        self.assertEqual(r.percent_completed, 0.0)
+
+        result = await r(es, params)
+
+        self.assertTrue(r.completed)
+        self.assertEqual(r.percent_completed, 1.0)
+
+        self.assertEqual(result["ops"]["pages-processed"], 1)
+        self.assertEqual(result["ops"]["documents-processed"], 2)
+        self.assertEqual(result["ops"]["documents-indexed"], 3)
+        self.assertEqual(result["ops"]["index-total"], 6)
+        self.assertEqual(result["ops"]["index-failures"], 7)
+        self.assertEqual(result["ops"]["search-total"], 9)
+        self.assertEqual(result["ops"]["search-failures"], 10)
+        self.assertEqual(result["ops"]["processing-total"], 12)
+
+        self.assertEqual(result["search-time-ms"], 8)
+        self.assertEqual(11, result["processing-time-ms"], 11)
+        self.assertEqual(5, result["index-time-ms"], 5)
+        self.assertEqual(2, result["weight"], 2)
+        self.assertEqual(result["unit"], "docs")
+
+        es.transform.stop_transform.assert_called_once_with(transform_id=transform_id, force=params["force"],
+                                                            timeout=params["timeout"],
+                                                            wait_for_completion=False,
+                                                            wait_for_checkpoint=params["wait-for-checkpoint"]
+                                                            )
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_stop_transform_progress(self, es):
+        es.transform.stop_transform.return_value = as_future()
+        transform_id = "a-transform"
+        params = {
+            "transform-id": transform_id,
+            "force": random.choice([False, True]),
+            "timeout": "5s"
+        }
+
+        # return 4 times, simulating progress
+        es.transform.get_transform_stats.side_effect = [
+            as_future({
+                "count": 1,
+                "transforms": [
+                    {
+                        "id": "a-transform",
+                        "state": "indexing",
+                        "stats": {},
+                        "checkpointing": {
+                            "last": {},
+                            "next": {
+                                "checkpoint": 1,
+                                "timestamp_millis": 16,
+                                "checkpoint_progress": {
+                                    "percent_complete": 10.20
+                                }
+                            },
+                            "changes_last_detected_at": 16
+                        }
+                    }
+                ]
+            }),
+            as_future({
+                "count": 1,
+                "transforms": [
+                    {
+                        "id": "a-transform",
+                        "state": "indexing",
+                        "stats": {},
+                        "checkpointing": {
+                            "last": {},
+                            "next": {
+                                "checkpoint": 1,
+                                "timestamp_millis": 16,
+                                "checkpoint_progress": {
+                                    "percent_complete": 20.40
+                                }
+                            },
+                            "changes_last_detected_at": 16
+                        }
+                    }
+                ]
+            }),
+            as_future({
+                "count": 1,
+                "transforms": [
+                    {
+                        "id": "a-transform",
+                        "state": "started",
+                        "stats": {},
+                        "checkpointing": {
+                            "last": {},
+                            "next": {
+                                "checkpoint": 1,
+                                "timestamp_millis": 16,
+                                "checkpoint_progress": {
+                                    "percent_complete": 30.60
+                                }
+                            },
+                            "changes_last_detected_at": 16
+                        }
+                    }
+                ]
+            }),
+            as_future({
+                "count": 1,
+                "transforms": [
+                    {
+                        "id": "a-transform",
+                        "state": "stopped",
+                        "stats": {
+                            "pages_processed": 1,
+                            "documents_processed": 2,
+                            "documents_indexed": 3,
+                            "trigger_count": 4,
+                            "index_time_in_ms": 5,
+                            "index_total": 6,
+                            "index_failures": 7,
+                            "search_time_in_ms": 8,
+                            "search_total": 9,
+                            "search_failures": 10,
+                            "processing_time_in_ms": 11,
+                            "processing_total": 12,
+                            "exponential_avg_checkpoint_duration_ms": 13.13,
+                            "exponential_avg_documents_indexed": 14.14,
+                            "exponential_avg_documents_processed": 15.15
+                        },
+                        "checkpointing": {
+                            "last": {
+                                "checkpoint": 1,
+                                "timestamp_millis": 16
+                            },
+                            "changes_last_detected_at": 16
+                        }
+                    }
+                ]
+            })
+        ]
+
+        r = runner.StopTransform()
+        self.assertFalse(r.completed)
+        self.assertEqual(r.percent_completed, 0.0)
+
+        total_calls = 0
+        while not r.completed:
+            result = await r(es, params)
+            total_calls += 1
+            if total_calls < 4:
+                self.assertAlmostEqual(r.percent_completed, (total_calls * 10.20) / 100.0)
+
+        self.assertEqual(total_calls, 4)
+        self.assertTrue(r.completed)
+        self.assertEqual(r.percent_completed, 1.0)
+
+        self.assertEqual(result["ops"]["pages-processed"], 1)
+        self.assertEqual(result["ops"]["documents-processed"], 2)
+        self.assertEqual(result["ops"]["documents-indexed"], 3)
+        self.assertEqual(result["ops"]["index-total"], 6)
+        self.assertEqual(result["ops"]["index-failures"], 7)
+        self.assertEqual(result["ops"]["search-total"], 9)
+        self.assertEqual(result["ops"]["search-failures"], 10)
+        self.assertEqual(result["ops"]["processing-total"], 12)
+
+        self.assertEqual(result["search-time-ms"], 8)
+        self.assertEqual(11, result["processing-time-ms"], 11)
+        self.assertEqual(5, result["index-time-ms"], 5)
+        self.assertEqual(2, result["weight"], 2)
+        self.assertEqual(result["unit"], "docs")
+
+        es.transform.stop_transform.assert_called_once_with(transform_id=transform_id, force=params["force"],
+                                                            timeout=params["timeout"],
+                                                            wait_for_completion=False,
+                                                            wait_for_checkpoint=True
+                                                            )
+
+
+class DeleteTransformTests(TestCase):
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_delete_transform(self, es):
+        es.transform.delete_transform.return_value = as_future()
+
+        transform_id = "a-transform"
+        params = {
+            "transform-id": transform_id,
+            "force": random.choice([False, True])
+        }
+
+        r = runner.DeleteTransform()
+        await r(es, params)
+
+        es.transform.delete_transform.assert_called_once_with(transform_id=transform_id, force=params["force"],
+                                                              ignore=[404])
+
+
 class RetryTests(TestCase):
     @run_async
     async def test_is_transparent_on_success_when_no_retries(self):

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -100,10 +100,11 @@ class StartupTimeTests(TestCase):
 
 
 class Client:
-    def __init__(self, nodes=None, info=None, indices=None, transport_client=None):
+    def __init__(self, nodes=None, info=None, indices=None, transform=None, transport_client=None):
         self.nodes = nodes
         self._info = wrap(info)
         self.indices = indices
+        self.transform = transform
         if transport_client:
             self.transport = transport_client
 
@@ -112,10 +113,11 @@ class Client:
 
 
 class SubClient:
-    def __init__(self, stats=None, info=None, recovery=None):
+    def __init__(self, stats=None, info=None, recovery=None, transform_stats=None):
         self._stats = wrap(stats)
         self._info = wrap(info)
         self._recovery = wrap(recovery)
+        self._transform_stats = wrap(transform_stats)
 
     def stats(self, *args, **kwargs):
         return self._stats()
@@ -125,6 +127,9 @@ class SubClient:
 
     def recovery(self, *args, **kwargs):
         return self._recovery()
+
+    def get_transform_stats(self, *args, **kwargs):
+        return self._transform_stats()
 
 
 def wrap(it):
@@ -1753,6 +1758,118 @@ class NodeStatsRecorderTests(TestCase):
                                     "The telemetry parameter 'node-stats-include-indices-metrics' must be "
                                     "a comma-separated string but was <class 'dict'>"):
             telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
+
+
+class TransformStatsTests(TestCase):
+    def test_negative_sample_interval_forbidden(self):
+        clients = {"default": Client(), "cluster_b": Client()}
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        telemetry_params = {
+            "transform-stats-sample-interval": -1 * random.random()
+        }
+        with self.assertRaisesRegex(exceptions.SystemSetupError,
+                                    r"The telemetry parameter 'transform-stats-sample-interval' must be greater than zero but was .*\."):
+            telemetry.TransformStats(telemetry_params, clients, metrics_store)
+
+    def test_wrong_cluster_name_in_transform_stats_indices_forbidden(self):
+        clients = {"default": Client(), "cluster_b": Client()}
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        telemetry_params = {
+            "transform-stats-transforms": {
+                "default": ["leader"],
+                "wrong_cluster_name": ["follower"]
+            }
+        }
+        with self.assertRaisesRegex(exceptions.SystemSetupError,
+                                    r"The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys matching "
+                                    r"the cluster names \[{}] specified in --target-hosts "
+                                    r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys())))
+                                    ):
+            telemetry.TransformStats(telemetry_params, clients, metrics_store)
+
+
+class TransformStatsRecorderTests(TestCase):
+    transform_stats_response = {}
+
+    @classmethod
+    def setUpClass(cls):
+        java_signed_maxlong = (2 ** 63) - 1
+        transform_id_prefix = "transform_job_"
+        count = random.randrange(1, 10)
+        transforms = []
+
+        for i in range(0, count):
+            transform = {
+                "id": transform_id_prefix + str(i),
+                "state": random.choice(["stopped", "indexing", "started", "failed"]),
+                "stats": {
+                    "pages_processed": 1,
+                    "documents_processed": 2,
+                    "documents_indexed": 3,
+                    "trigger_count": 4,
+                    "index_time_in_ms": 5,
+                    "index_total": 6,
+                    "index_failures": 7,
+                    "search_time_in_ms": 8,
+                    "search_total": 9,
+                    "search_failures": 10,
+                    "processing_time_in_ms": 11,
+                    "processing_total": 12,
+                    "exponential_avg_checkpoint_duration_ms": random.uniform(1.0, 100.0),
+                    "exponential_avg_documents_indexed": random.uniform(1.0, 1000.0),
+                    "exponential_avg_documents_processed": random.uniform(1.0, 10000.0)
+                },
+                "checkpointing": {
+                    "last": {
+                        "checkpoint": random.randint(0, java_signed_maxlong),
+                        "timestamp_millis": random.randint(0, java_signed_maxlong)
+                    },
+                    "changes_last_detected_at": random.randint(0, java_signed_maxlong)
+                }
+            }
+            transforms.append(transform)
+
+        TransformStatsRecorderTests.transform_stats_response = {
+            "count": count,
+            "transforms": transforms
+        }
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_count_cluster_level")
+    @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
+    def test_stores_default_stats(self, metrics_store_put_value, metrics_store_put_count):
+        client = Client(transform=SubClient(transform_stats=TransformStatsRecorderTests.transform_stats_response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        recorder = telemetry.TransformStatsRecorder(cluster_name="transform_cluster", client=client,
+                                                    metrics_store=metrics_store,
+                                                    sample_interval=1)
+        recorder.record()
+
+        meta_data = {
+            "transform_id": "transform_job_0"
+        }
+
+        metrics_store_put_count.assert_has_calls([
+            mock.call("transform_pages_processed", 1, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
+            mock.call("transform_documents_processed", 2, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
+            mock.call("transform_documents_indexed", 3, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
+            mock.call("transform_index_total", 6, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
+            mock.call("transform_index_failures", 7, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
+            mock.call("transform_search_total", 9, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
+            mock.call("transform_search_failures", 10, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
+            mock.call("transform_processing_total", 12, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
+        ])
+
+        metrics_store_put_value.assert_has_calls([
+            mock.call("transform_search_time_in_ms", 8, "ms", sample_type=metrics.SampleType.Normal,
+                      meta_data=meta_data),
+            mock.call("transform_index_time_in_ms", 5, "ms", sample_type=metrics.SampleType.Normal,
+                      meta_data=meta_data),
+            mock.call("transform_processing_time_in_ms", 11, "ms", sample_type=metrics.SampleType.Normal,
+                      meta_data=meta_data)
+        ])
 
 
 class ClusterEnvironmentInfoTests(TestCase):

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -1852,25 +1852,21 @@ class TransformStatsRecorderTests(TestCase):
         }
 
         metrics_store_put_count.assert_has_calls([
-            mock.call("transform_pages_processed", 1, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
-            mock.call("transform_documents_processed", 240, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
-            mock.call("transform_documents_indexed", 3, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
-            mock.call("transform_index_total", 6, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
-            mock.call("transform_index_failures", 7, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
-            mock.call("transform_search_total", 9, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
-            mock.call("transform_search_failures", 10, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
-            mock.call("transform_processing_total", 12, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
+            mock.call("transform_pages_processed", 1, meta_data=meta_data),
+            mock.call("transform_documents_processed", 240, meta_data=meta_data),
+            mock.call("transform_documents_indexed", 3, meta_data=meta_data),
+            mock.call("transform_index_total", 6, meta_data=meta_data),
+            mock.call("transform_index_failures", 7, meta_data=meta_data),
+            mock.call("transform_search_total", 9, meta_data=meta_data),
+            mock.call("transform_search_failures", 10, meta_data=meta_data),
+            mock.call("transform_processing_total", 12, meta_data=meta_data),
         ])
 
         metrics_store_put_value.assert_has_calls([
-            mock.call("transform_search_time_in_ms", 8, "ms", sample_type=metrics.SampleType.Normal,
-                      meta_data=meta_data),
-            mock.call("transform_index_time_in_ms", 5, "ms", sample_type=metrics.SampleType.Normal,
-                      meta_data=meta_data),
-            mock.call("transform_processing_time_in_ms", 11, "ms", sample_type=metrics.SampleType.Normal,
-                      meta_data=meta_data),
-            mock.call("transform_throughput", 10000, "docs/s", sample_type=metrics.SampleType.Normal,
-                      meta_data=meta_data)
+            mock.call("transform_search_time", 8, "ms", meta_data=meta_data),
+            mock.call("transform_index_time", 5, "ms", meta_data=meta_data),
+            mock.call("transform_processing_time", 11, "ms", meta_data=meta_data),
+            mock.call("transform_throughput", 10000, "docs/s", meta_data=meta_data)
         ])
 
 

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -1806,7 +1806,7 @@ class TransformStatsRecorderTests(TestCase):
                 "state": random.choice(["stopped", "indexing", "started", "failed"]),
                 "stats": {
                     "pages_processed": 1,
-                    "documents_processed": 2,
+                    "documents_processed": 240,
                     "documents_indexed": 3,
                     "trigger_count": 4,
                     "index_time_in_ms": 5,
@@ -1853,7 +1853,7 @@ class TransformStatsRecorderTests(TestCase):
 
         metrics_store_put_count.assert_has_calls([
             mock.call("transform_pages_processed", 1, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
-            mock.call("transform_documents_processed", 2, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
+            mock.call("transform_documents_processed", 240, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
             mock.call("transform_documents_indexed", 3, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
             mock.call("transform_index_total", 6, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
             mock.call("transform_index_failures", 7, sample_type=metrics.SampleType.Normal, meta_data=meta_data),
@@ -1868,6 +1868,8 @@ class TransformStatsRecorderTests(TestCase):
             mock.call("transform_index_time_in_ms", 5, "ms", sample_type=metrics.SampleType.Normal,
                       meta_data=meta_data),
             mock.call("transform_processing_time_in_ms", 11, "ms", sample_type=metrics.SampleType.Normal,
+                      meta_data=meta_data),
+            mock.call("transform_throughput", 10000, "docs/s", sample_type=metrics.SampleType.Normal,
                       meta_data=meta_data)
         ])
 


### PR DESCRIPTION
add support for transform, consisting of the following parts:

 - create, start, stop, delete API support
 - basic command-line reporting

follow up of #1011, differences:

 - removed telemetry device
 - stop-transform now reports progress and per default "blocks"(from the track perspective, not within rally) until progress == `1.0` and returns stats