### PR TITLE
Warn on request errors

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1615,8 +1615,9 @@ class GlobalStatsCalculator:
 
         for tasks in self.challenge.schedule:
             for task in tasks:
-                if task.operation.include_in_reporting:
-                    t = task.name
+                t = task.name
+                error_rate = self.error_rate(t)
+                if task.operation.include_in_reporting or error_rate > 0:
                     self.logger.debug("Gathering request metrics for [%s].", t)
                     result.add_op_metrics(
                         t,
@@ -1625,7 +1626,7 @@ class GlobalStatsCalculator:
                         self.single_latency(t),
                         self.single_latency(t, metric_name="service_time"),
                         self.single_latency(t, metric_name="processing_time"),
-                        self.error_rate(t),
+                        error_rate,
                         self.merge(
                             self.track.meta_data,
                             self.challenge.meta_data,

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -139,6 +139,8 @@ class SummaryReporter:
                 console.warn(warning)
 
     def add_warnings(self, warnings, values, op):
+        if values["error_rate"] > 0:
+            warnings.append(f"Error rate is {values['error_rate']} for operation '{op}'. Please check the logs.")
         if values["throughput"]["median"] is None:
             error_rate = values["error_rate"]
             if error_rate:

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -140,7 +140,7 @@ class SummaryReporter:
 
     def add_warnings(self, warnings, values, op):
         if values["error_rate"] > 0:
-            warnings.append(f"Error rate is {values['error_rate']} for operation '{op}'. Please check the logs.")
+            warnings.append(f"Error rate is {round(values['error_rate'] * 100, 2)} for operation '{op}'. Please check the logs.")
         if values["throughput"]["median"] is None:
             error_rate = values["error_rate"]
             if error_rate:


### PR DESCRIPTION
This PR attempts to solve #910

- It adds a new condition to allow "administrative" operations to be included in the command line report, as a result, users could be more aware of the errors.
- Emit a warning when the error rate of an operation is greater than zero

