### PR TITLE
Migrate configure test to new IT infrastructure

### DIFF
--- a/integration-test.sh
+++ b/integration-test.sh
@@ -250,12 +250,6 @@ function random_build_type {
     eval "$1='${BUILD_TYPES[$((RANDOM%num_build_types))]}'"
 }
 
-function test_configure {
-    info "test configure()"
-    # just run to test the configuration procedure, don't use this configuration in other tests.
-    esrally configure --assume-defaults --configuration-name="config-integration-test"
-}
-
 function test_proxy_connection {
     local cfg
 

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -409,8 +409,6 @@ function run_test {
         echo "**************************************** TESTING PROXY CONNECTIONS *********************************"
         test_proxy_connection
     fi
-    echo "**************************************** TESTING CONFIGURATION OF RALLY ****************************************"
-    test_configure
     echo "**************************************** TESTING RALLY DOCKER IMAGE ********************************************"
     test_docker_dev_image
     TEST_SUCCESS=1

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -198,8 +198,8 @@ def install_integration_test_config():
         copy_config(n)
 
 
-def remove_integration_test_config():
-    for n in CONFIG_NAMES:
+def remove_integration_test_config(config_names=None):
+    for n in config_names or CONFIG_NAMES:
         os.remove(ConfigFile(n).target_path)
 
 

--- a/it/configuration_test.py
+++ b/it/configuration_test.py
@@ -18,7 +18,14 @@
 import it
 
 
-@it.rally_in_mem
-def test_configure(cfg):
-    # just run to test the configuration procedure, don't use this configuration in other tests.
-    it.esrally_command_line_for(cfg, "configure --assume-defaults --configuration-name='config-integration-test'")
+CFG_FILE = "rally-config-integration-test"
+
+
+class TestConfigure:
+    def test_configure(self):
+        # just run to test the configuration procedure, don't use this configuration in other tests.
+        assert it.esrally(CFG_FILE, f"configure --assume-defaults --configuration-name='{CFG_FILE}'") == 0
+
+    @classmethod
+    def teardown_class(cls):
+        it.remove_integration_test_config([CFG_FILE])

--- a/it/configuration_test.py
+++ b/it/configuration_test.py
@@ -1,0 +1,24 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import it
+
+
+@it.rally_in_mem
+def test_configure(cfg):
+    # just run to test the configuration procedure, don't use this configuration in other tests.
+    it.esrally_command_line_for(cfg, "configure --assume-defaults --configuration-name='config-integration-test'")

--- a/it/configuration_test.py
+++ b/it/configuration_test.py
@@ -24,7 +24,7 @@ CFG_FILE = "rally-config-integration-test"
 class TestConfigure:
     def test_configure(self):
         # just run to test the configuration procedure, don't use this configuration in other tests.
-        assert it.esrally(CFG_FILE, f"configure --assume-defaults --configuration-name='{CFG_FILE}'") == 0
+        assert it.esrally(CFG_FILE, f"configure --assume-defaults") == 0
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
This commit moves the test_configure which validates the configure
command completes properly to the new infrastructure.

Relates #975
