### PR TITLE
Upgrade to Thespian 3.10.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ install_requires = [
     # transitive dependency Markupsafe: BSD
     "Jinja2==2.10.3",
     # License: MIT
-    "thespian==3.10.0",
+    "thespian==3.10.1",
     # recommended library for thespian to identify actors more easily with `ps`
     # "setproctitle==1.1.10",
     # always use the latest version, these are certificate files...


### PR DESCRIPTION
With this commit we upgrade from Thespian 3.10.0 to 3.10.1 which
includes a bugfix that improves stability when a remote actor has closed
a socket which still had pending messages.

Relates kquick/Thespian#63