### PR TITLE
Treat some zero target-intervals as unthrottled

### DIFF
--- a/esrally/driver/scheduler.py
+++ b/esrally/driver/scheduler.py
@@ -87,10 +87,10 @@ def scheduler_for(task: esrally.track.Task):
     :return: An initialized scheduler instance.
     """
     logger = logging.getLogger(__name__)
-    if not task.throttled:
+    if run_unthrottled(task):
         return Unthrottled()
 
-    schedule = task.schedule or "deterministic"
+    schedule = task.schedule or DeterministicScheduler.name
     try:
         scheduler_class = __SCHEDULERS[schedule]
     except KeyError:
@@ -106,6 +106,16 @@ def scheduler_for(task: esrally.track.Task):
     else:
         logger.debug("Treating [%s] for [%s] as non-simple scheduler.", scheduler_class, task)
         return scheduler_class(task)
+
+
+def run_unthrottled(task):
+    """
+    Determines whether a task needs to run unthrottled. Tasks that don't specify a target throughput are only considered
+    as unthrottled if no explicit schedule or one of the built-in schedules is specified. Custom schedules might need
+    more flexible approaches (e.g. because they simulate a throughput that changes according to a daily or weekly
+    pattern) and thus specifying a target throughput might not always be appropriate.
+    """
+    return task.target_throughput is None and task.schedule in [None, PoissonScheduler.name, DeterministicScheduler.name]
 
 
 def is_legacy_scheduler(scheduler_class):
@@ -215,6 +225,8 @@ class DeterministicScheduler(SimpleScheduler):
     Schedules the next execution according to a
     `deterministic distribution <https://en.wikipedia.org/wiki/Degenerate_distribution>`_.
     """
+    name = "deterministic"
+
     # pylint: disable=unused-variable
     def __init__(self, task, target_throughput):
         super().__init__()
@@ -236,6 +248,8 @@ class PoissonScheduler(SimpleScheduler):
 
     See also http://preshing.com/20111007/how-to-generate-random-timings-for-a-poisson-process/
     """
+    name = "poisson"
+
     # pylint: disable=unused-variable
     def __init__(self, task, target_throughput):
         super().__init__()
@@ -295,5 +309,5 @@ class UnitAwareScheduler(Scheduler):
         return f"Unit-aware scheduler delegating to [{self.scheduler_class}]"
 
 
-register_scheduler("deterministic", DeterministicScheduler)
-register_scheduler("poisson", PoissonScheduler)
+register_scheduler(DeterministicScheduler.name, DeterministicScheduler)
+register_scheduler(PoissonScheduler.name, PoissonScheduler)

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -805,7 +805,7 @@ def post_process_for_test_mode(t):
                         logger.debug("Resetting measurement time period for [%s] to [%d] seconds.", str(leaf_task), leaf_task.time_period)
 
                 # Keep throttled to expose any errors but increase the target throughput for short execution times.
-                if leaf_task.throttled and leaf_task.target_throughput:
+                if leaf_task.target_throughput:
                     original_throughput = leaf_task.target_throughput
                     leaf_task.params.pop("target-throughput", None)
                     leaf_task.params.pop("target-interval", None)

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -828,10 +828,6 @@ class Task:
         else:
             return None
 
-    @property
-    def throttled(self):
-        return self.schedule is not None or self.target_throughput is not None
-
     def __hash__(self):
         # Note that we do not include `params` in __hash__ and __eq__ (the other attributes suffice to uniquely define a task)
         return hash(self.name) ^ hash(self.operation) ^ hash(self.warmup_iterations) ^ hash(self.iterations) ^ \

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -260,33 +260,29 @@ class TaskFilterTests(TestCase):
 
 class TaskTests(TestCase):
     def task(self, schedule=None, target_throughput=None, target_interval=None):
-        op = track.Operation("bulk-index", track.OperationType.Bulk.name)
+        op = track.Operation("bulk-index", track.OperationType.Bulk.to_hyphenated_string())
         params = {}
-        if target_throughput:
+        if target_throughput is not None:
             params["target-throughput"] = target_throughput
-        if target_interval:
+        if target_interval is not None:
             params["target-interval"] = target_interval
         return track.Task("test", op, schedule=schedule, params=params)
 
     def test_unthrottled_task(self):
         task = self.task()
         self.assertIsNone(task.target_throughput)
-        self.assertFalse(task.throttled)
 
-    def test_task_with_scheduler_is_throttled(self):
-        task = self.task(schedule="daily-traffic-pattern")
+    def test_target_interval_zero_treated_as_unthrottled(self):
+        task = self.task(target_interval=0)
         self.assertIsNone(task.target_throughput)
-        self.assertTrue(task.throttled)
 
     def test_valid_throughput_with_unit(self):
         task = self.task(target_throughput="5 MB/s")
         self.assertEqual(track.Throughput(5.0, "MB/s"), task.target_throughput)
-        self.assertTrue(task.throttled)
 
     def test_valid_throughput_numeric(self):
         task = self.task(target_throughput=3.2)
         self.assertEqual(track.Throughput(3.2, "ops/s"), task.target_throughput)
-        self.assertTrue(task.throttled)
 
     def test_invalid_throughput_format_is_rejected(self):
         task = self.task(target_throughput="3.2 docs")


### PR DESCRIPTION
With this commit we adjust the predicate that considers a task as
unthrottled. Previously a task was unthrottled if and only if its target
throughput property was not defined and there was also not schedule set.
This lead to problems when a target-interval of zero was set on task
with an explicitly defined schedule (such as poisson). Now we treat
tasks as unthrottled if and only if the target throughput property is
not defined and the schedule is either unspecified or one of the
built-in schedules. This ensures that a target-interval of zero is
recognized as unthrottled for all built-in schedulers.

Closes #1120