### PR TITLE
[WIP] Migrate first test_docker_dev_image 

### DIFF
--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -28,15 +28,11 @@ def run_subprocess(command_line):
     return os.system(command_line)
 
 
-def run_subprocess_in_path(path, command_line):
-    return run_subprocess(f"cd {path} && {command_line}")
-
-
-def run_subprocess_with_output(command_line, path=None):
+def run_subprocess_with_output(command_line):
     logger = logging.getLogger(__name__)
     logger.debug("Running subprocess [%s] with output.", command_line)
     command_line_args = shlex.split(command_line)
-    with subprocess.Popen(command_line_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=path) as command_line_process:
+    with subprocess.Popen(command_line_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as command_line_process:
         has_output = True
         lines = []
         while has_output:

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -28,11 +28,15 @@ def run_subprocess(command_line):
     return os.system(command_line)
 
 
-def run_subprocess_with_output(command_line):
+def run_subprocess_in_path(path, command_line):
+    return run_subprocess(f"cd {path} && {command_line}")
+
+
+def run_subprocess_with_output(command_line, path=None):
     logger = logging.getLogger(__name__)
     logger.debug("Running subprocess [%s] with output.", command_line)
     command_line_args = shlex.split(command_line)
-    with subprocess.Popen(command_line_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as command_line_process:
+    with subprocess.Popen(command_line_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=path) as command_line_process:
         has_output = True
         lines = []
         while has_output:

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -356,20 +356,6 @@ function tests_for_all_docker_images {
     unset TEST_COMMAND
 }
 
-function test_docker_dev_image {
-    # First ensure any left overs have been cleaned up
-    docker_compose down
-
-    export RALLY_VERSION=$(cat version.txt)
-    export RALLY_LICENSE=$(awk 'FNR>=2 && FNR<=2' LICENSE | sed 's/^[ \t]*//')
-
-    # Build the docker image
-    docker build -t elastic/rally:${RALLY_VERSION} --build-arg RALLY_VERSION --build-arg RALLY_LICENSE -f docker/Dockerfiles/Dockerfile-dev $PWD
-
-    tests_for_all_docker_images
-}
-
-
 # This function gets called by release-docker.sh and assumes the image has been already built
 function test_docker_release_image {
     if [[ -z "${RALLY_VERSION}" ]]; then

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -23,10 +23,8 @@ from string import Template
 
 import pytest
 
-from esrally import client
+from esrally import client, version
 from esrally.utils import process, io
-from esrally.version import version
-from it.docker_dev_image_test import run_docker_compose_down
 
 CONFIG_NAMES = ["in-memory-it", "es-it"]
 DISTRIBUTIONS = ["2.4.6", "5.6.16", "6.8.0", "7.6.0"]
@@ -215,11 +213,7 @@ def get_license():
 
 
 def build_docker_image():
-    # First ensure any left overs have been cleaned up
-    run_docker_compose_down()
-
-    # We just want the release version without suffix
-    rally_version = version().split(" ")[0]
+    rally_version = version.__version__
 
     env_variables = os.environ.copy()
     env_variables['RALLY_VERSION'] = rally_version

--- a/it/docker_dev_image_test.py
+++ b/it/docker_dev_image_test.py
@@ -19,7 +19,7 @@ import os
 import it
 
 from esrally.utils import process
-from esrally.version import version
+from esrally import version
 
 
 def test_docker_geonames():
@@ -56,7 +56,7 @@ def run_docker_compose_test(test_command):
 def run_docker_compose_up(test_command):
     env_variables = os.environ.copy()
     env_variables["TEST_COMMAND"] = test_command
-    env_variables['RALLY_VERSION'] = version().split(" ")[0]
+    env_variables['RALLY_VERSION'] = version.__version__
 
     return process.run_subprocess_with_logging(f"docker-compose -f {it.ROOT_DIR}/docker/docker-compose-tests.yml up "
                                                f"--abort-on-container-exit", env=env_variables)

--- a/it/docker_dev_image_test.py
+++ b/it/docker_dev_image_test.py
@@ -1,0 +1,31 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+from esrally.utils import process
+from it import ROOT_DIR
+
+DOCKER_COMPOSE_UP = "docker-compose -f docker/docker-compose-tests.yml up --abort-on-container-exit"
+
+
+def test_docker_geonames():
+    test_command = "--pipeline=benchmark-only --test-mode --track=geonames --challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
+    os.environ["TEST_COMMAND"] = test_command
+
+    if process.run_subprocess_in_path(ROOT_DIR, DOCKER_COMPOSE_UP) != 0:
+        raise AssertionError("It was not possible to run the test_docker_geoname successfully")


### PR DESCRIPTION
This PR attempts to start test_docker_dev_image migration. 

At the moment, this only contains information about the first test:
https://github.com/elastic/rally/blob/b59bc099465b86b4d643bc999b85e982fae14d12/integration-test.sh#L334-L337

I was not able to run the integration tests with all them passing, I guess this may be related with my setup and some tests I guess needs a external ES to send metrics (I'm not sure about that). 

Anyway, if the project maintainers like it (and the CI of this PR occurs successfully or it is possible to obtain the root cause) I can expand the migration to the other tests.

