### PR TITLE
Improve isolation in race control tests

### DIFF
--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -16,79 +16,93 @@
 # under the License.
 
 import os
+import re
 import unittest.mock as mock
-from unittest import TestCase
+
+import pytest
 
 from esrally import config, exceptions, racecontrol
 
 
-class RaceControlTests(TestCase):
-    def test_finds_available_pipelines(self):
-        expected = [
-            ["from-sources", "Builds and provisions Elasticsearch, runs a benchmark and reports results."],
-            ["from-sources-complete", "Builds and provisions Elasticsearch, runs a benchmark and reports results [deprecated]."],
-            ["from-sources-skip-build", "Provisions Elasticsearch (skips the build), runs a benchmark and reports results [deprecated]."],
-            ["from-distribution", "Downloads an Elasticsearch distribution, provisions it, runs a benchmark and reports results."],
-            ["benchmark-only", "Assumes an already running Elasticsearch instance, runs a benchmark and reports results"],
-        ]
+@pytest.fixture
+def running_in_docker():
+    os.environ["RALLY_RUNNING_IN_DOCKER"] = "true"
+    # just yield anything to signal the fixture is ready
+    yield True
+    del os.environ["RALLY_RUNNING_IN_DOCKER"]
 
-        self.assertEqual(expected, racecontrol.available_pipelines())
 
-    def test_prevents_running_an_unknown_pipeline(self):
-        cfg = config.Config()
-        cfg.add(config.Scope.benchmark, "race", "pipeline", "invalid")
-        cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "5.0.0")
+@pytest.fixture
+def benchmark_only_pipeline():
+    test_pipeline_name = "benchmark-only"
+    original = racecontrol.pipelines[test_pipeline_name]
+    pipeline = racecontrol.Pipeline(test_pipeline_name, "Pipeline intended for unit-testing", mock.Mock())
+    yield pipeline
+    # restore prior pipeline!
+    racecontrol.pipelines[test_pipeline_name] = original
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            racecontrol.run(cfg)
-        self.assertRegex(ctx.exception.args[0], r"Unknown pipeline \[invalid\]. List the available pipelines with [\S]+? list pipelines.")
 
-    @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": "true"})
-    def test_passes_benchmark_only_pipeline_in_docker(self):
-        mock_pipeline = mock.Mock()
-        test_pipeline_name = "benchmark-only"
-        racecontrol.Pipeline("benchmark-only", "Mocked benchmark-only pipeline for unittest", mock_pipeline)
-        cfg = config.Config()
-        cfg.add(config.Scope.benchmark, "race", "pipeline", "benchmark-only")
+@pytest.fixture
+def unittest_pipeline():
+    pipeline = racecontrol.Pipeline("unit-test-pipeline", "Pipeline intended for unit-testing", mock.Mock())
+    yield pipeline
+    del racecontrol.pipelines[pipeline.name]
 
+
+def test_finds_available_pipelines():
+    expected = [
+        ["from-sources", "Builds and provisions Elasticsearch, runs a benchmark and reports results."],
+        ["from-sources-complete",
+         "Builds and provisions Elasticsearch, runs a benchmark and reports results [deprecated]."],
+        ["from-sources-skip-build",
+         "Provisions Elasticsearch (skips the build), runs a benchmark and reports results [deprecated]."],
+        ["from-distribution",
+         "Downloads an Elasticsearch distribution, provisions it, runs a benchmark and reports results."],
+        ["benchmark-only", "Assumes an already running Elasticsearch instance, runs a benchmark and reports results"],
+    ]
+
+    assert expected == racecontrol.available_pipelines()
+
+
+def test_prevents_running_an_unknown_pipeline():
+    cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "race", "pipeline", "invalid")
+    cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "5.0.0")
+
+    with pytest.raises(exceptions.SystemSetupError) as ex:
         racecontrol.run(cfg)
 
-        mock_pipeline.assert_called_once_with(cfg)
+    assert re.match(r"Unknown pipeline \[invalid]. List the available pipelines with [\S]+? list pipelines.",
+                    ex.value.message)
 
-        del racecontrol.pipelines[test_pipeline_name]
 
-    @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": "true"})
-    def test_fails_without_benchmark_only_pipeline_in_docker(self):
-        mock_pipeline = mock.Mock()
-        test_pipeline_name = "unit-test-pipeline"
-        racecontrol.Pipeline("unit-test-pipeline", "Pipeline intended for unit-testing", mock_pipeline)
-        cfg = config.Config()
-        cfg.add(config.Scope.benchmark, "race", "pipeline", "unit-test-pipeline")
+def test_passes_benchmark_only_pipeline_in_docker(running_in_docker, benchmark_only_pipeline):
+    cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "race", "pipeline", "benchmark-only")
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            racecontrol.run(cfg)
+    racecontrol.run(cfg)
 
-        self.assertEqual(
-            "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n"
-            "Add --pipeline=benchmark-only in your Rally arguments and try again.\n"
-            "For more details read the docs for the benchmark-only pipeline in "
-            "https://esrally.readthedocs.io/en/latest/pipelines.html#benchmark-only\n",
-            ctx.exception.args[0])
-        del racecontrol.pipelines[test_pipeline_name]
+    benchmark_only_pipeline.target.assert_called_once_with(cfg)
 
-    def test_runs_a_known_pipeline(self):
-        mock_pipeline = mock.Mock()
-        test_pipeline_name = "unit-test-pipeline"
 
-        racecontrol.Pipeline("unit-test-pipeline", "Pipeline intended for unit-testing", mock_pipeline)
+def test_fails_without_benchmark_only_pipeline_in_docker(running_in_docker, unittest_pipeline):
+    cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "race", "pipeline", "unit-test-pipeline")
 
-        cfg = config.Config()
-        cfg.add(config.Scope.benchmark, "race", "pipeline", "unit-test-pipeline")
-        cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "")
-
+    with pytest.raises(exceptions.SystemSetupError) as ex:
         racecontrol.run(cfg)
 
-        mock_pipeline.assert_called_once_with(cfg)
+    assert ex.value.message == "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n" \
+                               "Add --pipeline=benchmark-only in your Rally arguments and try again.\n" \
+                               "For more details read the docs for the benchmark-only pipeline in " \
+                               "https://esrally.readthedocs.io/en/latest/pipelines.html#benchmark-only\n"
 
-        # ensure we remove it again from the list of registered pipelines to avoid unwanted side effects
-        del racecontrol.pipelines[test_pipeline_name]
+
+def test_runs_a_known_pipeline(unittest_pipeline):
+    cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "race", "pipeline", "unit-test-pipeline")
+    cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "")
+
+    racecontrol.run(cfg)
+
+    unittest_pipeline.target.assert_called_once_with(cfg)

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -69,11 +69,10 @@ def test_prevents_running_an_unknown_pipeline():
     cfg.add(config.Scope.benchmark, "race", "pipeline", "invalid")
     cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "5.0.0")
 
-    with pytest.raises(exceptions.SystemSetupError) as ex:
+    with pytest.raises(
+            exceptions.SystemSetupError,
+            match=r"Unknown pipeline \[invalid]. List the available pipelines with [\S]+? list pipelines."):
         racecontrol.run(cfg)
-
-    assert re.match(r"Unknown pipeline \[invalid]. List the available pipelines with [\S]+? list pipelines.",
-                    ex.value.message)
 
 
 def test_passes_benchmark_only_pipeline_in_docker(running_in_docker, benchmark_only_pipeline):
@@ -89,13 +88,15 @@ def test_fails_without_benchmark_only_pipeline_in_docker(running_in_docker, unit
     cfg = config.Config()
     cfg.add(config.Scope.benchmark, "race", "pipeline", "unit-test-pipeline")
 
-    with pytest.raises(exceptions.SystemSetupError) as ex:
+    with pytest.raises(
+            exceptions.SystemSetupError,
+            match=re.escape(
+                "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n"
+                "Add --pipeline=benchmark-only in your Rally arguments and try again.\n"
+                "For more details read the docs for the benchmark-only pipeline in "
+                "https://esrally.readthedocs.io/en/latest/pipelines.html#benchmark-only\n"
+            )):
         racecontrol.run(cfg)
-
-    assert ex.value.message == "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n" \
-                               "Add --pipeline=benchmark-only in your Rally arguments and try again.\n" \
-                               "For more details read the docs for the benchmark-only pipeline in " \
-                               "https://esrally.readthedocs.io/en/latest/pipelines.html#benchmark-only\n"
 
 
 def test_runs_a_known_pipeline(unittest_pipeline):


### PR DESCRIPTION
With this commit we rely on pytest fixtures for proper cleanup even when
a test case fails. Previously, cleanup was only working when a test
succeeded leading to unwanted side-effects between tests.