### PR TITLE
Force Merge Runner Improvements -  Polling

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -672,6 +672,8 @@ Client certificates can be presented regardless of the ``verify_certs`` setting,
 * Enable SSL, verify server certificates using private CA: ``--client-options="use_ssl:true,verify_certs:true,ca_certs:'/path/to/cacert.pem'"``
 * Enable SSL, verify server certificates using private CA, present client certificates: ``--client-options="use_ssl:true,verify_certs:true,ca_certs:'/path/to/cacert.pem',client_cert:'/path/to/client_cert.pem',client_key:'/path/to/client_key.pem'"``
 
+.. _command_line_reference_on_error:
+
 ``on-error``
 ~~~~~~~~~~~~
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -39,6 +39,8 @@ Let's go through an example step by step: First run ``esrally``::
 
 Congratulations! Time to :doc:`run your first benchmark </race>`.
 
+.. _advanced_configuration:
+
 Advanced Configuration
 ----------------------
 
@@ -111,6 +113,8 @@ To verify that Rally will connect via the proxy server you can check the log fil
 .. note::
 
    Rally will use this proxy server only for downloading benchmark-related data. It will not use this proxy for the actual benchmark.
+
+.. _logging:
 
 Logging
 -------

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -172,3 +172,114 @@ Rally will push metrics to the metric store configured in 1. and they can be vis
 To tear down everything issue ``./stop.sh``.
 
 It is possible to specify a different version of Elasticsearch for step 3. by setting ``export ES_VERSION=<the_desired_version>``.
+
+Identifying when errors have been encountered
+--------------------------------------------------------------
+
+Custom track development can be error prone especially if you are testing a new query. A number of reasons can lead to queries returning errors.
+
+Consider a simple example Rally operation::
+
+    {
+      "name": "geo_distance",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+           "geo_distance": {
+              "distance": "12km",
+              "source.geo.location": "40,-70"
+           }
+        }
+      }
+    }
+
+This query requires the field ``source.geo.location`` to be mapped as a ``geo_point`` type. If incorrectly mapped, Elasticsearch will respond with an error. 
+
+Rally will not exit on errors (unless fatal e.g. `ECONNREFUSED <http://man7.org/linux/man-pages/man2/connect.2.html>`_) by default, instead reporting errors in the summary report via the :ref:`Error Rate <summary_report_error_rate>` statistic. This can potentially leading to misleading results. This behavior is by design and consistent with other load testing tools such as JMeter i.e. In most cases it is desirable that a large long running benchmark should not fail because of a single error response.
+
+This behavior can also be changed, by invoking Rally with the :ref:`--on-error <command_line_reference_on_error>` switch e.g.::
+
+	esrally --track=geonames --on-error=abort
+	
+Errors can also be investigated if you have configured a :ref:`dedicated Elasticsearch metrics store <advanced_configuration>`.
+
+Checking Queries and Responses
+--------------------------------------------------------------
+
+As described above, errors can lead to misleading benchmarking results. Some issues, however, are more subtle and the result of queries not behaving and matching as intended.
+
+Consider the following simple Rally operation::
+
+    {
+      "name": "geo_distance",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "term": {
+            "http.request.method": {
+              "value": "GET"
+            }
+          }
+        }
+      }
+    }
+
+For this term query to match the field ``http.request.method`` needs to be type ``keyword``. Should this field be `dynamically mapped <https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-field-mapping.html>`_, its default type will be ``text`` causing the value ``GET`` to be `analyzed <https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html>`_, and indexed as ``get``. The above query will in turn return ``0`` hits. The field should either be correctly mapped or the query modified to match on ``http.request.method.keyword``.
+
+Issues such as this can lead to misleading benchmarking results. Prior to running any benchmarks for analysis, we therefore recommended users ascertain whether queries are behaving as intended. Rally provides several tools to assist with this.
+
+Firstly, users can set the :ref:`log level <logging>` for the Elasticsearch client to ``DEBUG`` i.e.::
+
+	"loggers": {
+	  "elasticsearch": {
+	    "handlers": ["rally_log_handler"],
+	    "level": "DEBUG",
+	    "propagate": false
+	  },
+	  "rally.profile": {
+	    "handlers": ["rally_profile_handler"],
+	    "level": "INFO",
+	    "propagate": false
+	  }
+	}
+
+This will in turn ensure logs include the Elasticsearch query and accompanying response e.g.::
+
+	2019-12-16 14:56:08,389 -not-actor-/PID:9790 elasticsearch DEBUG > {"sort":[{"geonameid":"asc"}],"query":{"match_all":{}}}
+	2019-12-16 14:56:08,389 -not-actor-/PID:9790 elasticsearch DEBUG < {"took":1,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":{"value":1000,"relation":"eq"},"max_score":null,"hits":[{"_index":"geonames","_type":"_doc","_id":"Lb81D28Bu7VEEZ3mXFGw","_score":null,"_source":{"geonameid": 2986043, "name": "Pic de Font Blanca", "asciiname": "Pic de Font Blanca", "alternatenames": "Pic de Font Blanca,Pic du Port", "feature_class": "T", "feature_code": "PK", "country_code": "AD", "admin1_code": "00", "population": 0, "dem": "2860", "timezone": "Europe/Andorra", "location": [1.53335, 42.64991]},"sort":[2986043]},
+
+Users should discard any performance metrics collected from a benchmark with ``DEBUG`` logging. This will likely cause a client-side bottleneck so once the correctness of the queries has been established, disable this setting and re-run any benchmarks.
+
+The number of hits from queries can also be investigated if you have configured a :ref:`dedicated Elasticsearch metrics store <advanced_configuration>`. Specifically, documents within the index pattern ``rally-metrics-*`` contain a ``meta`` field with a summary of individual responses e.g.::
+
+	{
+	  "@timestamp" : 1597681313435,
+	  "relative-time" : 130273374,
+	  "race-id" : "452ad9d7-9c21-4828-848e-89974af3230e",
+	  "race-timestamp" : "20200817T160412Z",
+	  "environment" : "Personal",
+	  "track" : "geonames",
+	  "challenge" : "append-no-conflicts",
+	  "car" : "defaults",
+	  "name" : "latency",
+	  "value" : 270.77871300025436,
+	  "unit" : "ms",
+	  "sample-type" : "warmup",
+	  "meta" : {
+	    "source_revision" : "757314695644ea9a1dc2fecd26d1a43856725e65",
+	    "distribution_version" : "7.8.0",
+	    "distribution_flavor" : "oss",
+	    "pages" : 25,
+	    "hits" : 11396503,
+	    "hits_relation" : "eq",
+	    "timed_out" : false,
+	    "took" : 110,
+	    "success" : true
+	  },
+	  "task" : "scroll",
+	  "operation" : "scroll",
+	  "operation-type" : "Search"
+	}
+

--- a/docs/summary_report.rst
+++ b/docs/summary_report.rst
@@ -187,6 +187,8 @@ Rally reports several percentile numbers for each task. Which percentiles are sh
 * **Definition**: Time period between start of request processing and receiving the complete response. This metric can easily be mixed up with ``latency`` but does not include waiting time. This is what most load testing tools refer to as "latency" (although it is incorrect).
 * **Corresponding metrics key**: ``service_time``
 
+.. _summary_report_error_rate:
+
 Error rate
 ----------
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -25,6 +25,7 @@ from collections import Counter, OrderedDict
 from copy import deepcopy
 
 import ijson
+from elasticsearch.client import TasksClient
 
 from esrally import exceptions, track
 
@@ -605,7 +606,7 @@ class BulkIndex(Runner):
     def __repr__(self, *args, **kwargs):
         return "bulk-index"
 
-
+#TODO: Force Merge runner
 class ForceMerge(Runner):
     """
     Runs a force merge operation against Elasticsearch.
@@ -618,11 +619,24 @@ class ForceMerge(Runner):
         # the raw transport API (where the keyword argument is called `timeout`) in some cases we will always need
         # a special handling for the force-merge API.
         request_timeout = params.get("request-timeout")
+        mode = params.get("mode")
+        merge_params = { "request_timeout": request_timeout}
+        if max_num_segments:
+            merge_params["max_num_segments"] = max_num_segments
         try:
-            if max_num_segments:
-                await es.indices.forcemerge(index=params.get("index"), max_num_segments=max_num_segments, request_timeout=request_timeout)
+            if mode == "polling":
+                # we ignore the request_timeout if we are in polling mode and deliberately timeout early
+                merge_params["request_timeout"] = 1
+                await es.indices.forcemerge(index=params.get("index"), **merge_params)
+                while True:
+                    tasks = await TasksClient(es).list(params={"actions":"indices:admin/forcemerge"})
+                    if len(tasks["nodes"]) == 0:
+                        # empty nodes response indicates no tasks
+                        break
+                    #poll for tasks every 10 secs
+                    await asyncio.sleep(10)
             else:
-                await es.indices.forcemerge(index=params.get("index"), request_timeout=request_timeout)
+                await es.indices.forcemerge(index=params.get("index"), **merge_params)
         except elasticsearch.TransportError as e:
             # this is caused by older versions of Elasticsearch (< 2.1), fall back to optimize
             if e.status_code == 400:

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -605,6 +605,7 @@ class BulkIndex(Runner):
     def __repr__(self, *args, **kwargs):
         return "bulk-index"
 
+
 class ForceMerge(Runner):
     """
     Runs a force merge operation against Elasticsearch.
@@ -618,7 +619,7 @@ class ForceMerge(Runner):
         # a special handling for the force-merge API.
         request_timeout = params.get("request-timeout")
         mode = params.get("mode")
-        merge_params = { "request_timeout": request_timeout}
+        merge_params = {"request_timeout": request_timeout}
         if max_num_segments:
             merge_params["max_num_segments"] = max_num_segments
         try:

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -442,6 +442,8 @@ class ComparisonReporter:
 
     def report_transform_processing_times(self, baseline_stats, contender_stats):
         lines = []
+        if baseline_stats.total_transform_processing_times is None:
+            return lines
         for baseline in baseline_stats.total_transform_processing_times:
             transform_id = baseline["id"]
             for contender in contender_stats.total_transform_processing_times:

--- a/esrally/resources/track-schema.json
+++ b/esrally/resources/track-schema.json
@@ -436,6 +436,11 @@
           "body": {
             "type": "object",
             "description": "[Only for type 'search']: The query body."
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["blocking", "polling"],
+            "description": "[Only for type 'force-merge']: Determines whether forced merged is blocking, causing a potential client timeout, or if it polls until no further force merge tasks."
           }
         },
         "required": [

--- a/esrally/resources/track-schema.json
+++ b/esrally/resources/track-schema.json
@@ -441,6 +441,11 @@
             "type": "string",
             "enum": ["blocking", "polling"],
             "description": "[Only for type 'force-merge']: Determines whether forced merged is blocking, causing a potential client timeout, or if it polls until no further force merge tasks."
+          },
+          "poll-period": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "[Only for type 'force-merge']: Poll period in seconds for which to check action completion. Used on force-merge action when mode is 'polling' to determine periodicity of check to tasks API for merge completion. By default, set to 10s."
           }
         },
         "required": [

--- a/esrally/resources/track-schema.json
+++ b/esrally/resources/track-schema.json
@@ -440,7 +440,7 @@
           "mode": {
             "type": "string",
             "enum": ["blocking", "polling"],
-            "description": "[Only for type 'force-merge']: Determines whether forced merged is blocking, causing a potential client timeout, or if it polls until no further force merge tasks."
+            "description": "[Only for type 'force-merge']: Determines whether forced merge is blocking, causing a potential client timeout, or if it polls until no further force merge tasks."
           },
           "poll-period": {
             "type": "integer",

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -609,7 +609,6 @@ class PartitionBulkIndexParamSource:
     def percent_completed(self):
         return self.current_bulk / self.total_bulks
 
-
 class ForceMergeParamSource(ParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
@@ -621,12 +620,14 @@ class ForceMergeParamSource(ParamSource):
         self._index_name = params.get("index", default_index)
         self._max_num_segments = params.get("max-num-segments")
         self._request_timeout = params.get("request-timeout")
+        self._mode = params.get("mode", "blocking")
 
     def params(self):
         return {
             "index": self._index_name,
             "max-num-segments": self._max_num_segments,
-            "request-timeout": self._request_timeout
+            "request-timeout": self._request_timeout,
+            "mode": self._mode
         }
 
 

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -620,6 +620,7 @@ class ForceMergeParamSource(ParamSource):
         self._index_name = params.get("index", default_index)
         self._max_num_segments = params.get("max-num-segments")
         self._request_timeout = params.get("request-timeout")
+        self._poll_period = params.get("poll-period", 1)
         self._mode = params.get("mode", "blocking")
 
     def params(self):
@@ -627,7 +628,8 @@ class ForceMergeParamSource(ParamSource):
             "index": self._index_name,
             "max-num-segments": self._max_num_segments,
             "request-timeout": self._request_timeout,
-            "mode": self._mode
+            "mode": self._mode,
+            "poll-period": self._poll_period
         }
 
 

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -609,6 +609,7 @@ class PartitionBulkIndexParamSource:
     def percent_completed(self):
         return self.current_bulk / self.total_bulks
 
+
 class ForceMergeParamSource(ParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1034,7 +1034,8 @@ class ForceMergeRunnerTests(TestCase):
         ]
         force_merge = runner.ForceMerge()
         # request-timeout should be ignored as mode:polling
-        await force_merge(es, params={"index" : "_all", "mode": "polling", "max-num-segments": 1, "request-timeout": 50000, 'poll-period': 0})
+        await force_merge(es, params={"index" : "_all", "mode": "polling", "max-num-segments": 1,
+                                      "request-timeout": 50000, 'poll-period': 0})
         es.indices.forcemerge.assert_called_once_with(index="_all", max_num_segments=1, request_timeout=1)
 
     @mock.patch("elasticsearch.Elasticsearch")

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -22,6 +22,7 @@ import unittest.mock as mock
 from unittest import TestCase
 
 import elasticsearch
+from elasticsearch._async.client import TasksClient
 
 from esrally import exceptions
 from esrally.driver import runner
@@ -927,13 +928,115 @@ class ForceMergeRunnerTests(TestCase):
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
-    async def test_force_merge_with_polling(self, es):
+    async def test_force_merge_with_polling_no_timeout(self, es):
         es.indices.forcemerge.return_value = as_future()
 
         force_merge = runner.ForceMerge()
+        await force_merge(es, params={"index" : "_all", "mode": "polling", 'poll-period': 0})
+        es.indices.forcemerge.assert_called_once_with(index="_all", request_timeout=1)
 
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_force_merge_with_polling(self, es):
+        es.indices.forcemerge.return_value = as_future(exception=elasticsearch.ConnectionTimeout())
+        es.tasks.list.side_effect = [
+            as_future({
+                "nodes": {
+                    "Ap3OfntPT7qL4CBeKvamxg": {
+                        "name": "instance-0000000001",
+                        "transport_address": "10.46.79.231:19693",
+                        "host": "10.46.79.231",
+                        "ip": "10.46.79.231:19693",
+                        "roles": [
+                            "data",
+                            "ingest",
+                            "master",
+                            "remote_cluster_client",
+                            "transform"
+                        ],
+                        "attributes": {
+                            "logical_availability_zone": "zone-1",
+                            "server_name": "instance-0000000001.64cb4c66f4f24d85b41f120ef2df5526",
+                            "availability_zone": "us-east4-a",
+                            "xpack.installed": "true",
+                            "instance_configuration": "gcp.data.highio.1",
+                            "transform.node": "true",
+                            "region": "unknown-region"
+                        },
+                        "tasks": {
+                            "Ap3OfntPT7qL4CBeKvamxg:417009036": {
+                                "node": "Ap3OfntPT7qL4CBeKvamxg",
+                                "id": 417009036,
+                                "type": "transport",
+                                "action": "indices:admin/forcemerge",
+                                "start_time_in_millis": 1598018980850,
+                                "running_time_in_nanos": 3659821411,
+                                "cancellable": False,
+                                "headers": {}
+                            }
+                        }
+                    }
+                }
+            }),
+            as_future({
+                "nodes":{}
+            })
+        ]
+        force_merge = runner.ForceMerge()
+        await force_merge(es, params={"index" : "_all", "mode": "polling", 'poll-period': 0})
+        es.indices.forcemerge.assert_called_once_with(index="_all", request_timeout=1)
 
-
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_force_merge_with_polling_and_params(self, es):
+        es.indices.forcemerge.return_value = as_future(exception=elasticsearch.ConnectionTimeout())
+        es.tasks.list.side_effect = [
+            as_future({
+                "nodes": {
+                    "Ap3OfntPT7qL4CBeKvamxg": {
+                        "name": "instance-0000000001",
+                        "transport_address": "10.46.79.231:19693",
+                        "host": "10.46.79.231",
+                        "ip": "10.46.79.231:19693",
+                        "roles": [
+                            "data",
+                            "ingest",
+                            "master",
+                            "remote_cluster_client",
+                            "transform"
+                        ],
+                        "attributes": {
+                            "logical_availability_zone": "zone-1",
+                            "server_name": "instance-0000000001.64cb4c66f4f24d85b41f120ef2df5526",
+                            "availability_zone": "us-east4-a",
+                            "xpack.installed": "true",
+                            "instance_configuration": "gcp.data.highio.1",
+                            "transform.node": "true",
+                            "region": "unknown-region"
+                        },
+                        "tasks": {
+                            "Ap3OfntPT7qL4CBeKvamxg:417009036": {
+                                "node": "Ap3OfntPT7qL4CBeKvamxg",
+                                "id": 417009036,
+                                "type": "transport",
+                                "action": "indices:admin/forcemerge",
+                                "start_time_in_millis": 1598018980850,
+                                "running_time_in_nanos": 3659821411,
+                                "cancellable": False,
+                                "headers": {}
+                            }
+                        }
+                    }
+                }
+            }),
+            as_future({
+                "nodes":{}
+            })
+        ]
+        force_merge = runner.ForceMerge()
+        # request-timeout should be ignored as mode:polling
+        await force_merge(es, params={"index" : "_all", "mode": "polling", "max-num-segments": 1, "request-timeout": 50000, 'poll-period': 0})
+        es.indices.forcemerge.assert_called_once_with(index="_all", max_num_segments=1, request_timeout=1)
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -927,6 +927,16 @@ class ForceMergeRunnerTests(TestCase):
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
+    async def test_force_merge_with_polling(self, es):
+        es.indices.forcemerge.return_value = as_future()
+
+        force_merge = runner.ForceMerge()
+
+
+
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
     async def test_optimize_with_defaults(self, es):
         es.indices.forcemerge.side_effect = as_future(exception=elasticsearch.TransportError(400, "Bad Request"))
         es.transport.perform_request.return_value = as_future()

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -921,7 +921,7 @@ class ForceMergeRunnerTests(TestCase):
         es.indices.forcemerge.return_value = as_future()
 
         force_merge = runner.ForceMerge()
-        await force_merge(es, params={"index" : "_all", "max-num-segments": 1, "request-timeout": 50000})
+        await force_merge(es, params={"index": "_all", "max-num-segments": 1, "request-timeout": 50000})
 
         es.indices.forcemerge.assert_called_once_with(index="_all", max_num_segments=1, request_timeout=50000)
 
@@ -978,11 +978,11 @@ class ForceMergeRunnerTests(TestCase):
                 }
             }),
             as_future({
-                "nodes":{}
+                "nodes": {}
             })
         ]
         force_merge = runner.ForceMerge()
-        await force_merge(es, params={"index" : "_all", "mode": "polling", 'poll-period': 0})
+        await force_merge(es, params={"index" : "_all", "mode": "polling", "poll-period": 0})
         es.indices.forcemerge.assert_called_once_with(index="_all", request_timeout=1)
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -1029,13 +1029,13 @@ class ForceMergeRunnerTests(TestCase):
                 }
             }),
             as_future({
-                "nodes":{}
+                "nodes": {}
             })
         ]
         force_merge = runner.ForceMerge()
         # request-timeout should be ignored as mode:polling
         await force_merge(es, params={"index" : "_all", "mode": "polling", "max-num-segments": 1,
-                                      "request-timeout": 50000, 'poll-period': 0})
+                                      "request-timeout": 50000, "poll-period": 0})
         es.indices.forcemerge.assert_called_once_with(index="_all", max_num_segments=1, request_timeout=1)
 
     @mock.patch("elasticsearch.Elasticsearch")

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -22,7 +22,6 @@ import unittest.mock as mock
 from unittest import TestCase
 
 import elasticsearch
-from elasticsearch._async.client import TasksClient
 
 from esrally import exceptions
 from esrally.driver import runner

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1811,7 +1811,6 @@ class SearchParamSourceTests(TestCase):
 
         self.assertNotEqual(first, second)
 
-#TODO: TEST New Params
 class ForceMergeParamSourceTests(TestCase):
     def test_force_merge_index_from_track(self):
         source = params.ForceMergeParamSource(track.Track(name="unit-test", indices=[
@@ -1823,6 +1822,7 @@ class ForceMergeParamSourceTests(TestCase):
         p = source.params()
 
         self.assertEqual("index1,index2,index3", p["index"])
+        self.assertEqual("blocking", p["mode"])
 
     def test_force_merge_index_by_name(self):
         source = params.ForceMergeParamSource(track.Track(name="unit-test"), params={"index": "index2"})
@@ -1830,6 +1830,7 @@ class ForceMergeParamSourceTests(TestCase):
         p = source.params()
 
         self.assertEqual("index2", p["index"])
+        self.assertEqual("blocking", p["mode"])
 
     def test_default_force_merge_index(self):
         source = params.ForceMergeParamSource(track.Track(name="unit-test"), params={})
@@ -1837,14 +1838,18 @@ class ForceMergeParamSourceTests(TestCase):
         p = source.params()
 
         self.assertEqual("_all", p["index"])
+        self.assertEqual("blocking", p["mode"])
 
     def test_force_merge_all_params(self):
         source = params.ForceMergeParamSource(track.Track(name="unit-test"), params={"index": "index2",
                                                                                       "request-timeout": 30,
-                                                                                      "max-num-segments": 1})
+                                                                                      "max-num-segments": 1,
+                                                                                      "polling-period": 20,
+                                                                                     "mode": "polling"})
 
         p = source.params()
 
         self.assertEqual("index2", p["index"])
         self.assertEqual(30, p["request-timeout"])
         self.assertEqual(1, p["max-num-segments"])
+        self.assertEqual("polling", p["mode"])

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1811,6 +1811,7 @@ class SearchParamSourceTests(TestCase):
 
         self.assertNotEqual(first, second)
 
+
 class ForceMergeParamSourceTests(TestCase):
     def test_force_merge_index_from_track(self):
         source = params.ForceMergeParamSource(track.Track(name="unit-test", indices=[
@@ -1842,9 +1843,9 @@ class ForceMergeParamSourceTests(TestCase):
 
     def test_force_merge_all_params(self):
         source = params.ForceMergeParamSource(track.Track(name="unit-test"), params={"index": "index2",
-                                                                                      "request-timeout": 30,
-                                                                                      "max-num-segments": 1,
-                                                                                      "polling-period": 20,
+                                                                                     "request-timeout": 30,
+                                                                                     "max-num-segments": 1,
+                                                                                     "polling-period": 20,
                                                                                      "mode": "polling"})
 
         p = source.params()

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1811,7 +1811,7 @@ class SearchParamSourceTests(TestCase):
 
         self.assertNotEqual(first, second)
 
-
+#TODO: TEST New Params
 class ForceMergeParamSourceTests(TestCase):
     def test_force_merge_index_from_track(self):
         source = params.ForceMergeParamSource(track.Track(name="unit-test", indices=[


### PR DESCRIPTION
This adds a polling mode to the force-merge runner and in the process closes https://github.com/elastic/rally/issues/1050

Some considerations:

1. The change adds a `mode` parameter. This defaults to `blocking` which causes the current behaviour. 
2. If set to `polling` we ignore the `request-timeout` parameter and timeout the force_merge API call after 1s. We then poll the tasks API at an interval of `poll-period` (default 10s), until no force-merge tasks are listed.
3. Currently there is no timeout on the tasks API calls. It is possible this is susceptible to cluster pressure and may itself timeout under heavy load. However, i believe this represents a valid error condition.
4. The 1s timeout is a workaround to the force_merge API not supporting an async call and returning a task id. If multiple force_merge calls are issued in different runners in parallel, all force merges must complete to unblock. This seems low risk as consecutive calls are effectively a noop if `max-num-segments` has been reached.

Will add docs once parameter naming and usage is agreed.
