### PR TITLE
Bump ES Client, Asyncio client and add pytest-asyncio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
     # transitive dependencies:
     #   urllib3: MIT
     #   aiohttp: Apache 2.0
-    "elasticsearch[async]==7.8.0",
+    "elasticsearch[async]==7.9.1",
     # License: BSD
     "psutil==5.7.0",
     # License: MIT
@@ -83,8 +83,9 @@ install_requires = [
 ]
 
 tests_require = [
-    "pytest==5.2.0",
-    "pytest-benchmark==3.2.2"
+    "pytest==5.4.0",
+    "pytest-benchmark==3.2.2",
+    "pytest-asyncio==0.14.0"
 ]
 
 # These packages are only required when developing Rally


### PR DESCRIPTION
Bumps ES client to 7.9.1.
Introduces `pytest-asyncio`. This allows use of fixtures in mock tests for async methods. `pytest` needs moving up in minors to support.

All tests pass.