### PR TITLE
Only consider race id when loading a race

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1424,21 +1424,16 @@ class EsRaceStore(RaceStore):
             return []
 
     def find_by_race_id(self, race_id):
-        filters = [{
-                "term": {
-                    "environment": self.environment_name
-                }
-            },
-            {
-                "term": {
-                    "race-id": race_id
-                }
-            }]
-
         query = {
             "query": {
                 "bool": {
-                    "filter": filters
+                    "filter": [
+                        {
+                            "term": {
+                                "race-id": race_id
+                            }
+                        }
+                    ]
                 }
             }
         }


### PR DESCRIPTION
With this commit we drop the `environment` filter when searching a race
by its id in the Elasticsearch race store and only consider the race id.
The previous filter was a leftover from the times when we did not use a
race id but only a race timestamp as the identifier of a race. In that
case it was useful to also filter for the environment but as the race id
is unique we can drop the additional filter. This is also consistent how
the Elasticsearch metrics store works (see
`EsMetricsStore#_query_by_name`). With this change it is possible to use
the `compare` subcommand to compare races from differente environments
as long as the results have been written to the same Elasticsearch
metrics store. Note that we intentionally don't change the filter that
lists races; it still considers the environment name in order to ensure
we only show races that have been run in that environment.