### PR TITLE
Don't change scheduler on failed requests

### DIFF
--- a/esrally/driver/scheduler.py
+++ b/esrally/driver/scheduler.py
@@ -264,7 +264,7 @@ class UnitAwareScheduler(Scheduler):
         self.scheduler = Unthrottled()
 
     def after_request(self, now, weight, unit, request_meta_data):
-        if self.first_request or self.current_weight != weight:
+        if weight > 0 and (self.first_request or self.current_weight != weight):
             expected_unit = self.task.target_throughput.unit
             actual_unit = f"{unit}/s"
             if actual_unit != expected_unit:


### PR DESCRIPTION
With this commit we check whether a request has a non-zero weight before
attempting to calculate a target throughput. This ensures that
throughput is only calculated / adjusted if the request has returned
successfully and we're able to derive a throughput.