### PR TITLE
Ensure that request error meta-data is string

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1432,7 +1432,11 @@ async def execute_single(runner, es, params, on_error):
         elif e.info:
             request_meta_data["error-description"] = "%s (%s)" % (e.error, e.info)
         else:
-            request_meta_data["error-description"] = e.error
+            if isinstance(e.error, bytes):
+                error_description = e.error.decode("utf-8")
+            else:
+                error_description = str(e.error)
+            request_meta_data["error-description"] = error_description
     except KeyError as e:
         logging.getLogger(__name__).exception("Cannot execute runner [%s]; most likely due to missing parameters.", str(runner))
         msg = "Cannot execute [%s]. Provided parameters are: %s. Error: [%s]." % (str(runner), list(params.keys()), str(e))

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1460,6 +1460,26 @@ class AsyncExecutorTests(TestCase):
         }, request_meta_data)
 
     @run_async
+    async def test_execute_single_with_http_413(self):
+        import elasticsearch
+        es = None
+        params = None
+        runner = mock.Mock(side_effect=
+                           as_future(exception=elasticsearch.NotFoundError(413, b"", b"")))
+
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error="continue-on-non-fatal")
+
+        self.assertEqual(0, ops)
+        self.assertEqual("ops", unit)
+        self.assertEqual({
+            "http-status": 413,
+            "error-type": "transport",
+            "error-description": "",
+            "success": False
+        }, request_meta_data)
+
+    @run_async
     async def test_execute_single_with_key_error(self):
         class FailingRunner:
             async def __call__(self, *args):


### PR DESCRIPTION
With this commit we ensure that the `error-description` property that is
added to request metadata on errors always contains a string. This
avoids serialization issues later on when these objects are written to
the metrics store.