### PR TITLE
Check registered parameter sources more strictly

### DIFF
--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import inspect
 import logging
 import math
 import numbers
 import operator
 import random
 import time
-import types
 from enum import Enum
 
 from esrally import exceptions
@@ -43,18 +43,24 @@ def param_source_for_operation(op_type, track, params, task_name):
 def param_source_for_name(name, track, params):
     param_source = __PARAM_SOURCES_BY_NAME[name]
 
-    # we'd rather use callable() but this will erroneously also classify a class as callable...
-    if isinstance(param_source, types.FunctionType):
+    if inspect.isfunction(param_source):
         return DelegatingParamSource(track, params, param_source)
     else:
         return param_source(track, params)
 
 
+def ensure_valid_param_source(param_source):
+    if not inspect.isfunction(param_source) and not inspect.isclass(param_source):
+        raise exceptions.RallyAssertionError(f"Parameter source [{param_source}] must be either a function or a class.")
+
+
 def register_param_source_for_operation(op_type, param_source_class):
+    ensure_valid_param_source(param_source_class)
     __PARAM_SOURCES_BY_OP[op_type.name] = param_source_class
 
 
 def register_param_source_for_name(name, param_source_class):
+    ensure_valid_param_source(param_source_class)
     __PARAM_SOURCES_BY_NAME[name] = param_source_class
 
 

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1278,6 +1278,9 @@ class ParamsRegistrationTests(TestCase):
                 "class-key": self._params["parameter"]
             }
 
+        def __str__(self):
+            return "test param source"
+
     def test_can_register_legacy_function_as_param_source(self):
         source_name = "legacy-params-test-function-param-source"
 
@@ -1313,6 +1316,13 @@ class ParamsRegistrationTests(TestCase):
         self.assertEqual({"class-key": 42}, source.params())
 
         params._unregister_param_source_for_name(source_name)
+
+    def test_cannot_register_an_instance_as_param_source(self):
+        source_name = "params-test-class-param-source"
+        # we create an instance, instead of passing the class
+        with self.assertRaisesRegex(exceptions.RallyAssertionError,
+                                    "Parameter source \\[test param source\\] must be either a function or a class\\."):
+            params.register_param_source_for_name(source_name, ParamsRegistrationTests.ParamSourceClass())
 
 
 class SleepParamSourceTests(TestCase):


### PR DESCRIPTION
With this commit we add a stricter check when parameter sources are
registered with Rally. This ensures only functions or classes are
registered. If a user mistakenly registers e.g. an instance,
registration will fail immediately.