### PR TITLE
Add support for assertions

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -444,6 +444,11 @@ Selects the :doc:`pipeline </pipelines>` that Rally should run.
 
 Rally can autodetect the pipeline in most cases. If you specify ``--distribution-version`` it will auto-select the pipeline ``from-distribution`` otherwise it will use ``from-sources``.
 
+``enable-assertions``
+~~~~~~~~~~~~~~~~~~~~~
+
+This option enables assertions on tasks. If an assertion fails, the race is aborted with a message indicating which assertion has failed.
+
 .. _clr_enable_driver_profiling:
 
 ``enable-driver-profiling``

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -218,7 +218,7 @@ This behavior can also be changed, by invoking Rally with the :ref:`--on-error <
 Errors can also be investigated if you have configured a :doc:`dedicated Elasticsearch metrics store </configuration>`.
 
 Checking Queries and Responses
---------------------------------------------------------------
+------------------------------
 
 As described above, errors can lead to misleading benchmarking results. Some issues, however, are more subtle and the result of queries not behaving and matching as intended.
 
@@ -227,6 +227,7 @@ Consider the following simple Rally operation::
     {
       "name": "geo_distance",
       "operation-type": "search",
+      "detailed-results": true,
       "index": "logs-*",
       "body": {
         "query": {
@@ -295,4 +296,34 @@ The number of hits from queries can also be investigated if you have configured 
 	  "operation" : "scroll",
 	  "operation-type" : "Search"
 	}
+
+Finally, it is also possible to add assertions to an operation::
+
+    {
+      "name": "geo_distance",
+      "operation-type": "search",
+      "detailed-results": true,
+      "index": "logs-*",
+      "assertions": [
+        {
+          "property": "hits",
+          "condition": ">",
+          "value": 0
+        }
+      ],
+      "body": {
+        "query": {
+          "term": {
+            "http.request.method": {
+              "value": "GET"
+            }
+          }
+        }
+      }
+    }
+
+When a benchmark is executed with ``--enable-assertions`` and this query returns no hits, the benchmark is aborted with a message::
+
+    [ERROR] Cannot race. Error in load generator [0]
+        Cannot run task [geo_distance]: Expected [hits] to be > [0] but was [0].
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -579,7 +579,7 @@ Use assertions for sanity checks, e.g. to ensure a query returns results. Assert
 * ``condition``: The following conditions are supported: ``<``, ``<=``, ``==``, ``>=``, ``>=``.
 * ``value``: The expected value.
 
-While assertions are always evaluated and raise an error when they are violated, Rally's default behavior is to only record errors and continue executing the benchmark. To abort on assertion errors, run Rally with ``--on-error=abort``.
+Assertions are disabled by default and can be enabled with the command line flag ``--enable-assertions``. A failing assertion aborts the benchmark.
 
 Example::
 
@@ -607,7 +607,7 @@ Example::
 
     This requires to set ``detailed-results`` to ``true`` so the search operation gathers additional meta-data, such as the number of hits.
 
-If this assertion fails, and Rally is executed with ``--on-error=abort`` it exits with the following error message::
+If assertions are enabled with ``--enable-assertions`` and this assertion fails, it exits with the following error message::
 
     [ERROR] Cannot race. Error in load generator [0]
         Cannot run task [term]: Expected [hits] to be > [0] but was [0].

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1400,9 +1400,9 @@ class AsyncExecutor:
                 if completed:
                     self.logger.info("Task [%s] is considered completed due to external event.", self.task)
                     break
-        except BaseException:
+        except BaseException as e:
             self.logger.exception("Could not execute schedule")
-            raise
+            raise exceptions.RallyError(f"Cannot run task [{self.task}]: {e}") from None
         finally:
             # Actively set it if this task completes its parent
             if task_completes_parent:

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1206,6 +1206,7 @@ class AsyncIoAdapter:
         self.complete = complete
         self.abort_on_error = abort_on_error
         self.profiling_enabled = self.cfg.opts("driver", "profiling")
+        self.assertions_enabled = self.cfg.opts("driver", "assertions")
         self.debug_event_loop = self.cfg.opts("system", "async.debug", mandatory=False, default_value=False)
         self.logger = logging.getLogger(__name__)
 
@@ -1240,6 +1241,9 @@ class AsyncIoAdapter:
         client_count = len(self.task_allocations)
         es = es_clients(self.cfg.opts("client", "hosts").all_hosts,
                         self.cfg.opts("client", "options").with_max_connections(client_count))
+
+        self.logger.info("Task assertions enabled: %s", str(self.assertions_enabled))
+        runner.enable_assertions(self.assertions_enabled)
 
         aws = []
         # A parameter source should only be created once per task - it is partitioned later on per client.

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -109,24 +109,26 @@ def register_runner(operation_type, runner, **kwargs):
         if "__aenter__" in dir(runner) and "__aexit__" in dir(runner):
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("Registering runner object [%s] for [%s].", str(runner), str(operation_type))
-            __RUNNERS[operation_type] = _multi_cluster_runner(runner, str(runner), context_manager_enabled=True)
+            cluster_aware_runner = _multi_cluster_runner(runner, str(runner), context_manager_enabled=True)
         else:
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("Registering context-manager capable runner object [%s] for [%s].", str(runner), str(operation_type))
-            __RUNNERS[operation_type] = _multi_cluster_runner(runner, str(runner))
+            cluster_aware_runner = _multi_cluster_runner(runner, str(runner))
     # we'd rather use callable() but this will erroneously also classify a class as callable...
     elif isinstance(runner, types.FunctionType):
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Registering runner function [%s] for [%s].", str(runner), str(operation_type))
-        __RUNNERS[operation_type] = _single_cluster_runner(runner, runner.__name__)
+        cluster_aware_runner = _single_cluster_runner(runner, runner.__name__)
     elif "__aenter__" in dir(runner) and "__aexit__" in dir(runner):
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Registering context-manager capable runner object [%s] for [%s].", str(runner), str(operation_type))
-        __RUNNERS[operation_type] = _single_cluster_runner(runner, str(runner), context_manager_enabled=True)
+        cluster_aware_runner = _single_cluster_runner(runner, str(runner), context_manager_enabled=True)
     else:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Registering runner object [%s] for [%s].", str(runner), str(operation_type))
-        __RUNNERS[operation_type] = _single_cluster_runner(runner, str(runner))
+        cluster_aware_runner = _single_cluster_runner(runner, str(runner))
+
+    __RUNNERS[operation_type] = _with_completion(_with_assertions(cluster_aware_runner))
 
 
 # Only intended for unit-testing!
@@ -212,14 +214,16 @@ def unwrap(runner):
 
 def _single_cluster_runner(runnable, name, context_manager_enabled=False):
     # only pass the default ES client
-    delegate = MultiClientRunner(runnable, name, lambda es: es["default"], context_manager_enabled)
-    return _with_completion(delegate)
+    return MultiClientRunner(runnable, name, lambda es: es["default"], context_manager_enabled)
 
 
 def _multi_cluster_runner(runnable, name, context_manager_enabled=False):
     # pass all ES clients
-    delegate = MultiClientRunner(runnable, name, lambda es: es, context_manager_enabled)
-    return _with_completion(delegate)
+    return MultiClientRunner(runnable, name, lambda es: es, context_manager_enabled)
+
+
+def _with_assertions(delegate):
+    return AssertingRunner(delegate)
 
 
 def _with_completion(delegate):
@@ -309,6 +313,67 @@ class MultiClientRunner(Runner, Delegator):
             return await self.delegate.__aexit__(exc_type, exc_val, exc_tb)
         else:
             return False
+
+
+class AssertingRunner(Runner, Delegator):
+    def __init__(self, delegate):
+        super().__init__(delegate=delegate)
+        self.predicates = {
+            ">": self.greater_than,
+            ">=": self.greater_than_or_equal,
+            "<": self.smaller_than,
+            "<=": self.smaller_than_or_equal,
+            "==": self.equal,
+        }
+
+    def greater_than(self, expected, actual):
+        return actual > expected
+
+    def greater_than_or_equal(self, expected, actual):
+        return actual >= expected
+
+    def smaller_than(self, expected, actual):
+        return actual < expected
+
+    def smaller_than_or_equal(self, expected, actual):
+        return actual <= expected
+
+    def equal(self, expected, actual):
+        return actual == expected
+
+    def check_assertion(self, assertion, properties):
+        path = assertion["property"]
+        predicate_name = assertion["condition"]
+        expected_value = assertion["value"]
+        actual_value = properties
+        for k in path.split("."):
+            actual_value = actual_value[k]
+        predicate = self.predicates[predicate_name]
+        success = predicate(expected_value, actual_value)
+        if not success:
+            raise exceptions.RallyAssertionError(
+                f"Expected [{path}] to be {predicate_name} [{expected_value}] but was [{actual_value}].")
+
+    async def __call__(self, *args):
+        params = args[1]
+        return_value = await self.delegate(*args)
+        if "assertions" in params:
+            if isinstance(return_value, dict):
+                for assertion in params["assertions"]:
+                    self.check_assertion(assertion, return_value)
+            else:
+                self.logger.debug("Skipping assertion check as [%s] does not return a dict.", repr(self.delegate))
+        return return_value
+
+    def __repr__(self, *args, **kwargs):
+        return repr(self.delegate)
+
+    async def __aenter__(self):
+        await self.delegate.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return await self.delegate.__aexit__(exc_type, exc_val, exc_tb)
 
 
 def mandatory(params, key, op):
@@ -853,7 +918,10 @@ class Query(Runner):
 
     async def request_body_query(self, es, params):
         request_params, headers = self._transport_request_params(params)
-        index = params.get("index", "_all")
+        # Mandatory to ensure it is always provided. This is especially important when this runner is used in a
+        # composite context where there is no actual parameter source and the entire request structure must be provided
+        # by the composite's parameter source.
+        index = mandatory(params, "index", self)
         body = mandatory(params, "body", self)
         doc_type = params.get("type")
         detailed_results = params.get("detailed-results", False)
@@ -921,7 +989,10 @@ class Query(Runner):
         try:
             for page in range(total_pages):
                 if page == 0:
-                    index = params.get("index", "_all")
+                    # Mandatory to ensure it is always provided. This is especially important when this runner is used
+                    # in a composite context where there is no actual parameter source and the entire request structure
+                    # must be provided by the composite's parameter source.
+                    index = mandatory(params, "index", self)
                     body = mandatory(params, "body", self)
                     sort = "_doc"
                     scroll = "10s"
@@ -2042,15 +2113,26 @@ class GetAsyncSearch(Runner):
         success = True
         searches = mandatory(params, "retrieve-results-for", self)
         request_params = params.get("request-params", {})
-        for search_id, _ in async_search_ids(searches):
+        stats = {}
+        for search_id, search in async_search_ids(searches):
             response = await es.async_search.get(id=search_id,
                                                  params=request_params)
-            success = success and not response["is_running"]
+            is_running = response["is_running"]
+            success = success and not is_running
+            if not is_running:
+                stats[search] = {
+                    "hits": response["response"]["hits"]["total"]["value"],
+                    "hits_relation": response["response"]["hits"]["total"]["relation"],
+                    "timed_out": response["response"]["timed_out"],
+                    "took": response["response"]["took"]
+                }
 
         return {
-            "weight": len(searches),
+            # only count completed searches - there is one key per search id in `stats`
+            "weight": len(stats),
             "unit": "ops",
-            "success": success
+            "success": success,
+            "stats": stats
         }
 
     def __repr__(self, *args, **kwargs):
@@ -2119,6 +2201,7 @@ class Composite(Runner):
         self.supported_op_types = [
             "raw-request",
             "sleep",
+            "search",
             "submit-async-search",
             "get-async-search",
             "delete-async-search"

--- a/esrally/exceptions.py
+++ b/esrally/exceptions.py
@@ -29,6 +29,9 @@ class RallyError(Exception):
     def __repr__(self):
         return self.message
 
+    def __str__(self):
+        return self.message
+
 
 class LaunchError(RallyError):
     """

--- a/esrally/exceptions.py
+++ b/esrally/exceptions.py
@@ -51,6 +51,12 @@ class RallyAssertionError(RallyError):
     """
 
 
+class RallyTaskAssertionError(RallyAssertionError):
+    """
+    Thrown when an assertion on a task has been violated.
+    """
+
+
 class ConfigError(RallyError):
     pass
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -536,6 +536,11 @@ def create_arg_parser():
             help="Enables a profiler for analyzing the performance of calls in Rally's driver (default: false).",
             default=False,
             action="store_true")
+        p.add_argument(
+            "--enable-assertions",
+            help="Enables assertion checks for tasks (default: false).",
+            default=False,
+            action="store_true")
 
     ###############################################################################
     #
@@ -896,6 +901,7 @@ def main():
         cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
 
     cfg.add(config.Scope.applicationOverride, "driver", "profiling", args.enable_driver_profiling)
+    cfg.add(config.Scope.applicationOverride, "driver", "assertions", args.enable_assertions)
     cfg.add(config.Scope.applicationOverride, "driver", "on.error", args.on_error)
     cfg.add(config.Scope.applicationOverride, "driver", "load_driver_hosts", opts.csv_to_list(args.load_driver_hosts))
     if sub_command not in ("list", "install", "download"):

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -518,6 +518,11 @@ class SearchParamSource(ParamSource):
         if results_per_page:
             self.query_params["results-per-page"] = results_per_page
         if "assertions" in params:
+            if not detailed_results:
+                # for scroll queries the value does not matter because detailed results are always retrieved.
+                is_scroll_query = pages and results_per_page
+                if not is_scroll_query:
+                    raise exceptions.InvalidSyntax("The property [detailed-results] must be [true] if assertions are defined")
             self.query_params["assertions"] = params["assertions"]
 
         # Ensure we pass global parameters

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -492,6 +492,7 @@ class SearchParamSource(ParamSource):
                 raise exceptions.InvalidSyntax(
                     f"'type' not supported with 'data-stream' for operation '{kwargs.get('operation_name')}'")
         request_cache = params.get("cache", None)
+        detailed_results = params.get("detailed-results", False)
         query_body = params.get("body", None)
         pages = params.get("pages", None)
         results_per_page = params.get("results-per-page", None)
@@ -502,6 +503,7 @@ class SearchParamSource(ParamSource):
             "index": target_name,
             "type": type_name,
             "cache": request_cache,
+            "detailed-results": detailed_results,
             "request-params": request_params,
             "response-compression-enabled": response_compression_enabled,
             "body": query_body
@@ -515,23 +517,11 @@ class SearchParamSource(ParamSource):
             self.query_params["pages"] = pages
         if results_per_page:
             self.query_params["results-per-page"] = results_per_page
+        if "assertions" in params:
+            self.query_params["assertions"] = params["assertions"]
 
         # Ensure we pass global parameters
         self.query_params.update(self._client_params())
-
-    def get_from_dict(self, d, path):
-        v = d
-        for k in path:
-            v = v[k]
-        return v
-
-    def set_in_dict(self, d, path, val):
-        v = d
-        # navigate to the next to last path
-        for k in path[:-1]:
-            v = v[k]
-        # the value is now the inner-most dictionary and the last path element is its key
-        v[path[-1]] = val
 
     def params(self):
         return self.query_params

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -87,7 +87,7 @@ def race(cfg, command_line):
     This method should be used for rally invocations of the race command.
     It sets up some defaults for how the integration tests expect to run races.
     """
-    return esrally(cfg, f"race {command_line} --on-error='abort'")
+    return esrally(cfg, f"race {command_line} --on-error='abort' --enable-assertions")
 
 
 def wait_until_port_is_free(port_number=39200, timeout=120):

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1373,7 +1373,9 @@ class AsyncExecutorTests(TestCase):
     @run_async
     async def test_execute_schedule_aborts_on_error(self, es):
         class ExpectedUnitTestException(Exception):
-            pass
+
+            def __str__(self):
+                return "expected unit test exception"
 
         def run(*args, **kwargs):
             raise ExpectedUnitTestException()
@@ -1410,7 +1412,7 @@ class AsyncExecutorTests(TestCase):
                                                 complete=complete,
                                                 on_error="continue")
 
-        with self.assertRaises(ExpectedUnitTestException):
+        with self.assertRaisesRegex(exceptions.RallyError, r"Cannot run task \[no-op\]: expected unit test exception"):
             await execute_schedule()
 
         self.assertEqual(0, es.call_count)

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -490,7 +490,7 @@ class ElasticsearchSourceSupplierTests(TestCase):
                                                   builder=builder,
                                                   template_renderer=renderer)
         with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    "Car \"default\" requires config key \"system.build_command\"."):
+                                    "Car \"default\" requires config key \"system.build_command\""):
             es.prepare()
 
         self.assertEqual(0, builder.build.call_count)

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2249,6 +2249,26 @@ class SearchParamSourceTests(TestCase):
         self.assertEqual("'type' not supported with 'data-stream' for operation 'test_operation'",
                          ctx.exception.args[0])
 
+    def test_assertions_without_detailed_results_are_invalid(self):
+        index1 = track.Index(name="index1", types=["type1"])
+        with self.assertRaisesRegex(exceptions.InvalidSyntax,
+                                    r"The property \[detailed-results\] must be \[true\] if assertions are defined"):
+            params.SearchParamSource(track=track.Track(name="unit-test", indices=[index1]), params={
+                "index": "_all",
+                # unset!
+                #"detailed-results": True,
+                "assertions": [{
+                    "property": "hits",
+                    "condition": ">",
+                    "value": 0
+                }],
+                "body": {
+                    "query": {
+                        "match_all": {}
+                    }
+                }
+            })
+
 
 class ForceMergeParamSourceTests(TestCase):
     def test_force_merge_index_from_track(self):

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2061,15 +2061,17 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(9, len(p))
+        self.assertEqual(10, len(p))
         self.assertEqual("index1", p["index"])
         self.assertIsNone(p["type"])
         self.assertIsNone(p["request-timeout"])
         self.assertIsNone(p["opaque-id"])
         self.assertDictEqual({"header1": "value1"}, p["headers"])
         self.assertEqual({}, p["request-params"])
+        # Explicitly check in these tests for equality - assertFalse would also succeed if it is `None`.
         self.assertEqual(True, p["cache"])
         self.assertEqual(True, p["response-compression-enabled"])
+        self.assertEqual(False, p["detailed-results"])
         self.assertEqual({
             "query": {
                 "match_all": {}
@@ -2095,7 +2097,7 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(9, len(p))
+        self.assertEqual(10, len(p))
         self.assertEqual("data-stream-1", p["index"])
         self.assertIsNone(p["type"])
         self.assertEqual(1.0, p["request-timeout"])
@@ -2107,6 +2109,7 @@ class SearchParamSourceTests(TestCase):
         self.assertEqual({}, p["request-params"])
         self.assertEqual(True, p["cache"])
         self.assertEqual(True, p["response-compression-enabled"])
+        self.assertEqual(False, p["detailed-results"])
         self.assertEqual({
             "query": {
                 "match_all": {}
@@ -2141,7 +2144,7 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(9, len(p))
+        self.assertEqual(10, len(p))
         self.assertEqual("index1", p["index"])
         self.assertIsNone(p["type"])
         self.assertIsNone(p["request-timeout"])
@@ -2152,6 +2155,7 @@ class SearchParamSourceTests(TestCase):
         }, p["request-params"])
         self.assertIsNone(p["cache"])
         self.assertEqual(True, p["response-compression-enabled"])
+        self.assertEqual(False, p["detailed-results"])
         self.assertEqual({
             "query": {
                 "match_all": {}
@@ -2166,6 +2170,7 @@ class SearchParamSourceTests(TestCase):
             "type": "type1",
             "cache": False,
             "response-compression-enabled": False,
+            "detailed-results": True,
             "opaque-id": "12345abcde",
             "body": {
                 "query": {
@@ -2175,7 +2180,7 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(9, len(p))
+        self.assertEqual(10, len(p))
         self.assertEqual("_all", p["index"])
         self.assertEqual("type1", p["type"])
         self.assertDictEqual({}, p["request-params"])
@@ -2185,6 +2190,7 @@ class SearchParamSourceTests(TestCase):
         # Explicitly check for equality to `False` - assertFalse would also succeed if it is `None`.
         self.assertEqual(False, p["cache"])
         self.assertEqual(False, p["response-compression-enabled"])
+        self.assertEqual(True, p["detailed-results"])
         self.assertEqual({
             "query": {
                 "match_all": {}
@@ -2207,7 +2213,7 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(9, len(p))
+        self.assertEqual(10, len(p))
         self.assertEqual("data-stream-2", p["index"])
         self.assertIsNone(p["type"])
         self.assertEqual(1.0, p["request-timeout"])
@@ -2217,6 +2223,7 @@ class SearchParamSourceTests(TestCase):
         # Explicitly check for equality to `False` - assertFalse would also succeed if it is `None`.
         self.assertEqual(False, p["cache"])
         self.assertEqual(False, p["response-compression-enabled"])
+        self.assertEqual(False, p["detailed-results"])
         self.assertEqual({
             "query": {
                 "match_all": {}


### PR DESCRIPTION
With this commit we add a new `assertions` property for operations. When
this property is present and assertions are enabled with `--enable-assertions`,
Rally checks all assertions and raises an error if the check fails.