### PR TITLE
Upgrade google-auth to latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ install_requires = [
     #   google-crc32c: Apache 2.0
     "google-resumable-media==1.1.0",
     # License: Apache 2.0
-    "google-auth==1.21.1"
+    "google-auth==1.22.1"
 ]
 
 tests_require = [


### PR DESCRIPTION
With this commit we upgrade google-auth from 1.21.1 to the currently
latest version 1.22.1.