### PR TITLE
Allow to load test resources from files

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,12 @@
 # under the License.
 
 import asyncio
+import json
+import os
+import re
+import sys
+
+__CAMEL_CASE_PATTERN = re.compile(r"(?<!^)(?=[A-Z])")
 
 
 def run_async(t):
@@ -46,3 +52,49 @@ def as_future(result=None, exception=None):
     else:
         f.set_result(result)
     return f
+
+
+def load_test_resource(name=None):
+    """
+
+    Loads a JSON file containing e.g. mocked Elasticsearch responses from a file. The path to that file is based on the
+    following convention:
+
+    ``$TEST_ROOT_PATH/resources/$MODULE_NAME/$TEST_CLASS_NAME/$TEST_METHOD_NAME.json``
+
+    Where:
+
+    * ``$TEST_ROOT_PATH`` is the root path for all tests.
+    * ``$MODULE_NAME`` is the full name of the module where the test is implemented excluding the leading "tests".
+    * ``$TEST_CLASS_NAME`` is the name of the test class but snake-cased (instead of camel-cased).
+    * ``$TEST_METHOD_NAME`` is the name of the test method.
+
+    Example: If we want to load test resources for a test in
+             ``tests.driver.runner_test.SelectiveJsonParserTests.test_list_length`` we need to place the file in
+             ``$TEST_ROOT_PATH/resources/driver/runner_test/selective_json_parser_tests/test_list_length.json``.
+
+    Note: This method needs to be called directly from the test in which it is used as it works by inspecting the
+          caller stack.
+
+    :param name: An optional suffix of the test resource. If a suffix is specified the file name
+                 is ``$FILE_$name.json`` instead of ``$FILE.json``.
+    :return: A dict representation of the respective file.
+    """
+    prior_frame = sys._getframe(1)
+    # TODO: This assumes that it is always called in the context of a class.
+    test_class = prior_frame.f_locals["self"].__class__
+    # strip leading "tests" from the module name
+    test_module = test_class.__module__[len("tests"):]
+    class_name = test_class.__name__
+    test_method_name = prior_frame.f_code.co_name
+
+    snake_cased_class_name = __CAMEL_CASE_PATTERN.sub("_", class_name).lower()
+
+    cwd = os.path.dirname(__file__)
+    if name is None:
+        resource_file_name = f"{test_method_name}.json"
+    else:
+        resource_file_name = f"{test_method_name}_{name}.json"
+    path = os.path.join(cwd, "resources", *test_module.split("."), snake_cased_class_name, resource_file_name)
+    with open(path) as f:
+        return json.load(f)

--- a/tests/resources/telemetry_test/recovery_stats_tests/test_stores_single_shard_stats.json
+++ b/tests/resources/telemetry_test/recovery_stats_tests/test_stores_single_shard_stats.json
@@ -1,0 +1,68 @@
+{
+  "index1": {
+    "shards": [{
+      "id": 0,
+      "type": "STORE",
+      "stage": "DONE",
+      "primary": true,
+      "start_time": "2014-02-24T12:38:06.349",
+      "start_time_in_millis": "1393245486349",
+      "stop_time": "2014-02-24T12:38:08.464",
+      "stop_time_in_millis": "1393245488464",
+      "total_time": "2.1s",
+      "total_time_in_millis": 2115,
+      "source": {
+        "id": "RGMdRc-yQWWKIBM4DGvwqQ",
+        "host": "my.fqdn",
+        "transport_address": "my.fqdn",
+        "ip": "10.0.1.7",
+        "name": "my_es_node"
+      },
+      "target": {
+        "id": "RGMdRc-yQWWKIBM4DGvwqQ",
+        "host": "my.fqdn",
+        "transport_address": "my.fqdn",
+        "ip": "10.0.1.7",
+        "name": "my_es_node"
+      },
+      "index": {
+        "size": {
+          "total": "24.7mb",
+          "total_in_bytes": 26001617,
+          "reused": "24.7mb",
+          "reused_in_bytes": 26001617,
+          "recovered": "0b",
+          "recovered_in_bytes": 0,
+          "percent": "100.0%"
+        },
+        "files": {
+          "total": 26,
+          "reused": 26,
+          "recovered": 0,
+          "percent": "100.0%"
+        },
+        "total_time": "2ms",
+        "total_time_in_millis": 2,
+        "source_throttle_time": "0s",
+        "source_throttle_time_in_millis": 0,
+        "target_throttle_time": "0s",
+        "target_throttle_time_in_millis": 0
+      },
+      "translog": {
+        "recovered": 71,
+        "total": 0,
+        "percent": "100.0%",
+        "total_on_start": 0,
+        "total_time": "2.0s",
+        "total_time_in_millis": 2025
+      },
+      "verify_index": {
+        "check_index_time": 0,
+        "check_index_time_in_millis": 0,
+        "total_time": "88ms",
+        "total_time_in_millis": 88
+      }
+    }
+    ]
+  }
+}

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -28,6 +28,7 @@ from esrally import config, metrics, exceptions, telemetry
 from esrally.mechanic import cluster
 from esrally.metrics import MetaInfoScope
 from esrally.utils import console
+from tests import load_test_resource
 
 
 def create_config():
@@ -683,74 +684,7 @@ class RecoveryStatsTests(TestCase):
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_single_shard_stats(self, metrics_store_put_doc):
-        response = {
-            "index1": {
-                "shards": [{
-                    "id": 0,
-                    "type": "STORE",
-                    "stage": "DONE",
-                    "primary": True,
-                    "start_time": "2014-02-24T12:38:06.349",
-                    "start_time_in_millis": "1393245486349",
-                    "stop_time": "2014-02-24T12:38:08.464",
-                    "stop_time_in_millis": "1393245488464",
-                    "total_time": "2.1s",
-                    "total_time_in_millis": 2115,
-                    "source": {
-                        "id": "RGMdRc-yQWWKIBM4DGvwqQ",
-                        "host": "my.fqdn",
-                        "transport_address": "my.fqdn",
-                        "ip": "10.0.1.7",
-                        "name": "my_es_node"
-                    },
-                    "target": {
-                        "id": "RGMdRc-yQWWKIBM4DGvwqQ",
-                        "host": "my.fqdn",
-                        "transport_address": "my.fqdn",
-                        "ip": "10.0.1.7",
-                        "name": "my_es_node"
-                    },
-                    "index": {
-                        "size": {
-                            "total": "24.7mb",
-                            "total_in_bytes": 26001617,
-                            "reused": "24.7mb",
-                            "reused_in_bytes": 26001617,
-                            "recovered": "0b",
-                            "recovered_in_bytes": 0,
-                            "percent": "100.0%"
-                        },
-                        "files": {
-                            "total": 26,
-                            "reused": 26,
-                            "recovered": 0,
-                            "percent": "100.0%"
-                        },
-                        "total_time": "2ms",
-                        "total_time_in_millis": 2,
-                        "source_throttle_time": "0s",
-                        "source_throttle_time_in_millis": 0,
-                        "target_throttle_time": "0s",
-                        "target_throttle_time_in_millis": 0
-                    },
-                    "translog": {
-                        "recovered": 71,
-                        "total": 0,
-                        "percent": "100.0%",
-                        "total_on_start": 0,
-                        "total_time": "2.0s",
-                        "total_time_in_millis": 2025
-                    },
-                    "verify_index": {
-                        "check_index_time": 0,
-                        "check_index_time_in_millis": 0,
-                        "total_time": "88ms",
-                        "total_time_in_millis": 88
-                    }
-                }
-                ]
-            }
-        }
+        response = load_test_resource()
 
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)


### PR DESCRIPTION
With this commit we add a helper function `load_test_resource` that
evaluates caller context so we can automagically load JSON files with
data relevant for the current test.

Relates #734