### PR TITLE
Ensure that sleep tasks are timed

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1630,7 +1630,11 @@ class Sleep(Runner):
     """
 
     async def __call__(self, es, params):
-        await asyncio.sleep(mandatory(params, "duration", "sleep"))
+        es.on_request_start()
+        try:
+            await asyncio.sleep(mandatory(params, "duration", "sleep"))
+        finally:
+            es.on_request_end()
 
     def __repr__(self, *args, **kwargs):
         return "sleep"

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -3328,6 +3328,8 @@ class SleepTests(TestCase):
             await r(es, params={})
 
         self.assertEqual(0, es.call_count)
+        self.assertEqual(1, es.on_request_start.call_count)
+        self.assertEqual(1, es.on_request_end.call_count)
         self.assertEqual(0, sleep.call_count)
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -3339,6 +3341,8 @@ class SleepTests(TestCase):
         await r(es, params={"duration": 4.3})
 
         self.assertEqual(0, es.call_count)
+        self.assertEqual(1, es.on_request_start.call_count)
+        self.assertEqual(1, es.on_request_end.call_count)
         sleep.assert_called_once_with(4.3)
 
 


### PR DESCRIPTION
With this commit we ensure that also the `sleep` task is included in
time measurements. Regular runners in Rally issue requests against
Elasticsearch and time measurement is done via callbacks in the request
lifecycle but the `sleep` runner is different because it only waits for
a certain time without any calls.