### PR TITLE
Fetch artifact revision lazily on build

### DIFF
--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -220,6 +220,7 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
         self.assertEqual(0, copy.call_count)
         self.assertFalse(cached_supplier.cached)
         self.assertIn("elasticsearch", binaries)
+        self.assertEqual("/path/to/artifact.tar.gz", binaries["elasticsearch"])
 
     @mock.patch("os.path.exists")
     @mock.patch("esrally.mechanic.supplier.ElasticsearchSourceSupplier")


### PR DESCRIPTION
With this commit we avoid touching the source repository when a specific
git revision is provided for an artifact (with `--revision`) and the
artifact is already present in the source artifact cache. This helps in
situations where an external process has put artifacts into Rally's
source artifact cache from a fork (in which case the artifact revision
will not be present in the main repo and the resolution would fail).