### PR TITLE
Accept some differing units for throttling

### DIFF
--- a/esrally/driver/scheduler.py
+++ b/esrally/driver/scheduler.py
@@ -205,6 +205,9 @@ class Unthrottled(Scheduler):
     def next(self, current):
         return 0
 
+    def __str__(self):
+        return "unthrottled"
+
 
 class DeterministicScheduler(SimpleScheduler):
     """
@@ -264,9 +267,19 @@ class UnitAwareScheduler(Scheduler):
             expected_unit = self.task.target_throughput.unit
             actual_unit = f"{unit}/s"
             if actual_unit != expected_unit:
-                raise exceptions.RallyAssertionError(f"Target throughput for [{self.task}] is specified in "
-                                                     f"[{expected_unit}] but the task throughput is measured "
-                                                     f"in [{actual_unit}].")
+                # *temporary* workaround to convert pages/s (scrolls) to ops/s to stay backwards-compatible.
+                #
+                # This ensures that we throttle based on ops/s but report based on pages/s (as before).
+                if actual_unit == "pages/s" and expected_unit == "ops/s":
+                    weight = 1
+                    if self.first_request:
+                        logging.getLogger(__name__).warning("Task [%s] throttles based on ops/s but reports pages/s. "
+                                                            "Please specify the target throughput in pages/s instead.",
+                                                            self.task)
+                else:
+                    raise exceptions.RallyAssertionError(f"Target throughput for [{self.task}] is specified in "
+                                                         f"[{expected_unit}] but the task throughput is measured "
+                                                         f"in [{actual_unit}].")
 
             self.first_request = False
             self.current_weight = weight

--- a/esrally/driver/scheduler.py
+++ b/esrally/driver/scheduler.py
@@ -267,15 +267,15 @@ class UnitAwareScheduler(Scheduler):
             expected_unit = self.task.target_throughput.unit
             actual_unit = f"{unit}/s"
             if actual_unit != expected_unit:
-                # *temporary* workaround to convert pages/s (scrolls) to ops/s to stay backwards-compatible.
+                # *temporary* workaround to convert mismatching units to ops/s to stay backwards-compatible.
                 #
-                # This ensures that we throttle based on ops/s but report based on pages/s (as before).
-                if actual_unit == "pages/s" and expected_unit == "ops/s":
+                # This ensures that we throttle based on ops/s but report based on the original unit (as before).
+                if expected_unit == "ops/s":
                     weight = 1
                     if self.first_request:
-                        logging.getLogger(__name__).warning("Task [%s] throttles based on ops/s but reports pages/s. "
-                                                            "Please specify the target throughput in pages/s instead.",
-                                                            self.task)
+                        logging.getLogger(__name__).warning("Task [%s] throttles based on [%s] but reports [%s]. "
+                                                            "Please specify the target throughput in [%s] instead.",
+                                                            self.task, expected_unit, actual_unit, actual_unit)
                 else:
                     raise exceptions.RallyAssertionError(f"Target throughput for [{self.task}] is specified in "
                                                          f"[{expected_unit}] but the task throughput is measured "

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import re
+import sys
 import tempfile
 import urllib.error
 
@@ -794,8 +795,12 @@ def post_process_for_test_mode(t):
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.debug("Resetting measurement time period for [%s] to [%d] seconds.", str(leaf_task), leaf_task.time_period)
 
-                leaf_task.params.pop("target-throughput", None)
-                leaf_task.params.pop("target-interval", None)
+                # Keep throttled to expose any errors but increase the target throughput for short execution times.
+                if leaf_task.throttled:
+                    original_throughput = leaf_task.target_throughput
+                    leaf_task.params.pop("target-throughput", None)
+                    leaf_task.params.pop("target-interval", None)
+                    leaf_task.params["target-throughput"] = f"{sys.maxsize} {original_throughput.unit}"
 
     return t
 


### PR DESCRIPTION
With #1100 we introduced more flexible throttling which requires that
the unit in which requests are throttled and the unit in which they are
reported, are aligned. This causes issues at the moment with scroll
requests which are throttled in ops/s but reported in pages/s. Similarly we have
also throttled bulk requests based on ops/s sometimes but their throughput is
reported in docs/s.

With this commit we correct the unit mismatch for this special case in
order to stay backwards-compatible with older versions of Rally. We also
ensure that throttling is preserved in test mode so our integration
tests can spot such issues in the future.

Relates #1100