### PR TITLE
Upgrade psutil dependency

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -30,8 +30,6 @@ Installation Instructions for Development
 Known Issues
 ~~~~~~~~~~~~
 
-If you get errors during installation, it is probably due to the installation of ``psutil`` which we use to gather system metrics like CPU utilization. Check the `installation instructions of psutil <https://github.com/giampaolo/psutil/blob/master/INSTALL.rst>`_ in this case. Keep in mind that Rally is based on Python 3 and you need to install the Python 3 header files instead of the Python 2 header files on Linux.
-
 On MacOS Mojave the step ``make prereq`` might fail with the following message::
 
     zipimport.ZipImportError: can't decompress data; zlib not available

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -115,8 +115,6 @@ Installing Rally
 1. Ensure ``~/.local/bin`` is in your ``$PATH``.
 2. Install Rally: ``python3 -m pip install --user esrally``.
 
-If you get errors during installation, it is probably due to the installation of ``psutil`` which we use to gather system metrics like CPU utilization. Ensure that you have installed the Python development package as documented in the prerequisites section above.
-
 VirtualEnv Install
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_requires = [
     #   aiohttp: Apache 2.0
     "elasticsearch[async]==7.9.1",
     # License: BSD
-    "psutil==5.7.0",
+    "psutil==5.8.0",
     # License: MIT
     "py-cpuinfo==7.0.0",
     # License: MIT


### PR DESCRIPTION
With this commit we upgrade the `psutil` dependency of Rally to the
newest version. Among other improvements, `psutil` provides a binary
build now on Linux and MacOS which simplifies setup for Rally users.