### PR TITLE
Use regular dependency resolver in pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,11 @@ check-venv:
 
 install-user: venv-create
 	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install --upgrade pip setuptools wheel
-	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e . --use-feature=2020-resolver
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .
 
 install: install-user
 	# Also install development dependencies
-	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .[develop] --use-feature=2020-resolver
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .[develop]
 
 clean: nondocs-clean docs-clean
 

--- a/docker/Dockerfiles/Dockerfile-dev
+++ b/docker/Dockerfiles/Dockerfile-dev
@@ -26,7 +26,7 @@ WORKDIR /rally
 RUN find /rally -name "__pycache__" -exec rm -rf -- \{\} \; 2>/dev/null || true
 RUN find /rally -name ".pyc" -exec rm -rf -- \{\} \; 2>/dev/null || true
 RUN pip3 install --upgrade pip setuptools wheel
-RUN pip3 install --use-feature=2020-resolver /rally
+RUN pip3 install /rally
 
 ################################################################################
 # Build stage 1 (the actual Rally image):

--- a/docker/Dockerfiles/Dockerfile-release
+++ b/docker/Dockerfiles/Dockerfile-release
@@ -13,7 +13,7 @@ RUN groupadd --gid 1000 rally && \
     useradd -d /rally -m -k /dev/null -g 1000 -N -u 1000 -l -s /bin/bash rally
 
 RUN pip3 install --upgrade pip setuptools wheel
-RUN pip3 install esrally==$RALLY_VERSION --use-feature=2020-resolver
+RUN pip3 install esrally==$RALLY_VERSION
 
 WORKDIR /rally
 COPY --chown=1000:0 docker/bin/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
In order to workaround issues with the old PIP resolver we have resorted
to the pip command line flag `--use-feature=2020-resolver`. In newer
versions of pip this doesn't have any effect but issues a warning:

```
--use-feature=2020-resolver no longer has any effect,
since it is now the default dependency resolver in pip.
This will become an error in pip 21.0.
```

In order to avoid this warning, we drop the flag from all invocations of
pip in our development workflow and our Docker images.