### PR TITLE
Error wrapper script on unclean local state

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -103,8 +103,9 @@ then
       #else
       # offline - skipping update
       fi
-    # else
-      # Uncommitted changes - don't upgrade, just run
+    else
+      >&2 echo "There are uncommitted changes. Please cleanup your working copy or specify --skip-update."
+      exit 1
     fi
 #else -> No self update
 fi


### PR DESCRIPTION
With this commit we exit the Rally wrapper script with an error if the
local working copy contains uncommitted files. This avoids skipping
automatic updates silently if uncommitted files are unintentionally
present. Users that still want to continue running can do so by
specifying `--skip-update`.

Closes #911