### PR TITLE
Check if total_transform_processing_times exist for compare reports

### DIFF
--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -442,6 +442,8 @@ class ComparisonReporter:
 
     def report_transform_processing_times(self, baseline_stats, contender_stats):
         lines = []
+        if baseline_stats.total_transform_processing_times is None:
+            return lines
         for baseline in baseline_stats.total_transform_processing_times:
             transform_id = baseline["id"]
             for contender in contender_stats.total_transform_processing_times:


### PR DESCRIPTION
When race didn't have total_transform_processing_times to report, `esrally compare` fails

Relates to https://github.com/elastic/rally/pull/1022
