### PR TITLE
Clarify task execution order in docs with respect to --include-tasks

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -328,6 +328,10 @@ Each challenge consists of one or more tasks but sometimes you are only interest
 
 You can use ``--include-tasks`` to specify a comma-separated list of tasks that you want to run. Each item in the list defines either the name of a task or the operation type of a task. Only the tasks that match will be executed. Currently there is also no command that lists the tasks of a challenge so you need to look at the track source.
 
+.. note::
+
+    Tasks will be executed in the order that are defined in the challenge, not in the order they are defined in the command.
+
 **Examples**:
 
 * Execute only the tasks with the name ``index`` and ``term``: ``--include-tasks="index,term"``


### PR DESCRIPTION
Improves commit message for https://github.com/elastic/rally/pull/1102