### PR TITLE
Allow to customize track preparation

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -318,16 +318,8 @@ class TrackPreparationActor(actor.RallyActor):
     def receiveMsg_PrepareTrack(self, msg, sender):
         # load node-specific config to have correct paths available
         cfg = load_local_config(msg.config)
-        self.logger.info("Preparing track [%s]", msg.track.name)
-        # for "proper" track repositories this will ensure that all state is identical to the coordinator node. For simple tracks
-        # the track is usually self-contained but in some cases (plugins are defined) we still need to ensure that the track
-        # is present on all machines.
-        if msg.track.has_plugins:
-            track.track_repo(cfg, fetch=True, update=True)
-            # we also need to load track plugins eagerly as the respective parameter sources could require
-            track.load_track_plugins(cfg, runner.register_runner, scheduler.register_scheduler)
-        # Beware: This is a potentially long-running operation and we're completely blocking our actor here. We should do this
-        # maybe in a background thread.
+        # Beware: This is a potentially long-running operation and we're completely blocking our actor here.
+        # We should do this maybe in a background thread.
         track.prepare_track(msg.track, cfg)
         self.send(sender, TrackPrepared())
 

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -49,7 +49,6 @@ class TrackProcessor:
 
         :param track: The current track.
         """
-        ...
 
     def on_prepare_track(self, track, data_root_dir):
         """
@@ -63,8 +62,6 @@ class TrackProcessor:
         :param data_root_dir: The data root directory on the current machine as configured by the user.
         :return: `True` if the next track processor should be executed, `False` to prohibit further processing.
         """
-
-        ...
 
 
 class CompositeTrackProcessor(TrackProcessor):
@@ -504,8 +501,8 @@ class Downloader:
             self.logger.info("Downloaded data from [%s] to [%s].", data_url, target_path)
         except urllib.error.HTTPError as e:
             if e.code == 404 and self.test_mode:
-                raise exceptions.DataError("This track does not support test mode. Please ask the track author "
-                                           "to add it or disable test mode and retry.") from None
+                raise exceptions.DataError("This track does not support test mode. Ask the track author to add it or"
+                                           " disable test mode and retry.") from None
             else:
                 msg = f"Could not download [{data_url}] to [{target_path}]"
                 if e.reason:
@@ -517,7 +514,7 @@ class Downloader:
             raise exceptions.DataError(f"Could not download [{data_url}] to [{target_path}].") from e
 
         if not os.path.isfile(target_path):
-            raise exceptions.SystemSetupError(f"Could not download [{data_url}] to [{target_path}]. Please verify data "
+            raise exceptions.SystemSetupError(f"Could not download [{data_url}] to [{target_path}]. Verify data "
                                               f"are available at [{data_url}] and check your Internet connection.")
 
         actual_size = os.path.getsize(target_path)
@@ -875,11 +872,11 @@ class TestModeTrackProcessor(TrackProcessor):
                         path, ext = io.splitext(document_set.document_archive)
                         path_2, ext_2 = io.splitext(path)
 
-                        document_set.document_archive = "%s-1k%s%s" % (path_2, ext_2, ext)
-                        document_set.document_file = "%s-1k%s" % (path_2, ext_2)
+                        document_set.document_archive = f"{path_2}-1k{ext_2}{ext}"
+                        document_set.document_file = f"{path_2}-1k{ext_2}"
                     elif document_set.has_uncompressed_corpus():
                         path, ext = io.splitext(document_set.document_file)
-                        document_set.document_file = "%s-1k%s" % (path, ext)
+                        document_set.document_file = f"{path}-1k{ext}"
                     else:
                         raise exceptions.RallyAssertionError(f"Document corpus [{corpus.name}] has neither compressed "
                                                              f"nor uncompressed corpus.")

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -32,13 +32,66 @@ from jinja2 import meta
 
 from esrally import exceptions, time, PROGRAM_NAME, config, version
 from esrally.track import params, track
-from esrally.utils import io, convert, net, console, modules, opts, repo
+from esrally.utils import io, collections, convert, net, console, modules, opts, repo
 
 
 class TrackSyntaxError(exceptions.InvalidSyntax):
     """
     Raised whenever a syntax problem is encountered when loading the track specification.
     """
+
+
+class TrackProcessor:
+    def on_after_load_track(self, track):
+        """
+        This method is called by Rally after a track has been loaded. Implementations are expected to modify the
+        provided track object in place.
+
+        :param track: The current track.
+        """
+        ...
+
+    def on_prepare_track(self, track, data_root_dir):
+        """
+        This method is called by Rally after the "after_load_track" phase. Here, any data that is necessary for
+        benchmark execution should be prepared, e.g. by downloading data or generating it. Implementations should
+        be aware that this method might be called on a different machine than "on_after_load_track" and they cannot
+        share any state in between phases.
+
+        :param track: The current track. This parameter should be treated as effectively immutable. Any modifications
+                      will not be reflected in subsequent phases of the benchmark.
+        :param data_root_dir: The data root directory on the current machine as configured by the user.
+        :return: `True` if the next track processor should be executed, `False` to prohibit further processing.
+        """
+
+        ...
+
+
+class CompositeTrackProcessor(TrackProcessor):
+    def __init__(self, cfg):
+        self.track_processors = []
+        self.offline = cfg.opts("system", "offline.mode")
+        self.test_mode = cfg.opts("track", "test.mode.enabled")
+
+    def register_track_processor(self, processor):
+        if hasattr(processor, "downloader"):
+            processor.downloader = Downloader(self.offline, self.test_mode)
+        if hasattr(processor, "decompressor"):
+            processor.decompressor = Decompressor()
+        self.track_processors.append(processor)
+
+    def on_after_load_track(self, track):
+        current_track = track
+        for t in self.track_processors:
+            t.on_after_load_track(current_track)
+        return current_track
+
+    def on_prepare_track(self, track, data_root_dir):
+        for t in self.track_processors:
+            if not t.on_prepare_track(track, data_root_dir):
+                break
+
+        return False
 
 
 def tracks(cfg):
@@ -51,11 +104,7 @@ def tracks(cfg):
     :return: A list of tracks that are available for the provided distribution version or else for the master version.
     """
     repo = track_repo(cfg)
-    reader = TrackFileReader(cfg)
-    return [reader.read(track_name,
-                        repo.track_file(track_name),
-                        repo.track_dir(track_name))
-            for track_name in repo.track_names]
+    return [_load_single_track(cfg, repo, track_name) for track_name in repo.track_names]
 
 
 def list_tracks(cfg):
@@ -117,10 +166,8 @@ def track_info(cfg):
         console.println("* Uncompressed Size: {}".format(convert.bytes_to_human_string(t.uncompressed_size_in_bytes)))
     console.println("")
 
-    challenge_name = cfg.opts("track", "challenge.name", mandatory=False)
-    if challenge_name:
-        challenge = t.find_challenge(challenge_name)
-        challenge_info(challenge)
+    if t.selected_challenge:
+        challenge_info(t.selected_challenge)
     else:
         for challenge in t.challenges:
             challenge_info(challenge)
@@ -135,47 +182,61 @@ def load_track(cfg):
     :param cfg: The config object. It contains the name of the track to load.
     :return: The loaded track.
     """
-    track_name = None
+    repo = track_repo(cfg)
+    return _load_single_track(cfg, repo, repo.track_name)
+
+
+def _load_single_track(cfg, track_repository, track_name):
     try:
-        repo = track_repo(cfg)
-        track_name = repo.track_name
-        track_dir = repo.track_dir(track_name)
+        track_dir = track_repository.track_dir(track_name)
         reader = TrackFileReader(cfg)
-        filtered_tasks = []
-        exclude = False
-        if cfg.opts("track", "include.tasks"):
-            filtered_tasks = cfg.opts("track", "include.tasks")
-        else:
-            filtered_tasks = cfg.opts("track", "exclude.tasks")
-            exclude = True
 
-        current_track = reader.read(track_name, repo.track_file(track_name), track_dir)
-        current_track = filter_tasks(current_track, filters_from_filtered_tasks(filtered_tasks), exclude)
-        plugin_reader = TrackPluginReader(track_dir)
-        current_track.has_plugins = plugin_reader.can_load()
+        current_track = reader.read(track_name, track_repository.track_file(track_name), track_dir)
 
-        if cfg.opts("track", "test.mode.enabled"):
-            return post_process_for_test_mode(current_track)
-        else:
-            return current_track
-    except FileNotFoundError:
+        track_processor = CompositeTrackProcessor(cfg)
+        track_processor.register_track_processor(TaskFilterTrackProcessor(cfg))
+        track_processor.register_track_processor(TestModeTrackProcessor(cfg))
+
+        has_plugins = load_track_plugins(cfg, register_track_processor=track_processor.register_track_processor)
+        current_track.has_plugins = has_plugins
+
+        return track_processor.on_after_load_track(current_track)
+    except FileNotFoundError as e:
         logging.getLogger(__name__).exception("Cannot load track [%s]", track_name)
-        raise exceptions.SystemSetupError("Cannot load track %s. List the available tracks with %s list tracks." %
-                                          (track_name, PROGRAM_NAME))
+        raise exceptions.SystemSetupError(f"Cannot load track [{track_name}]. "
+                                          f"List the available tracks with [{PROGRAM_NAME} list tracks].") from e
     except BaseException:
         logging.getLogger(__name__).exception("Cannot load track [%s]", track_name)
         raise
 
 
-def load_track_plugins(cfg, register_runner, register_scheduler):
-    repo = track_repo(cfg, fetch=False, update=False)
+def load_track_plugins(cfg,
+                       register_runner=None,
+                       register_scheduler=None,
+                       register_track_processor=None,
+                       force_update=False):
+    """
+    Loads plugins that are defined for the current track (as specified by the configuration).
+
+    :param cfg: The config object.
+    :param register_runner: An optional function where runners can be registered.
+    :param register_scheduler: An optional function where custom schedulers can be registered.
+    :param register_track_processor: An optional function where track processors can be registered.
+    :param force_update: If set to ``True`` this ensures that the track is first updated from the remote repository.
+                         Defaults to ``False``.
+    :return: True iff this track defines plugins and they have been loaded.
+    """
+    repo = track_repo(cfg, fetch=force_update, update=force_update)
     track_name = repo.track_name
     track_plugin_path = repo.track_dir(track_name)
 
-    plugin_reader = TrackPluginReader(track_plugin_path, register_runner, register_scheduler)
+    plugin_reader = TrackPluginReader(track_plugin_path, register_runner, register_scheduler, register_track_processor)
 
     if plugin_reader.can_load():
         plugin_reader.load()
+        return True
+    else:
+        return False
 
 
 def set_absolute_data_path(cfg, t):
@@ -318,10 +379,10 @@ def operation_parameters(t, task):
         return params.param_source_for_operation(op.type, t, op.params, task.name)
 
 
-def used_corpora(t, cfg):
+def used_corpora(t):
     corpora = {}
     if t.corpora:
-        challenge = t.find_challenge_or_default(cfg.opts("track", "challenge.name"))
+        challenge = t.selected_challenge_or_default
         for task in challenge.schedule:
             for sub_task in task:
                 param_source = operation_parameters(t, sub_task)
@@ -339,64 +400,88 @@ def prepare_track(t, cfg):
     :param t: A track that is about to be run.
     :param cfg: The config object.
     """
+    data_root_dir = cfg.opts("benchmarks", "local.dataset.cache")
+    tp = CompositeTrackProcessor(cfg)
     logger = logging.getLogger(__name__)
-    offline = cfg.opts("system", "offline.mode")
-    test_mode = cfg.opts("track", "test.mode.enabled")
-    for corpus in used_corpora(t, cfg):
-        data_root = data_dir(cfg, t.name, corpus.name)
-        logger.info("Resolved data root directory for document corpus [%s] in track [%s] to %s.", corpus.name, t.name, data_root)
-        prep = DocumentSetPreparator(t.name, offline, test_mode)
 
-        for document_set in corpus.documents:
-            if document_set.is_bulk:
-                if len(data_root) == 1:
-                    prep.prepare_document_set(document_set, data_root[0])
-                # attempt to prepare everything in the current directory and fallback to the corpus directory
-                elif not prep.prepare_bundled_document_set(document_set, data_root[0]):
-                    prep.prepare_document_set(document_set, data_root[1])
+    logger.info("Preparing track [%s]", t.name)
+    if t.has_plugins:
+        logger.info("Reloading track [%s] to ensure plugins are up-to-date.", t.name)
+        # the track might have been loaded on a different machine (the coordinator machine) so we force a track update
+        # to ensure we use the latest version of plugins.
+        load_track_plugins(cfg, register_track_processor=tp.register_track_processor, force_update=True)
+
+    # register last so user-defined track processors can override the default behavior
+    tp.register_track_processor(DefaultTrackPreparator(cfg))
+
+    tp.on_prepare_track(t, data_root_dir)
 
 
-class DocumentSetPreparator:
-    def __init__(self, track_name, offline, test_mode):
-        self.track_name = track_name
+class DefaultTrackPreparator(TrackProcessor):
+    def __init__(self, cfg):
+        super().__init__()
+        self.cfg = cfg
+        self.logger = logging.getLogger(__name__)
+        # just declare here, will be injected later
+        self.downloader = None
+        self.decompressor = None
+
+    def on_prepare_track(self, track, data_root_dir):
+        for corpus in used_corpora(track):
+            data_root = data_dir(self.cfg, track.name, corpus.name)
+            self.logger.info("Resolved data root directory for document corpus [%s] in track [%s] to [%s].",
+                             corpus.name, track.name, data_root)
+            prep = DocumentSetPreparator(track.name, self.downloader, self.decompressor)
+
+            for document_set in corpus.documents:
+                if document_set.is_bulk:
+                    if len(data_root) == 1:
+                        prep.prepare_document_set(document_set, data_root[0])
+                    # attempt to prepare everything in the current directory and fallback to the corpus directory
+                    elif not prep.prepare_bundled_document_set(document_set, data_root[0]):
+                        prep.prepare_document_set(document_set, data_root[1])
+        # don't run any other track processors
+        return False
+
+
+class Decompressor:
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+
+    def decompress(self, archive_path, documents_path, uncompressed_size):
+        if uncompressed_size:
+            msg = f"Decompressing track data from [{archive_path}] to [{documents_path}] (resulting size: " \
+                  f"[{convert.bytes_to_gb(uncompressed_size):.2f}] GB) ... "
+        else:
+            msg = f"Decompressing track data from [{archive_path}] to [{documents_path}] ... "
+
+        console.info(msg, end="", flush=True, logger=self.logger)
+        io.decompress(archive_path, io.dirname(archive_path))
+        console.println("[OK]")
+        if not os.path.isfile(documents_path):
+            raise exceptions.DataError(
+                f"Decompressing [{archive_path}] did not create [{documents_path}]. Please check with the track "
+                f"author if the compressed archive has been created correctly.")
+
+        extracted_bytes = os.path.getsize(documents_path)
+        if uncompressed_size is not None and extracted_bytes != uncompressed_size:
+            raise exceptions.DataError(f"[{documents_path}] is corrupt. Extracted [{extracted_bytes}] bytes "
+                                       f"but [{uncompressed_size}] bytes are expected.")
+
+
+class Downloader:
+    def __init__(self, offline, test_mode):
         self.offline = offline
         self.test_mode = test_mode
         self.logger = logging.getLogger(__name__)
 
-    def is_locally_available(self, file_name):
-        return os.path.isfile(file_name)
-
-    def has_expected_size(self, file_name, expected_size):
-        return expected_size is None or os.path.getsize(file_name) == expected_size
-
-    def decompress(self, archive_path, documents_path, uncompressed_size):
-        if uncompressed_size:
-            console.info("Decompressing track data from [%s] to [%s] (resulting size: %.2f GB) ... " %
-                         (archive_path, documents_path, convert.bytes_to_gb(uncompressed_size)),
-                         end='', flush=True, logger=self.logger)
-        else:
-            console.info("Decompressing track data from [%s] to [%s] ... " % (archive_path, documents_path), end='',
-                         flush=True, logger=self.logger)
-
-        io.decompress(archive_path, io.dirname(archive_path))
-        console.println("[OK]")
-        if not os.path.isfile(documents_path):
-            raise exceptions.DataError("Decompressing [%s] did not create [%s]. Please check with the track author if the compressed "
-                                       "archive has been created correctly." % (archive_path, documents_path))
-
-        extracted_bytes = os.path.getsize(documents_path)
-        if uncompressed_size is not None and extracted_bytes != uncompressed_size:
-            raise exceptions.DataError("[%s] is corrupt. Extracted [%d] bytes but [%d] bytes are expected." %
-                                       (documents_path, extracted_bytes, uncompressed_size))
-
-    def download(self, base_url, target_path, size_in_bytes, detail_on_missing_root_url):
+    def download(self, base_url, target_path, size_in_bytes):
         file_name = os.path.basename(target_path)
 
         if not base_url:
-            raise exceptions.DataError("%s and it cannot be downloaded because no base URL is provided."
-                                       % detail_on_missing_root_url)
+            raise exceptions.DataError("Cannot download data because no base URL is provided.")
         if self.offline:
-            raise exceptions.SystemSetupError("Cannot find %s. Please disable offline mode and retry again." % target_path)
+            raise exceptions.SystemSetupError(f"Cannot find [{target_path}]. Please disable offline mode and retry.")
 
         if base_url.endswith("/"):
             separator = ""
@@ -413,42 +498,53 @@ class DocumentSetPreparator:
                 self.logger.info("Downloading data from [%s] to [%s].", data_url, target_path)
 
             # we want to have a bit more accurate download progress as these files are typically very large
-            progress = net.Progress("[INFO] Downloading data for track %s" % self.track_name, accuracy=1)
+            progress = net.Progress("[INFO] Downloading track data", accuracy=1)
             net.download(data_url, target_path, size_in_bytes, progress_indicator=progress)
             progress.finish()
             self.logger.info("Downloaded data from [%s] to [%s].", data_url, target_path)
         except urllib.error.HTTPError as e:
             if e.code == 404 and self.test_mode:
-                raise exceptions.DataError("Track [%s] does not support test mode. Please ask the track author to add it or "
-                                           "disable test mode and retry." % self.track_name)
+                raise exceptions.DataError("This track does not support test mode. Please ask the track author "
+                                           "to add it or disable test mode and retry.") from None
             else:
-                msg = "Could not download [%s] to [%s]" % (data_url, target_path)
+                msg = f"Could not download [{data_url}] to [{target_path}]"
                 if e.reason:
-                    msg += " (HTTP status: %s, reason: %s)" % (str(e.code), e.reason)
+                    msg += f" (HTTP status: {e.code}, reason: {e.reason})"
                 else:
-                    msg += " (HTTP status: %s)" % str(e.code)
-                raise exceptions.DataError(msg)
-        except urllib.error.URLError:
-            self.logger.exception("Could not download [%s] to [%s].", data_url, target_path)
-            raise exceptions.DataError("Could not download [%s] to [%s]." % (data_url, target_path))
+                    msg += f" (HTTP status: {e.code})"
+                raise exceptions.DataError(msg) from e
+        except urllib.error.URLError as e:
+            raise exceptions.DataError(f"Could not download [{data_url}] to [{target_path}].") from e
 
         if not os.path.isfile(target_path):
-            raise exceptions.SystemSetupError(
-                "Cannot download from %s to %s. Please verify that data are available at %s and "
-                "check your Internet connection." % (data_url, target_path, data_url))
+            raise exceptions.SystemSetupError(f"Could not download [{data_url}] to [{target_path}]. Please verify data "
+                                              f"are available at [{data_url}] and check your Internet connection.")
 
         actual_size = os.path.getsize(target_path)
         if size_in_bytes is not None and actual_size != size_in_bytes:
-            raise exceptions.DataError("[%s] is corrupt. Downloaded [%d] bytes but [%d] bytes are expected." %
-                                       (target_path, actual_size, size_in_bytes))
+            raise exceptions.DataError(f"[{target_path}] is corrupt. Downloaded [{actual_size}] bytes "
+                                       f"but [{size_in_bytes}] bytes are expected.")
+
+
+class DocumentSetPreparator:
+    def __init__(self, track_name, downloader, decompressor):
+        self.track_name = track_name
+        self.downloader = downloader
+        self.decompressor = decompressor
+
+    def is_locally_available(self, file_name):
+        return os.path.isfile(file_name)
+
+    def has_expected_size(self, file_name, expected_size):
+        return expected_size is None or os.path.getsize(file_name) == expected_size
 
     def create_file_offset_table(self, document_file_path, expected_number_of_lines):
         # just rebuild the file every time for the time being. Later on, we might check the data file fingerprint to avoid it
         lines_read = io.prepare_file_offset_table(document_file_path)
         if lines_read and lines_read != expected_number_of_lines:
             io.remove_file_offset_table(document_file_path)
-            raise exceptions.DataError("Data in [%s] for track [%s] are invalid. Expected [%d] lines but got [%d]."
-                                       % (document_file_path, track, expected_number_of_lines, lines_read))
+            raise exceptions.DataError(f"Data in [{document_file_path}] for track [{self.track_name}] are invalid. "
+                                       f"Expected [{expected_number_of_lines}] lines but got [{lines_read}].")
 
     def prepare_document_set(self, document_set, data_root):
         """
@@ -475,7 +571,7 @@ class DocumentSetPreparator:
             if document_set.has_compressed_corpus() and \
                     self.is_locally_available(archive_path) and \
                     self.has_expected_size(archive_path, document_set.compressed_size_in_bytes):
-                self.decompress(archive_path, doc_path, document_set.uncompressed_size_in_bytes)
+                self.decompressor.decompress(archive_path, doc_path, document_set.uncompressed_size_in_bytes)
             else:
                 if document_set.has_compressed_corpus():
                     target_path = archive_path
@@ -485,15 +581,18 @@ class DocumentSetPreparator:
                     expected_size = document_set.uncompressed_size_in_bytes
                 else:
                     # this should not happen in practice as the JSON schema should take care of this
-                    raise exceptions.RallyAssertionError("Track %s specifies documents but no corpus" % self.track_name)
-                # provide a specific error message in case there is no download URL
-                if self.is_locally_available(target_path):
-                    # convert expected_size eagerly to a string as it might be None (but in that case we'll never see that error message)
-                    msg = "%s is present but does not have the expected size of %s bytes" % (target_path, str(expected_size))
-                else:
-                    msg = "%s is missing" % target_path
+                    raise exceptions.RallyAssertionError(f"Track {self.track_name} specifies documents but no corpus")
 
-                self.download(document_set.base_url, target_path, expected_size, msg)
+                try:
+                    self.downloader.download(document_set.base_url, target_path, expected_size)
+                except exceptions.DataError as e:
+                    if e.message == "Cannot download data because no base URL is provided." and \
+                       self.is_locally_available(target_path):
+                        raise exceptions.DataError(f"[{target_path}] is present but does not have the expected "
+                                                   f"size of [{expected_size}] bytes and it cannot be downloaded "
+                                                   f"because no base URL is provided.") from None
+                    else:
+                        raise
 
         self.create_file_offset_table(doc_path, document_set.number_of_lines)
 
@@ -525,17 +624,18 @@ class DocumentSetPreparator:
                     self.create_file_offset_table(doc_path, document_set.number_of_lines)
                     return True
                 else:
-                    raise exceptions.DataError("%s is present but does not have the expected size of %s bytes." %
-                                               (doc_path, str(document_set.uncompressed_size_in_bytes)))
+                    raise exceptions.DataError(f"[{doc_path}] is present but does not have the expected size "
+                                               f"of [{document_set.uncompressed_size_in_bytes}] bytes.")
 
             if document_set.has_compressed_corpus() and self.is_locally_available(archive_path):
                 if self.has_expected_size(archive_path, document_set.compressed_size_in_bytes):
-                    self.decompress(archive_path, doc_path, document_set.uncompressed_size_in_bytes)
+                    self.decompressor.decompress(archive_path, doc_path, document_set.uncompressed_size_in_bytes)
                 else:
-                    # treat this is an error because if the file is present but the size does not match, something is really fishy.
-                    # It is likely that the user is currently creating a new track and did not specify the file size correctly.
-                    raise exceptions.DataError("%s is present but does not have the expected size of %s bytes." %
-                                               (archive_path, str(document_set.compressed_size_in_bytes)))
+                    # treat this is an error because if the file is present but the size does not match, something is
+                    # really fishy. It is likely that the user is currently creating a new track and did not specify
+                    # the file size correctly.
+                    raise exceptions.DataError(f"[{archive_path}] is present but does not have "
+                                               f"the expected size of [{document_set.compressed_size_in_bytes}] bytes.")
             else:
                 return False
 
@@ -692,120 +792,137 @@ def render_template_from_file(template_file_name, template_vars, complete_track_
                            template_internal_vars=default_internal_template_vars(glob_helper=lambda f: relative_glob(base_path, f)))
 
 
-def filter_tasks(t, filters, exclude=False):
-    if not filters:
-        return t
+class TaskFilterTrackProcessor(TrackProcessor):
+    def __init__(self, cfg):
+        self.logger = logging.getLogger(__name__)
+        if cfg.opts("track", "include.tasks"):
+            filtered_tasks = cfg.opts("track", "include.tasks")
+            self.exclude = False
+        else:
+            filtered_tasks = cfg.opts("track", "exclude.tasks")
+            self.exclude = True
+        self.filters = self._filters_from_filtered_tasks(filtered_tasks)
 
-    logger = logging.getLogger(__name__)
+    def _filters_from_filtered_tasks(self, filtered_tasks):
+        filters = []
+        if filtered_tasks:
+            for t in filtered_tasks:
+                spec = t.split(":")
+                if len(spec) == 1:
+                    filters.append(track.TaskNameFilter(spec[0]))
+                elif len(spec) == 2:
+                    if spec[0] == "type":
+                        filters.append(track.TaskOpTypeFilter(spec[1]))
+                    else:
+                        raise exceptions.SystemSetupError(f"Invalid format for filtered tasks: [{t}]. "
+                                                          f"Expected [type] but got [{spec[0]}].")
+                else:
+                    raise exceptions.SystemSetupError(f"Invalid format for filtered tasks: [{t}]")
+        return filters
 
-    def filter_out_match(task, user_defined_filters, exclude):
-
-        for f in user_defined_filters:
+    def _filter_out_match(self, task):
+        for f in self.filters:
             if task.matches(f):
-                if hasattr(task, "tasks") and exclude:
+                if hasattr(task, "tasks") and self.exclude:
                     return False
-                return exclude
-        return not exclude
+                return self.exclude
+        return not self.exclude
 
-    for challenge in t.challenges:
-        # don't modify the schedule while iterating over it
-        tasks_to_remove = []
-        for task in challenge.schedule:
-            if filter_out_match(task, filters, exclude):
-                tasks_to_remove.append(task)
-            else:
-                leafs_to_remove = []
+    def on_after_load_track(self, track):
+        if not self.filters:
+            return track
+
+        for challenge in track.challenges:
+            # don't modify the schedule while iterating over it
+            tasks_to_remove = []
+            for task in challenge.schedule:
+                if self._filter_out_match(task):
+                    tasks_to_remove.append(task)
+                else:
+                    leafs_to_remove = []
+                    for leaf_task in task:
+                        if self._filter_out_match(leaf_task):
+                            leafs_to_remove.append(leaf_task)
+                    for leaf_task in leafs_to_remove:
+                        self.logger.info("Removing sub-task [%s] from challenge [%s] due to task filter.",
+                                         leaf_task, challenge)
+                        task.remove_task(leaf_task)
+            for task in tasks_to_remove:
+                self.logger.info("Removing task [%s] from challenge [%s] due to task filter.", task, challenge)
+                challenge.remove_task(task)
+
+        return track
+
+
+class TestModeTrackProcessor(TrackProcessor):
+    def __init__(self, cfg):
+        self.test_mode_enabled = cfg.opts("track", "test.mode.enabled")
+        self.logger = logging.getLogger(__name__)
+
+    def on_after_load_track(self, track):
+        if not self.test_mode_enabled:
+            return track
+        self.logger.info("Preparing track [%s] for test mode.", str(track))
+        for corpus in track.corpora:
+            if self.logger.isEnabledFor(logging.DEBUG):
+                self.logger.debug("Reducing corpus size to 1000 documents for [%s]", corpus.name)
+            for document_set in corpus.documents:
+                # TODO #341: Should we allow this for snapshots too?
+                if document_set.is_bulk:
+                    document_set.number_of_documents = 1000
+
+                    if document_set.has_compressed_corpus():
+                        path, ext = io.splitext(document_set.document_archive)
+                        path_2, ext_2 = io.splitext(path)
+
+                        document_set.document_archive = "%s-1k%s%s" % (path_2, ext_2, ext)
+                        document_set.document_file = "%s-1k%s" % (path_2, ext_2)
+                    elif document_set.has_uncompressed_corpus():
+                        path, ext = io.splitext(document_set.document_file)
+                        document_set.document_file = "%s-1k%s" % (path, ext)
+                    else:
+                        raise exceptions.RallyAssertionError(f"Document corpus [{corpus.name}] has neither compressed "
+                                                             f"nor uncompressed corpus.")
+
+                    # we don't want to check sizes
+                    document_set.compressed_size_in_bytes = None
+                    document_set.uncompressed_size_in_bytes = None
+
+        for challenge in track.challenges:
+            for task in challenge.schedule:
+                # we need iterate over leaf tasks and await iterating over possible intermediate 'parallel' elements
                 for leaf_task in task:
-                    if filter_out_match(leaf_task, filters, exclude):
-                        leafs_to_remove.append(leaf_task)
-                for leaf_task in leafs_to_remove:
-                    logger.info("Removing sub-task [%s] from challenge [%s] due to task filter.", leaf_task, challenge)
-                    task.remove_task(leaf_task)
-        for task in tasks_to_remove:
-            logger.info("Removing task [%s] from challenge [%s] due to task filter.", task, challenge)
-            challenge.remove_task(task)
+                    # iteration-based schedules are divided among all clients and we should provide
+                    # at least one iteration for each client.
+                    if leaf_task.warmup_iterations is not None and leaf_task.warmup_iterations > leaf_task.clients:
+                        count = leaf_task.clients
+                        if self.logger.isEnabledFor(logging.DEBUG):
+                            self.logger.debug("Resetting warmup iterations to %d for [%s]", count, str(leaf_task))
+                        leaf_task.warmup_iterations = count
+                    if leaf_task.iterations is not None and leaf_task.iterations > leaf_task.clients:
+                        count = leaf_task.clients
+                        if self.logger.isEnabledFor(logging.DEBUG):
+                            self.logger.debug("Resetting measurement iterations to %d for [%s]", count, str(leaf_task))
+                        leaf_task.iterations = count
+                    if leaf_task.warmup_time_period is not None and leaf_task.warmup_time_period > 0:
+                        leaf_task.warmup_time_period = 0
+                        if self.logger.isEnabledFor(logging.DEBUG):
+                            self.logger.debug("Resetting warmup time period for [%s] to [%d] seconds.",
+                                              str(leaf_task), leaf_task.warmup_time_period)
+                    if leaf_task.time_period is not None and leaf_task.time_period > 10:
+                        leaf_task.time_period = 10
+                        if self.logger.isEnabledFor(logging.DEBUG):
+                            self.logger.debug("Resetting measurement time period for [%s] to [%d] seconds.",
+                                              str(leaf_task), leaf_task.time_period)
 
-    return t
+                    # Keep throttled to expose any errors but increase the target throughput for short execution times.
+                    if leaf_task.target_throughput:
+                        original_throughput = leaf_task.target_throughput
+                        leaf_task.params.pop("target-throughput", None)
+                        leaf_task.params.pop("target-interval", None)
+                        leaf_task.params["target-throughput"] = f"{sys.maxsize} {original_throughput.unit}"
 
-
-def filters_from_filtered_tasks(filtered_tasks):
-    filters = []
-    if filtered_tasks:
-        for t in filtered_tasks:
-            spec = t.split(":")
-            if len(spec) == 1:
-                filters.append(track.TaskNameFilter(spec[0]))
-            elif len(spec) == 2:
-                if spec[0] == "type":
-                    filters.append(track.TaskOpTypeFilter(spec[1]))
-                else:
-                    raise exceptions.SystemSetupError(
-                        "Invalid format for filtered tasks: [%s]. Expected [type] but got [%s]." % (t, spec[0]))
-            else:
-                raise exceptions.SystemSetupError("Invalid format for filtered tasks: [%s]" % t)
-    return filters
-
-
-def post_process_for_test_mode(t):
-    logger = logging.getLogger(__name__)
-    logger.info("Preparing track [%s] for test mode.", str(t))
-    for corpus in t.corpora:
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug("Reducing corpus size to 1000 documents for [%s]", corpus.name)
-        for document_set in corpus.documents:
-            # TODO #341: Should we allow this for snapshots too?
-            if document_set.is_bulk:
-                document_set.number_of_documents = 1000
-
-                if document_set.has_compressed_corpus():
-                    path, ext = io.splitext(document_set.document_archive)
-                    path_2, ext_2 = io.splitext(path)
-
-                    document_set.document_archive = "%s-1k%s%s" % (path_2, ext_2, ext)
-                    document_set.document_file = "%s-1k%s" % (path_2, ext_2)
-                elif document_set.has_uncompressed_corpus():
-                    path, ext = io.splitext(document_set.document_file)
-                    document_set.document_file = "%s-1k%s" % (path, ext)
-                else:
-                    raise exceptions.RallyAssertionError("Document corpus [%s] has neither compressed nor uncompressed corpus." %
-                                                         corpus.name)
-
-                # we don't want to check sizes
-                document_set.compressed_size_in_bytes = None
-                document_set.uncompressed_size_in_bytes = None
-
-    for challenge in t.challenges:
-        for task in challenge.schedule:
-            # we need iterate over leaf tasks and await iterating over possible intermediate 'parallel' elements
-            for leaf_task in task:
-                # iteration-based schedules are divided among all clients and we should provide at least one iteration for each client.
-                if leaf_task.warmup_iterations is not None and leaf_task.warmup_iterations > leaf_task.clients:
-                    count = leaf_task.clients
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.debug("Resetting warmup iterations to %d for [%s]", count, str(leaf_task))
-                    leaf_task.warmup_iterations = count
-                if leaf_task.iterations is not None and leaf_task.iterations > leaf_task.clients:
-                    count = leaf_task.clients
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.debug("Resetting measurement iterations to %d for [%s]", count, str(leaf_task))
-                    leaf_task.iterations = count
-                if leaf_task.warmup_time_period is not None and leaf_task.warmup_time_period > 0:
-                    leaf_task.warmup_time_period = 0
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.debug("Resetting warmup time period for [%s] to [%d] seconds.", str(leaf_task), leaf_task.warmup_time_period)
-                if leaf_task.time_period is not None and leaf_task.time_period > 10:
-                    leaf_task.time_period = 10
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.debug("Resetting measurement time period for [%s] to [%d] seconds.", str(leaf_task), leaf_task.time_period)
-
-                # Keep throttled to expose any errors but increase the target throughput for short execution times.
-                if leaf_task.target_throughput:
-                    original_throughput = leaf_task.target_throughput
-                    leaf_task.params.pop("target-throughput", None)
-                    leaf_task.params.pop("target-interval", None)
-                    leaf_task.params["target-throughput"] = f"{sys.maxsize} {original_throughput.unit}"
-
-    return t
+        return track
 
 
 class CompleteTrackParams:
@@ -842,7 +959,9 @@ class TrackFileReader:
         self.complete_track_params = CompleteTrackParams(user_specified_track_params=self.track_params)
         self.read_track = TrackSpecificationReader(
             track_params=self.track_params,
-            complete_track_params=self.complete_track_params)
+            complete_track_params=self.complete_track_params,
+            selected_challenge=cfg.opts("track", "challenge.name", mandatory=False)
+        )
         self.logger = logging.getLogger(__name__)
 
     def read(self, track_name, track_spec_file, mapping_dir):
@@ -940,9 +1059,10 @@ class TrackPluginReader:
     Loads track plugins
     """
 
-    def __init__(self, track_plugin_path, runner_registry=None, scheduler_registry=None):
+    def __init__(self, track_plugin_path, runner_registry=None, scheduler_registry=None, track_processor_registry=None):
         self.runner_registry = runner_registry
         self.scheduler_registry = scheduler_registry
+        self.track_processor_registry = track_processor_registry
         self.loader = modules.ComponentLoader(root_path=track_plugin_path, component_entry_point="track")
 
     def can_load(self):
@@ -962,10 +1082,16 @@ class TrackPluginReader:
         params.register_param_source_for_name(name, param_source)
 
     def register_runner(self, name, runner, **kwargs):
-        self.runner_registry(name, runner, **kwargs)
+        if self.runner_registry:
+            self.runner_registry(name, runner, **kwargs)
 
     def register_scheduler(self, name, scheduler):
-        self.scheduler_registry(name, scheduler)
+        if self.scheduler_registry:
+            self.scheduler_registry(name, scheduler)
+
+    def register_track_processor(self, name, track_processor):
+        if self.track_processor_registry:
+            self.track_processor_registry(name, track_processor)
 
     @property
     def meta_data(self):
@@ -980,10 +1106,11 @@ class TrackSpecificationReader:
     Creates a track instances based on its parsed JSON description.
     """
 
-    def __init__(self, track_params=None, complete_track_params=None, source=io.FileSource):
+    def __init__(self, track_params=None, complete_track_params=None, selected_challenge=None, source=io.FileSource):
         self.name = None
         self.track_params = track_params if track_params else {}
         self.complete_track_params = complete_track_params
+        self.selected_challenge = selected_challenge
         self.source = source
         self.logger = logging.getLogger(__name__)
 
@@ -1201,6 +1328,7 @@ class TrackSpecificationReader:
 
     def _create_challenges(self, track_spec):
         ops = self.parse_operations(self._r(track_spec, "operations", mandatory=False, default_value=[]))
+        track_params = self._r(track_spec, "parameters", mandatory=False, default_value={})
         challenges = []
         known_challenge_names = set()
         default_challenge = None
@@ -1210,9 +1338,11 @@ class TrackSpecificationReader:
             name = self._r(challenge_spec, "name", error_ctx="challenges")
             description = self._r(challenge_spec, "description", error_ctx=name, mandatory=False)
             user_info = self._r(challenge_spec, "user-info", error_ctx=name, mandatory=False)
+            challenge_params = self._r(challenge_spec, "parameters", error_ctx=name, mandatory=False, default_value={})
             meta_data = self._r(challenge_spec, "meta", error_ctx=name, mandatory=False)
             # if we only have one challenge it is treated as default challenge, no matter what the user has specified
             default = number_of_challenges == 1 or self._r(challenge_spec, "default", error_ctx=name, mandatory=False)
+            selected = number_of_challenges == 1 or self.selected_challenge == name
             cluster_settings = self._r(challenge_spec, "cluster-settings", error_ctx=name, mandatory=False)
             if cluster_settings:
                 console.warn("Track [{}] uses the deprecated property [cluster-settings]. Please replace it with an "
@@ -1244,12 +1374,17 @@ class TrackSpecificationReader:
                     else:
                         known_task_names.add(sub_task.name)
 
+            # merge params
+            final_challenge_params = dict(collections.merge_dicts(track_params, challenge_params))
+
             challenge = track.Challenge(name=name,
+                                        parameters=final_challenge_params,
                                         meta_data=meta_data,
                                         description=description,
                                         user_info=user_info,
                                         cluster_settings=cluster_settings,
                                         default=default,
+                                        selected=selected,
                                         auto_generated=auto_generated,
                                         schedule=schedule)
             if default:

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -395,6 +395,18 @@ class Track:
         # This should only happen if we don't have any challenges
         return None
 
+    @property
+    def selected_challenge(self):
+        for challenge in self.challenges:
+            if challenge.selected:
+                return challenge
+        return None
+
+    @property
+    def selected_challenge_or_default(self):
+        selected = self.selected_challenge
+        return selected if selected else self.default_challenge
+
     def find_challenge_or_default(self, name):
         """
         :param name: The name of the challenge to find.
@@ -476,15 +488,19 @@ class Challenge:
                  user_info=None,
                  cluster_settings=None,
                  default=False,
+                 selected=False,
                  auto_generated=False,
+                 parameters=None,
                  meta_data=None,
                  schedule=None):
         self.name = name
+        self.parameters = parameters if parameters else {}
         self.meta_data = meta_data if meta_data else {}
         self.description = description
         self.user_info = user_info
         self.cluster_settings = cluster_settings if cluster_settings else {}
         self.default = default
+        self.selected = selected
         self.auto_generated = auto_generated
         self.schedule = schedule if schedule else []
 
@@ -505,12 +521,15 @@ class Challenge:
 
     def __hash__(self):
         return hash(self.name) ^ hash(self.description) ^ hash(self.cluster_settings) ^ hash(self.default) ^ \
-               hash(self.auto_generated) ^ hash(self.meta_data) ^ hash(self.schedule)
+               hash(self.selected) ^ hash(self.auto_generated) ^ hash(self.parameters) ^ hash(self.meta_data) ^ \
+               hash(self.schedule)
 
     def __eq__(self, othr):
         return (isinstance(othr, type(self)) and
-                (self.name, self.description, self.cluster_settings, self.default, self.auto_generated, self.meta_data, self.schedule) ==
-                (othr.name, othr.description, othr.cluster_settings, othr.default, othr.auto_generated, othr.meta_data, othr.schedule))
+                (self.name, self.description, self.cluster_settings, self.default, self.selected, self.auto_generated,
+                 self.parameters, self.meta_data, self.schedule) ==
+                (othr.name, othr.description, othr.cluster_settings, othr.default, othr.selected, othr.auto_generated,
+                 othr.parameters, othr.meta_data, othr.schedule))
 
 
 @unique

--- a/esrally/utils/collections.py
+++ b/esrally/utils/collections.py
@@ -1,0 +1,39 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any, Generator, Mapping
+
+
+def merge_dicts(d1: Mapping[str, Any], d2: Mapping[str, Any]) -> Generator[Any, None, Any]:
+    """
+    Merges two dictionaries which may contain nested dictionaries or lists. Conflicting keys in d2 override keys in d1.
+
+    :param d1: A dictionary. May be empty.
+    :param d2: A dictionary. May be empty.
+    :return: A generator that contains a merged view of both dictionaries.
+    """
+    for k in set(d1) | set(d2):
+        if k in d1 and k in d2:
+            if isinstance(d1[k], dict) and isinstance(d2[k], dict):
+                yield k, dict(merge_dicts(d1[k], d2[k]))
+            elif isinstance(d1[k], list) and isinstance(d2[k], list):
+                yield k, list(set(d1[k] + d2[k]))
+            else:
+                yield k, d2[k]
+        elif k in d1:
+            yield k, d1[k]
+        else:
+            yield k, d2[k]

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -147,7 +147,9 @@ class TrackPreparationTests(TestCase):
         get_size.return_value = 2000
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
                                                             document_file="docs.json",
@@ -167,7 +169,9 @@ class TrackPreparationTests(TestCase):
         get_size.return_value = 2000
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
                                                             document_file="docs.json",
@@ -191,7 +195,9 @@ class TrackPreparationTests(TestCase):
         # uncompressed is corrupt, only 1 byte available
         get_size.side_effect = [200, 1]
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         with self.assertRaises(exceptions.DataError) as ctx:
             p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -216,7 +222,9 @@ class TrackPreparationTests(TestCase):
         # compressed file size is 200
         get_size.return_value = 200
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         with self.assertRaises(exceptions.DataError) as ctx:
             p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -242,12 +250,11 @@ class TrackPreparationTests(TestCase):
                                                             prepare_file_offset_table):
         # uncompressed file does not exist
         # compressed file does not exist
-        # file check for compressed file before download attempt (for potential error message)
         # after download compressed file exists
         # after download uncompressed file still does not exist (in main loop)
         # after download compressed file exists (in main loop)
         # after decompression, uncompressed file exists
-        is_file.side_effect = [False, False, False, True, False, True, True, True]
+        is_file.side_effect = [False, False, True, False, True, True, True]
         # compressed file size is 200 after download
         # compressed file size is 200 after download (in main loop)
         # uncompressed file size is 2000 after decompression
@@ -256,7 +263,9 @@ class TrackPreparationTests(TestCase):
 
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
                                                             base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
@@ -282,17 +291,18 @@ class TrackPreparationTests(TestCase):
     def test_download_document_with_trailing_baseurl_slash(self, is_file, get_size, ensure_dir, download, decompress,
                                                            prepare_file_offset_table):
         # uncompressed file does not exist
-        # file check for uncompressed file before download attempt (for potential error message)
         # after download uncompressed file exists
         # after download uncompressed file exists (main loop)
-        is_file.side_effect = [False, False, True, True]
+        is_file.side_effect = [False, True, True]
         # uncompressed file size is 2000
         get_size.return_value = 2000
         scheme = random.choice(["http", "https", "s3", "gs"])
 
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
                                                             base_url=f"{scheme}://benchmarks.elasticsearch.org/corpora/unit-test/",
@@ -316,16 +326,17 @@ class TrackPreparationTests(TestCase):
     @mock.patch("os.path.isfile")
     def test_download_document_file_if_no_file_available(self, is_file, get_size, ensure_dir, download, prepare_file_offset_table):
         # uncompressed file does not exist
-        # file check for uncompressed file before download attempt (for potential error message)
         # after download uncompressed file exists
         # after download uncompressed file exists (main loop)
-        is_file.side_effect = [False, False, True, True]
+        is_file.side_effect = [False, True, True]
         # uncompressed file size is 2000
         get_size.return_value = 2000
 
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
                                                             base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
@@ -349,7 +360,9 @@ class TrackPreparationTests(TestCase):
         # uncompressed file does not exist
         is_file.return_value = False
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=True, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=True, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -359,7 +372,7 @@ class TrackPreparationTests(TestCase):
                                                                 uncompressed_size_in_bytes=2000),
                                    data_root="/tmp")
 
-        self.assertEqual("Cannot find /tmp/docs.json. Please disable offline mode and retry again.", ctx.exception.args[0])
+        self.assertEqual("Cannot find [/tmp/docs.json]. Please disable offline mode and retry.", ctx.exception.args[0])
 
         self.assertEqual(0, ensure_dir.call_count)
         self.assertEqual(0, download.call_count)
@@ -371,7 +384,9 @@ class TrackPreparationTests(TestCase):
         # uncompressed file does not exist
         is_file.return_value = False
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         with self.assertRaises(exceptions.DataError) as ctx:
             p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -382,8 +397,7 @@ class TrackPreparationTests(TestCase):
                                                                 uncompressed_size_in_bytes=2000),
                                    data_root="/tmp")
 
-        self.assertEqual("/tmp/docs.json is missing and it cannot be downloaded because no base URL is provided.",
-                         ctx.exception.args[0])
+        self.assertEqual("Cannot download data because no base URL is provided.", ctx.exception.args[0])
 
         self.assertEqual(0, ensure_dir.call_count)
         self.assertEqual(0, download.call_count)
@@ -398,7 +412,9 @@ class TrackPreparationTests(TestCase):
         # but it's size is wrong
         get_size.return_value = 100
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         with self.assertRaises(exceptions.DataError) as ctx:
             p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -407,8 +423,8 @@ class TrackPreparationTests(TestCase):
                                                                 uncompressed_size_in_bytes=2000),
                                    data_root="/tmp")
 
-        self.assertEqual("/tmp/docs.json is present but does not have the expected size of 2000 bytes and it cannot be downloaded because "
-                         "no base URL is provided.", ctx.exception.args[0])
+        self.assertEqual("[/tmp/docs.json] is present but does not have the expected size of [2000] bytes and it "
+                         "cannot be downloaded because no base URL is provided.", ctx.exception.args[0])
 
         self.assertEqual(0, ensure_dir.call_count)
         self.assertEqual(0, download.call_count)
@@ -423,7 +439,9 @@ class TrackPreparationTests(TestCase):
         download.side_effect = urllib.error.HTTPError("http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/unit-test/docs-1k.json",
                                                       404, "", None, None)
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=True)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=True),
+                                         decompressor=loader.Decompressor())
 
         with self.assertRaises(exceptions.DataError) as ctx:
             p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -433,8 +451,8 @@ class TrackPreparationTests(TestCase):
                                                                 uncompressed_size_in_bytes=None),
                                    data_root="/tmp")
 
-        self.assertEqual("Track [unit-test] does not support test mode. Please ask the track author to add it or disable test mode "
-                         "and retry.", ctx.exception.args[0])
+        self.assertEqual("This track does not support test mode. Please ask the track author to add it or disable "
+                         "test mode and retry.", ctx.exception.args[0])
 
         ensure_dir.assert_called_with("/tmp")
         download.assert_called_with("http://benchmarks.elasticsearch.org/corpora/unit-test/docs-1k.json",
@@ -450,7 +468,9 @@ class TrackPreparationTests(TestCase):
         download.side_effect = urllib.error.HTTPError("http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json",
                                                       500, "Internal Server Error", None, None)
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         with self.assertRaises(exceptions.DataError) as ctx:
             p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -477,7 +497,9 @@ class TrackPreparationTests(TestCase):
         get_size.side_effect = [2000]
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         self.assertTrue(p.prepare_bundled_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
                                                                                     document_file="docs.json",
@@ -497,7 +519,9 @@ class TrackPreparationTests(TestCase):
         # no files present
         is_file.return_value = False
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         self.assertFalse(p.prepare_bundled_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
                                                                                      document_file="docs.json",
@@ -511,8 +535,6 @@ class TrackPreparationTests(TestCase):
         self.assertEqual(0, prepare_file_offset_table.call_count)
 
     def test_used_corpora(self):
-        cfg = config.Config()
-        cfg.add(config.Scope.application, "track", "challenge.name", "default-challenge")
         track_specification = {
             "description": "description for unit test",
             "indices": [
@@ -632,9 +654,9 @@ class TrackPreparationTests(TestCase):
                 }
             ]
         }
-        reader = loader.TrackSpecificationReader()
+        reader = loader.TrackSpecificationReader(selected_challenge="default-challenge")
         full_track = reader("unittest", track_specification, "/mappings")
-        used_corpora = sorted(loader.used_corpora(full_track, cfg), key=lambda c: c.name)
+        used_corpora = sorted(loader.used_corpora(full_track), key=lambda c: c.name)
         self.assertEqual(2, len(used_corpora))
         self.assertEqual("http_logs", used_corpora[0].name)
         # each bulk operation requires a different data file but they should have been merged properly.
@@ -660,7 +682,9 @@ class TrackPreparationTests(TestCase):
         get_size.side_effect = [200, 2000, 2000]
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         self.assertTrue(p.prepare_bundled_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
                                                                                     document_file="docs.json",
@@ -681,7 +705,9 @@ class TrackPreparationTests(TestCase):
         # compressed has wrong size
         get_size.side_effect = [150]
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         with self.assertRaises(exceptions.DataError) as ctx:
             p.prepare_bundled_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -692,7 +718,8 @@ class TrackPreparationTests(TestCase):
                                                                         uncompressed_size_in_bytes=2000),
                                            data_root=".")
 
-        self.assertEqual("./docs.json.bz2 is present but does not have the expected size of 200 bytes.", ctx.exception.args[0])
+        self.assertEqual("[./docs.json.bz2] is present but does not have the expected size of [200] bytes.",
+                         ctx.exception.args[0])
 
     @mock.patch("esrally.utils.io.prepare_file_offset_table")
     @mock.patch("esrally.utils.io.decompress")
@@ -704,7 +731,9 @@ class TrackPreparationTests(TestCase):
         # uncompressed
         get_size.side_effect = [1500]
 
-        p = loader.DocumentSetPreparator(track_name="unit-test", offline=False, test_mode=False)
+        p = loader.DocumentSetPreparator(track_name="unit-test",
+                                         downloader=loader.Downloader(offline=False, test_mode=False),
+                                         decompressor=loader.Decompressor())
 
         with self.assertRaises(exceptions.DataError) as ctx:
             p.prepare_bundled_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -714,7 +743,8 @@ class TrackPreparationTests(TestCase):
                                                                         compressed_size_in_bytes=200,
                                                                         uncompressed_size_in_bytes=2000),
                                            data_root=".")
-        self.assertEqual("./docs.json is present but does not have the expected size of 2000 bytes.", ctx.exception.args[0])
+        self.assertEqual("[./docs.json] is present but does not have the expected size of [2000] bytes.",
+                         ctx.exception.args[0])
 
         self.assertEqual(0, prepare_file_offset_table.call_count)
 
@@ -1236,9 +1266,12 @@ class TrackPostProcessingTests(TestCase):
         index_body = '{"settings": {"index.number_of_shards": {{ number_of_shards | default(5) }}, '\
                      '"index.number_of_replicas": {{ number_of_replicas | default(0)}} }}'
 
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "track", "test.mode.enabled", True)
+
         self.assertEqual(
             self.as_track(expected_post_processed, complete_track_params=complete_track_params, index_body=index_body),
-            loader.post_process_for_test_mode(
+            loader.TestModeTrackProcessor(cfg).on_after_load_track(
                 self.as_track(track_specification, complete_track_params=complete_track_params, index_body=index_body)
             )
         )
@@ -1288,23 +1321,24 @@ class TrackPathTests(TestCase):
 
 
 class TrackFilterTests(TestCase):
-    def test_create_filters_from_empty_filtered_tasks(self):
-        self.assertEqual(0, len(loader.filters_from_filtered_tasks(None)))
-        self.assertEqual(0, len(loader.filters_from_filtered_tasks([])))
+    def filter(self, track_specification, include_tasks=None, exclude_tasks=None):
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "track", "include.tasks", include_tasks)
+        cfg.add(config.Scope.application, "track", "exclude.tasks", exclude_tasks)
 
-    def test_create_filters_from_mixed_filtered_tasks(self):
-        filters = loader.filters_from_filtered_tasks(["force-merge", "type:search"])
-        self.assertListEqual([track.TaskNameFilter("force-merge"), track.TaskOpTypeFilter("search")], filters)
+        processor = loader.TaskFilterTrackProcessor(cfg)
+        return processor.on_after_load_track(track_specification)
 
     def test_rejects_invalid_syntax(self):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            loader.filters_from_filtered_tasks(["valid", "a:b:c"])
+            self.filter(track_specification=None, include_tasks=["valid", "a:b:c"])
         self.assertEqual("Invalid format for filtered tasks: [a:b:c]", ctx.exception.args[0])
 
     def test_rejects_unknown_filter_type(self):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            loader.filters_from_filtered_tasks(["valid", "op-type:index"])
-        self.assertEqual("Invalid format for filtered tasks: [op-type:index]. Expected [type] but got [op-type].", ctx.exception.args[0])
+            self.filter(track_specification=None, include_tasks=["valid", "op-type:index"])
+        self.assertEqual("Invalid format for filtered tasks: [op-type:index]. Expected [type] but got [op-type].",
+                         ctx.exception.args[0])
 
     def test_filters_tasks(self):
         track_specification = {
@@ -1384,11 +1418,10 @@ class TrackFilterTests(TestCase):
         full_track = reader("unittest", track_specification, "/mappings")
         self.assertEqual(5, len(full_track.challenges[0].schedule))
 
-        filtered = loader.filter_tasks(full_track, [track.TaskNameFilter("index-3"),
-                                                             track.TaskOpTypeFilter("search"),
-                                                             # Filtering should also work for non-core operation types.
-                                                             track.TaskOpTypeFilter("custom-operation-type")
-                                                             ])
+        filtered = self.filter(full_track, include_tasks=["index-3",
+                                                          "type:search",
+                                                          # Filtering should also work for non-core operation types.
+                                                          "type:custom-operation-type"])
 
         schedule = filtered.challenges[0].schedule
         self.assertEqual(3, len(schedule))
@@ -1474,8 +1507,7 @@ class TrackFilterTests(TestCase):
         full_track = reader("unittest", track_specification, "/mappings")
         self.assertEqual(5, len(full_track.challenges[0].schedule))
 
-        filters = [track.TaskNameFilter("index-3"), track.TaskOpTypeFilter("search"), track.TaskNameFilter("create-index")]
-        filtered = loader.filter_tasks(full_track, filters, exclude=True)
+        filtered = self.filter(full_track, exclude_tasks=["index-3", "type:search", "create-index"])
 
         schedule = filtered.challenges[0].schedule
         self.assertEqual(3, len(schedule))
@@ -1544,7 +1576,7 @@ class TrackFilterTests(TestCase):
         self.assertEqual(5, len(full_track.challenges[0].schedule))
 
         expected_schedule = full_track.challenges[0].schedule.copy()
-        filtered = loader.filter_tasks(full_track, [track.TaskNameFilter("nothing")], exclude=True)
+        filtered = self.filter(full_track, exclude_tasks=["nothing"])
 
         schedule = filtered.challenges[0].schedule
         self.assertEqual(expected_schedule, schedule)
@@ -1610,10 +1642,11 @@ class TrackFilterTests(TestCase):
         self.assertEqual(5, len(full_track.challenges[0].schedule))
 
         expected_schedule = []
-        filtered = loader.filter_tasks(full_track, [track.TaskNameFilter("nothing")], exclude=False)
+        filtered = self.filter(full_track, include_tasks=["nothing"])
 
         schedule = filtered.challenges[0].schedule
         self.assertEqual(expected_schedule, schedule)
+
 
 # pylint: disable=too-many-public-methods
 class TrackSpecificationReaderTests(TestCase):
@@ -1985,10 +2018,12 @@ class TrackSpecificationReaderTests(TestCase):
                 ]
             }
         }
-        reader = loader.TrackSpecificationReader()
+        reader = loader.TrackSpecificationReader(selected_challenge="default-challenge")
         resulting_track = reader("unittest", track_specification, "/mappings")
         self.assertEqual("unittest", resulting_track.name)
-        schedule = resulting_track.challenges[0].schedule
+        challenge = resulting_track.challenges[0]
+        self.assertTrue(challenge.selected)
+        schedule = challenge.schedule
         self.assertEqual(2, len(schedule))
         self.assertEqual("search-one-client", schedule[0].name)
         self.assertEqual("search", schedule[0].operation.name)
@@ -2956,12 +2991,13 @@ class TrackSpecificationReaderTests(TestCase):
 
             ]
         }
-        reader = loader.TrackSpecificationReader()
+        reader = loader.TrackSpecificationReader(selected_challenge="another-challenge")
         resulting_track = reader("unittest", track_specification, "/mappings")
         self.assertEqual(2, len(resulting_track.challenges))
         self.assertEqual("challenge", resulting_track.challenges[0].name)
         self.assertTrue(resulting_track.challenges[0].default)
         self.assertFalse(resulting_track.challenges[1].default)
+        self.assertTrue(resulting_track.challenges[1].selected)
 
     def test_selects_sole_challenge_implicitly_as_default(self):
         track_specification = {
@@ -2987,6 +3023,7 @@ class TrackSpecificationReaderTests(TestCase):
         self.assertEqual(1, len(resulting_track.challenges))
         self.assertEqual("challenge", resulting_track.challenges[0].name)
         self.assertTrue(resulting_track.challenges[0].default)
+        self.assertTrue(resulting_track.challenges[0].selected)
 
     def test_auto_generates_challenge_from_schedule(self):
         track_specification = {
@@ -3009,6 +3046,7 @@ class TrackSpecificationReaderTests(TestCase):
         self.assertEqual(1, len(resulting_track.challenges))
         self.assertTrue(resulting_track.challenges[0].auto_generated)
         self.assertTrue(resulting_track.challenges[0].default)
+        self.assertTrue(resulting_track.challenges[0].selected)
 
     def test_inline_operations(self):
         track_specification = {
@@ -3404,3 +3442,60 @@ class TrackSpecificationReaderTests(TestCase):
         self.assertEqual("Track 'unittest' is invalid. 'parallel' element for challenge 'default-challenge' contains multiple tasks with "
                          "the name 'index-1' which are marked with 'completed-by' but only task is allowed to match.",
                          ctx.exception.args[0])
+
+    def test_propagate_parameters_to_challenge_level(self):
+        track_specification = {
+            "description": "description for unit test",
+            "parameters": {
+                "level": "track",
+                "value": 7
+            },
+            "indices": [{"name": "test-index"}],
+            "operations": [
+                {
+                    "name": "index-append",
+                    "operation-type": "bulk"
+                }
+            ],
+            "challenges": [
+                {
+                    "name": "challenge",
+                    "default": True,
+                    "parameters": {
+                        "level": "challenge",
+                        "another-value": 17
+                    },
+                    "schedule": [
+                        {
+                            "operation": "index-append"
+                        }
+                    ]
+                },
+                {
+                    "name": "another-challenge",
+                    "schedule": [
+                        {
+                            "operation": "index-append"
+                        }
+                    ]
+                }
+
+            ]
+        }
+        reader = loader.TrackSpecificationReader(selected_challenge="another-challenge")
+        resulting_track = reader("unittest", track_specification, "/mappings")
+        self.assertEqual(2, len(resulting_track.challenges))
+        self.assertEqual("challenge", resulting_track.challenges[0].name)
+        self.assertTrue(resulting_track.challenges[0].default)
+        self.assertDictEqual({
+            "level": "challenge",
+            "value": 7,
+            "another-value": 17
+        }, resulting_track.challenges[0].parameters)
+
+        self.assertFalse(resulting_track.challenges[1].default)
+        self.assertTrue(resulting_track.challenges[1].selected)
+        self.assertDictEqual({
+            "level": "track",
+            "value": 7
+        }, resulting_track.challenges[1].parameters)

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -451,7 +451,7 @@ class TrackPreparationTests(TestCase):
                                                                 uncompressed_size_in_bytes=None),
                                    data_root="/tmp")
 
-        self.assertEqual("This track does not support test mode. Please ask the track author to add it or disable "
+        self.assertEqual("This track does not support test mode. Ask the track author to add it or disable "
                          "test mode and retry.", ctx.exception.args[0])
 
         ensure_dir.assert_called_with("/tmp")

--- a/tests/utils/collections_test.py
+++ b/tests/utils/collections_test.py
@@ -1,0 +1,111 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import random
+from typing import Any, Mapping
+
+import pytest  # type: ignore
+
+from esrally.utils import collections
+
+
+class TestMergeDicts:
+    def test_can_merge_empty_dicts(self):
+        d1: Mapping[Any, Any] = {}
+        d2: Mapping[Any, Any] = {}
+
+        assert dict(collections.merge_dicts(d1, d2)) == {}
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_can_merge_randomized_empty_and_non_empty_dict(self, seed):
+        random.seed(seed)
+
+        dct = {"params": {"car-params": {"data_paths": "/mnt/local_ssd"}}}
+        d1: Mapping[Any, Any] = random.choice([{}, dct])
+        d2: Mapping[Any, Any] = dct if not d1 else {}
+
+        assert dict(collections.merge_dicts(d1, d2)) == dct
+
+    def test_can_merge_nested_dicts(self):
+        d1 = {
+            "params": {
+                "car": "4gheap",
+                "car-params": {
+                    "additional_cluster_settings": {
+                        "indices.queries.cache.size": "5%",
+                        "transport.tcp.compress": True
+                    }
+                },
+                "unique-param": "foobar"
+            }
+        }
+
+        d2 = {"params": {"car-params": {"data_paths": "/mnt/local_ssd"}}}
+
+        assert dict(collections.merge_dicts(d1, d2)) == {
+            "params": {
+                "car-params": {
+                    "additional_cluster_settings": {
+                        "indices.queries.cache.size": "5%",
+                        "transport.tcp.compress": True
+                    },
+                    "data_paths": "/mnt/local_ssd"},
+                "car": "4gheap",
+                "unique-param": "foobar"
+            }
+        }
+
+    def test_can_merge_nested_lists_in_dicts(self):
+        d1 = {
+            "params": {
+                "foo": [1, 2, 3]
+            }
+        }
+
+        d2 = {
+            "params": {
+                "foo": [3, 4, 5]
+            }
+        }
+
+        assert dict(collections.merge_dicts(d1, d2)) == {
+            "params": {
+                "foo": [1, 2, 3, 4, 5]
+            }
+        }
+
+    def test_can_merge_nested_booleans_in_dicts(self):
+        d1 = {
+            "params": {
+                "foo": True,
+                "other": [1, 2, 3]
+            }
+        }
+
+        d2 = {
+            "params": {
+                "foo": False
+            }
+        }
+
+        assert dict(collections.merge_dicts(d1, d2)) == {
+            "params": {
+                # d2 wins
+                "foo": False,
+                "other": [1, 2, 3]
+            }
+        }


### PR DESCRIPTION
With this commit we introduce track processors and define two phases in the
track lifecycle where they can hook into:

* `on_after_load_track`: This callback is executed after the track has been
successfully loaded and converted into Rally's domain representation. Rally
defines some out-of-the-box track processors for task filters and test mode
support which will be called in any case.
* `on_prepare_track`: This callback is executed before a load generator will
start executing the benchmark. It can be used to download or generate any
datasets that are needed for the benchmark. Rally defines a default behavior
that downloads and extracts all relevant corpora. That behavior can be
overridden via a custom track processor (i.e. Rally's default behavior is then
*disabled*.).

Like all custom track components, track processors are registered via the
`register` function and we implement a new registration method on the registry
called `register_track_processor` for that, which expects an instance that
implements the two methods above.

Note that track processors cannot share state in between these phases. Some
phases might only be invoked on the coordinating node of a benchmark
(`on_after_load_track`) whereas others will need to be called on each load
generator machine (`on_prepare_track`).

We introduce a new `parameters` dictionary on track as well as on challenge
level, where the challenge properties override the defaults defined track level.
These parameters are only exposed on challenge level and track processors are
expected to operate only on that level. Track processors can determine the
current challenge with the new property `selected_challenge_or_default`.
Mid-term we intend to restrict the current track parameter feature in a way that
all values provided via `--track-params` on the command line must be declared
within the `parameters` block, either on track or on challenge level. That's the
reason why we have called this block already `parameters` although it will only
be used by track processors for now.

We intentionally do not provide user documentation for this feature yet as we
want to gain more experience first before exposing it to a wider user base.

Closes #1066