### PR TITLE
Improve Python 3.8 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ install_requires = [
     # License: BSD
     "psutil==5.7.0",
     # License: MIT
-    "py-cpuinfo==3.2.0",
+    "py-cpuinfo==7.0.0",
     # License: MIT
-    "tabulate==0.8.5",
+    "tabulate==0.8.7",
     # License: MIT
     "jsonschema==3.1.1",
     # License: BSD


### PR DESCRIPTION
With this commit we upgrade two third-party libraries (py-cpuinfo and
tabulate) that produce the following deprecation warnings:

```
.venv/lib/python3.8/site-packages/tabulate.py:415
  .venv/lib/python3.8/site-packages/tabulate.py:415: DeprecationWarning: invalid escape sequence \[
    _invisible_codes_bytes = re.compile(b"\x1b\[\d+[;\d]*m|\x1b\[\d*\;\d*\;\d*m")  # ANSI color codes

.venv/lib/python3.8/site-packages/tabulate.py:977
  .venv/lib/python3.8/site-packages/tabulate.py:977: DeprecationWarning: invalid escape sequence \e
    """Format a fixed width table for pretty printing.

.venv/lib/python3.8/site-packages/cpuinfo/cpuinfo.py:492
  .venv/lib/python3.8/site-packages/cpuinfo/cpuinfo.py:492: DeprecationWarning: invalid escape sequence \d
    if re.match('^i\d86$|^x86$|^x86_32$|^i86pc$|^ia32$|^ia-32$|^bepc$', raw_arch_string):
```