### PR TITLE
Optionally use generated api_key auth to ES

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -275,6 +275,24 @@ class EsClientFactoryTests(TestCase):
 
         self.assertDictEqual(original_client_options, client_options)
 
+    @mock.patch("elasticsearch.Elasticsearch")
+    def test_use_api_keys(self, _):
+        hosts = [{"host": "127.0.0.1", "port": 9200}]
+        client_options = {"use_api_key": True, "http_auth": ("a", "b")}
+
+        f = client.EsClientFactory(hosts, client_options)
+        self.assertIsNotNone(f.client_options["http_auth"])
+        f.create()
+        self.assertIsNone(f.client_options.get("http_auth", None))
+        self.assertIsNotNone(f.client_options["api_key"])
+
+        # now assert that not having a http_auth client option does not cause issue
+        del f.client_options["api_key"]
+        self.assertIsNone(f.client_options.get("api_key", None))
+        f.create()
+        self.assertIsNone(f.client_options.get("http_auth", None))
+        self.assertIsNotNone(f.client_options["api_key"])
+
 
 class RestLayerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")


### PR DESCRIPTION
This commit adds a optional client arg, use_api_key, which will generate
and use an api key for every client and async client created by
Rally. It uses an initial call via the existing auth scheme to ES to
generate the key, and then creates a new client using the api_key for
general use by Rally.

The async client also does this, and temporarily creates a sync client
to generate the key, and then uses it when creating an async client.

Closes #1067
