### PR TITLE
Allow to filter tasks by tag

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -327,6 +327,10 @@ You can use ``--include-tasks`` to specify a comma-separated list of tasks that 
 
     Tasks will be executed in the order that are defined in the challenge, not in the order they are defined in the command.
 
+.. note::
+
+    Task filters are case-sensitive.
+
 **Examples**:
 
 * Execute only the tasks with the name ``index`` and ``term``: ``--include-tasks="index,term"``

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -331,6 +331,7 @@ You can use ``--include-tasks`` to specify a comma-separated list of tasks that 
 
 * Execute only the tasks with the name ``index`` and ``term``: ``--include-tasks="index,term"``
 * Execute only tasks of type ``search``: ``--include-tasks="type:search"``
+* Execute only tasks that contain the tag ``read-op``: ``--include-tasks="tag:read-op"``
 * You can also mix and match: ``--include-tasks="index,type:search"``
 
 ``exclude-tasks``
@@ -344,7 +345,8 @@ You can use ``--exclude-tasks`` to specify a comma-separated list of tasks that 
 
 * Skip any tasks with the name ``index`` and ``term``: ``--exclude-tasks="index,term"``
 * Skip any tasks of type ``search``: ``--exclude-tasks="type:search"``
-* You can also mix and match: ``--exclude-tasks="index,type:search"``
+* Skip any tasks that contain the tag ``setup``: ``--exclude-tasks="tag:setup"``
+* You can also mix and match: ``--exclude-tasks="index,type:search,tag:setup"``
 
 ``team-repository``
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -410,6 +410,7 @@ schedule
 The ``schedule`` element contains a list of tasks that are executed by Rally, i.e. it describes the workload. Each task consists of the following properties:
 
 * ``name`` (optional): This property defines an explicit name for the given task. By default the operation's name is implicitly used as the task name but if the same operation is run multiple times, a unique task name must be specified using this property.
+* ``tags`` (optional): This property defines one or more tags for the given task. This can be used for :ref:`task filtering <clr_include_tasks>`, e.g. with ``--exclude-tasks="tag:setup"`` all tasks except the ones that contain the tag ``setup`` are executed.
 * ``operation`` (mandatory): This property refers either to the name of an operation that has been defined in the ``operations`` section or directly defines an operation inline.
 * ``clients`` (optional, defaults to 1): The number of clients that should execute a task concurrently.
 * ``warmup-iterations`` (optional, defaults to 0): Number of iterations that each client should execute to warmup the benchmark candidate. Warmup iterations will not show up in the measurement results.

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -810,6 +810,8 @@ class TaskFilterTrackProcessor(TrackProcessor):
                 elif len(spec) == 2:
                     if spec[0] == "type":
                         filters.append(track.TaskOpTypeFilter(spec[1]))
+                    elif spec[0] == "tag":
+                        filters.append(track.TaskTagFilter(spec[1]))
                     else:
                         raise exceptions.SystemSetupError(f"Invalid format for filtered tasks: [{t}]. "
                                                           f"Expected [type] but got [{spec[0]}].")
@@ -1458,6 +1460,7 @@ class TrackSpecificationReader:
         task_name = self._r(task_spec, "name", error_ctx=op.name, mandatory=False, default_value=op.name)
         task = track.Task(name=task_name,
                           operation=op,
+                          tags=self._r(task_spec, "tags", error_ctx=op.name, mandatory=False),
                           meta_data=self._r(task_spec, "meta", error_ctx=op.name, mandatory=False),
                           warmup_iterations=self._r(task_spec, "warmup-iterations", error_ctx=op.name, mandatory=False,
                                                     default_value=default_warmup_iterations),

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -704,7 +704,7 @@ class TaskNameFilter:
         return isinstance(other, type(self)) and self.name == other.name
 
     def __str__(self, *args, **kwargs):
-        return "filter for task name [%s]" % self.name
+        return f"filter for task name [{self.name}]"
 
 
 class TaskOpTypeFilter:
@@ -721,7 +721,24 @@ class TaskOpTypeFilter:
         return isinstance(other, type(self)) and self.op_type == other.op_type
 
     def __str__(self, *args, **kwargs):
-        return "filter for operation type [%s]" % self.op_type
+        return f"filter for operation type [{self.op_type}]"
+
+
+class TaskTagFilter:
+    def __init__(self, tag_name):
+        self.tag_name = tag_name
+
+    def matches(self, task):
+        return self.tag_name in task.tags
+
+    def __hash__(self):
+        return hash(self.tag_name)
+
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and self.tag_name == other.tag_name
+
+    def __str__(self, *args, **kwargs):
+        return f"filter for tasks tagged [{self.tag_name}]"
 
 
 class Singleton(type):
@@ -785,10 +802,16 @@ Throughput = collections.namedtuple("Throughput", ["value", "unit"])
 class Task:
     THROUGHPUT_PATTERN = re.compile(r"(?P<value>(\d*\.)?\d+)\s(?P<unit>\w+/s)")
 
-    def __init__(self, name, operation, meta_data=None, warmup_iterations=None, iterations=None, warmup_time_period=None,
-                 time_period=None, clients=1, completes_parent=False, schedule=None, params=None):
+    def __init__(self, name, operation, tags=None, meta_data=None, warmup_iterations=None, iterations=None,
+                 warmup_time_period=None, time_period=None, clients=1, completes_parent=False, schedule=None, params=None):
         self.name = name
         self.operation = operation
+        if isinstance(tags, str):
+            self.tags = [tags]
+        elif tags:
+            self.tags = tags
+        else:
+            self.tags = []
         self.meta_data = meta_data if meta_data else {}
         self.warmup_iterations = warmup_iterations
         self.iterations = iterations

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -235,12 +235,14 @@ class TaskFilterTests(TestCase):
     def create_index_task(self):
         return track.Task("create-index-task",
                           track.Operation("create-index-op",
-                                          operation_type=track.OperationType.CreateIndex.to_hyphenated_string()))
+                                          operation_type=track.OperationType.CreateIndex.to_hyphenated_string()),
+                          tags=["write-op", "admin-op"])
 
     def search_task(self):
         return track.Task("search-task",
                           track.Operation("search-op",
-                                          operation_type=track.OperationType.Search.to_hyphenated_string()))
+                                          operation_type=track.OperationType.Search.to_hyphenated_string()),
+                          tags="read-op")
 
     def test_task_name_filter(self):
         f = track.TaskNameFilter("create-index-task")
@@ -249,6 +251,11 @@ class TaskFilterTests(TestCase):
 
     def test_task_op_type_filter(self):
         f = track.TaskOpTypeFilter(track.OperationType.CreateIndex.to_hyphenated_string())
+        self.assertTrue(f.matches(self.create_index_task()))
+        self.assertFalse(f.matches(self.search_task()))
+
+    def test_task_tag_filter(self):
+        f = track.TaskTagFilter(tag_name="write-op")
         self.assertTrue(f.matches(self.create_index_task()))
         self.assertFalse(f.matches(self.search_task()))
 


### PR DESCRIPTION
With this commit we allow users to filter tasks by tags. Tasks define a
new property `tags` and we add a new `tag` keyword prefix for task
filters. A usage example is:

```
--exclude-tasks="tag:setup"
```

By adding this task filter, Rally executes all tasks but the ones that
contain this tag.