### PR TITLE
Drop support for Elasticsearch 2.x

### DIFF
--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -266,7 +266,7 @@ You can also show details about your track with ``esrally info --track-path=~/ra
     5. force-merge
     6. query-match-all (8 clients)
 
-Congratulations, you have created your first track! You can test it with ``esrally --distribution-version=6.0.0 --track-path=~/rally-tracks/tutorial``.
+Congratulations, you have created your first track! You can test it with ``esrally --distribution-version=7.0.0 --track-path=~/rally-tracks/tutorial``.
 
 .. _add_track_test_mode:
 

--- a/docs/car.rst
+++ b/docs/car.rst
@@ -164,7 +164,7 @@ You can now verify that everything works by listing all teams in this team repos
 
 This shows all teams that are available on the ``master`` branch of this repository. Suppose you only created tracks on the branch ``2`` because you're interested in the performance of Elasticsearch 2.x, then you can specify also the distribution version::
 
-    esrally list teams --team-repository=private --distribution-version=2.0.0
+    esrally list teams --team-repository=private --distribution-version=7.0.0
 
 
 Rally will follow the same branch fallback logic as described above.

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -523,16 +523,16 @@ and reference it when running Rally::
 ``runtime-jdk``
 ~~~~~~~~~~~~~~~
 
-By default, Rally will derive the appropriate runtime JDK versions automatically per version of Elasticsearch. For example, it will choose JDK 8 or 7 for Elasticsearch 2.x but only JDK 8 for Elasticsearch 5.0.0. It will choose the highest available version.
+By default, Rally will derive the appropriate runtime JDK versions automatically per version of Elasticsearch. For example, it will choose JDK 8 for Elasticsearch 5.0.0 but JDK 12, 11 or 8 for Elasticsearch 7.0.0. It will choose the highest available version.
 
-This command line parameter sets the major version of the JDK that Rally should use to run Elasticsearch. It is required that either ``JAVA_HOME`` or ``JAVAx_HOME`` (where ``x`` is the major version, e.g. ``JAVA8_HOME`` for a JDK 8) points to the appropriate JDK.
+This command line parameter sets the major version of the JDK that Rally should use to run Elasticsearch. It is required that either ``JAVA_HOME`` or ``JAVAx_HOME`` (where ``x`` is the major version, e.g. ``JAVA11_HOME`` for a JDK 11) points to the appropriate JDK.
 
 Example::
 
    # Run a benchmark with defaults (i.e. JDK 8)
-   esrally --distribution-version=2.4.0
-   # Force to run with JDK 7
-   esrally --distribution-version=2.4.0 --runtime-jdk=7
+   esrally --distribution-version=5.0.0
+   # Force to run with JDK 11
+   esrally --distribution-version=7.0.0 --runtime-jdk=11
 
 It is also possible to specify the JDK that is bundled with Elasticsearch with the special value ``bundled``. The `JDK is bundled from Elasticsearch 7.0.0 onwards <https://www.elastic.co/guide/en/elasticsearch/reference/current/release-highlights-7.0.0.html#_bundle_jdk_in_elasticsearch_distribution>`_.
 
@@ -574,10 +574,10 @@ If you want Rally to launch and benchmark a cluster using a binary distribution,
 
  ::
 
-   esrally --distribution-version=2.3.3
+   esrally --distribution-version=7.0.0
 
 
-Rally will then benchmark the official Elasticsearch 2.3.3 distribution. Please check our :doc:`version support page </versions>` to see which Elasticsearch versions are currently supported by Rally.
+Rally will then benchmark the official Elasticsearch 7.0.0 distribution. Please check our :doc:`version support page </versions>` to see which Elasticsearch versions are currently supported by Rally.
 
 ``distribution-repository``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/elasticsearch_plugins.rst
+++ b/docs/elasticsearch_plugins.rst
@@ -1,10 +1,7 @@
 Using Elasticsearch Plugins
 ===========================
 
-You can have Rally setup an Elasticsearch cluster with plugins for you. However, there are a couple of restrictions:
-
-* This feature is only supported from Elasticsearch 5.0.0 onwards
-* Whereas Rally caches downloaded Elasticsearch distributions, plugins will always be installed via the Internet and thus each machine where an Elasticsearch node will be installed, requires an active Internet connection.
+You can have Rally setup an Elasticsearch cluster with plugins for you. Whereas Rally caches downloaded Elasticsearch distributions, plugins will always be installed via the Internet and thus each machine where an Elasticsearch node will be installed, requires an active Internet connection.
 
 Listing plugins
 ---------------
@@ -39,13 +36,7 @@ To see which plugins are available, run ``esrally list elasticsearch-plugins``::
     repository-s3
     store-smb
 
-Rally supports plugins only for Elasticsearch 5.0 or better. As the availability of plugins may change from release to release we recommend that you include the ``--distribution-version`` parameter when listing plugins. By default Rally assumes that you want to benchmark the latest master version of Elasticsearch.
-
-Let's see what happens if we run ``esrally list elasticsearch-plugins --distribution-version=2.4.0``::
-
-    No Elasticsearch plugins are available.
-
-As mentioned before, this is expected as only Elasticsearch 5.0 or better is supported.
+As the availability of plugins may change from release to release we recommend that you include the ``--distribution-version`` parameter when listing plugins. By default Rally assumes that you want to benchmark the latest master version of Elasticsearch.
 
 Running a benchmark with plugins
 --------------------------------

--- a/docs/pipelines.rst
+++ b/docs/pipelines.rst
@@ -30,9 +30,9 @@ To benchmark a cluster, you also have to specify the hosts to connect to. An exa
 from-distribution
 ~~~~~~~~~~~~~~~~~
 
-This pipeline allows to benchmark an official Elasticsearch distribution which will be automatically downloaded by Rally. The earliest supported version is Elasticsearch 1.7.0. An example invocation::
+This pipeline allows to benchmark an official Elasticsearch distribution which will be automatically downloaded by Rally. An example invocation::
 
-    esrally --pipeline=from-distribution --distribution-version=1.7.5
+    esrally --pipeline=from-distribution --distribution-version=7.0.0
 
 The version numbers have to match the name in the download URL path.
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -78,7 +78,7 @@ You can now verify that everything works by listing all tracks in this track rep
 
 This shows all tracks that are available on the ``master`` branch of this repository. Suppose you only created tracks on the branch ``2`` because you're interested in the performance of Elasticsearch 2.x, then you can specify also the distribution version::
 
-    esrally list tracks --track-repository=private --distribution-version=2.0.0
+    esrally list tracks --track-repository=private --distribution-version=7.0.0
 
 
 Rally will follow the same branch fallback logic as described above.

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,17 +4,9 @@ Elasticsearch Version Support
 Minimum supported version
 =========================
 
-Rally |release| can benchmark Elasticsearch 2.0.0 and above.
+Rally |release| can benchmark Elasticsearch 5.0.0 and above.
 
 End-of-life Policy
 ==================
 
 The latest version of Rally allows to benchmark all currently supported versions of Elasticsearch. Once an `Elasticsearch version reaches end-of-life <https://www.elastic.co/support/eol>`_, Rally will support benchmarking the corresponding version for two more years. For example, Elasticsearch 1.7.x has been supported until 2017-01-16. Rally drops support for Elasticsearch 1.7.x two years after that date on 2019-01-16. Version support is dropped in the next Rally maintenance release after that date.
-
-Version-specific Limitations
-============================
-
-The following features require at least Elasticsearch 5.0.0:
-
-* :doc:`Benchmarking with plugins </elasticsearch_plugins>`
-* :ref:`Benchmarking source builds <pipelines_from-sources>`

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -158,8 +158,7 @@ class ProcessLauncher:
         ]
 
         t = telemetry.Telemetry(enabled_devices, devices=node_telemetry)
-        # TODO #822: Remove reference to car's environment
-        env = self._prepare_env(node_configuration.car_env, node_name, java_home, t)
+        env = self._prepare_env(node_name, java_home, t)
         t.on_pre_node_start(node_name)
         node_pid = self._start_process(binary_path, env)
         self.logger.info("Successfully started node [%s] with PID [%s].", node_name, node_pid)
@@ -170,9 +169,8 @@ class ProcessLauncher:
 
         return node
 
-    def _prepare_env(self, car_env, node_name, java_home, t):
+    def _prepare_env(self, node_name, java_home, t):
         env = {k: v for k, v in os.environ.items() if k in self.pass_env_vars}
-        env.update(car_env)
         if java_home:
             self._set_env(env, "PATH", os.path.join(java_home, "bin"), separator=os.pathsep, prepend=True)
             # Don't merge here!

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -54,10 +54,9 @@ def docker(cfg, car, cluster_settings, ip, http_port, target_root, node_name):
 
 
 class NodeConfiguration:
-    def __init__(self, build_type, car_env, car_runtime_jdks, car_provides_bundled_jdk, ip, node_name, node_root_path,
+    def __init__(self, build_type, car_runtime_jdks, car_provides_bundled_jdk, ip, node_name, node_root_path,
                  binary_path, data_paths):
         self.build_type = build_type
-        self.car_env = car_env
         self.car_runtime_jdks = car_runtime_jdks
         self.car_provides_bundled_jdk = car_provides_bundled_jdk
         self.ip = ip
@@ -69,7 +68,6 @@ class NodeConfiguration:
     def as_dict(self):
         return {
             "build-type": self.build_type,
-            "car-env": self.car_env,
             "car-runtime-jdks": self.car_runtime_jdks,
             "car-provides-bundled-jdk": self.car_provides_bundled_jdk,
             "ip": self.ip,
@@ -82,7 +80,7 @@ class NodeConfiguration:
     @staticmethod
     def from_dict(d):
         return NodeConfiguration(d["build-type"], d["car-env"], d["car-runtime-jdks"], d["car-provides-bundled-jdk"], d["ip"],
-                                 d["node-name"], d["node-root-path"], d["binary-path"], d["data-paths"])
+                                 d["node-name"], d["node-root-path"], d["binary-path"])
 
 
 def save_node_configuration(path, n):
@@ -196,7 +194,7 @@ class BareProvisioner:
         for installer in self.plugin_installers:
             installer.invoke_install_hook(team.BootstrapPhase.post_install, provisioner_vars.copy())
 
-        return NodeConfiguration("tar", self.es_installer.car.env, self.es_installer.car.mandatory_var("runtime.jdk"),
+        return NodeConfiguration("tar", self.es_installer.car.mandatory_var("runtime.jdk"),
                                  convert.to_bool(self.es_installer.car.mandatory_var("runtime.jdk.bundled")),
                                  self.es_installer.node_ip, self.es_installer.node_name,
                                  self.es_installer.node_root_dir, self.es_installer.es_home_path,

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -79,8 +79,8 @@ class NodeConfiguration:
 
     @staticmethod
     def from_dict(d):
-        return NodeConfiguration(d["build-type"], d["car-env"], d["car-runtime-jdks"], d["car-provides-bundled-jdk"], d["ip"],
-                                 d["node-name"], d["node-root-path"], d["binary-path"])
+        return NodeConfiguration(d["build-type"], d["car-runtime-jdks"], d["car-provides-bundled-jdk"], d["ip"],
+                                 d["node-name"], d["node-root-path"], d["binary-path"], d["data-paths"])
 
 
 def save_node_configuration(path, n):
@@ -461,7 +461,7 @@ class DockerProvisioner:
         with open(os.path.join(self.binary_path, "docker-compose.yml"), mode="wt", encoding="utf-8") as f:
             f.write(docker_cfg)
 
-        return NodeConfiguration("docker", self.car.env, self.car.mandatory_var("runtime.jdk"),
+        return NodeConfiguration("docker", self.car.mandatory_var("runtime.jdk"),
                                  convert.to_bool(self.car.mandatory_var("runtime.jdk.bundled")), self.node_ip,
                                  self.node_name, self.node_root_dir, self.binary_path, self.data_paths)
 

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -27,7 +27,7 @@ from esrally import client, version
 from esrally.utils import process, io
 
 CONFIG_NAMES = ["in-memory-it", "es-it"]
-DISTRIBUTIONS = ["2.4.6", "5.6.16", "6.8.0", "7.6.0"]
+DISTRIBUTIONS = ["5.6.16", "6.8.0", "7.6.0"]
 TRACKS = ["geonames", "nyc_taxis", "http_logs", "nested"]
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1092,44 +1092,6 @@ class ForceMergeRunnerTests(TestCase):
                                       "request-timeout": 50000, "poll-period": 0})
         es.indices.forcemerge.assert_called_once_with(index="_all", max_num_segments=1, request_timeout=1)
 
-    @mock.patch("elasticsearch.Elasticsearch")
-    @run_async
-    async def test_optimize_with_defaults(self, es):
-        es.indices.forcemerge.side_effect = as_future(exception=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request.return_value = as_future()
-
-        force_merge = runner.ForceMerge()
-        await force_merge(es, params={})
-
-        es.transport.perform_request.assert_called_once_with(method="POST", url="/_optimize", params={}, headers={})
-
-    @mock.patch("elasticsearch.Elasticsearch")
-    @run_async
-    async def test_optimize_with_timeout_and_headers(self, es):
-        es.indices.forcemerge.side_effect = as_future(exception=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request.return_value = as_future()
-
-        force_merge = runner.ForceMerge()
-        await force_merge(es, params={"request-timeout": 3.0, "opaque-id": "test-id", "headers": {"header1": "value1"}})
-
-        es.transport.perform_request.assert_called_once_with(method="POST",
-                                                             url="/_optimize",
-                                                             params={"request_timeout": 3.0},
-                                                             headers={"header1": "value1", "x-opaque-id": "test-id"})
-
-    @mock.patch("elasticsearch.Elasticsearch")
-    @run_async
-    async def test_optimize_with_params(self, es):
-        es.indices.forcemerge.side_effect = as_future(exception=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request.return_value = as_future()
-        force_merge = runner.ForceMerge()
-        await force_merge(es, params={"max-num-segments": 3, "request-timeout": 17000})
-
-        es.transport.perform_request.assert_called_once_with(method="POST",
-                                                             url="/_optimize",
-                                                             params={"request_timeout": 17000, "max_num_segments": 3},
-                                                             headers={})
-
 
 class IndicesStatsRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")

--- a/tests/mechanic/data/cars/v1/32gheap.ini
+++ b/tests/mechanic/data/cars/v1/32gheap.ini
@@ -8,6 +8,3 @@ base=vanilla
 [variables]
 heap_size=32g
 assertions=false
-
-[env]
-JAVA_TOOL_OPTS=A B C

--- a/tests/mechanic/data/cars/v1/ea.ini
+++ b/tests/mechanic/data/cars/v1/ea.ini
@@ -5,6 +5,3 @@ description=Enables Java assertions
 # no config base here
 [variables]
 assertions=true
-
-[env]
-JAVA_TOOL_OPTS=D E F

--- a/tests/mechanic/data/cars/v1/verbose.ini
+++ b/tests/mechanic/data/cars/v1/verbose.ini
@@ -6,6 +6,3 @@ description=Verbose Logging
 # actually preserve order of the "vanilla" config base when overriding.
 [config]
 base=verbose_logging,vanilla
-
-[env]
-JAVA_TOOL_OPTS=G H I

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -178,7 +178,7 @@ class ProcessLauncherTests(TestCase):
 
         node_configs = []
         for node in range(2):
-            node_configs.append(NodeConfiguration(build_type="tar", car_env={}, car_runtime_jdks="12,11", car_provides_bundled_jdk=True,
+            node_configs.append(NodeConfiguration(build_type="tar", car_runtime_jdks="12,11", car_provides_bundled_jdk=True,
                                                   ip="127.0.0.1", node_name="testnode-{}".format(node),
                                                   node_root_path="/tmp", binary_path="/tmp", data_paths="/tmp"))
 
@@ -227,7 +227,7 @@ class ProcessLauncherTests(TestCase):
             telemetry.FlightRecorder(telemetry_params={}, log_root="/tmp/telemetry", java_major_version=8)
         ]
         t = telemetry.Telemetry(["jfr"], devices=node_telemetry)
-        env = proc_launcher._prepare_env(car_env={}, node_name="node0", java_home="/java_home", t=t)
+        env = proc_launcher._prepare_env(node_name="node0", java_home="/java_home", t=t)
 
         self.assertEqual("/java_home/bin" + os.pathsep + os.environ["PATH"], env["PATH"])
         self.assertEqual("-XX:+ExitOnOutOfMemoryError -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints "
@@ -245,7 +245,7 @@ class ProcessLauncherTests(TestCase):
 
         t = telemetry.Telemetry()
         # no JAVA_HOME -> use the bundled JDK
-        env = proc_launcher._prepare_env(car_env={}, node_name="node0", java_home=None, t=t)
+        env = proc_launcher._prepare_env(node_name="node0", java_home=None, t=t)
 
         # unmodified
         self.assertEqual(os.environ["PATH"], env["PATH"])
@@ -263,7 +263,7 @@ class ProcessLauncherTests(TestCase):
 
         t = telemetry.Telemetry()
         # no JAVA_HOME -> use the bundled JDK
-        env = proc_launcher._prepare_env(car_env={}, node_name="node0", java_home=None, t=t)
+        env = proc_launcher._prepare_env(node_name="node0", java_home=None, t=t)
 
         # unmodified
         self.assertEqual(os.environ["JAVA_HOME"], env["JAVA_HOME"])
@@ -281,7 +281,7 @@ class ProcessLauncherTests(TestCase):
 
         t = telemetry.Telemetry()
         # no JAVA_HOME -> use the bundled JDK
-        env = proc_launcher._prepare_env(car_env={}, node_name="node0", java_home=None, t=t)
+        env = proc_launcher._prepare_env(node_name="node0", java_home=None, t=t)
 
         # unmodified
         self.assertEqual(os.environ["ES_JAVA_OPTS"], env["ES_JAVA_OPTS"])
@@ -364,7 +364,7 @@ class DockerLauncherTests(TestCase):
         cfg = config.Config()
         docker = launcher.DockerLauncher(cfg)
 
-        node_config = NodeConfiguration(build_type="docker", car_env={}, car_runtime_jdks="12,11", car_provides_bundled_jdk=True,
+        node_config = NodeConfiguration(build_type="docker", car_runtime_jdks="12,11", car_provides_bundled_jdk=True,
                                         ip="127.0.0.1", node_name="testnode", node_root_path="/tmp", binary_path="/bin",
                                         data_paths="/tmp")
 
@@ -396,7 +396,7 @@ class DockerLauncherTests(TestCase):
         stop_watch = IterationBasedStopWatch(max_iterations=2)
         docker = launcher.DockerLauncher(cfg, clock=TestClock(stop_watch=stop_watch))
 
-        node_config = NodeConfiguration(build_type="docker", car_env={}, car_runtime_jdks="12,11", car_provides_bundled_jdk=True,
+        node_config = NodeConfiguration(build_type="docker", car_runtime_jdks="12,11", car_provides_bundled_jdk=True,
                                         ip="127.0.0.1", node_name="testnode", node_root_path="/tmp", binary_path="/bin",
                                         data_paths="/tmp")
 

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -57,7 +57,6 @@ class BareProvisionerTests(TestCase):
                                         apply_config=null_apply_config)
 
         node_config = p.prepare({"elasticsearch": "/opt/elasticsearch-5.0.0.tar.gz"})
-        self.assertEqual({}, node_config.car_env)
         self.assertEqual("8", node_config.car_runtime_jdks)
         self.assertEqual("/opt/elasticsearch-5.0.0", node_config.binary_path)
         self.assertEqual(["/opt/elasticsearch-5.0.0/data"], node_config.data_paths)
@@ -171,7 +170,6 @@ class BareProvisionerTests(TestCase):
                                         apply_config=null_apply_config)
 
         node_config = p.prepare({"elasticsearch": "/opt/elasticsearch-5.0.0.tar.gz"})
-        self.assertEqual({}, node_config.car_env)
         self.assertEqual("8", node_config.car_runtime_jdks)
         self.assertEqual("/opt/elasticsearch-5.0.0", node_config.binary_path)
         self.assertEqual(["/opt/elasticsearch-5.0.0/data"], node_config.data_paths)
@@ -252,7 +250,6 @@ class BareProvisionerTests(TestCase):
                                         apply_config=null_apply_config)
 
         node_config = p.prepare({"elasticsearch": "/opt/elasticsearch-6.3.0.tar.gz"})
-        self.assertEqual({}, node_config.car_env)
         self.assertEqual("8", node_config.car_runtime_jdks)
         self.assertEqual("/opt/elasticsearch-6.3.0", node_config.binary_path)
         self.assertEqual(["/opt/elasticsearch-6.3.0/data"], node_config.data_paths)

--- a/tests/mechanic/team_test.py
+++ b/tests/mechanic/team_test.py
@@ -51,7 +51,6 @@ class CarLoaderTests(TestCase):
             "clean_command": "./gradlew clean",
             "data_paths": ["/mnt/disk0", "/mnt/disk1"]
         }, car.variables)
-        self.assertEqual({}, car.env)
         self.assertIsNone(car.root_path)
 
     def test_load_car_with_mixin_single_config_base(self):
@@ -64,7 +63,6 @@ class CarLoaderTests(TestCase):
             "clean_command": "./gradlew clean",
             "assertions": "true"
         }, car.variables)
-        self.assertEqual({"JAVA_TOOL_OPTS": "A B C D E F"}, car.env)
         self.assertIsNone(car.root_path)
 
     def test_load_car_with_mixin_multiple_config_bases(self):
@@ -81,7 +79,6 @@ class CarLoaderTests(TestCase):
             "verbose_logging": "true",
             "assertions": "true"
         }, car.variables)
-        self.assertEqual({"JAVA_TOOL_OPTS": "A B C D E F G H I"}, car.env)
 
     def test_load_car_with_install_hook(self):
         car = team.load_car(self.team_dir, ["default", "with_hook"], car_params={"data_paths": ["/mnt/disk0", "/mnt/disk1"]})
@@ -96,7 +93,6 @@ class CarLoaderTests(TestCase):
             "clean_command": "./gradlew clean",
             "data_paths": ["/mnt/disk0", "/mnt/disk1"]
         }, car.variables)
-        self.assertEqual({}, car.env)
 
     def test_load_car_with_multiple_bases_referring_same_install_hook(self):
         car = team.load_car(self.team_dir, ["with_hook", "another_with_hook"])
@@ -112,7 +108,6 @@ class CarLoaderTests(TestCase):
             "clean_command": "./gradlew clean",
             "verbose_logging": "true"
         }, car.variables)
-        self.assertEqual({}, car.env)
 
     def test_raises_error_on_unknown_car(self):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:


### PR DESCRIPTION
With this commit we drop support in Rally to benchmark Elasticsearch
2.x. This version is end-of-life since February 28, 2018.

Closes #822