### PR TITLE
Wait until cluster health is green

### DIFF
--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -173,7 +173,8 @@ Finally, store the track as ``track.json`` in the tutorial directory::
             "operation-type": "cluster-health",
             "request-params": {
               "wait_for_status": "green"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -327,7 +328,8 @@ To specify different workloads in the same track you can use so-called challenge
                 "operation-type": "cluster-health",
                 "request-params": {
                   "wait_for_status": "green"
-                }
+                },
+                "retry-until-success": true
               }
             },
             {
@@ -396,7 +398,8 @@ Structuring your track
             "operation-type": "cluster-health",
             "request-params": {
               "wait_for_status": "green"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -499,7 +502,8 @@ To reuse operation definitions across challenges, you can define them in a separ
           "operation-type": "cluster-health",
           "request-params": {
             "wait_for_status": "green"
-          }
+          },
+          "retry-until-success": true
         },
         {
           "name": "bulk-index",
@@ -601,7 +605,8 @@ You can also use Rally's collect helper to simplify including multiple challenge
           "operation-type": "cluster-health",
           "request-params": {
             "wait_for_status": "green"
-          }
+          },
+          "retry-until-success": true
         },
         {
           "name": "bulk-index",

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -800,7 +800,8 @@ Example::
       "request-params": {
         "wait_for_status": "green",
         "wait_for_no_relocating_shards": "true"
-      }
+      },
+      "retry-until-success": true
     }
 
 This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.

--- a/esrally/resources/track.json.j2
+++ b/esrally/resources/track.json.j2
@@ -39,7 +39,8 @@
         "request-params": {
           "wait_for_status": "{{cluster_health | default('green')}}",
           "wait_for_no_relocating_shards": "true"
-        }
+        },
+        "retry-until-success": true
       }
     },
     {


### PR DESCRIPTION
With this commit we adapt examples in the documentation and the track
generator to retry in cluster health check calls until the cluster
health is green.

Without this change the cluster health check might time out
before the desired status has been reached and the benchmark continues
earlier than intended.