### PR TITLE
Require unit for bulk operations

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,16 @@
 Migration Guide
 ===============
 
+Migrating to Rally 2.1.0
+------------------------
+
+Custom bulk parameter sources need to provide a unit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Previously, Rally has implicitly used the unit ``docs`` for bulk operations. With this release, custom parameter sources for bulk operations need to provide also a ``unit`` property or benchmarks will fail with::
+
+    esrally.exceptions.DataError: Parameter source for operation 'bulk-index' did not provide the mandatory parameter 'unit'. Add it to your parameter source and try again.
+
 Migrating to Rally 2.0.4
 ------------------------
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -424,10 +424,6 @@ class BulkIndex(Runner):
     Bulk indexes the given documents.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.first_request = True
-
     async def __call__(self, es, params):
         """
         Runs one bulk indexing operation.
@@ -596,14 +592,7 @@ class BulkIndex(Runner):
 
         with_action_metadata = mandatory(params, "action-metadata-present", self)
         bulk_size = mandatory(params, "bulk-size", self)
-        # TODO: Remove this bwc-layer and turn "unit" into a mandatory parameter
-        # unit = mandatory(params, "unit", self)
-        if self.first_request:
-            self.first_request = False
-            if "unit" not in params:
-                self.logger.warning("Specify the mandatory parameter [unit] in the bulk parameter source. "
-                                    "Otherwise this track will fail with the next Rally version.")
-        unit = params.get("unit", "docs")
+        unit = mandatory(params, "unit", self)
         # parse responses lazily in the standard case - responses might be large thus parsing skews results and if no
         # errors have occurred we only need a small amount of information from the potentially large response.
         if not detailed_results:

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1091,6 +1091,7 @@ class AsyncExecutorTests(TestCase):
                                                             "body": ["action_metadata_line", "index_line"],
                                                             "action-metadata-present": True,
                                                             "bulk-size": 1,
+                                                            "unit": "docs",
                                                             # we need this because DriverTestParamSource does not know
                                                             # that we only have one bulk and hence size() returns
                                                             # incorrect results

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -383,7 +383,8 @@ class BulkIndexRunnerTests(TestCase):
                     "action_meta_data\n" +
                     "index_line\n",
             "action-metadata-present": True,
-            "bulk-size": 3
+            "bulk-size": 3,
+            "unit": "docs"
         }
 
         result = await bulk(es, bulk_params)
@@ -419,7 +420,8 @@ class BulkIndexRunnerTests(TestCase):
             "request-timeout": 3.0,
             "headers": { "x-test-id": "1234"},
             "opaque-id": "DESIRED-OPAQUE-ID",
-            "bulk-size": 3
+            "bulk-size": 3,
+            "unit": "docs"
         }
 
         result = await bulk(es, bulk_params)
@@ -455,6 +457,7 @@ class BulkIndexRunnerTests(TestCase):
                     "index_line\n",
             "action-metadata-present": False,
             "bulk-size": 3,
+            "unit": "docs",
             "index": "test-index",
             "type": "_doc"
         }
@@ -487,6 +490,7 @@ class BulkIndexRunnerTests(TestCase):
                     "index_line\n",
             "action-metadata-present": False,
             "bulk-size": 3,
+            "unit": "docs",
             "index": "test-index"
         }
 


### PR DESCRIPTION
With this commit we remove the deprecated logic to automatically set a
unit for bulk operations when the parameter source does not provide one.
Note that this only affects custom parameter sources because Rally's
default bulk parameter source will provide this parameter.

Relates #1100