### PR TITLE
Use the new pip dependency resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,9 @@ check-venv:
 
 install: venv-create
 	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install --upgrade pip setuptools wheel
-	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e . --use-feature=2020-resolver
 	# Also install development dependencies
-	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .[develop]
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .[develop] --use-feature=2020-resolver
 
 clean: nondocs-clean docs-clean
 

--- a/docker/Dockerfiles/Dockerfile-dev
+++ b/docker/Dockerfiles/Dockerfile-dev
@@ -25,7 +25,8 @@ WORKDIR /rally
 # Wipe away any lingering caches, copied over from the local machine
 RUN find /rally -name "__pycache__" -exec rm -rf -- \{\} \; 2>/dev/null || true
 RUN find /rally -name ".pyc" -exec rm -rf -- \{\} \; 2>/dev/null || true
-RUN pip3 install /rally
+RUN pip3 install --upgrade pip setuptools wheel
+RUN pip3 install --use-feature=2020-resolver /rally
 
 ################################################################################
 # Build stage 1 (the actual Rally image):

--- a/docker/Dockerfiles/Dockerfile-release
+++ b/docker/Dockerfiles/Dockerfile-release
@@ -12,7 +12,8 @@ RUN apt-get -y update && \
 RUN groupadd --gid 1000 rally && \
     useradd -d /rally -m -k /dev/null -g 1000 -N -u 1000 -l -s /bin/bash rally
 
-RUN pip3 install esrally==$RALLY_VERSION
+RUN pip3 install --upgrade pip setuptools wheel
+RUN pip3 install esrally==$RALLY_VERSION --use-feature=2020-resolver
 
 WORKDIR /rally
 COPY --chown=1000:0 docker/bin/entrypoint.sh /entrypoint.sh

--- a/tox.ini
+++ b/tox.ini
@@ -36,12 +36,10 @@ setenv =
     # LC_ALL should have priority but to ensure that non-confirming
     # applications behave identically, we also set LANG explicitly.
     LANG=C
+    PIP_USE_FEATURE={env:PIP_USE_FEATURE:2020-resolver}
 commands =
     pytest --junitxml=junit-{envname}.xml
     pytest -s it --junitxml=junit-{envname}-it.xml
-deps =
-    --use-feature=2020-resolver
-    aiohttp
 
 whitelist_externals =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,9 @@ setenv =
 commands =
     pytest --junitxml=junit-{envname}.xml
     pytest -s it --junitxml=junit-{envname}-it.xml
+deps =
+    --use-feature=2020-resolver
+    aiohttp
 
 whitelist_externals =
     pytest


### PR DESCRIPTION
There is currently an issue with incompatible versions in our dependency
of aiohttp, which is causing installations to fail. Using the stricter
pip 2020 resolver, which is off by default in pip 20, fixes this
issue. The new resolver, which will be the new default in future pip
versions, is not ready for all use cases, but works fine for our use
case, so we are choosing to use it.

Relates https://discuss.python.org/t/announcement-pip-20-2-release/4863
Relates https://github.com/aio-libs/aiohttp/commit/2d36ef6911a1d49001381da40d658a70d64168fa
Relates https://github.com/aio-libs/aiohttp/issues/4987
