### PR TITLE
Deprecate invoking Rally without a subcommand

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Run your first race
 
 Now we're ready to run our first race::
 
-    esrally --distribution-version=6.0.0
+    esrally race --distribution-version=6.0.0
 
 This will download Elasticsearch 6.0.0 and run Rally's default track - the `geonames track <https://github.com/elastic/rally-tracks/tree/master/geonames>`_ - against it. After the race, a summary report is written to the command line:::
 

--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -267,7 +267,7 @@ You can also show details about your track with ``esrally info --track-path=~/ra
     5. force-merge
     6. query-match-all (8 clients)
 
-Congratulations, you have created your first track! You can test it with ``esrally --distribution-version=7.0.0 --track-path=~/rally-tracks/tutorial``.
+Congratulations, you have created your first track! You can test it with ``esrally race --distribution-version=7.0.0 --track-path=~/rally-tracks/tutorial``.
 
 .. _add_track_test_mode:
 

--- a/docs/cluster_management.rst
+++ b/docs/cluster_management.rst
@@ -50,7 +50,7 @@ After installation, we can start the node. To tie all metrics of a benchmark tog
 
 After the Elasticsearch node has started, we can run a benchmark. Be sure to pass the same race id so you can match results later in your metrics store::
 
-    esrally --pipeline=benchmark-only --target-host=127.0.0.1:39200 --track=geonames --challenge=append-no-conflicts-index-only --on-error=abort --race-id=${RACE_ID}
+    esrally race --pipeline=benchmark-only --target-host=127.0.0.1:39200 --track=geonames --challenge=append-no-conflicts-index-only --on-error=abort --race-id=${RACE_ID}
 
 When the benchmark has finished, we can stop the node again::
 
@@ -90,7 +90,7 @@ We should see that our cluster consisting of three nodes is up and running::
 
 Now we can start the benchmark on the load generator machine (remember to set the race id there)::
 
-    esrally --pipeline=benchmark-only --target-host=192.168.14.77:39200,192.168.14.78:39200,192.168.14.79:39200 --track=geonames --challenge=append-no-conflicts-index-only --on-error=abort --race-id=${RACE_ID}
+    esrally race --pipeline=benchmark-only --target-host=192.168.14.77:39200,192.168.14.78:39200,192.168.14.79:39200 --track=geonames --challenge=append-no-conflicts-index-only --on-error=abort --race-id=${RACE_ID}
 
 Similarly to the single-node benchmark, we can now shutdown the cluster again by issuing the following command on each node::
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -12,7 +12,7 @@ Subcommands
 ``race``
 ~~~~~~~~
 
-The ``race`` subcommand is used to actually run a benchmark. It is the default one and chosen implicitly if none is given.
+The ``race`` subcommand is used to execute a benchmark.
 
 
 ``list``
@@ -167,10 +167,10 @@ Examples::
 
    # provide a directory - Rally searches for a track.json file in this directory
    # Track name is "app-logs"
-   esrally --track-path=~/Projects/tracks/app-logs
+   esrally race --track-path=~/Projects/tracks/app-logs
    # provide a file name - Rally uses this file directly
    # Track name is "syslog"
-   esrally --track-path=~/Projects/tracks/syslog.json
+   esrally race --track-path=~/Projects/tracks/syslog.json
 
 
 ``track-repository``
@@ -364,7 +364,7 @@ A directory that contains a team configuration. ``--team-path`` and ``--team-rep
 
 Example::
 
-   esrally --team-path=~/Projects/es-teams
+   esrally race --team-path=~/Projects/es-teams
 
 ``target-os``
 ~~~~~~~~~~~~~
@@ -390,7 +390,7 @@ A :doc:`car </car>` defines the Elasticsearch configuration that will be used fo
 
  ::
 
-   esrally --car="4gheap,ea"
+   esrally race --car="4gheap,ea"
 
 
 Rally will configure Elasticsearch with 4GB of heap (``4gheap``) and enable Java assertions (``ea``).
@@ -404,7 +404,7 @@ Allows to override config variables of Elasticsearch. It accepts a list of comma
 
  ::
 
-   esrally --car="4gheap" --car-params="data_paths:'/opt/elasticsearch'"
+   esrally race --car="4gheap" --car-params="data_paths:'/opt/elasticsearch'"
 
 The variables that are exposed depend on the `car's configuration <https://github.com/elastic/rally-teams/tree/master/cars>`__. In addition, Rally implements special handling for the variable ``data_paths`` (by default the value for this variable is determined by Rally).
 
@@ -416,7 +416,7 @@ A comma-separated list of Elasticsearch plugins to install for the benchmark. If
 
 Example::
 
-   esrally --elasticsearch-plugins="analysis-icu,xpack:security"
+   esrally race --elasticsearch-plugins="analysis-icu,xpack:security"
 
 In this example, Rally will install the ``analysis-icu`` plugin and the ``x-pack`` plugin with the ``security`` configuration. See the reference documentation about :doc:`Elasticsearch plugins </elasticsearch_plugins>` for more details.
 
@@ -427,7 +427,7 @@ Allows to override variables of Elasticsearch plugins. It accepts a list of comm
 
 Example::
 
-    esrally --distribution-version=6.1.1. --elasticsearch-plugins="x-pack:monitoring-http" --plugin-params="monitoring_type:'https',monitoring_host:'some_remote_host',monitoring_port:10200,monitoring_user:'rally',monitoring_password:'m0n1t0r1ng'"
+    esrally race --distribution-version=6.1.1. --elasticsearch-plugins="x-pack:monitoring-http" --plugin-params="monitoring_type:'https',monitoring_host:'some_remote_host',monitoring_port:10200,monitoring_user:'rally',monitoring_password:'m0n1t0r1ng'"
 
 This enables the HTTP exporter of `X-Pack Monitoring <https://www.elastic.co/products/x-pack/monitoring>`_ and exports the data to the configured monitoring host.
 
@@ -485,7 +485,7 @@ Activates the provided :doc:`telemetry devices </telemetry>` for this race.
 
  ::
 
-   esrally --telemetry=jfr,jit
+   esrally race --telemetry=jfr,jit
 
 
 This activates Java flight recorder and the JIT compiler telemetry devices.
@@ -499,7 +499,7 @@ Allows to set parameters for telemetry devices. It accepts a list of comma-separ
 
 Example::
 
-    esrally --telemetry=jfr --telemetry-params="recording-template:'profile'"
+    esrally race --telemetry=jfr --telemetry-params="recording-template:'profile'"
 
 This enables the Java flight recorder telemetry device and sets the ``recording-template`` parameter to "profile".
 
@@ -512,7 +512,7 @@ For more complex cases specify a JSON file. Store the following as ``telemetry-p
 
 and reference it when running Rally::
 
-   esrally --telemetry="node-stats" --telemetry-params="telemetry-params.json"
+   esrally race --telemetry="node-stats" --telemetry-params="telemetry-params.json"
 
 
 ``runtime-jdk``
@@ -525,9 +525,9 @@ This command line parameter sets the major version of the JDK that Rally should 
 Example::
 
    # Run a benchmark with defaults (i.e. JDK 8)
-   esrally --distribution-version=5.0.0
+   esrally race --distribution-version=5.0.0
    # Force to run with JDK 11
-   esrally --distribution-version=7.0.0 --runtime-jdk=11
+   esrally race --distribution-version=7.0.0 --runtime-jdk=11
 
 It is also possible to specify the JDK that is bundled with Elasticsearch with the special value ``bundled``. The `JDK is bundled from Elasticsearch 7.0.0 onwards <https://www.elastic.co/guide/en/elasticsearch/reference/current/release-highlights-7.0.0.html#_bundle_jdk_in_elasticsearch_distribution>`_.
 
@@ -569,7 +569,7 @@ If you want Rally to launch and benchmark a cluster using a binary distribution,
 
  ::
 
-   esrally --distribution-version=7.0.0
+   esrally race --distribution-version=7.0.0
 
 
 Rally will then benchmark the official Elasticsearch 7.0.0 distribution. Please check our :doc:`version support page </versions>` to see which Elasticsearch versions are currently supported by Rally.
@@ -592,7 +592,7 @@ The ``url`` property defines the URL pattern for this repository. The ``cache`` 
 
 You can use this distribution repository with the name "in_house_snapshot" as follows::
 
-   esrally --distribution-repository=in_house_snapshot --distribution-version=7.0.0-SNAPSHOT
+   esrally race --distribution-repository=in_house_snapshot --distribution-version=7.0.0-SNAPSHOT
 
 This will benchmark the latest 7.0.0 snapshot build of Elasticsearch.
 
@@ -618,7 +618,7 @@ By default, the command line reporter will print the results only on standard ou
 
  ::
 
-   esrally --report-format=csv --report-file=~/benchmarks/result.csv
+   esrally race --report-format=csv --report-file=~/benchmarks/result.csv
 
 .. _clr_client_options:
 
@@ -691,7 +691,7 @@ By default, Rally will run its load driver on the same machine where you start t
 
  ::
 
-   esrally --load-driver-hosts=10.17.20.5,10.17.20.6
+   esrally race --load-driver-hosts=10.17.20.5,10.17.20.6
 
 In the example, above Rally will generate load from the hosts ``10.17.20.5`` and ``10.17.20.6``. For this to work, you need to start a Rally daemon on these machines, see :ref:`distributing the load test driver <recipe_distributed_load_driver>` for a complete example.
 
@@ -704,7 +704,7 @@ If you run the ``benchmark-only`` :doc:`pipeline </pipelines>` or you want Rally
 
  ::
 
-   esrally --pipeline=benchmark-only --target-hosts=10.17.0.5:9200,10.17.0.6:9200
+   esrally race --pipeline=benchmark-only --target-hosts=10.17.0.5:9200,10.17.0.6:9200
 
 This will run the benchmark against the hosts 10.17.0.5 and 10.17.0.6 on port 9200. See ``client-options`` if you use X-Pack Security and need to authenticate or Rally should use https.
 
@@ -760,7 +760,7 @@ The required format is ``key`` ":" ``value``. You can choose ``key`` and  ``valu
 
  ::
 
-   esrally --user-tag="intention:github-issue-1234-baseline,gc:cms"
+   esrally race --user-tag="intention:github-issue-1234-baseline,gc:cms"
 
 You can also specify multiple tags. They need to be separated by a comma.
 
@@ -768,7 +768,7 @@ You can also specify multiple tags. They need to be separated by a comma.
 
  ::
 
-   esrally --user-tag="disk:SSD,data_node_count:4"
+   esrally race --user-tag="disk:SSD,data_node_count:4"
 
 
 

--- a/docs/elasticsearch_plugins.rst
+++ b/docs/elasticsearch_plugins.rst
@@ -44,7 +44,7 @@ In order to tell Rally to install a plugin, use the ``--elasticsearch-plugins`` 
 
 Example::
 
-    esrally --distribution-version=5.5.0 --elasticsearch-plugins="analysis-icu,analysis-phonetic"
+    esrally race --distribution-version=5.5.0 --elasticsearch-plugins="analysis-icu,analysis-phonetic"
 
 This will install the plugins ``analysis-icu`` and ``analysis-phonetic`` (in that order). In order to use the features that these plugins provide, you need to write a :doc:`custom track </adding_tracks>`.
 
@@ -97,7 +97,7 @@ Let's discuss these properties one by one:
 .. warning::
     ``plugin.my-plugin.build.command`` has replaced ``plugin.my-plugin.build.task`` in earlier Rally versions. It now requires the **full** build command.
 
-In order to run a benchmark with ``my-plugin``, you'd invoke Rally as follows: ``esrally --revision="elasticsearch:some-elasticsearch-revision,my-plugin:some-plugin-revision" --elasticsearch-plugins="my-plugin"`` where you need to replace ``some-elasticsearch-revision`` and ``some-plugin-revision`` with the appropriate :ref:`git revisions <clr_revision>`. Adjust other command line parameters (like track or car) accordingly. In order for this to work, you need to ensure that:
+In order to run a benchmark with ``my-plugin``, you'd invoke Rally as follows: ``esrally race --revision="elasticsearch:some-elasticsearch-revision,my-plugin:some-plugin-revision" --elasticsearch-plugins="my-plugin"`` where you need to replace ``some-elasticsearch-revision`` and ``some-plugin-revision`` with the appropriate :ref:`git revisions <clr_revision>`. Adjust other command line parameters (like track or car) accordingly. In order for this to work, you need to ensure that:
 
 * All prerequisites for source builds are installed.
 * The Elasticsearch source revision is compatible with the chosen plugin revision. Note that you do not need to know the revision hash to build against an already released version and can use git tags instead. E.g. if you want to benchmark against Elasticsearch 5.6.1, you can specify ``--revision="elasticsearch:v5.6.1,my-plugin:some-plugin-revision"`` (see e.g. the `Elasticsearch tags on Github <https://github.com/elastic/elasticsearch/tags>`_ or use ``git tag`` in the Elasticsearch source directory on the console).
@@ -126,7 +126,7 @@ Let's discuss these properties one by one:
 .. warning::
     ``plugin.my-plugin.build.command`` has replaced ``plugin.my-plugin.build.task`` in earlier Rally versions. It now requires the **full** build command.
 
-In order to run a benchmark with ``my-plugin``, you'd invoke Rally as follows: ``esrally --distribution-version="elasticsearch-version" --revision="my-plugin:some-plugin-revision" --elasticsearch-plugins="my-plugin"`` where you need to replace ``elasticsearch-version`` with the correct release (e.g. 6.0.0) and ``some-plugin-revision`` with the appropriate :ref:`git revisions <clr_revision>`. Adjust other command line parameters (like track or car) accordingly. In order for this to work, you need to ensure that:
+In order to run a benchmark with ``my-plugin``, you'd invoke Rally as follows: ``esrally race --distribution-version="elasticsearch-version" --revision="my-plugin:some-plugin-revision" --elasticsearch-plugins="my-plugin"`` where you need to replace ``elasticsearch-version`` with the correct release (e.g. 6.0.0) and ``some-plugin-revision`` with the appropriate :ref:`git revisions <clr_revision>`. Adjust other command line parameters (like track or car) accordingly. In order for this to work, you need to ensure that:
 
 * All prerequisites for source builds are installed.
 * The Elasticsearch release is compatible with the chosen plugin revision.
@@ -223,7 +223,7 @@ As ``myplugin`` is not a core plugin, the Elasticsearch plugin manager does not 
     [distributions]
     plugin.myplugin.release.url=https://example.org/myplugin/releases/{{VERSION}}/myplugin-{{VERSION}}.zip
 
-Now you can run benchmarks with the custom Elasticsearch plugin, e.g. with ``esrally --distribution-version=5.5.0 --elasticsearch-plugins="myplugin:simple"``.
+Now you can run benchmarks with the custom Elasticsearch plugin, e.g. with ``esrally race --distribution-version=5.5.0 --elasticsearch-plugins="myplugin:simple"``.
 
 For this to work you need ensure two things:
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -17,9 +17,7 @@ Invoke Rally with the ``race`` subcommand instead::
 
 When Rally is invoked without a subcommand it will issue the following warning on the command line and in the log file::
 
-    [WARNING] Invoking Rally without a subcommand is deprecated. Specify the 'race' subcommand explicitly.
-
-A subcommand will be required starting with the next minor release 2.1.0.
+    [WARNING] Invoking Rally without a subcommand is deprecated and will be required with Rally 2.1.0. Specify the 'race' subcommand explicitly.
 
 Migrating to Rally 2.0.3
 ------------------------

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,26 @@
 Migration Guide
 ===============
 
+Migrating to Rally 2.0.4
+------------------------
+
+Running without a subcommand is deprecated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Rally 2.0.4 will warn when invoked without subcommand. So instead of invoking::
+
+    esrally --distribution-version=7.10.0
+
+Invoke Rally with the ``race`` subcommand instead::
+
+    esrally race --distribution-version=7.10.0
+
+When Rally is invoked without a subcommand it will issue the following warning on the command line and in the log file::
+
+    [WARNING] Invoking Rally without a subcommand is deprecated. Specify the 'race' subcommand explicitly.
+
+A subcommand will be required starting with the next minor release 2.1.0.
+
 Migrating to Rally 2.0.3
 ------------------------
 

--- a/docs/pipelines.rst
+++ b/docs/pipelines.rst
@@ -24,7 +24,7 @@ This is intended if you want to provision a cluster by yourself. Do not use this
 
 To benchmark a cluster, you also have to specify the hosts to connect to. An example invocation::
 
-    esrally --pipeline=benchmark-only --target-hosts=search-node-a.intranet.acme.com:9200,search-node-b.intranet.acme.com:9200
+    esrally race --pipeline=benchmark-only --target-hosts=search-node-a.intranet.acme.com:9200,search-node-b.intranet.acme.com:9200
 
 
 from-distribution
@@ -32,13 +32,13 @@ from-distribution
 
 This pipeline allows to benchmark an official Elasticsearch distribution which will be automatically downloaded by Rally. An example invocation::
 
-    esrally --pipeline=from-distribution --distribution-version=7.0.0
+    esrally race --pipeline=from-distribution --distribution-version=7.0.0
 
 The version numbers have to match the name in the download URL path.
 
 You can also benchmark Elasticsearch snapshot versions by specifying the snapshot repository::
 
-    esrally --pipeline=from-distribution --distribution-version=5.0.0-SNAPSHOT --distribution-repository=snapshot
+    esrally race --pipeline=from-distribution --distribution-version=5.0.0-SNAPSHOT --distribution-repository=snapshot
 
 However, this feature is mainly intended for continuous integration environments and by default you should just benchmark official distributions.
 
@@ -55,7 +55,7 @@ You should use this pipeline when you want to build and benchmark Elasticsearch 
 
 Remember that you also need git installed. If that's not the case you'll get an error. An example invocation::
 
-    esrally --pipeline=from-sources --revision=latest
+    esrally race --pipeline=from-sources --revision=latest
 
 You have to specify a :ref:`revision <clr_revision>`.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,7 +18,7 @@ Run your first race
 
 Now we're ready to run our first :doc:`race </glossary>`::
 
-    esrally --distribution-version=6.5.3
+    esrally race --distribution-version=6.5.3
 
 This will download Elasticsearch 6.5.3 and run Rally's default :doc:`track </glossary>` - the `geonames track <https://github.com/elastic/rally-tracks/tree/master/geonames>`_ - against it. After the race, a :doc:`summary report </summary_report>` is written to the command line:::
 

--- a/docs/race.rst
+++ b/docs/race.rst
@@ -36,11 +36,11 @@ Starting a Race
 
 To start a race you have to define the track and challenge to run. For example::
 
-    esrally --distribution-version=6.0.0 --track=geopoint --challenge=append-fast-with-conflicts
+    esrally race --distribution-version=6.0.0 --track=geopoint --challenge=append-fast-with-conflicts
 
 Rally will then start racing on this track. If you have never started Rally before, it should look similar to the following output::
 
-    dm@io:~ $ esrally --distribution-version=6.0.0 --track=geopoint --challenge=append-fast-with-conflicts
+    dm@io:~ $ esrally race --distribution-version=6.0.0 --track=geopoint --challenge=append-fast-with-conflicts
 
         ____        ____
        / __ \____ _/ / /_  __

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -12,7 +12,7 @@ Benchmarking an Elastic Cloud cluster
 
 Benchmarking an `Elastic Cloud <https://www.elastic.co/cloud/>`_ cluster with Rally is similar to :ref:`benchmarking any other existing cluster <recipe_benchmark_existing_cluster>`. In the following example we will run a benchmark against a cluster reachable via the endpoint ``https://abcdef123456.europe-west1.gcp.cloud.es.io:9243`` by the user ``elastic`` with the password ``changeme``::
 
-    esrally --track=pmc --target-hosts=abcdef123456.europe-west1.gcp.cloud.es.io:9243 --pipeline=benchmark-only --client-options="timeout:60,use_ssl:true,verify_certs:true,basic_auth_user:'elastic',basic_auth_password:'changeme'"
+    esrally race --track=pmc --target-hosts=abcdef123456.europe-west1.gcp.cloud.es.io:9243 --pipeline=benchmark-only --client-options="timeout:60,use_ssl:true,verify_certs:true,basic_auth_user:'elastic',basic_auth_password:'changeme'"
 
 .. _recipe_benchmark_existing_cluster:
 
@@ -53,11 +53,11 @@ Finally we need to check which :doc:`pipeline </pipelines>` to use. For this cas
 
 Now we can invoke Rally::
 
-    esrally --track=pmc --target-hosts=10.5.5.10:9200,10.5.5.11:9200,10.5.5.12:9200 --pipeline=benchmark-only
+    esrally race --track=pmc --target-hosts=10.5.5.10:9200,10.5.5.11:9200,10.5.5.12:9200 --pipeline=benchmark-only
 
 If you have `X-Pack Security <https://www.elastic.co/products/x-pack/security>`_  enabled, then you'll also need to specify another parameter to use https and to pass credentials::
 
-    esrally --track=pmc --target-hosts=10.5.5.10:9243,10.5.5.11:9243,10.5.5.12:9243 --pipeline=benchmark-only --client-options="use_ssl:true,verify_certs:true,basic_auth_user:'elastic',basic_auth_password:'changeme'"
+    esrally race --track=pmc --target-hosts=10.5.5.10:9243,10.5.5.11:9243,10.5.5.12:9243 --pipeline=benchmark-only --client-options="use_ssl:true,verify_certs:true,basic_auth_user:'elastic',basic_auth_password:'changeme'"
 
 .. _recipe_benchmark_remote_cluster:
 
@@ -84,7 +84,7 @@ To run a benchmark for this scenario follow these steps:
 
 1. :doc:`Install </install>` and :doc:`configure </configuration>` Rally on all machines. Be sure that the same version is installed on all of them and fully :doc:`configured </configuration>`.
 2. Start the :doc:`Rally daemon </rally_daemon>` on each machine. The Rally daemon allows Rally to communicate with all remote machines. On the benchmark coordinator run ``esrallyd start --node-ip=10.5.5.5 --coordinator-ip=10.5.5.5`` and on the benchmark candidate machines run ``esrallyd start --node-ip=10.5.5.10 --coordinator-ip=10.5.5.5`` and ``esrallyd start --node-ip=10.5.5.11 --coordinator-ip=10.5.5.5`` respectively. The ``--node-ip`` parameter tells Rally the IP of the machine on which it is running. As some machines have more than one network interface, Rally will not attempt to auto-detect the machine IP. The ``--coordinator-ip`` parameter tells Rally the IP of the benchmark coordinator node.
-3. Start the benchmark by invoking Rally as usual on the benchmark coordinator, for example: ``esrally --distribution-version=5.0.0 --target-hosts=10.5.5.10:39200,10.5.5.11:39200``. Rally will derive from the ``--target-hosts``  parameter that it should provision the nodes ``10.5.5.10`` and ``10.5.5.11``.
+3. Start the benchmark by invoking Rally as usual on the benchmark coordinator, for example: ``esrally race --distribution-version=5.0.0 --target-hosts=10.5.5.10:39200,10.5.5.11:39200``. Rally will derive from the ``--target-hosts``  parameter that it should provision the nodes ``10.5.5.10`` and ``10.5.5.11``.
 4. After the benchmark has finished you can stop the Rally daemon again. On the benchmark coordinator and on the benchmark candidates run ``esrallyd stop``.
 
 .. note::
@@ -124,7 +124,7 @@ By default, Rally will generate load on the same machine where you start a bench
 
 1. :doc:`Install </install>` and :doc:`configure </configuration>` Rally on all machines. Be sure that the same version is installed on all of them and fully :doc:`configured </configuration>`.
 2. Start the :doc:`Rally daemon </rally_daemon>` on each machine. The Rally daemon allows Rally to communicate with all remote machines. On the benchmark coordinator run ``esrallyd start --node-ip=10.5.5.5 --coordinator-ip=10.5.5.5`` and on the load driver machines run ``esrallyd start --node-ip=10.5.5.6 --coordinator-ip=10.5.5.5`` and ``esrallyd start --node-ip=10.5.5.7 --coordinator-ip=10.5.5.5`` respectively. The ``--node-ip`` parameter tells Rally the IP of the machine on which it is running. As some machines have more than one network interface, Rally will not attempt to auto-detect the machine IP. The ``--coordinator-ip`` parameter tells Rally the IP of the benchmark coordinator node.
-3. Start the benchmark by invoking Rally on the benchmark coordinator, for example: ``esrally --pipeline=benchmark-only --load-driver-hosts=10.5.5.6,10.5.5.7 --target-hosts=10.5.5.11:9200,10.5.5.12:9200,10.5.5.13:9200``.
+3. Start the benchmark by invoking Rally on the benchmark coordinator, for example: ``esrally race --pipeline=benchmark-only --load-driver-hosts=10.5.5.6,10.5.5.7 --target-hosts=10.5.5.11:9200,10.5.5.12:9200,10.5.5.13:9200``.
 4. After the benchmark has finished you can stop the Rally daemon again. On the benchmark coordinator and on the load driver machines run ``esrallyd stop``.
 
 .. note::
@@ -213,7 +213,7 @@ Rally will not exit on errors (unless fatal e.g. `ECONNREFUSED <http://man7.org/
 
 This behavior can also be changed, by invoking Rally with the :ref:`--on-error <command_line_reference_on_error>` switch e.g.::
 
-	esrally --track=geonames --on-error=abort
+	esrally race --track=geonames --on-error=abort
 	
 Errors can also be investigated if you have configured a :doc:`dedicated Elasticsearch metrics store </configuration>`.
 

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -36,7 +36,7 @@ jfr
 
 The ``jfr`` telemetry device enables the `Java Flight Recorder <http://docs.oracle.com/javacomponents/jmc-5-5/jfr-runtime-guide/index.html>`_ on the benchmark candidate. Up to JDK 11, Java flight recorder ships only with Oracle JDK, so Rally assumes that Oracle JDK is used for benchmarking. If you run benchmarks on JDK 11 or later, Java flight recorder is also available on OpenJDK.
 
-To enable ``jfr``, invoke Rally with ``esrally --telemetry jfr``. ``jfr`` will then write a flight recording file which can be opened in `Java Mission Control <https://jdk.java.net/jmc/>`_. Rally prints the location of the flight recording file on the command line.
+To enable ``jfr``, invoke Rally with ``esrally race --telemetry jfr``. ``jfr`` will then write a flight recording file which can be opened in `Java Mission Control <https://jdk.java.net/jmc/>`_. Rally prints the location of the flight recording file on the command line.
 
 .. image:: jfr-es.png
    :alt: Sample Java Flight Recording

--- a/docs/tournament.rst
+++ b/docs/tournament.rst
@@ -5,13 +5,13 @@ Suppose, we want to analyze the impact of a performance improvement.
 
 First, we need a baseline measurement. For example::
 
-    esrally --track=pmc --revision=latest --user-tag="intention:baseline_github_1234"
+    esrally race --track=pmc --revision=latest --user-tag="intention:baseline_github_1234"
 
 Above we run the baseline measurement based on the latest source code revision of Elasticsearch. We can use the command line parameter ``--user-tag`` to provide a key-value pair to document the intent of a race.
 
 Then we implement our changes and finally we want to run another benchmark to see the performance impact of the change. In that case, we do not want Rally to change our source tree and thus specify the pseudo-revision ``current``::
 
-    esrally --track=pmc --revision=current --user-tag="intention:reduce_alloc_1234"
+    esrally race --track=pmc --revision=current --user-tag="intention:reduce_alloc_1234"
 
 After we've run both races, we want to know about the performance impact. With Rally we can analyze differences of two given races easily. First of all, we need to find two races to compare by issuing ``esrally list races``::
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -23,10 +23,10 @@ For ad-hoc use you can store a track definition anywhere on the file system and 
 
    # provide a directory - Rally searches for a track.json file in this directory
    # Track name is "app-logs"
-   esrally --track-path=~/Projects/tracks/app-logs
+   esrally race --track-path=~/Projects/tracks/app-logs
    # provide a file name - Rally uses this file directly
    # Track name is "syslog"
-   esrally --track-path=~/Projects/tracks/syslog.json
+   esrally race --track-path=~/Projects/tracks/syslog.json
 
 Rally will also search for additional files like mappings or data files in the provided directory. If you use advanced features like :ref:`custom runners <adding_tracks_custom_runners>` or :ref:`parameter sources <adding_tracks_custom_param_sources>` we recommend that you create a separate directory per track.
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -589,7 +589,8 @@ def derive_sub_command(args):
     sub_command = args.subcommand
     if sub_command is None:
         logger = logging.getLogger(__name__)
-        console.warn("Invoking Rally without a subcommand is deprecated. Specify the 'race' subcommand explicitly.", logger=logger)
+        console.warn("Invoking Rally without a subcommand is deprecated and will be required with Rally 2.1.0. Specify "
+                     "the 'race' subcommand explicitly.", logger=logger)
         return "race"
     else:
         return sub_command

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -587,8 +587,12 @@ def create_arg_parser():
 
 def derive_sub_command(args):
     sub_command = args.subcommand
-    # TODO: Can we select a subcommand by default?
-    return sub_command if sub_command is not None else "race"
+    if sub_command is None:
+        logger = logging.getLogger(__name__)
+        console.warn("Invoking Rally without a subcommand is deprecated. Specify the 'race' subcommand explicitly.", logger=logger)
+        return "race"
+    else:
+        return sub_command
 
 
 def dispatch_list(cfg):

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -84,7 +84,7 @@ def esrally(cfg, command_line):
 
 def race(cfg, command_line):
     """
-    This method should be used for rally invocations of the default race command.
+    This method should be used for rally invocations of the race command.
     It sets up some defaults for how the integration tests expect to run races.
     """
     return esrally(cfg, f"race {command_line} --on-error='abort'")

--- a/it/docker_dev_image_test.py
+++ b/it/docker_dev_image_test.py
@@ -23,7 +23,7 @@ from esrally import version
 
 
 def test_docker_geonames():
-    test_command = "--pipeline=benchmark-only --test-mode --track=geonames " \
+    test_command = "race --pipeline=benchmark-only --test-mode --track=geonames " \
                    "--challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
     run_docker_compose_test(test_command)
 
@@ -39,7 +39,7 @@ def test_docker_help():
 
 
 def test_docker_override_cmd():
-    test_command = "esrally --pipeline=benchmark-only --test-mode --track=geonames " \
+    test_command = "esrally race --pipeline=benchmark-only --test-mode --track=geonames " \
                    "--challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
     run_docker_compose_test(test_command)
 


### PR DESCRIPTION
With this commit we deprecate running Rally without a subcommand. This
makes the user's intention explicit and avoids any leniency in Rally
around subcommand handling. Once a subcommand is required, command line
help can also be improved by only showing command line flags relevant to
a specific subcommand.

Relates #1142