### PR TITLE
Add runner to wait until snapshot has been created

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1119,13 +1119,13 @@ With the operation ``create-snapshot`` you can `create a snapshot <https://www.e
 * ``request-params`` (optional): A structure containing HTTP request parameters.
 
 .. note::
-    It's not recommend to rely on ``wait-for-completion=true``. Instead you should keep the default value (``False``) and use an additional ``wait-for-snapshot-create`` operation in the next step.
-    This is mandatory on the `Elastic Cloud <https://www.elastic.co/cloud>`_ or environments where Elasticsearch is sitting behind a network element that may terminate the blocking connection after a timeout.
+    It's not recommended to rely on ``wait-for-completion=true``. Instead you should keep the default value (``False``) and use an additional ``wait-for-snapshot-create`` operation in the next step.
+    This is mandatory on `Elastic Cloud <https://www.elastic.co/cloud>`_ or environments where Elasticsearch is connected via intermediate network components, such as proxies, that may terminate the blocking connection after a timeout.
 
 wait-for-snapshot-create
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-With the operation ``wait-for-snapshot-create`` you can wait until a snapshot has finished successfully.
+With the operation ``wait-for-snapshot-create`` you can wait until a `snapshot has finished successfully <https://www.elastic.co/guide/en/elasticsearch/reference/current/get-snapshot-status-api.html>`_.
 Typically you'll use this operation directly after a ``create-snapshot`` operation.
 
 It supports the following parameters:
@@ -1134,7 +1134,7 @@ It supports the following parameters:
 * ``snapshot`` (mandatory): The name of the snapshot that this operation will wait until it succeeds.
 * ``completion-recheck-wait-period`` (optional, defaults to 1 second): Time in seconds to wait in between consecutive attempts.
 
-Rally will report the achieved throughput in byte/s, the duration in seconds, the start and stop time in milliseconds and the total amount of files snapshotted as returned by the the `Elasticsearch snapshot status API call <https://www.elastic.co/guide/en/elasticsearch/reference/current/get-snapshot-status-api.html>`_.
+Rally will report the achieved throughput in byte/s.
 
 This operation is :ref:`retryable <track_operations>`.
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1119,7 +1119,24 @@ With the operation ``create-snapshot`` you can `create a snapshot <https://www.e
 * ``request-params`` (optional): A structure containing HTTP request parameters.
 
 .. note::
-    When ``wait-for-completion`` is set to ``true`` Rally will report the achieved throughput in byte/s.
+    It's not recommend to rely on ``wait-for-completion=true``. Instead you should keep the default value (``False``) and use an additional ``wait-for-snapshot-create`` operation in the next step.
+    This is mandatory on the `Elastic Cloud <https://www.elastic.co/cloud>`_ or environments where Elasticsearch is sitting behind a network element that may terminate the blocking connection after a timeout.
+
+wait-for-snapshot-create
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+With the operation ``wait-for-snapshot-create`` you can wait until a snapshot has finished successfully.
+Typically you'll use this operation directly after a ``create-snapshot`` operation.
+
+It supports the following parameters:
+
+* ``repository`` (mandatory): The name of the snapshot repository to use.
+* ``snapshot`` (mandatory): The name of the snapshot that this operation will wait until it succeeds.
+* ``completion-recheck-wait-period`` (optional, defaults to 1 second): Time in seconds to wait in between consecutive attempts.
+
+Rally will report the achieved throughput in byte/s, the duration in seconds, the start and stop time in milliseconds and the total amount of files snapshotted as returned by the the `Elasticsearch snapshot status API call <https://www.elastic.co/guide/en/elasticsearch/reference/current/get-snapshot-status-api.html>`_.
+
+This operation is :ref:`retryable <track_operations>`.
 
 restore-snapshot
 ~~~~~~~~~~~~~~~~

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1494,10 +1494,8 @@ class WaitForSnapshotCreate(Runner):
                 # Possible states:
                 # https://www.elastic.co/guide/en/elasticsearch/reference/current/get-snapshot-status-api.html#get-snapshot-status-api-response-body
                 if response_state == "FAILED":
-                    self.logger.error("Snapshot [%s] failed. Response status:\n%s", snapshot, json.dumps(response))
-                    raise exceptions.RallyAssertionError(
-                        f"Snapshot [{snapshot}] failed. Please check logs."
-                    )
+                    self.logger.error("Snapshot [%s] failed. Response:\n%s", snapshot, json.dumps(response, indent=2))
+                    raise exceptions.RallyAssertionError(f"Snapshot [{snapshot}] failed. Please check logs.")
                 snapshot_done = response_state == "SUCCESS"
                 stats = response["snapshots"][0]["stats"]
 

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -419,8 +419,7 @@ class OperationType(Enum):
     Bulk = 4
     RawRequest = 5
     WaitForRecovery = 6
-    CreateSnapshot = 7
-    WaitForSnapshotCreate = 8
+    WaitForSnapshotCreate = 7
 
     # administrative actions
     ForceMerge = 1001
@@ -443,12 +442,13 @@ class OperationType(Enum):
     Sleep = 1018
     DeleteSnapshotRepository = 1019
     CreateSnapshotRepository = 1020
-    RestoreSnapshot = 1021
-    PutSettings = 1022
-    CreateTransform = 1023
-    StartTransform = 1024
-    WaitForTransform = 1025
-    DeleteTransform = 1026
+    CreateSnapshot = 1021
+    RestoreSnapshot = 1022
+    PutSettings = 1023
+    CreateTransform = 1024
+    StartTransform = 1025
+    WaitForTransform = 1026
+    DeleteTransform = 1027
 
     @property
     def admin_op(self):

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -420,7 +420,7 @@ class OperationType(Enum):
     RawRequest = 5
     WaitForRecovery = 6
     CreateSnapshot = 7
-
+    WaitForSnapshotCreate = 8
 
     # administrative actions
     ForceMerge = 1001
@@ -510,6 +510,8 @@ class OperationType(Enum):
             return OperationType.CreateSnapshotRepository
         elif v == "create-snapshot":
             return OperationType.CreateSnapshot
+        elif v == "wait-for-snapshot-create":
+            return OperationType.WaitForSnapshotCreate
         elif v == "restore-snapshot":
             return OperationType.RestoreSnapshot
         elif v == "wait-for-recovery":

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -17,7 +17,6 @@
 
 import io
 import json
-import logging
 import random
 import unittest.mock as mock
 from unittest import TestCase
@@ -2727,7 +2726,6 @@ class CreateSnapshotTests(TestCase):
                                                    },
                                                    params={"request_timeout": 7200},
                                                    wait_for_completion=False)
-        self.assertEqual(0, es.snapshot.status.call_count)
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -2956,8 +2954,7 @@ class WaitForSnapshotCreateTests(TestCase):
 
         r = runner.WaitForSnapshotCreate()
 
-        logger = logging.getLogger("esrally.driver.runner")
-        with mock.patch.object(logger, "error") as mocked_error_logger:
+        with mock.patch.object(r.logger, "error") as mocked_error_logger:
             with self.assertRaises(exceptions.RallyAssertionError) as ctx:
                 await r(es, params)
                 self.assertEqual("Snapshot [snapshot-001] failed. Please check logs.", ctx.exception.args[0])

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2959,7 +2959,7 @@ class WaitForSnapshotCreateTests(TestCase):
                 await r(es, params)
                 self.assertEqual("Snapshot [snapshot-001] failed. Please check logs.", ctx.exception.args[0])
             mocked_error_logger.assert_has_calls([
-                mock.call("Snapshot [%s] failed. Response status:\n%s", "snapshot-001", json.dumps(snapshot_status))
+                mock.call("Snapshot [%s] failed. Response:\n%s", "snapshot-001", json.dumps(snapshot_status, indent=2))
             ])
 
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2701,8 +2701,6 @@ class CreateSnapshotTests(TestCase):
     @run_async
     async def test_create_snapshot_no_wait(self, es):
         es.snapshot.create.return_value = as_future({})
-        # should not be called
-        es.snapshot.status.return_value = as_future({})
 
         params = {
             "repository": "backups",


### PR DESCRIPTION
For snapshot creation (and metrics) so far we've relied only the
`create-snapshot` runner with a blocking call.

In this commit we are introducing a new runner
`wait-for-snapshot-create`to complement `create-snapshot`. This is
similar to `restore-snapshot` and `wait-for-recovery` and helps in cases
 where network connections maybe terminated making a blocking call
 unsuitable.
