### PR TITLE
Correct Rally forum URL

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 Please ask questions in our forum at 
 
-https://discuss.elastic.co/c/elasticsearch/rally
+https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally
 
 GitHub is reserved for bug reports and feature requests only and we will 
 close your issue immediately if it is just a question.

--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ Getting help
 
 * Quick help: ``esrally --help``
 * Look in `Rally's user guide <https://esrally.readthedocs.io/>`_ for more information
-* Ask questions about Rally in the `Rally Discuss forum <https://discuss.elastic.co/c/elasticsearch/rally>`_.
+* Ask questions about Rally in the `Rally Discuss forum <https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally>`_.
 * File improvements or bug reports in our `Github repo <https://github.com/elastic/rally/issues>`_.
 
 How to Contribute

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -35,7 +35,7 @@ Let's go through an example step by step: First run ``esrally``::
 
     * Type esrally --help
     * Read the documentation at https://esrally.readthedocs.io/en/latest/
-    * Ask a question on the forum at https://discuss.elastic.co/c/elasticsearch/rally
+    * Ask a question on the forum at https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally
 
 Congratulations! Time to :doc:`run your first benchmark </race>`.
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -106,7 +106,7 @@ Example::
 
     * Type esrally --help
     * Read the documentation at https://esrally.readthedocs.io/en/latest/
-    * Ask a question on the forum at https://discuss.elastic.co/c/elasticsearch/rally
+    * Ask a question on the forum at https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally
 
     # now run our benchmark
     docker run --rm -v $PWD/myrally:/rally/.rally elastic/rally --track=nyc_taxis --test-mode --pipeline=benchmark-only --target-hosts=es01:9200

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -66,7 +66,7 @@ There are a few more directories but the ones above are the most disk-hogging on
 Does Rally spy on me?
 ---------------------
 
-No. Rally does not collect or send any usage data and also the complete source code is open. We do value your feedback a lot though and if you got any ideas for improvements, found a bug or have any other feedback, head over to `Rally's Discuss forum <https://discuss.elastic.co/c/elasticsearch/rally>`_ or `raise an issue on Github <https://github.com/elastic/rally>`_.
+No. Rally does not collect or send any usage data and also the complete source code is open. We do value your feedback a lot though and if you got any ideas for improvements, found a bug or have any other feedback, head over to `Rally's Discuss forum <https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally>`_ or `raise an issue on Github <https://github.com/elastic/rally>`_.
 
 Do I need an Internet connection?
 ---------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ We have also put considerable effort in Rally to ensure that benchmarking data a
 Getting Help or Contributing to Rally
 -------------------------------------
 
-* Use our `Discuss forum <https://discuss.elastic.co/c/elasticsearch/rally>`_ to provide feedback or ask questions about Rally.
+* Use our `Discuss forum <https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally>`_ to provide feedback or ask questions about Rally.
 * See our `contribution guide <https://github.com/elastic/rally/blob/master/CONTRIBUTING.md>`_ on guidelines for contributors.
 
 Source Code

--- a/esrally/__init__.py
+++ b/esrally/__init__.py
@@ -31,6 +31,9 @@ if __version__.endswith("dev0"):
 else:
     DOC_LINK = "https://esrally.readthedocs.io/en/%s/" % __version__
 
+
+FORUM_LINK = "https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally"
+
 BANNER = r"""
     ____        ____
    / __ \____ _/ / /_  __

--- a/esrally/config.py
+++ b/esrally/config.py
@@ -23,7 +23,7 @@ import re
 import shutil
 from enum import Enum
 
-from esrally import PROGRAM_NAME, doc_link, exceptions, paths
+from esrally import FORUM_LINK, PROGRAM_NAME, doc_link, exceptions, paths
 from esrally.utils import io, git, console, convert
 
 
@@ -411,13 +411,13 @@ class ConfigFactory:
 
         config_file.store(config)
 
-        self.o("Configuration successfully written to %s. Happy benchmarking!" % config_file.location)
+        self.o(f"Configuration successfully written to {config_file.location}. Happy benchmarking!")
         self.o("")
         self.o("More info about Rally:")
         self.o("")
-        self.o("* Type %s --help" % PROGRAM_NAME)
-        self.o("* Read the documentation at %s" % console.format.link(doc_link()))
-        self.o("* Ask a question on the forum at %s" % console.format.link("https://discuss.elastic.co/c/elasticsearch/rally"))
+        self.o(f"* Type {PROGRAM_NAME} --help")
+        self.o(f"* Read the documentation at {console.format.link(doc_link())}")
+        self.o(f"* Ask a question on the forum at {console.format.link(FORUM_LINK)}")
 
     def print_detection_result(self, what, result, warn_if_missing=False, additional_message=None):
         self.logger.debug("Autodetected %s at [%s]", what, result)

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -24,7 +24,7 @@ import sys
 import time
 import uuid
 
-from esrally import PROGRAM_NAME, BANNER, SKULL, check_python_version, doc_link, telemetry
+from esrally import PROGRAM_NAME, BANNER, FORUM_LINK, SKULL, check_python_version, doc_link, telemetry
 from esrally import version, actor, config, paths, racecontrol, reporter, metrics, track, chart_generator, exceptions, \
     log
 from esrally.mechanic import team, mechanic
@@ -644,11 +644,11 @@ def print_help_on_errors():
     heading = "Getting further help:"
     console.println(console.format.bold(heading))
     console.println(console.format.underline_for(heading))
-    console.println("* Check the log files in {} for errors.".format(paths.logs()))
-    console.println("* Read the documentation at {}".format(console.format.link(doc_link())))
-    console.println("* Ask a question on the forum at {}".format(console.format.link("https://discuss.elastic.co/c/elasticsearch/rally")))
-    console.println("* Raise an issue at {} and include the log files in {}."
-                    .format(console.format.link("https://github.com/elastic/rally/issues"), paths.logs()))
+    console.println(f"* Check the log files in {paths.logs()} for errors.")
+    console.println(f"* Read the documentation at {console.format.link(doc_link())}.")
+    console.println(f"* Ask a question on the forum at {console.format.link(FORUM_LINK)}.")
+    console.println(f"* Raise an issue at {console.format.link('https://github.com/elastic/rally/issues')} "
+                    f"and include the log files in {paths.logs()}.")
 
 
 def race(cfg):


### PR DESCRIPTION
After a recent reorganization of the Discuss forum structure the Rally
forum URL is not valid anymore. With this commit we update all forum
URLs to the new one.

Closes #1036