### PR TITLE
Resolve JAVA_HOME for source builds lazily

### DIFF
--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -53,7 +53,7 @@ def create(cfg, sources, distribution, build, car, plugins=None):
         try:
             build_jdk = int(raw_build_jdk)
         except ValueError:
-            raise exceptions.SystemSetupError(f"Car config key \"build.jdk\" is invalid: \"{raw_build_jdk}\" (must be int)")
+            raise exceptions.SystemSetupError(f"Car config key [build.jdk] is invalid: [{raw_build_jdk}] (must be int)")
 
         es_src_dir = os.path.join(_src_dir(cfg), _config_value(src_config, "elasticsearch.src.subdir"))
         builder = Builder(es_src_dir, build_jdk, paths.logs())

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -134,12 +134,12 @@ class SourceRepositoryTests(TestCase):
 
 class BuilderTests(TestCase):
     @mock.patch("esrally.utils.process.run_subprocess")
-    @mock.patch("esrally.utils.jvm.major_version")
-    def test_build_on_jdk_8(self, jvm_major_version, mock_run_subprocess):
-        jvm_major_version.return_value = 8
+    @mock.patch("esrally.utils.jvm.resolve_path")
+    def test_build_on_jdk_8(self, jvm_resolve_path, mock_run_subprocess):
+        jvm_resolve_path.return_value = (8, "/opt/jdk8")
         mock_run_subprocess.return_value = False
 
-        b = supplier.Builder(src_dir="/src", java_home="/opt/jdk8", log_dir="logs")
+        b = supplier.Builder(src_dir="/src", build_jdk=8, log_dir="logs")
         b.build(["./gradlew clean", "./gradlew assemble"])
 
         calls = [
@@ -152,12 +152,12 @@ class BuilderTests(TestCase):
         mock_run_subprocess.assert_has_calls(calls)
 
     @mock.patch("esrally.utils.process.run_subprocess")
-    @mock.patch("esrally.utils.jvm.major_version")
-    def test_build_on_jdk_10(self, jvm_major_version, mock_run_subprocess):
-        jvm_major_version.return_value = 10
+    @mock.patch("esrally.utils.jvm.resolve_path")
+    def test_build_on_jdk_10(self, jvm_resolve_path, mock_run_subprocess):
+        jvm_resolve_path.return_value = (10, "/opt/jdk10")
         mock_run_subprocess.return_value = False
 
-        b = supplier.Builder(src_dir="/src", java_home="/opt/jdk10", log_dir="logs")
+        b = supplier.Builder(src_dir="/src", build_jdk=8, log_dir="logs")
         b.build(["./gradlew clean", "./gradlew assemble"])
 
         calls = [


### PR DESCRIPTION
With this commit we resolve JAVA_HOME lazily when attempting to build
Elasticsearch. When a source build is externally provided to Rally's
source artifact cache, there is no need to actually build it. However,
if the target system does not have any JDK installed and we attempt to
install Elasticsearch, the build subsystem is eagerly initialized
(despite the artifact being already cached) and is complaining that it
cannot find a JDK to build the artifact. By lazily resolving JAVA_HOME
we avoid that error.