### PR TITLE
Add request-id to search operator

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -904,7 +904,8 @@ class Query(Runner):
     * `pages`: Number of pages to retrieve at most for this scroll. If a scroll query does yield less results than the specified number of
                pages we will terminate earlier.
     * `results-per-page`: Number of results to retrieve per page.
-    * `request-id`: a user specified string identifying the query. This will be included in rally metrics to allow query execution to be tracked.
+    * `request-id`: a user specified string identifying the query. This will be included in rally metrics to allow query
+                execution to be tracked.
 
     Returned meta data
 
@@ -962,8 +963,7 @@ class Query(Runner):
         stats = {
                 "weight": 1,
                 "unit": "ops",
-                "success": True,
-                "request_id": request_id
+                "success": True
         }
         if request_id:
             stats["request_id"] = request_id

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -904,8 +904,7 @@ class Query(Runner):
     * `pages`: Number of pages to retrieve at most for this scroll. If a scroll query does yield less results than the specified number of
                pages we will terminate earlier.
     * `results-per-page`: Number of results to retrieve per page.
-    * `request-id`: a user specified string identifying the query. This will be included in rally metrics to allow query
-                execution to be tracked.
+    * `request-id`: a user specified string identifying the query. This will be included in rally metrics to allow query execution to be tracked.
 
     Returned meta data
 

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -493,6 +493,7 @@ class SearchParamSource(ParamSource):
                     f"'type' not supported with 'data-stream' for operation '{kwargs.get('operation_name')}'")
         request_cache = params.get("cache", None)
         detailed_results = params.get("detailed-results", False)
+        request_id = params.get("request-id", None)
         query_body = params.get("body", None)
         pages = params.get("pages", None)
         results_per_page = params.get("results-per-page", None)
@@ -512,7 +513,8 @@ class SearchParamSource(ParamSource):
         if not target_name:
             raise exceptions.InvalidSyntax(
                 f"'index' or 'data-stream' is mandatory and is missing for operation '{kwargs.get('operation_name')}'")
-
+        if request_id:
+            self.query_params["request-id"] = request_id
         if pages:
             self.query_params["pages"] = pages
         if results_per_page:

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1498,6 +1498,7 @@ class QueryRunnerTests(TestCase):
             "index": "_all",
             "cache": False,
             "detailed-results": True,
+            "request-id": "user-specified-id",
             "body": None,
             "request-params": {
                 "q": "user:kimchy"
@@ -1514,6 +1515,7 @@ class QueryRunnerTests(TestCase):
         self.assertFalse(result["timed_out"])
         self.assertEqual(62, result["took"])
         self.assertFalse("error-type" in result)
+        self.assertEqual("user-specified-id", result["request_id"])
 
         es.transport.perform_request.assert_called_once_with(
             "GET",
@@ -1558,7 +1560,8 @@ class QueryRunnerTests(TestCase):
             "request-params": {
                 "q": "user:kimchy"
             },
-            "detailed-results": False
+            "detailed-results": False,
+            "request-id": "user-specified-id"
         }
 
         async with query_runner:
@@ -1571,6 +1574,7 @@ class QueryRunnerTests(TestCase):
         self.assertNotIn("timed_out", result)
         self.assertNotIn("took", result)
         self.assertNotIn("error-type", result)
+        self.assertEqual("user-specified-id", result["request_id"])
 
         es.transport.perform_request.assert_called_once_with(
             "GET",

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2133,6 +2133,7 @@ class SearchParamSourceTests(TestCase):
         index1 = track.Index(name="index1", types=["type1"])
 
         source = params.SearchParamSource(track=track.Track(name="unit-test", indices=[index1]), params={
+            "request-id": "user-specified-id",
             "request-params": {
                 "_source_include": "some_field"
             },
@@ -2144,7 +2145,7 @@ class SearchParamSourceTests(TestCase):
         })
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
         self.assertEqual("index1", p["index"])
         self.assertIsNone(p["type"])
         self.assertIsNone(p["request-timeout"])
@@ -2161,6 +2162,7 @@ class SearchParamSourceTests(TestCase):
                 "match_all": {}
             }
         }, p["body"])
+        self.assertEqual("user-specified-id", p["request-id"])
 
     def test_user_specified_overrides_defaults(self):
         index1 = track.Index(name="index1", types=["type1"])


### PR DESCRIPTION
This allows a user to specify a request-id to a search operator. This will be passed down to the runner from the parameter source and include in metrics if specified. @danielmitterdorfer if you're happy with this approach ill push docs.