### PR TITLE
Show mean throughput in command line report

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -77,6 +77,7 @@ This will download Elasticsearch 6.5.3 and run Rally's default :doc:`track </glo
     |   All |                                     Heap used for stored fields |                        |  0.788307 |      MB |
     |   All |                                                   Segment count |                        |        94 |         |
     |   All |                                                  Min Throughput |           index-append |   38089.5 |  docs/s |
+    |   All |                                                 Mean Throughput |           index-append |   38325.2 |  docs/s |
     |   All |                                               Median Throughput |           index-append |   38613.9 |  docs/s |
     |   All |                                                  Max Throughput |           index-append |   40693.3 |  docs/s |
     |   All |                                         50th percentile latency |           index-append |   803.417 |      ms |
@@ -93,6 +94,7 @@ This will download Elasticsearch 6.5.3 and run Rally's default :doc:`track </glo
     |   All |                                                            ...  |                    ... |       ... |     ... |
     |   All |                                                            ...  |                    ... |       ... |     ... |
     |   All |                                                  Min Throughput | large_prohibited_terms |         2 |   ops/s |
+    |   All |                                                 Mean Throughput | large_prohibited_terms |         2 |   ops/s |
     |   All |                                               Median Throughput | large_prohibited_terms |         2 |   ops/s |
     |   All |                                                  Max Throughput | large_prohibited_terms |         2 |   ops/s |
     |   All |                                         50th percentile latency | large_prohibited_terms |   344.429 |      ms |

--- a/docs/race.rst
+++ b/docs/race.rst
@@ -82,6 +82,7 @@ When the race has finished, Rally will show a summary on the command line::
     |     Heap used for stored fields |              |  0.683708 |     MB |
     |                   Segment count |              |       115 |        |
     |                  Min Throughput | index-update |   59210.4 | docs/s |
+    |                 Mean Throughput | index-update |   60110.3 | docs/s |
     |               Median Throughput | index-update |   65276.2 | docs/s |
     |                  Max Throughput | index-update |   76516.6 | docs/s |
     |       50.0th percentile latency | index-update |   556.269 |     ms |
@@ -97,6 +98,7 @@ When the race has finished, Rally will show a summary on the command line::
     | 99.99th percentile service time | index-update |   4106.91 |     ms |
     |   100th percentile service time | index-update |   4542.84 |     ms |
     |                  Min Throughput |  force-merge |  0.221067 |  ops/s |
+    |                 Mean Throughput |  force-merge |  0.221067 |  ops/s |
     |               Median Throughput |  force-merge |  0.221067 |  ops/s |
     |                  Max Throughput |  force-merge |  0.221067 |  ops/s |
     |        100th percentile latency |  force-merge |   4523.52 |     ms |

--- a/docs/summary_report.rst
+++ b/docs/summary_report.rst
@@ -166,7 +166,7 @@ Segment count
 Throughput
 ----------
 
-Rally reports the minimum, median and maximum throughput for each task.
+Rally reports the minimum, mean, median and maximum throughput for each task.
 
 * **Definition**: Number of operations that Elasticsearch can perform within a certain time period, usually per second.
 * **Corresponding metrics key**: ``throughput``

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -161,6 +161,7 @@ class SummaryReporter:
 
         return self._join(
             self._line("Min Throughput", task, throughput["min"], unit, lambda v: "%.2f" % v),
+            self._line("Mean Throughput", task, throughput["mean"], unit, lambda v: "%.2f" % v),
             self._line("Median Throughput", task, throughput["median"], unit, lambda v: "%.2f" % v),
             self._line("Max Throughput", task, throughput["max"], unit, lambda v: "%.2f" % v)
         )
@@ -376,16 +377,19 @@ class ComparisonReporter:
 
     def _report_throughput(self, baseline_stats, contender_stats, task):
         b_min = baseline_stats.metrics(task)["throughput"]["min"]
+        b_mean = baseline_stats.metrics(task)["throughput"]["mean"]
         b_median = baseline_stats.metrics(task)["throughput"]["median"]
         b_max = baseline_stats.metrics(task)["throughput"]["max"]
         b_unit = baseline_stats.metrics(task)["throughput"]["unit"]
 
         c_min = contender_stats.metrics(task)["throughput"]["min"]
+        c_mean = contender_stats.metrics(task)["throughput"]["mean"]
         c_median = contender_stats.metrics(task)["throughput"]["median"]
         c_max = contender_stats.metrics(task)["throughput"]["max"]
 
         return self._join(
             self._line("Min Throughput", b_min, c_min, task, b_unit, treat_increase_as_improvement=True),
+            self._line("Mean Throughput", b_mean, c_mean, task, b_unit, treat_increase_as_improvement=True),
             self._line("Median Throughput", b_median, c_median, task, b_unit, treat_increase_as_improvement=True),
             self._line("Max Throughput", b_max, c_max, task, b_unit, treat_increase_as_improvement=True)
         )


### PR DESCRIPTION
With this commit Rally shows also the mean throughput in the command
line report. The mean is useful e.g. for calculating summary statistics
across several races or for conducting statistical significance tests.