### PR TITLE
Fail fast if leading `/` is missing from `path` in raw-request

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1425,8 +1425,13 @@ class RawRequest(Runner):
             request_params["ignore"] = params["ignore"]
         request_params.update(params.get("request-params", {}))
 
+        path = mandatory(params, "path", self)
+        if not path.startswith("/"):
+            self.logger.error("RawRequest failed. Path parameter: [%s] must begin with a '/'", path)
+            raise exceptions.RallyAssertionError(f"RawRequest [{path}] failed. Path parameter must begin with a '/'.")
+
         await es.transport.perform_request(method=params.get("method", "GET"),
-                                           url=mandatory(params, "path", self),
+                                           url=path,
                                            headers=params.get("headers"),
                                            body=params.get("body"),
                                            params=request_params)

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1427,7 +1427,7 @@ class RawRequest(Runner):
 
         path = mandatory(params, "path", self)
         if not path.startswith("/"):
-            self.logger.error("RawRequest failed. Path parameter: [%s] must begin with a '/'", path)
+            self.logger.error("RawRequest failed. Path parameter: [%s] must begin with a '/'.", path)
             raise exceptions.RallyAssertionError(f"RawRequest [{path}] failed. Path parameter must begin with a '/'.")
 
         await es.transport.perform_request(method=params.get("method", "GET"),

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2639,6 +2639,24 @@ class CloseMlJobTests(TestCase):
 class RawRequestRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
+    async def test_raises_missing_slash(self, es):
+        es.transport.perform_request.return_value = as_future()
+        r = runner.RawRequest()
+
+        params = {
+            "path": "_cat/count"
+        }
+
+        with mock.patch.object(r.logger, "error") as mocked_error_logger:
+            with self.assertRaises(exceptions.RallyAssertionError) as ctx:
+                await r(es, params)
+                self.assertEqual("RawRequest [_cat/count] failed. Path parameter must begin with a '/'.", ctx.exception.args[0])
+            mocked_error_logger.assert_has_calls([
+                mock.call("RawRequest failed. Path parameter: [%s] must begin with a '/'", params["path"])
+            ])
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
     async def test_issue_request_with_defaults(self, es):
         es.transport.perform_request.return_value = as_future()
         r = runner.RawRequest()

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2652,7 +2652,7 @@ class RawRequestRunnerTests(TestCase):
                 await r(es, params)
                 self.assertEqual("RawRequest [_cat/count] failed. Path parameter must begin with a '/'.", ctx.exception.args[0])
             mocked_error_logger.assert_has_calls([
-                mock.call("RawRequest failed. Path parameter: [%s] must begin with a '/'", params["path"])
+                mock.call("RawRequest failed. Path parameter: [%s] must begin with a '/'.", params["path"])
             ])
 
     @mock.patch("elasticsearch.Elasticsearch")


### PR DESCRIPTION
Check for mandatory leading `/` in path parameter of raw-request. Raise RallyException if it's missing.

Closes https://github.com/elastic/rally/issues/1063
