### PR TITLE
Don't require a name to register a track processor

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1086,9 +1086,9 @@ class TrackPluginReader:
         if self.scheduler_registry:
             self.scheduler_registry(name, scheduler)
 
-    def register_track_processor(self, name, track_processor):
+    def register_track_processor(self, track_processor):
         if self.track_processor_registry:
-            self.track_processor_registry(name, track_processor)
+            self.track_processor_registry(track_processor)
 
     @property
     def meta_data(self):


### PR DESCRIPTION
With this commit we drop the `name` argument from the registration
method for track processors. Contrary to runners, schedulers and
parameter sources there is no need to refer to track processors by name
and this parameter has been introduced by mistake.

Relates #1135