### PR TITLE
Noop for Async Elasticsearch client

### DIFF
--- a/esrally/client.py
+++ b/esrally/client.py
@@ -187,14 +187,11 @@ class EsClientFactory:
 
             def noop(self, request_start=None, request_end=None):
                 ctx = RallyAsyncElasticsearch.request_context.get()
-                if request_start:
-                    ctx["request_start"] = request_start
-                else:
-                    ctx["request_start"] = time.perf_counter()
-                if request_end and request_end > request_start:
-                    ctx["request_end"] = time.perf_counter()
-                else:
-                    ctx["request_end"] = time.perf_counter()
+                current_time = time.perf_counter()
+                ctx["request_start"] = request_start if request_start else current_time
+                ctx["request_end"] = request_end if request_end else current_time
+                if ctx["request_end"] < ctx["request_start"]:
+                    raise exceptions.RallyAssertionError("request_end cannot be less than request_start")
 
         return RallyAsyncElasticsearch(hosts=self.hosts,
                                        connection_class=esrally.async_connection.AIOHttpConnection,


### PR DESCRIPTION
Currently any custom async runners must make an Elasticsearch call. If they don't the code responsible for invoking the runner fails as it expects a "request_end" key on the context - https://github.com/elastic/rally/blob/master/esrally/driver/driver.py#L1338-L1343

We anticipate runners in the future which might do something else rather than query ES. This represents a larger effort and needs a clear scope and discussion. For now, this introduces a simple `noop` on the ES client. This can be called by a customer runner, after which it can proceed to do any desired work. This also provides the opportunity for the user to introduce their own timing, with a simple precondition check that timing can't result in a negative value.

By default the noop records no time.