### PR TITLE
Always require a subcommand

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Run your first race
 
 Now we're ready to run our first race::
 
-    esrally race --distribution-version=6.0.0
+    esrally race --distribution-version=6.0.0 --track=geonames
 
 This will download Elasticsearch 6.0.0 and run Rally's default track - the `geonames track <https://github.com/elastic/rally-tracks/tree/master/geonames>`_ - against it. After the race, a summary report is written to the command line:::
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -186,7 +186,7 @@ Selects a specific revision in the track repository. By default, Rally will choo
 ``track``
 ~~~~~~~~~
 
-Selects the track that Rally should run. By default the ``geonames`` track is run. For more details on how tracks work, see :doc:`adding tracks </adding_tracks>` or the :doc:`track reference </track>`. ``--track-path`` and ``--track-repository`` as well as ``--track`` are mutually exclusive.
+Selects the track that Rally should run. For more details on how tracks work, see :doc:`adding tracks </adding_tracks>` or the :doc:`track reference </track>`. ``--track-path`` and ``--track-repository`` as well as ``--track`` are mutually exclusive.
 
 .. _clr_track_params:
 
@@ -396,7 +396,7 @@ A :doc:`car </car>` defines the Elasticsearch configuration that will be used fo
 
  ::
 
-   esrally race --car="4gheap,ea"
+   esrally race --track=geonames --car="4gheap,ea"
 
 
 Rally will configure Elasticsearch with 4GB of heap (``4gheap``) and enable Java assertions (``ea``).
@@ -410,7 +410,7 @@ Allows to override config variables of Elasticsearch. It accepts a list of comma
 
  ::
 
-   esrally race --car="4gheap" --car-params="data_paths:'/opt/elasticsearch'"
+   esrally race --track=geonames --car="4gheap" --car-params="data_paths:'/opt/elasticsearch'"
 
 The variables that are exposed depend on the `car's configuration <https://github.com/elastic/rally-teams/tree/master/cars>`__. In addition, Rally implements special handling for the variable ``data_paths`` (by default the value for this variable is determined by Rally).
 
@@ -422,7 +422,7 @@ A comma-separated list of Elasticsearch plugins to install for the benchmark. If
 
 Example::
 
-   esrally race --elasticsearch-plugins="analysis-icu,xpack:security"
+   esrally race --track=geonames --elasticsearch-plugins="analysis-icu,xpack:security"
 
 In this example, Rally will install the ``analysis-icu`` plugin and the ``x-pack`` plugin with the ``security`` configuration. See the reference documentation about :doc:`Elasticsearch plugins </elasticsearch_plugins>` for more details.
 
@@ -433,7 +433,7 @@ Allows to override variables of Elasticsearch plugins. It accepts a list of comm
 
 Example::
 
-    esrally race --distribution-version=6.1.1. --elasticsearch-plugins="x-pack:monitoring-http" --plugin-params="monitoring_type:'https',monitoring_host:'some_remote_host',monitoring_port:10200,monitoring_user:'rally',monitoring_password:'m0n1t0r1ng'"
+    esrally race --track=geonames --distribution-version=6.1.1. --elasticsearch-plugins="x-pack:monitoring-http" --plugin-params="monitoring_type:'https',monitoring_host:'some_remote_host',monitoring_port:10200,monitoring_user:'rally',monitoring_password:'m0n1t0r1ng'"
 
 This enables the HTTP exporter of `X-Pack Monitoring <https://www.elastic.co/products/x-pack/monitoring>`_ and exports the data to the configured monitoring host.
 
@@ -496,7 +496,7 @@ Activates the provided :doc:`telemetry devices </telemetry>` for this race.
 
  ::
 
-   esrally race --telemetry=jfr,jit
+   esrally race --track=geonames --telemetry=jfr,jit
 
 
 This activates Java flight recorder and the JIT compiler telemetry devices.
@@ -510,7 +510,7 @@ Allows to set parameters for telemetry devices. It accepts a list of comma-separ
 
 Example::
 
-    esrally race --telemetry=jfr --telemetry-params="recording-template:'profile'"
+    esrally race --track=geonames --telemetry=jfr --telemetry-params="recording-template:'profile'"
 
 This enables the Java flight recorder telemetry device and sets the ``recording-template`` parameter to "profile".
 
@@ -523,7 +523,7 @@ For more complex cases specify a JSON file. Store the following as ``telemetry-p
 
 and reference it when running Rally::
 
-   esrally race --telemetry="node-stats" --telemetry-params="telemetry-params.json"
+   esrally race --track=geonames --telemetry="node-stats" --telemetry-params="telemetry-params.json"
 
 
 ``runtime-jdk``
@@ -536,9 +536,9 @@ This command line parameter sets the major version of the JDK that Rally should 
 Example::
 
    # Run a benchmark with defaults (i.e. JDK 8)
-   esrally race --distribution-version=5.0.0
+   esrally race --track=geonames --distribution-version=5.0.0
    # Force to run with JDK 11
-   esrally race --distribution-version=7.0.0 --runtime-jdk=11
+   esrally race --track=geonames --distribution-version=7.0.0 --runtime-jdk=11
 
 It is also possible to specify the JDK that is bundled with Elasticsearch with the special value ``bundled``. The `JDK is bundled from Elasticsearch 7.0.0 onwards <https://www.elastic.co/guide/en/elasticsearch/reference/current/release-highlights-7.0.0.html#_bundle_jdk_in_elasticsearch_distribution>`_.
 
@@ -580,7 +580,7 @@ If you want Rally to launch and benchmark a cluster using a binary distribution,
 
  ::
 
-   esrally race --distribution-version=7.0.0
+   esrally race --track=geonames --distribution-version=7.0.0
 
 
 Rally will then benchmark the official Elasticsearch 7.0.0 distribution. Please check our :doc:`version support page </versions>` to see which Elasticsearch versions are currently supported by Rally.
@@ -603,7 +603,7 @@ The ``url`` property defines the URL pattern for this repository. The ``cache`` 
 
 You can use this distribution repository with the name "in_house_snapshot" as follows::
 
-   esrally race --distribution-repository=in_house_snapshot --distribution-version=7.0.0-SNAPSHOT
+   esrally race --track=geonames --distribution-repository=in_house_snapshot --distribution-version=7.0.0-SNAPSHOT
 
 This will benchmark the latest 7.0.0 snapshot build of Elasticsearch.
 
@@ -629,7 +629,7 @@ By default, the command line reporter will print the results only on standard ou
 
  ::
 
-   esrally race --report-format=csv --report-file=~/benchmarks/result.csv
+   esrally race --track=geonames --report-format=csv --report-file=~/benchmarks/result.csv
 
 .. _clr_client_options:
 
@@ -702,7 +702,7 @@ By default, Rally will run its load driver on the same machine where you start t
 
  ::
 
-   esrally race --load-driver-hosts=10.17.20.5,10.17.20.6
+   esrally race --track=geonames --load-driver-hosts=10.17.20.5,10.17.20.6
 
 In the example, above Rally will generate load from the hosts ``10.17.20.5`` and ``10.17.20.6``. For this to work, you need to start a Rally daemon on these machines, see :ref:`distributing the load test driver <recipe_distributed_load_driver>` for a complete example.
 
@@ -715,7 +715,7 @@ If you run the ``benchmark-only`` :doc:`pipeline </pipelines>` or you want Rally
 
  ::
 
-   esrally race --pipeline=benchmark-only --target-hosts=10.17.0.5:9200,10.17.0.6:9200
+   esrally race --track=geonames --pipeline=benchmark-only --target-hosts=10.17.0.5:9200,10.17.0.6:9200
 
 This will run the benchmark against the hosts 10.17.0.5 and 10.17.0.6 on port 9200. See ``client-options`` if you use X-Pack Security and need to authenticate or Rally should use https.
 
@@ -771,7 +771,7 @@ The required format is ``key`` ":" ``value``. You can choose ``key`` and  ``valu
 
  ::
 
-   esrally race --user-tag="intention:github-issue-1234-baseline,gc:cms"
+   esrally race --track=pmc --user-tag="intention:github-issue-1234-baseline,gc:cms"
 
 You can also specify multiple tags. They need to be separated by a comma.
 
@@ -779,7 +779,7 @@ You can also specify multiple tags. They need to be separated by a comma.
 
  ::
 
-   esrally race --user-tag="disk:SSD,data_node_count:4"
+   esrally race --track=pmc --user-tag="disk:SSD,data_node_count:4"
 
 
 

--- a/docs/elasticsearch_plugins.rst
+++ b/docs/elasticsearch_plugins.rst
@@ -44,7 +44,7 @@ In order to tell Rally to install a plugin, use the ``--elasticsearch-plugins`` 
 
 Example::
 
-    esrally race --distribution-version=5.5.0 --elasticsearch-plugins="analysis-icu,analysis-phonetic"
+    esrally race --track=geonames --distribution-version=5.5.0 --elasticsearch-plugins="analysis-icu,analysis-phonetic"
 
 This will install the plugins ``analysis-icu`` and ``analysis-phonetic`` (in that order). In order to use the features that these plugins provide, you need to write a :doc:`custom track </adding_tracks>`.
 
@@ -97,7 +97,7 @@ Let's discuss these properties one by one:
 .. warning::
     ``plugin.my-plugin.build.command`` has replaced ``plugin.my-plugin.build.task`` in earlier Rally versions. It now requires the **full** build command.
 
-In order to run a benchmark with ``my-plugin``, you'd invoke Rally as follows: ``esrally race --revision="elasticsearch:some-elasticsearch-revision,my-plugin:some-plugin-revision" --elasticsearch-plugins="my-plugin"`` where you need to replace ``some-elasticsearch-revision`` and ``some-plugin-revision`` with the appropriate :ref:`git revisions <clr_revision>`. Adjust other command line parameters (like track or car) accordingly. In order for this to work, you need to ensure that:
+In order to run a benchmark with ``my-plugin``, you'd invoke Rally as follows: ``esrally race --track=geonames --revision="elasticsearch:some-elasticsearch-revision,my-plugin:some-plugin-revision" --elasticsearch-plugins="my-plugin"`` where you need to replace ``some-elasticsearch-revision`` and ``some-plugin-revision`` with the appropriate :ref:`git revisions <clr_revision>`. Adjust other command line parameters (like track or car) accordingly. In order for this to work, you need to ensure that:
 
 * All prerequisites for source builds are installed.
 * The Elasticsearch source revision is compatible with the chosen plugin revision. Note that you do not need to know the revision hash to build against an already released version and can use git tags instead. E.g. if you want to benchmark against Elasticsearch 5.6.1, you can specify ``--revision="elasticsearch:v5.6.1,my-plugin:some-plugin-revision"`` (see e.g. the `Elasticsearch tags on Github <https://github.com/elastic/elasticsearch/tags>`_ or use ``git tag`` in the Elasticsearch source directory on the console).
@@ -126,7 +126,7 @@ Let's discuss these properties one by one:
 .. warning::
     ``plugin.my-plugin.build.command`` has replaced ``plugin.my-plugin.build.task`` in earlier Rally versions. It now requires the **full** build command.
 
-In order to run a benchmark with ``my-plugin``, you'd invoke Rally as follows: ``esrally race --distribution-version="elasticsearch-version" --revision="my-plugin:some-plugin-revision" --elasticsearch-plugins="my-plugin"`` where you need to replace ``elasticsearch-version`` with the correct release (e.g. 6.0.0) and ``some-plugin-revision`` with the appropriate :ref:`git revisions <clr_revision>`. Adjust other command line parameters (like track or car) accordingly. In order for this to work, you need to ensure that:
+In order to run a benchmark with ``my-plugin``, you'd invoke Rally as follows: ``esrally race --track=geonames --distribution-version="elasticsearch-version" --revision="my-plugin:some-plugin-revision" --elasticsearch-plugins="my-plugin"`` where you need to replace ``elasticsearch-version`` with the correct release (e.g. 6.0.0) and ``some-plugin-revision`` with the appropriate :ref:`git revisions <clr_revision>`. Adjust other command line parameters (like track or car) accordingly. In order for this to work, you need to ensure that:
 
 * All prerequisites for source builds are installed.
 * The Elasticsearch release is compatible with the chosen plugin revision.
@@ -223,7 +223,7 @@ As ``myplugin`` is not a core plugin, the Elasticsearch plugin manager does not 
     [distributions]
     plugin.myplugin.release.url=https://example.org/myplugin/releases/{{VERSION}}/myplugin-{{VERSION}}.zip
 
-Now you can run benchmarks with the custom Elasticsearch plugin, e.g. with ``esrally race --distribution-version=5.5.0 --elasticsearch-plugins="myplugin:simple"``.
+Now you can run benchmarks with the custom Elasticsearch plugin, e.g. with ``esrally race --track=geonames --distribution-version=5.5.0 --elasticsearch-plugins="myplugin:simple"``.
 
 For this to work you need ensure two things:
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -11,6 +11,18 @@ Previously, Rally has implicitly used the unit ``docs`` for bulk operations. Wit
 
     esrally.exceptions.DataError: Parameter source for operation 'bulk-index' did not provide the mandatory parameter 'unit'. Add it to your parameter source and try again.
 
+Rally requires a subcommand
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Previously a subcommand was optional when running a benchmark. With Rally 2.1.0 a subcommand is always required. So instead of invoking::
+
+    esrally --distribution-version=7.10.0
+
+Invoke Rally with the ``race`` subcommand instead::
+
+    esrally race --distribution-version=7.10.0
+
+
 Migrating to Rally 2.0.4
 ------------------------
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -28,6 +28,18 @@ Invoke Rally with the ``race`` subcommand instead::
     esrally race --distribution-version=7.10.0
 
 
+Running without a track is deprecated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Previously Rally has implicitly chosen the geonames track as default when ``--track`` was not provided. To ensure the workload is chosen deliberately, it is now deprecated to not specify a track. So instead of invoking::
+
+    esrally race --distribution-version=7.10.0
+
+Invoke Rally with ``--track=geonames`` instead::
+
+    esrally race --distribution-version=7.10.0 --track=geonames
+
+
 Migrating to Rally 2.0.4
 ------------------------
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -31,7 +31,7 @@ Invoke Rally with the ``race`` subcommand instead::
 Running without a track is deprecated
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Previously Rally has implicitly chosen the geonames track as default when ``--track`` was not provided. To ensure the workload is chosen deliberately, it is now deprecated to not specify a track. So instead of invoking::
+Previously Rally has implicitly chosen the geonames track as default when ``--track`` was not provided. We want users to make a conscious choice of the workload and not specifying the track explicitly is deprecated (to be removed in Rally 2.2.0). So instead of invoking::
 
     esrally race --distribution-version=7.10.0
 

--- a/docs/pipelines.rst
+++ b/docs/pipelines.rst
@@ -22,7 +22,7 @@ This is intended if you want to provision a cluster by yourself. Do not use this
 
 To benchmark a cluster, you also have to specify the hosts to connect to. An example invocation::
 
-    esrally race --pipeline=benchmark-only --target-hosts=search-node-a.intranet.acme.com:9200,search-node-b.intranet.acme.com:9200
+    esrally race --track=geonames --pipeline=benchmark-only --target-hosts=search-node-a.intranet.acme.com:9200,search-node-b.intranet.acme.com:9200
 
 
 from-distribution
@@ -30,13 +30,13 @@ from-distribution
 
 This pipeline allows to benchmark an official Elasticsearch distribution which will be automatically downloaded by Rally. An example invocation::
 
-    esrally race --pipeline=from-distribution --distribution-version=7.0.0
+    esrally race --track=geonames --pipeline=from-distribution --distribution-version=7.0.0
 
 The version numbers have to match the name in the download URL path.
 
 You can also benchmark Elasticsearch snapshot versions by specifying the snapshot repository::
 
-    esrally race --pipeline=from-distribution --distribution-version=5.0.0-SNAPSHOT --distribution-repository=snapshot
+    esrally race --track=geonames --pipeline=from-distribution --distribution-version=5.0.0-SNAPSHOT --distribution-repository=snapshot
 
 However, this feature is mainly intended for continuous integration environments and by default you should just benchmark official distributions.
 
@@ -53,7 +53,7 @@ You should use this pipeline when you want to build and benchmark Elasticsearch 
 
 Remember that you also need git installed. If that's not the case you'll get an error. An example invocation::
 
-    esrally race --pipeline=from-sources --revision=latest
+    esrally race --track=geonames --pipeline=from-sources --revision=latest
 
 You have to specify a :ref:`revision <clr_revision>`.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,7 +18,7 @@ Run your first race
 
 Now we're ready to run our first :doc:`race </glossary>`::
 
-    esrally race --distribution-version=6.5.3- -track=geonames
+    esrally race --distribution-version=6.5.3 --track=geonames
 
 This will download Elasticsearch 6.5.3 and run the `geonames <https://github.com/elastic/rally-tracks/tree/master/geonames>`_ :doc:`track </glossary>` against it. After the race, a :doc:`summary report </summary_report>` is written to the command line:::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,9 +18,9 @@ Run your first race
 
 Now we're ready to run our first :doc:`race </glossary>`::
 
-    esrally race --distribution-version=6.5.3
+    esrally race --distribution-version=6.5.3- -track=geonames
 
-This will download Elasticsearch 6.5.3 and run Rally's default :doc:`track </glossary>` - the `geonames track <https://github.com/elastic/rally-tracks/tree/master/geonames>`_ - against it. After the race, a :doc:`summary report </summary_report>` is written to the command line:::
+This will download Elasticsearch 6.5.3 and run the `geonames <https://github.com/elastic/rally-tracks/tree/master/geonames>`_ :doc:`track </glossary>` against it. After the race, a :doc:`summary report </summary_report>` is written to the command line:::
 
 
     ------------------------------------------------------

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -84,7 +84,7 @@ To run a benchmark for this scenario follow these steps:
 
 1. :doc:`Install </install>` and :doc:`configure </configuration>` Rally on all machines. Be sure that the same version is installed on all of them and fully :doc:`configured </configuration>`.
 2. Start the :doc:`Rally daemon </rally_daemon>` on each machine. The Rally daemon allows Rally to communicate with all remote machines. On the benchmark coordinator run ``esrallyd start --node-ip=10.5.5.5 --coordinator-ip=10.5.5.5`` and on the benchmark candidate machines run ``esrallyd start --node-ip=10.5.5.10 --coordinator-ip=10.5.5.5`` and ``esrallyd start --node-ip=10.5.5.11 --coordinator-ip=10.5.5.5`` respectively. The ``--node-ip`` parameter tells Rally the IP of the machine on which it is running. As some machines have more than one network interface, Rally will not attempt to auto-detect the machine IP. The ``--coordinator-ip`` parameter tells Rally the IP of the benchmark coordinator node.
-3. Start the benchmark by invoking Rally as usual on the benchmark coordinator, for example: ``esrally race --distribution-version=5.0.0 --target-hosts=10.5.5.10:39200,10.5.5.11:39200``. Rally will derive from the ``--target-hosts``  parameter that it should provision the nodes ``10.5.5.10`` and ``10.5.5.11``.
+3. Start the benchmark by invoking Rally as usual on the benchmark coordinator, for example: ``esrally race --track=pmc --distribution-version=5.0.0 --target-hosts=10.5.5.10:39200,10.5.5.11:39200``. Rally will derive from the ``--target-hosts``  parameter that it should provision the nodes ``10.5.5.10`` and ``10.5.5.11``.
 4. After the benchmark has finished you can stop the Rally daemon again. On the benchmark coordinator and on the benchmark candidates run ``esrallyd stop``.
 
 .. note::
@@ -124,7 +124,7 @@ By default, Rally will generate load on the same machine where you start a bench
 
 1. :doc:`Install </install>` and :doc:`configure </configuration>` Rally on all machines. Be sure that the same version is installed on all of them and fully :doc:`configured </configuration>`.
 2. Start the :doc:`Rally daemon </rally_daemon>` on each machine. The Rally daemon allows Rally to communicate with all remote machines. On the benchmark coordinator run ``esrallyd start --node-ip=10.5.5.5 --coordinator-ip=10.5.5.5`` and on the load driver machines run ``esrallyd start --node-ip=10.5.5.6 --coordinator-ip=10.5.5.5`` and ``esrallyd start --node-ip=10.5.5.7 --coordinator-ip=10.5.5.5`` respectively. The ``--node-ip`` parameter tells Rally the IP of the machine on which it is running. As some machines have more than one network interface, Rally will not attempt to auto-detect the machine IP. The ``--coordinator-ip`` parameter tells Rally the IP of the benchmark coordinator node.
-3. Start the benchmark by invoking Rally on the benchmark coordinator, for example: ``esrally race --pipeline=benchmark-only --load-driver-hosts=10.5.5.6,10.5.5.7 --target-hosts=10.5.5.11:9200,10.5.5.12:9200,10.5.5.13:9200``.
+3. Start the benchmark by invoking Rally on the benchmark coordinator, for example: ``esrally race --track=pmc --pipeline=benchmark-only --load-driver-hosts=10.5.5.6,10.5.5.7 --target-hosts=10.5.5.11:9200,10.5.5.12:9200,10.5.5.13:9200``.
 4. After the benchmark has finished you can stop the Rally daemon again. On the benchmark coordinator and on the load driver machines run ``esrallyd stop``.
 
 .. note::

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -36,7 +36,7 @@ jfr
 
 The ``jfr`` telemetry device enables the `Java Flight Recorder <http://docs.oracle.com/javacomponents/jmc-5-5/jfr-runtime-guide/index.html>`_ on the benchmark candidate. Up to JDK 11, Java flight recorder ships only with Oracle JDK, so Rally assumes that Oracle JDK is used for benchmarking. If you run benchmarks on JDK 11 or later, Java flight recorder is also available on OpenJDK.
 
-To enable ``jfr``, invoke Rally with ``esrally race --telemetry jfr``. ``jfr`` will then write a flight recording file which can be opened in `Java Mission Control <https://jdk.java.net/jmc/>`_. Rally prints the location of the flight recording file on the command line.
+To enable ``jfr``, invoke Rally with ``esrally race --track=pmc --telemetry jfr``. ``jfr`` will then write a flight recording file which can be opened in `Java Mission Control <https://jdk.java.net/jmc/>`_. Rally prints the location of the flight recording file on the command line.
 
 .. image:: jfr-es.png
    :alt: Sample Java Flight Recording

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -855,7 +855,7 @@ class Worker(actor.RallyActor):
             self.wakeup_interval = 0.5
         runner.register_default_runners()
         if self.track.has_plugins:
-            track.load_track_plugins(self.config, runner.register_runner, scheduler.register_scheduler)
+            track.load_track_plugins(self.config, self.track.name, runner.register_runner, scheduler.register_scheduler)
         self.drive()
 
     @actor.no_retry("worker")  # pylint: disable=no-value-for-parameter

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -615,7 +615,9 @@ def load_team(cfg, external):
     else:
         team_path = team.team_path(cfg)
         car = team.load_car(team_path, cfg.opts("mechanic", "car.names"), cfg.opts("mechanic", "car.params"))
-        plugins = team.load_plugins(team_path, cfg.opts("mechanic", "car.plugins"), cfg.opts("mechanic", "plugin.params"))
+        plugins = team.load_plugins(team_path,
+                                    cfg.opts("mechanic", "car.plugins", mandatory=False),
+                                    cfg.opts("mechanic", "plugin.params", mandatory=False))
     return car, plugins
 
 

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -36,7 +36,7 @@ def create(cfg, sources, distribution, build, car, plugins=None):
     if plugins is None:
         plugins = []
     caching_enabled = cfg.opts("source", "cache", mandatory=False, default_value=True)
-    revisions = _extract_revisions(cfg.opts("mechanic", "source.revision"))
+    revisions = _extract_revisions(cfg.opts("mechanic", "source.revision", mandatory=sources))
     distribution_version = cfg.opts("mechanic", "distribution.version", mandatory=False)
     supply_requirements = _supply_requirements(sources, distribution, build, plugins, revisions, distribution_version)
     build_needed = any([build for _, _, build in supply_requirements.values()])
@@ -563,7 +563,7 @@ def _config_value(src_config, key):
 
 
 def _extract_revisions(revision):
-    revisions = revision.split(",")
+    revisions = revision.split(",") if revision else []
     if len(revisions) == 1:
         r = revisions[0]
         if r.startswith("elasticsearch:"):

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -109,9 +109,10 @@ def load_plugins(repo, plugin_names, plugin_params=None):
             raise ValueError("Unrecognized plugin specification [%s]. Use either 'PLUGIN_NAME' or 'PLUGIN_NAME:PLUGIN_CONFIG'." % p)
 
     plugins = []
-    for plugin in plugin_names:
-        plugin_name, plugin_config = name_and_config(plugin)
-        plugins.append(load_plugin(repo, plugin_name, plugin_config, plugin_params))
+    if plugin_names:
+        for plugin in plugin_names:
+            plugin_name, plugin_config = name_and_config(plugin)
+            plugins.append(load_plugin(repo, plugin_name, plugin_config, plugin_params))
     return plugins
 
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1286,9 +1286,6 @@ class RaceStore:
     def __init__(self, cfg):
         self.cfg = cfg
         self.environment_name = cfg.opts("system", "env.name")
-        self.race_timestamp = cfg.opts("system", "time.start")
-        self.race_id = cfg.opts("system", "race.id")
-        self.current_race = None
 
     def find_by_race_id(self, race_id):
         raise NotImplementedError("abstract method")
@@ -1297,9 +1294,6 @@ class RaceStore:
         raise NotImplementedError("abstract method")
 
     def store_race(self, race):
-        self._store(race.as_dict())
-
-    def _store(self, doc):
         raise NotImplementedError("abstract method")
 
     def _max_results(self):
@@ -1329,13 +1323,10 @@ class CompositeRaceStore:
 
 
 class FileRaceStore(RaceStore):
-    def __init__(self, cfg):
-        super().__init__(cfg)
-        self.races_path = paths.races_root(self.cfg)
-        self.race_path = paths.race_root(self.cfg)
-
-    def _store(self, doc):
-        io.ensure_dir(self.race_path)
+    def store_race(self, race):
+        doc = race.as_dict()
+        race_path = paths.race_root(self.cfg, race_id=race.race_id)
+        io.ensure_dir(race_path)
         with open(self._race_file(), mode="wt", encoding="utf-8") as f:
             f.write(json.dumps(doc, indent=True, ensure_ascii=False))
 
@@ -1383,13 +1374,15 @@ class EsRaceStore(RaceStore):
         self.client = client_factory_class(cfg).create()
         self.index_template_provider = index_template_provider_class(cfg)
 
-    def _store(self, doc):
+    def store_race(self, race):
+        doc = race.as_dict()
         # always update the mapping to the latest version
         self.client.put_template("rally-races", self.index_template_provider.races_template())
-        self.client.index(index=self.index_name(), doc_type=EsRaceStore.RACE_DOC_TYPE, item=doc, id=doc["race-id"])
+        self.client.index(index=self.index_name(race), doc_type=EsRaceStore.RACE_DOC_TYPE, item=doc, id=race.race_id)
 
-    def index_name(self):
-        return "%s%04d-%02d" % (EsRaceStore.INDEX_PREFIX, self.race_timestamp.year, self.race_timestamp.month)
+    def index_name(self, race):
+        race_timestamp = race.race_timestamp
+        return f"{EsRaceStore.INDEX_PREFIX}{race_timestamp:%Y-%m}"
 
     def list(self):
         filters = [{
@@ -1467,17 +1460,19 @@ class EsResultsStore:
         :param index_template_provider_class: This parameter is optional and needed for testing.
         """
         self.cfg = cfg
-        self.race_timestamp = cfg.opts("system", "time.start")
         self.client = client_factory_class(cfg).create()
         self.index_template_provider = index_template_provider_class(cfg)
 
     def store_results(self, race):
         # always update the mapping to the latest version
         self.client.put_template("rally-results", self.index_template_provider.results_template())
-        self.client.bulk_index(index=self.index_name(), doc_type=EsResultsStore.RESULTS_DOC_TYPE, items=race.to_result_dicts())
+        self.client.bulk_index(index=self.index_name(race),
+                               doc_type=EsResultsStore.RESULTS_DOC_TYPE,
+                               items=race.to_result_dicts())
 
-    def index_name(self):
-        return "%s%04d-%02d" % (EsResultsStore.INDEX_PREFIX, self.race_timestamp.year, self.race_timestamp.month)
+    def index_name(self, race):
+        race_timestamp = race.race_timestamp
+        return f"{EsResultsStore.INDEX_PREFIX}{race_timestamp:%Y-%m}"
 
 
 class NoopResultsStore:

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -323,7 +323,8 @@ def list_pipelines():
 def run(cfg):
     logger = logging.getLogger(__name__)
     name = cfg.opts("race", "pipeline")
-
+    race_id = cfg.opts("system", "race.id")
+    logger.info("Race id [%s]", race_id)
     if len(name) == 0:
         # assume from-distribution pipeline if distribution.version has been specified and --pipeline cli arg not set
         if cfg.exists("mechanic", "distribution.version"):

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -75,7 +75,7 @@ def create_arg_parser():
         dest="subcommand",
         help="")
 
-    race_parser = subparsers.add_parser("race", help="Run the benchmarking pipeline. This sub-command should typically be used.")
+    race_parser = subparsers.add_parser("race", help="Run a benchmark")
     # change in favor of "list telemetry", "list tracks", "list pipelines"
     list_parser = subparsers.add_parser("list", help="List configuration options")
     list_parser.add_argument(
@@ -370,7 +370,7 @@ def create_arg_parser():
         default=preserve_install,
         action="store_true")
 
-    for p in [parser, list_parser, race_parser, generate_parser]:
+    for p in [list_parser, race_parser, generate_parser]:
         p.add_argument(
             "--distribution-version",
             help="Define the version of the Elasticsearch distribution to download. "
@@ -410,165 +410,163 @@ def create_arg_parser():
             default=False,
             action="store_true")
 
-    for p in [parser, race_parser]:
-        p.add_argument(
-            "--race-id",
-            help="Define a unique id for this race.",
-            default=str(uuid.uuid4()))
-        p.add_argument(
-            "--pipeline",
-            help="Select the pipeline to run.",
-            # the default will be dynamically derived by racecontrol based on the presence / absence of other command line options
-            default="")
-        p.add_argument(
-            "--revision",
-            help="Define the source code revision for building the benchmark candidate. 'current' uses the source tree as is,"
-                 " 'latest' fetches the latest version on master. It is also possible to specify a commit id or a timestamp."
-                 " The timestamp must be specified as: \"@ts\" where \"ts\" must be a valid ISO 8601 timestamp, "
-                 "e.g. \"@2013-07-27T10:37:00Z\" (default: current).",
-            default="current")  # optimized for local usage, don't fetch sources
-        p.add_argument(
-            "--track",
-            help="Define the track to use. List possible tracks with `%s list tracks` (default: geonames)." % PROGRAM_NAME
-            # we set the default value later on because we need to determine whether the user has provided this value.
-            # default="geonames"
-        )
-        p.add_argument(
-            "--track-params",
-            help="Define a comma-separated list of key:value pairs that are injected verbatim to the track as variables.",
-            default=""
-        )
-        p.add_argument(
-            "--challenge",
-            help="Define the challenge to use. List possible challenges for tracks with `%s list tracks`." % PROGRAM_NAME)
-        p.add_argument(
-            "--team-path",
-            help="Define the path to the car and plugin configurations to use.")
-        p.add_argument(
-            "--car",
-            help="Define the car to use. List possible cars with `%s list cars` (default: defaults)." % PROGRAM_NAME,
-            default="defaults")  # optimized for local usage
-        p.add_argument(
-            "--car-params",
-            help="Define a comma-separated list of key:value pairs that are injected verbatim as variables for the car.",
-            default=""
-        )
-        p.add_argument(
-            "--elasticsearch-plugins",
-            help="Define the Elasticsearch plugins to install. (default: install no plugins).",
-            default="")
-        p.add_argument(
-            "--plugin-params",
-            help="Define a comma-separated list of key:value pairs that are injected verbatim to all plugins as variables.",
-            default=""
-        )
-        p.add_argument(
-            "--target-hosts",
-            help="Define a comma-separated list of host:port pairs which should be targeted if using the pipeline 'benchmark-only' "
-                 "(default: localhost:9200).",
-            default="")  # actually the default is pipeline specific and it is set later
-        p.add_argument(
-            "--load-driver-hosts",
-            help="Define a comma-separated list of hosts which should generate load (default: localhost).",
-            default="localhost")
-        p.add_argument(
-            "--client-options",
-            help="Define a comma-separated list of client options to use. The options will be passed to the Elasticsearch Python client "
-                 "(default: {}).".format(opts.ClientOptions.DEFAULT_CLIENT_OPTIONS),
-            default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS)
-        p.add_argument("--on-error",
-                       choices=["continue", "continue-on-non-fatal", "abort"],
-                       help="Controls how Rally behaves on response errors (default: continue-on-non-fatal).",
-                       default="continue-on-non-fatal")
-        p.add_argument(
-            "--telemetry",
-            help="Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry devices "
-                 "with `%s list telemetry`." % PROGRAM_NAME,
-            default="")
-        p.add_argument(
-            "--telemetry-params",
-            help="Define a comma-separated list of key:value pairs that are injected verbatim to the telemetry devices as parameters.",
-            default=""
-        )
-        p.add_argument(
-            "--distribution-repository",
-            help="Define the repository from where the Elasticsearch distribution should be downloaded (default: release).",
-            default="release")
+    race_parser.add_argument(
+        "--race-id",
+        help="Define a unique id for this race.",
+        default=str(uuid.uuid4()))
+    race_parser.add_argument(
+        "--pipeline",
+        help="Select the pipeline to run.",
+        # the default will be dynamically derived by racecontrol based on the presence / absence of other command line options
+        default="")
+    race_parser.add_argument(
+        "--revision",
+        help="Define the source code revision for building the benchmark candidate. 'current' uses the source tree as is,"
+             " 'latest' fetches the latest version on master. It is also possible to specify a commit id or a timestamp."
+             " The timestamp must be specified as: \"@ts\" where \"ts\" must be a valid ISO 8601 timestamp, "
+             "e.g. \"@2013-07-27T10:37:00Z\" (default: current).",
+        default="current")  # optimized for local usage, don't fetch sources
+    race_parser.add_argument(
+        "--track",
+        help="Define the track to use. List possible tracks with `%s list tracks` (default: geonames)." % PROGRAM_NAME
+        # we set the default value later on because we need to determine whether the user has provided this value.
+        # default="geonames"
+    )
+    race_parser.add_argument(
+        "--track-params",
+        help="Define a comma-separated list of key:value pairs that are injected verbatim to the track as variables.",
+        default=""
+    )
+    race_parser.add_argument(
+        "--challenge",
+        help="Define the challenge to use. List possible challenges for tracks with `%s list tracks`." % PROGRAM_NAME)
+    race_parser.add_argument(
+        "--team-path",
+        help="Define the path to the car and plugin configurations to use.")
+    race_parser.add_argument(
+        "--car",
+        help="Define the car to use. List possible cars with `%s list cars` (default: defaults)." % PROGRAM_NAME,
+        default="defaults")  # optimized for local usage
+    race_parser.add_argument(
+        "--car-params",
+        help="Define a comma-separated list of key:value pairs that are injected verbatim as variables for the car.",
+        default=""
+    )
+    race_parser.add_argument(
+        "--elasticsearch-plugins",
+        help="Define the Elasticsearch plugins to install. (default: install no plugins).",
+        default="")
+    race_parser.add_argument(
+        "--plugin-params",
+        help="Define a comma-separated list of key:value pairs that are injected verbatim to all plugins as variables.",
+        default=""
+    )
+    race_parser.add_argument(
+        "--target-hosts",
+        help="Define a comma-separated list of host:port pairs which should be targeted if using the pipeline 'benchmark-only' "
+             "(default: localhost:9200).",
+        default="")  # actually the default is pipeline specific and it is set later
+    race_parser.add_argument(
+        "--load-driver-hosts",
+        help="Define a comma-separated list of hosts which should generate load (default: localhost).",
+        default="localhost")
+    race_parser.add_argument(
+        "--client-options",
+        help="Define a comma-separated list of client options to use. The options will be passed to the Elasticsearch Python client "
+             "(default: {}).".format(opts.ClientOptions.DEFAULT_CLIENT_OPTIONS),
+        default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS)
+    race_parser.add_argument("--on-error",
+                   choices=["continue", "continue-on-non-fatal", "abort"],
+                   help="Controls how Rally behaves on response errors (default: continue-on-non-fatal).",
+                   default="continue-on-non-fatal")
+    race_parser.add_argument(
+        "--telemetry",
+        help="Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry devices "
+             "with `%s list telemetry`." % PROGRAM_NAME,
+        default="")
+    race_parser.add_argument(
+        "--telemetry-params",
+        help="Define a comma-separated list of key:value pairs that are injected verbatim to the telemetry devices as parameters.",
+        default=""
+    )
+    race_parser.add_argument(
+        "--distribution-repository",
+        help="Define the repository from where the Elasticsearch distribution should be downloaded (default: release).",
+        default="release")
 
-        task_filter_group = p.add_mutually_exclusive_group()
-        task_filter_group.add_argument(
-            "--include-tasks",
-            help="Defines a comma-separated list of tasks to run. By default all tasks of a challenge are run.")
-        task_filter_group.add_argument(
-            "--exclude-tasks",
-            help="Defines a comma-separated list of tasks not to run. By default all tasks of a challenge are run.")
-        p.add_argument(
-            "--user-tag",
-            help="Define a user-specific key-value pair (separated by ':'). It is added to each metric record as meta info. "
-                 "Example: intention:baseline-ticket-12345",
-            default="")
-        p.add_argument(
-            "--report-format",
-            help="Define the output format for the command line report (default: markdown).",
-            choices=["markdown", "csv"],
-            default="markdown")
-        p.add_argument(
-            "--show-in-report",
-            help="Define which values are shown in the summary report (default: available).",
-            choices=["available", "all-percentiles", "all"],
-            default="available")
-        p.add_argument(
-            "--report-file",
-            help="Write the command line report also to the provided file.",
-            default="")
-        p.add_argument(
-            "--preserve-install",
-            help="Keep the benchmark candidate and its index. (default: %s)." % str(preserve_install).lower(),
-            default=preserve_install,
-            action="store_true")
-        p.add_argument(
-            "--test-mode",
-            help="Runs the given track in 'test mode'. Meant to check a track for errors but not for real benchmarks (default: false).",
-            default=False,
-            action="store_true")
-        p.add_argument(
-            "--enable-driver-profiling",
-            help="Enables a profiler for analyzing the performance of calls in Rally's driver (default: false).",
-            default=False,
-            action="store_true")
-        p.add_argument(
-            "--enable-assertions",
-            help="Enables assertion checks for tasks (default: false).",
-            default=False,
-            action="store_true")
+    task_filter_group = race_parser.add_mutually_exclusive_group()
+    task_filter_group.add_argument(
+        "--include-tasks",
+        help="Defines a comma-separated list of tasks to run. By default all tasks of a challenge are run.")
+    task_filter_group.add_argument(
+        "--exclude-tasks",
+        help="Defines a comma-separated list of tasks not to run. By default all tasks of a challenge are run.")
+    race_parser.add_argument(
+        "--user-tag",
+        help="Define a user-specific key-value pair (separated by ':'). It is added to each metric record as meta info. "
+             "Example: intention:baseline-ticket-12345",
+        default="")
+    race_parser.add_argument(
+        "--report-format",
+        help="Define the output format for the command line report (default: markdown).",
+        choices=["markdown", "csv"],
+        default="markdown")
+    race_parser.add_argument(
+        "--show-in-report",
+        help="Define which values are shown in the summary report (default: available).",
+        choices=["available", "all-percentiles", "all"],
+        default="available")
+    race_parser.add_argument(
+        "--report-file",
+        help="Write the command line report also to the provided file.",
+        default="")
+    race_parser.add_argument(
+        "--preserve-install",
+        help="Keep the benchmark candidate and its index. (default: %s)." % str(preserve_install).lower(),
+        default=preserve_install,
+        action="store_true")
+    race_parser.add_argument(
+        "--test-mode",
+        help="Runs the given track in 'test mode'. Meant to check a track for errors but not for real benchmarks (default: false).",
+        default=False,
+        action="store_true")
+    race_parser.add_argument(
+        "--enable-driver-profiling",
+        help="Enables a profiler for analyzing the performance of calls in Rally's driver (default: false).",
+        default=False,
+        action="store_true")
+    race_parser.add_argument(
+        "--enable-assertions",
+        help="Enables assertion checks for tasks (default: false).",
+        default=False,
+        action="store_true")
 
     ###############################################################################
     #
     # The options below are undocumented and can be removed or changed at any time.
     #
     ###############################################################################
-    for p in [parser, race_parser]:
-        # This option is intended to tell Rally to assume a different start date than 'now'. This is effectively just useful for things like
-        # backtesting or a benchmark run across environments (think: comparison of EC2 and bare metal) but never for the typical user.
-        p.add_argument(
-            "--effective-start-date",
-            help=argparse.SUPPRESS,
-            type=lambda s: datetime.datetime.strptime(s, "%Y-%m-%d %H:%M:%S"),
-            default=None)
-        # keeps the cluster running after the benchmark, only relevant if Rally provisions the cluster
-        p.add_argument(
-            "--keep-cluster-running",
-            help=argparse.SUPPRESS,
-            action="store_true",
-            default=False)
-        # skips checking that the REST API is available before proceeding with the benchmark
-        p.add_argument(
-            "--skip-rest-api-check",
-            help=argparse.SUPPRESS,
-            action="store_true",
-            default=False)
+    # This option is intended to tell Rally to assume a different start date than 'now'. This is effectively just useful for things like
+    # backtesting or a benchmark run across environments (think: comparison of EC2 and bare metal) but never for the typical user.
+    race_parser.add_argument(
+        "--effective-start-date",
+        help=argparse.SUPPRESS,
+        type=lambda s: datetime.datetime.strptime(s, "%Y-%m-%d %H:%M:%S"),
+        default=None)
+    # keeps the cluster running after the benchmark, only relevant if Rally provisions the cluster
+    race_parser.add_argument(
+        "--keep-cluster-running",
+        help=argparse.SUPPRESS,
+        action="store_true",
+        default=False)
+    # skips checking that the REST API is available before proceeding with the benchmark
+    race_parser.add_argument(
+        "--skip-rest-api-check",
+        help=argparse.SUPPRESS,
+        action="store_true",
+        default=False)
 
-    for p in [parser, list_parser, race_parser, compare_parser, download_parser, install_parser,
+    for p in [list_parser, race_parser, compare_parser, download_parser, install_parser,
               start_parser, stop_parser, info_parser, generate_parser, create_track_parser]:
         # This option is needed to support a separate configuration for the integration tests on the same machine
         p.add_argument(
@@ -588,17 +586,6 @@ def create_arg_parser():
         )
 
     return parser
-
-
-def derive_sub_command(args):
-    sub_command = args.subcommand
-    if sub_command is None:
-        logger = logging.getLogger(__name__)
-        console.warn("Invoking Rally without a subcommand is deprecated and will be required with Rally 2.1.0. Specify "
-                     "the 'race' subcommand explicitly.", logger=logger)
-        return "race"
-    else:
-        return sub_command
 
 
 def dispatch_list(cfg):
@@ -800,7 +787,7 @@ def main():
         cfg.install_default_config()
     cfg.load_config(auto_upgrade=True)
 
-    sub_command = derive_sub_command(args)
+    sub_command = args.subcommand
 
     if args.effective_start_date:
         cfg.add(config.Scope.application, "system", "time.start", args.effective_start_date)

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -167,23 +167,9 @@ def create_arg_parser():
     # argparse to validate that everything is correct *might* be doable but it is simpler to just do this manually.
     generate_parser.add_argument(
         "--chart-spec-path",
+        required=True,
         help="Path to a JSON file(s) containing all combinations of charts to generate. Wildcard patterns can be used to specify "
              "multiple files.")
-    add_track_source(generate_parser)
-    generate_parser.add_argument(
-        "--track",
-        help=f"Define the track to use. List possible tracks with `{PROGRAM_NAME} list tracks`."
-    )
-    generate_parser.add_argument(
-        "--challenge",
-        help=f"Define the challenge to use. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`.")
-    generate_parser.add_argument(
-        "--car",
-        help=f"Define the car to use. List possible cars with `{PROGRAM_NAME} list cars` (default: defaults).")
-    generate_parser.add_argument(
-        "--node-count",
-        type=positive_number,
-        help="The number of Elasticsearch nodes to use in charts.")
     generate_parser.add_argument(
         "--chart-type",
         help="Chart type to generate (default: time-series).",
@@ -856,18 +842,9 @@ def dispatch_sub_command(arg_parser, args, cfg):
 
             race(cfg, args.kill_running_processes)
         elif sub_command == "generate":
+            cfg.add(config.Scope.applicationOverride, "generator", "chart.spec.path", args.chart_spec_path)
             cfg.add(config.Scope.applicationOverride, "generator", "chart.type", args.chart_type)
             cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
-            configure_track_params(arg_parser, args, cfg)
-
-            if args.chart_spec_path and (args.track or args.challenge or args.car or args.node_count):
-                arg_parser.error("argument --chart-spec-path not allowed with --track, --challenge, --car or --node-count")
-            if args.chart_spec_path:
-                cfg.add(config.Scope.applicationOverride, "generator", "chart.spec.path", args.chart_spec_path)
-            else:
-                # other options are stored elsewhere already
-                cfg.add(config.Scope.applicationOverride, "generator", "node.count", args.node_count)
-
             generate(cfg)
         elif sub_command == "create-track":
             cfg.add(config.Scope.applicationOverride, "generator", "indices", args.indices)

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -38,7 +38,7 @@ def create_arg_parser():
     def positive_number(v):
         value = int(v)
         if value <= 0:
-            raise argparse.ArgumentTypeError("must be positive but was {}".format(value))
+            raise argparse.ArgumentTypeError(f"must be positive but was {value}")
         return value
 
     def non_empty_list(arg):
@@ -54,7 +54,23 @@ def create_arg_parser():
             try:
                 return positive_number(v)
             except argparse.ArgumentTypeError:
-                raise argparse.ArgumentTypeError("must be a positive number or 'bundled' but was {}".format(v))
+                raise argparse.ArgumentTypeError(f"must be a positive number or 'bundled' but was {v}")
+
+    def add_track_source(subparser):
+        track_source_group = subparser.add_mutually_exclusive_group()
+        track_source_group.add_argument(
+            "--track-repository",
+            help="Define the repository from where Rally will load tracks (default: default).",
+            # argparse is smart enough to use this default only if the user did not use --track-path and also did not specify anything
+            default="default"
+        )
+        track_source_group.add_argument(
+            "--track-path",
+            help="Define the path to a track.")
+        subparser.add_argument(
+            "--track-revision",
+            help="Define a specific revision in the track repository that Rally should use.",
+            default=None)
 
     # try to preload configurable defaults, but this does not work together with `--configuration-name` (which is undocumented anyway)
     cfg = config.Config()
@@ -89,25 +105,17 @@ def create_arg_parser():
         help="Limit the number of search results for recent races (default: 10).",
         default=10,
     )
+    add_track_source(list_parser)
 
     info_parser = subparsers.add_parser("info", help="Show info about a track")
-    info_track_source_group = info_parser.add_mutually_exclusive_group()
-    info_track_source_group.add_argument(
-        "--track-repository",
-        help="Define the repository from where Rally will load tracks (default: default).",
-        # argparse is smart enough to use this default only if the user did not use --track-path and also did not specify anything
-        default="default"
-    )
-    info_track_source_group.add_argument(
-        "--track-path",
-        help="Define the path to a track.")
-
+    add_track_source(info_parser)
     info_parser.add_argument(
         "--track",
-        help="Define the track to use. List possible tracks with `{} list tracks` (default: geonames).".format(PROGRAM_NAME)
+        help=f"Define the track to use. List possible tracks with `{PROGRAM_NAME} list tracks`."
         # we set the default value later on because we need to determine whether the user has provided this value.
         # default="geonames"
     )
+
     info_parser.add_argument(
         "--track-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to the track as variables.",
@@ -115,7 +123,7 @@ def create_arg_parser():
     )
     info_parser.add_argument(
         "--challenge",
-        help="Define the challenge to use. List possible challenges for tracks with `{} list tracks`.".format(PROGRAM_NAME)
+        help=f"Define the challenge to use. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`."
     )
     info_task_filter_group = info_parser.add_mutually_exclusive_group()
     info_task_filter_group.add_argument(
@@ -161,18 +169,17 @@ def create_arg_parser():
         "--chart-spec-path",
         help="Path to a JSON file(s) containing all combinations of charts to generate. Wildcard patterns can be used to specify "
              "multiple files.")
+    add_track_source(generate_parser)
     generate_parser.add_argument(
         "--track",
-        help="Define the track to use. List possible tracks with `%s list tracks` (default: geonames)." % PROGRAM_NAME
-        # we set the default value later on because we need to determine whether the user has provided this value.
-        # default="geonames"
+        help=f"Define the track to use. List possible tracks with `{PROGRAM_NAME} list tracks`."
     )
     generate_parser.add_argument(
         "--challenge",
-        help="Define the challenge to use. List possible challenges for tracks with `%s list tracks`." % PROGRAM_NAME)
+        help=f"Define the challenge to use. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`.")
     generate_parser.add_argument(
         "--car",
-        help="Define the car to use. List possible cars with `%s list cars` (default: defaults)." % PROGRAM_NAME)
+        help=f"Define the car to use. List possible cars with `{PROGRAM_NAME} list cars` (default: defaults).")
     generate_parser.add_argument(
         "--node-count",
         type=positive_number,
@@ -191,11 +198,11 @@ def create_arg_parser():
     compare_parser.add_argument(
         "--baseline",
         required=True,
-        help="Race ID of the baseline (see %s list races)." % PROGRAM_NAME)
+        help=f"Race ID of the baseline (see {PROGRAM_NAME} list races).")
     compare_parser.add_argument(
         "--contender",
         required=True,
-        help="Race ID of the contender (see %s list races)." % PROGRAM_NAME)
+        help=f"Race ID of the contender (see {PROGRAM_NAME} list races).")
     compare_parser.add_argument(
         "--report-format",
         help="Define the output format for the command line report (default: markdown).",
@@ -212,6 +219,10 @@ def create_arg_parser():
         help="Define the repository from where Rally will load teams and cars (default: default).",
         default="default")
     download_parser.add_argument(
+        "--team-revision",
+        help="Define a specific revision in the team repository that Rally should use.",
+        default=None)
+    download_parser.add_argument(
         "--team-path",
         help="Define the path to the car and plugin configurations to use.")
     download_parser.add_argument(
@@ -225,7 +236,7 @@ def create_arg_parser():
         default="release")
     download_parser.add_argument(
         "--car",
-        help="Define the car to use. List possible cars with `%s list cars` (default: defaults)." % PROGRAM_NAME,
+        help=f"Define the car to use. List possible cars with `{PROGRAM_NAME} list cars` (default: defaults).",
         default="defaults")  # optimized for local usage
     download_parser.add_argument(
         "--car-params",
@@ -287,7 +298,7 @@ def create_arg_parser():
         default="")
     install_parser.add_argument(
         "--car",
-        help="Define the car to use. List possible cars with `%s list cars` (default: defaults)." % PROGRAM_NAME,
+        help=f"Define the car to use. List possible cars with `{PROGRAM_NAME} list cars` (default: defaults).",
         default="defaults")  # optimized for local usage
     install_parser.add_argument(
         "--car-params",
@@ -348,8 +359,8 @@ def create_arg_parser():
         default=None)
     start_parser.add_argument(
         "--telemetry",
-        help="Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry devices "
-             "with `%s list telemetry`." % PROGRAM_NAME,
+        help=f"Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry "
+             f"devices with `{PROGRAM_NAME} list telemetry`.",
         default="")
     start_parser.add_argument(
         "--telemetry-params",
@@ -366,36 +377,19 @@ def create_arg_parser():
         default="")
     stop_parser.add_argument(
         "--preserve-install",
-        help="Keep the benchmark candidate and its index. (default: %s)." % str(preserve_install).lower(),
+        help=f"Keep the benchmark candidate and its index. (default: {str(preserve_install).lower()}).",
         default=preserve_install,
         action="store_true")
 
-    for p in [list_parser, race_parser, generate_parser]:
+    for p in [list_parser, race_parser]:
         p.add_argument(
             "--distribution-version",
             help="Define the version of the Elasticsearch distribution to download. "
                  "Check https://www.elastic.co/downloads/elasticsearch for released versions.",
             default="")
         p.add_argument(
-            "--runtime-jdk",
-            type=runtime_jdk,
-            help="The major version of the runtime JDK to use.",
-            default=None)
-
-        track_source_group = p.add_mutually_exclusive_group()
-        track_source_group.add_argument(
-            "--track-repository",
-            help="Define the repository from where Rally will load tracks (default: default).",
-            # argparse is smart enough to use this default only if the user did not use --track-path and also did not specify anything
-            default="default"
-        )
-        track_source_group.add_argument(
-            "--track-path",
-            help="Define the path to a track.")
-        p.add_argument(
-            "--track-revision",
-            help="Define a specific revision in the track repository that Rally should use.",
-            default=None)
+            "--team-path",
+            help="Define the path to the car and plugin configurations to use.")
         p.add_argument(
             "--team-repository",
             help="Define the repository from where Rally will load teams and cars (default: default).",
@@ -404,11 +398,6 @@ def create_arg_parser():
             "--team-revision",
             help="Define a specific revision in the team repository that Rally should use.",
             default=None)
-        p.add_argument(
-            "--offline",
-            help="Assume that Rally has no connection to the Internet (default: false).",
-            default=False,
-            action="store_true")
 
     race_parser.add_argument(
         "--race-id",
@@ -426,11 +415,10 @@ def create_arg_parser():
              " The timestamp must be specified as: \"@ts\" where \"ts\" must be a valid ISO 8601 timestamp, "
              "e.g. \"@2013-07-27T10:37:00Z\" (default: current).",
         default="current")  # optimized for local usage, don't fetch sources
+    add_track_source(race_parser)
     race_parser.add_argument(
         "--track",
-        help="Define the track to use. List possible tracks with `%s list tracks` (default: geonames)." % PROGRAM_NAME
-        # we set the default value later on because we need to determine whether the user has provided this value.
-        # default="geonames"
+        help=f"Define the track to use. List possible tracks with `{PROGRAM_NAME} list tracks`."
     )
     race_parser.add_argument(
         "--track-params",
@@ -439,19 +427,21 @@ def create_arg_parser():
     )
     race_parser.add_argument(
         "--challenge",
-        help="Define the challenge to use. List possible challenges for tracks with `%s list tracks`." % PROGRAM_NAME)
-    race_parser.add_argument(
-        "--team-path",
-        help="Define the path to the car and plugin configurations to use.")
+        help=f"Define the challenge to use. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`.")
     race_parser.add_argument(
         "--car",
-        help="Define the car to use. List possible cars with `%s list cars` (default: defaults)." % PROGRAM_NAME,
+        help=f"Define the car to use. List possible cars with `{PROGRAM_NAME} list cars` (default: defaults).",
         default="defaults")  # optimized for local usage
     race_parser.add_argument(
         "--car-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim as variables for the car.",
         default=""
     )
+    race_parser.add_argument(
+        "--runtime-jdk",
+        type=runtime_jdk,
+        help="The major version of the runtime JDK to use.",
+        default=None)
     race_parser.add_argument(
         "--elasticsearch-plugins",
         help="Define the Elasticsearch plugins to install. (default: install no plugins).",
@@ -472,17 +462,17 @@ def create_arg_parser():
         default="localhost")
     race_parser.add_argument(
         "--client-options",
-        help="Define a comma-separated list of client options to use. The options will be passed to the Elasticsearch Python client "
-             "(default: {}).".format(opts.ClientOptions.DEFAULT_CLIENT_OPTIONS),
+        help=f"Define a comma-separated list of client options to use. The options will be passed to the Elasticsearch "
+             f"Python client (default: {opts.ClientOptions.DEFAULT_CLIENT_OPTIONS}).",
         default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS)
     race_parser.add_argument("--on-error",
-                   choices=["continue", "continue-on-non-fatal", "abort"],
-                   help="Controls how Rally behaves on response errors (default: continue-on-non-fatal).",
-                   default="continue-on-non-fatal")
+                             choices=["continue", "continue-on-non-fatal", "abort"],
+                             help="Controls how Rally behaves on response errors (default: continue-on-non-fatal).",
+                             default="continue-on-non-fatal")
     race_parser.add_argument(
         "--telemetry",
-        help="Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry devices "
-             "with `%s list telemetry`." % PROGRAM_NAME,
+        help=f"Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry "
+             f"devices with `{PROGRAM_NAME} list telemetry`.",
         default="")
     race_parser.add_argument(
         "--telemetry-params",
@@ -522,7 +512,7 @@ def create_arg_parser():
         default="")
     race_parser.add_argument(
         "--preserve-install",
-        help="Keep the benchmark candidate and its index. (default: %s)." % str(preserve_install).lower(),
+        help=f"Keep the benchmark candidate and its index. (default: {str(preserve_install).lower()}).",
         default=preserve_install,
         action="store_true")
     race_parser.add_argument(
@@ -540,6 +530,12 @@ def create_arg_parser():
         help="Enables assertion checks for tasks (default: false).",
         default=False,
         action="store_true")
+    race_parser.add_argument(
+        "--kill-running-processes",
+        action="store_true",
+        default=False,
+        help="If any processes is running, it is going to kill them and allow Rally to continue to run."
+    )
 
     ###############################################################################
     #
@@ -553,12 +549,6 @@ def create_arg_parser():
         help=argparse.SUPPRESS,
         type=lambda s: datetime.datetime.strptime(s, "%Y-%m-%d %H:%M:%S"),
         default=None)
-    # keeps the cluster running after the benchmark, only relevant if Rally provisions the cluster
-    race_parser.add_argument(
-        "--keep-cluster-running",
-        help=argparse.SUPPRESS,
-        action="store_true",
-        default=False)
     # skips checking that the REST API is available before proceeding with the benchmark
     race_parser.add_argument(
         "--skip-rest-api-check",
@@ -579,11 +569,10 @@ def create_arg_parser():
             default=False,
             action="store_true")
         p.add_argument(
-            "--kill-running-processes",
-            action="store_true",
+            "--offline",
+            help="Assume that Rally has no connection to the Internet (default: false).",
             default=False,
-            help="If any processes is running, it is going to kill them and allow Rally to continue to run."
-        )
+            action="store_true")
 
     return parser
 
@@ -617,10 +606,8 @@ def print_help_on_errors():
                     f"and include the log files in {paths.logs()}.")
 
 
-def race(cfg):
+def race(cfg, kill_running_processes=False):
     logger = logging.getLogger(__name__)
-
-    kill_running_processes = cfg.opts("system", "kill.running.processes")
 
     if kill_running_processes:
         logger.info("Killing running Rally processes")
@@ -717,30 +704,183 @@ def generate(cfg):
     chart_generator.generate(cfg)
 
 
-def dispatch_sub_command(cfg, sub_command):
+def configure_telemetry_params(args, cfg):
+    cfg.add(config.Scope.applicationOverride, "telemetry", "devices", opts.csv_to_list(args.telemetry))
+    cfg.add(config.Scope.applicationOverride, "telemetry", "params", opts.to_dict(args.telemetry_params))
+
+
+def configure_track_params(arg_parser, args, cfg, command_requires_track=True):
+    cfg.add(config.Scope.applicationOverride, "track", "repository.revision", args.track_revision)
+    # We can assume here that if a track-path is given, the user did not specify a repository either (although argparse sets it to
+    # its default value)
+    if args.track_path:
+        cfg.add(config.Scope.applicationOverride, "track", "track.path", os.path.abspath(io.normalize_path(args.track_path)))
+        cfg.add(config.Scope.applicationOverride, "track", "repository.name", None)
+        if args.track_revision:
+            # stay as close as possible to argparse errors although we have a custom validation.
+            arg_parser.error("argument --track-revision not allowed with argument --track-path")
+        if command_requires_track and args.track:
+            # stay as close as possible to argparse errors although we have a custom validation.
+            arg_parser.error("argument --track not allowed with argument --track-path")
+    else:
+        cfg.add(config.Scope.applicationOverride, "track", "repository.name", args.track_repository)
+        if command_requires_track:
+            # TODO #1176: We should not choose a track implicitly.
+            # set the default programmatically because we need to determine whether the user has provided a value
+            if args.track:
+                chosen_track = args.track
+            else:
+                chosen_track = "geonames"
+                console.warn(f"Starting Rally without --track is deprecated. Add --track={chosen_track} to your parameters.")
+
+            cfg.add(config.Scope.applicationOverride, "track", "track.name", chosen_track)
+
+    if command_requires_track:
+        cfg.add(config.Scope.applicationOverride, "track", "params", opts.to_dict(args.track_params))
+        cfg.add(config.Scope.applicationOverride, "track", "challenge.name", args.challenge)
+        cfg.add(config.Scope.applicationOverride, "track", "include.tasks", opts.csv_to_list(args.include_tasks))
+        cfg.add(config.Scope.applicationOverride, "track", "exclude.tasks", opts.csv_to_list(args.exclude_tasks))
+
+
+def configure_mechanic_params(args, cfg, command_requires_car=True):
+    if args.team_path:
+        cfg.add(config.Scope.applicationOverride, "mechanic", "team.path", os.path.abspath(io.normalize_path(args.team_path)))
+        cfg.add(config.Scope.applicationOverride, "mechanic", "repository.name", None)
+        cfg.add(config.Scope.applicationOverride, "mechanic", "repository.revision", None)
+    else:
+        cfg.add(config.Scope.applicationOverride, "mechanic", "repository.name", args.team_repository)
+        cfg.add(config.Scope.applicationOverride, "mechanic", "repository.revision", args.team_revision)
+
+    if command_requires_car:
+        if args.distribution_version:
+            cfg.add(config.Scope.applicationOverride, "mechanic", "distribution.version", args.distribution_version)
+        cfg.add(config.Scope.applicationOverride, "mechanic", "distribution.repository", args.distribution_repository)
+        cfg.add(config.Scope.applicationOverride, "mechanic", "car.names", opts.csv_to_list(args.car))
+        cfg.add(config.Scope.applicationOverride, "mechanic", "car.params", opts.to_dict(args.car_params))
+
+
+def configure_connection_params(arg_parser, args, cfg):
+    # Also needed by mechanic (-> telemetry) - duplicate by module?
+    target_hosts = opts.TargetHosts(args.target_hosts)
+    cfg.add(config.Scope.applicationOverride, "client", "hosts", target_hosts)
+    client_options = opts.ClientOptions(args.client_options, target_hosts=target_hosts)
+    cfg.add(config.Scope.applicationOverride, "client", "options", client_options)
+    if "timeout" not in client_options.default:
+        console.info("You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.")
+    if list(target_hosts.all_hosts) != list(client_options.all_client_options):
+        arg_parser.error("--target-hosts and --client-options must define the same keys for multi cluster setups.")
+
+
+def configure_reporting_params(args, cfg):
+    cfg.add(config.Scope.applicationOverride, "reporting", "format", args.report_format)
+    cfg.add(config.Scope.applicationOverride, "reporting", "values", args.show_in_report)
+    cfg.add(config.Scope.applicationOverride, "reporting", "output.path", args.report_file)
+
+
+def dispatch_sub_command(arg_parser, args, cfg):
+    sub_command = args.subcommand
+
+    cfg.add(config.Scope.application, "system", "quiet.mode", args.quiet)
+    cfg.add(config.Scope.application, "system", "offline.mode", args.offline)
+
     try:
         if sub_command == "compare":
-            reporter.compare(cfg)
+            configure_reporting_params(args, cfg)
+            reporter.compare(cfg, args.baseline, args.contender)
         elif sub_command == "list":
+            cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
+            cfg.add(config.Scope.applicationOverride, "system", "list.races.max_results", args.limit)
+            configure_mechanic_params(args, cfg, command_requires_car=False)
+            configure_track_params(arg_parser, args, cfg, command_requires_track=False)
             dispatch_list(cfg)
         elif sub_command == "download":
+            cfg.add(config.Scope.applicationOverride, "mechanic", "target.os", args.target_os)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "target.arch", args.target_arch)
+            configure_mechanic_params(args, cfg)
             mechanic.download(cfg)
         elif sub_command == "install":
+            cfg.add(config.Scope.applicationOverride, "system", "install.id", str(uuid.uuid4()))
+            cfg.add(config.Scope.applicationOverride, "mechanic", "network.host", args.network_host)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "network.http.port", args.http_port)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
+            # TODO: Remove this special treatment and rely on artifact caching (follow-up PR)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "skip.build", args.skip_build)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "build.type", args.build_type)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "node.name", args.node_name)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "master.nodes", opts.csv_to_list(args.master_nodes))
+            cfg.add(config.Scope.applicationOverride, "mechanic", "seed.hosts", opts.csv_to_list(args.seed_hosts))
+            cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", opts.csv_to_list(args.elasticsearch_plugins))
+            cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", opts.to_dict(args.plugin_params))
+            configure_mechanic_params(args, cfg)
             mechanic.install(cfg)
         elif sub_command == "start":
+            cfg.add(config.Scope.applicationOverride, "system", "race.id", args.race_id)
+            cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
+            configure_telemetry_params(args, cfg)
             mechanic.start(cfg)
         elif sub_command == "stop":
+            cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
+            cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
             mechanic.stop(cfg)
         elif sub_command == "race":
-            race(cfg)
+            # As the race command is doing more work than necessary at the moment, we duplicate several parameters
+            # in this section that actually belong to dedicated subcommands (like install, start or stop). Over time
+            # these duplicated parameters will vanish as we move towards dedicated subcommands and use "race" only
+            # to run the actual benchmark (i.e. generating load).
+            if args.effective_start_date:
+                cfg.add(config.Scope.applicationOverride, "system", "time.start", args.effective_start_date)
+            cfg.add(config.Scope.applicationOverride, "system", "race.id", args.race_id)
+            # use the race id implicitly also as the install id.
+            cfg.add(config.Scope.applicationOverride, "system", "install.id", args.race_id)
+            cfg.add(config.Scope.applicationOverride, "race", "pipeline", args.pipeline)
+            cfg.add(config.Scope.applicationOverride, "race", "user.tag", args.user_tag)
+            cfg.add(config.Scope.applicationOverride, "driver", "profiling", args.enable_driver_profiling)
+            cfg.add(config.Scope.applicationOverride, "driver", "assertions", args.enable_assertions)
+            cfg.add(config.Scope.applicationOverride, "driver", "on.error", args.on_error)
+            cfg.add(config.Scope.applicationOverride, "driver", "load_driver_hosts", opts.csv_to_list(args.load_driver_hosts))
+            cfg.add(config.Scope.applicationOverride, "track", "test.mode.enabled", args.test_mode)
+            configure_track_params(arg_parser, args, cfg)
+            configure_connection_params(arg_parser, args, cfg)
+            configure_telemetry_params(args, cfg)
+            configure_mechanic_params(args, cfg)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", opts.csv_to_list(args.elasticsearch_plugins))
+            cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", opts.to_dict(args.plugin_params))
+            cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
+            cfg.add(config.Scope.applicationOverride, "mechanic", "skip.rest.api.check", convert.to_bool(args.skip_rest_api_check))
+
+            configure_reporting_params(args, cfg)
+
+            race(cfg, args.kill_running_processes)
         elif sub_command == "generate":
+            cfg.add(config.Scope.applicationOverride, "generator", "chart.type", args.chart_type)
+            cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
+            configure_track_params(arg_parser, args, cfg)
+
+            if args.chart_spec_path and (args.track or args.challenge or args.car or args.node_count):
+                arg_parser.error("argument --chart-spec-path not allowed with --track, --challenge, --car or --node-count")
+            if args.chart_spec_path:
+                cfg.add(config.Scope.applicationOverride, "generator", "chart.spec.path", args.chart_spec_path)
+            else:
+                # other options are stored elsewhere already
+                cfg.add(config.Scope.applicationOverride, "generator", "node.count", args.node_count)
+
             generate(cfg)
         elif sub_command == "create-track":
+            cfg.add(config.Scope.applicationOverride, "generator", "indices", args.indices)
+            cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
+            cfg.add(config.Scope.applicationOverride, "track", "track.name", args.track)
+            configure_connection_params(arg_parser, args, cfg)
+
             tracker.create_track(cfg)
         elif sub_command == "info":
+            configure_track_params(arg_parser, args, cfg)
             track.track_info(cfg)
         else:
-            raise exceptions.SystemSetupError("Unknown subcommand [%s]" % sub_command)
+            raise exceptions.SystemSetupError(f"Unknown subcommand [{sub_command}]")
         return True
     except exceptions.RallyError as e:
         logging.getLogger(__name__).exception("Cannot run subcommand [%s].", sub_command)
@@ -786,141 +926,11 @@ def main():
     if not cfg.config_present():
         cfg.install_default_config()
     cfg.load_config(auto_upgrade=True)
-
-    sub_command = args.subcommand
-
-    if args.effective_start_date:
-        cfg.add(config.Scope.application, "system", "time.start", args.effective_start_date)
-        cfg.add(config.Scope.application, "system", "time.start.user_provided", True)
-    else:
-        cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.utcnow())
-        cfg.add(config.Scope.application, "system", "time.start.user_provided", False)
-
-    # The installation id is overridden later on if nodes are managed via Rally subcommands (install / start / stop)
-    cfg.add(config.Scope.applicationOverride, "system", "install.id", args.race_id)
-    cfg.add(config.Scope.applicationOverride, "system", "race.id", args.race_id)
-    cfg.add(config.Scope.applicationOverride, "system", "quiet.mode", args.quiet)
-    cfg.add(config.Scope.applicationOverride, "system", "offline.mode", args.offline)
-    cfg.add(config.Scope.applicationOverride, "system", "kill.running.processes", args.kill_running_processes)
-
+    cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.utcnow())
     # Local config per node
     cfg.add(config.Scope.application, "node", "rally.root", paths.rally_root())
     cfg.add(config.Scope.application, "node", "rally.cwd", os.getcwd())
 
-    cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
-    if args.distribution_version:
-        cfg.add(config.Scope.applicationOverride, "mechanic", "distribution.version", args.distribution_version)
-    cfg.add(config.Scope.applicationOverride, "mechanic", "distribution.repository", args.distribution_repository)
-    cfg.add(config.Scope.applicationOverride, "mechanic", "car.names", opts.csv_to_list(args.car))
-    if args.team_path:
-        cfg.add(config.Scope.applicationOverride, "mechanic", "team.path", os.path.abspath(io.normalize_path(args.team_path)))
-        cfg.add(config.Scope.applicationOverride, "mechanic", "repository.name", None)
-        cfg.add(config.Scope.applicationOverride, "mechanic", "repository.revision", None)
-    else:
-        cfg.add(config.Scope.applicationOverride, "mechanic", "repository.name", args.team_repository)
-        cfg.add(config.Scope.applicationOverride, "mechanic", "repository.revision", args.team_revision)
-    cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", opts.csv_to_list(args.elasticsearch_plugins))
-    cfg.add(config.Scope.applicationOverride, "mechanic", "car.params", opts.to_dict(args.car_params))
-    cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", opts.to_dict(args.plugin_params))
-    if args.keep_cluster_running:
-        cfg.add(config.Scope.applicationOverride, "mechanic", "keep.running", True)
-        # force-preserve the cluster nodes.
-        cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", True)
-    else:
-        cfg.add(config.Scope.applicationOverride, "mechanic", "keep.running", False)
-        cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
-    cfg.add(config.Scope.applicationOverride, "mechanic", "skip.rest.api.check", convert.to_bool(args.skip_rest_api_check))
-    cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
-    cfg.add(config.Scope.applicationOverride, "telemetry", "devices", opts.csv_to_list(args.telemetry))
-    cfg.add(config.Scope.applicationOverride, "telemetry", "params", opts.to_dict(args.telemetry_params))
-
-    cfg.add(config.Scope.applicationOverride, "race", "pipeline", args.pipeline)
-    cfg.add(config.Scope.applicationOverride, "race", "user.tag", args.user_tag)
-
-    cfg.add(config.Scope.applicationOverride, "track", "repository.revision", args.track_revision)
-
-    # We can assume here that if a track-path is given, the user did not specify a repository either (although argparse sets it to
-    # its default value)
-    if args.track_path:
-        cfg.add(config.Scope.applicationOverride, "track", "track.path", os.path.abspath(io.normalize_path(args.track_path)))
-        cfg.add(config.Scope.applicationOverride, "track", "repository.name", None)
-        if args.track_revision:
-            # stay as close as possible to argparse errors although we have a custom validation.
-            arg_parser.error("argument --track-revision not allowed with argument --track-path")
-        if args.track:
-            # stay as close as possible to argparse errors although we have a custom validation.
-            arg_parser.error("argument --track not allowed with argument --track-path")
-        # cfg.add(config.Scope.applicationOverride, "track", "track.name", None)
-    else:
-        # cfg.add(config.Scope.applicationOverride, "track", "track.path", None)
-        cfg.add(config.Scope.applicationOverride, "track", "repository.name", args.track_repository)
-        # set the default programmatically because we need to determine whether the user has provided a value
-        chosen_track = args.track if args.track else "geonames"
-        cfg.add(config.Scope.applicationOverride, "track", "track.name", chosen_track)
-
-    cfg.add(config.Scope.applicationOverride, "track", "params", opts.to_dict(args.track_params))
-    cfg.add(config.Scope.applicationOverride, "track", "challenge.name", args.challenge)
-    cfg.add(config.Scope.applicationOverride, "track", "include.tasks", opts.csv_to_list(args.include_tasks))
-    cfg.add(config.Scope.applicationOverride, "track", "exclude.tasks", opts.csv_to_list(args.exclude_tasks))
-    cfg.add(config.Scope.applicationOverride, "track", "test.mode.enabled", args.test_mode)
-
-    cfg.add(config.Scope.applicationOverride, "reporting", "format", args.report_format)
-    cfg.add(config.Scope.applicationOverride, "reporting", "values", args.show_in_report)
-    cfg.add(config.Scope.applicationOverride, "reporting", "output.path", args.report_file)
-    if sub_command == "compare":
-        cfg.add(config.Scope.applicationOverride, "reporting", "baseline.id", args.baseline)
-        cfg.add(config.Scope.applicationOverride, "reporting", "contender.id", args.contender)
-    if sub_command == "generate":
-        cfg.add(config.Scope.applicationOverride, "generator", "chart.type", args.chart_type)
-        cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
-
-        if args.chart_spec_path and (args.track or args.challenge or args.car or args.node_count):
-            console.println("You need to specify either --chart-spec-path or --track, --challenge, --car and "
-                            "--node-count but not both.")
-            sys.exit(1)
-        if args.chart_spec_path:
-            cfg.add(config.Scope.applicationOverride, "generator", "chart.spec.path", args.chart_spec_path)
-        else:
-            # other options are stored elsewhere already
-            cfg.add(config.Scope.applicationOverride, "generator", "node.count", args.node_count)
-    if sub_command == "create-track":
-        cfg.add(config.Scope.applicationOverride, "generator", "indices", args.indices)
-        cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
-
-    cfg.add(config.Scope.applicationOverride, "driver", "profiling", args.enable_driver_profiling)
-    cfg.add(config.Scope.applicationOverride, "driver", "assertions", args.enable_assertions)
-    cfg.add(config.Scope.applicationOverride, "driver", "on.error", args.on_error)
-    cfg.add(config.Scope.applicationOverride, "driver", "load_driver_hosts", opts.csv_to_list(args.load_driver_hosts))
-    if sub_command not in ("list", "install", "download"):
-        # Also needed by mechanic (-> telemetry) - duplicate by module?
-        target_hosts = opts.TargetHosts(args.target_hosts)
-        cfg.add(config.Scope.applicationOverride, "client", "hosts", target_hosts)
-        client_options = opts.ClientOptions(args.client_options, target_hosts=target_hosts)
-        cfg.add(config.Scope.applicationOverride, "client", "options", client_options)
-        if "timeout" not in client_options.default:
-            console.info("You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.")
-        if list(target_hosts.all_hosts) != list(client_options.all_client_options):
-            console.println("--target-hosts and --client-options must define the same keys for multi cluster setups.")
-            sys.exit(1)
-    # split by component?
-    if sub_command == "download":
-        cfg.add(config.Scope.applicationOverride, "mechanic", "target.os", args.target_os)
-        cfg.add(config.Scope.applicationOverride, "mechanic", "target.arch", args.target_arch)
-    if sub_command == "list":
-        cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
-        cfg.add(config.Scope.applicationOverride, "system", "list.races.max_results", args.limit)
-    if sub_command == "install":
-        cfg.add(config.Scope.applicationOverride, "mechanic", "network.host", args.network_host)
-        cfg.add(config.Scope.applicationOverride, "mechanic", "network.http.port", args.http_port)
-        cfg.add(config.Scope.applicationOverride, "mechanic", "skip.build", args.skip_build)
-        cfg.add(config.Scope.applicationOverride, "mechanic", "build.type", args.build_type)
-        cfg.add(config.Scope.applicationOverride, "mechanic", "node.name", args.node_name)
-        cfg.add(config.Scope.applicationOverride, "mechanic", "master.nodes", opts.csv_to_list(args.master_nodes))
-        cfg.add(config.Scope.applicationOverride, "mechanic", "seed.hosts", opts.csv_to_list(args.seed_hosts))
-    if sub_command in ["start", "stop"]:
-        cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
-
-    logger.info("Race id [%s]", args.race_id)
     logger.info("OS [%s]", str(platform.uname()))
     logger.info("Python [%s]", str(sys.implementation))
     logger.info("Rally version [%s]", version.version())
@@ -936,7 +946,7 @@ def main():
         else:
             logger.info("Detected a working Internet connection.")
 
-    success = dispatch_sub_command(cfg, sub_command)
+    success = dispatch_sub_command(arg_parser, args, cfg)
 
     end = time.time()
     if success:

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -40,10 +40,7 @@ def summarize(results, cfg):
     SummaryReporter(results, cfg).report()
 
 
-def compare(cfg):
-    baseline_id = cfg.opts("reporting", "baseline.id")
-    contender_id = cfg.opts("reporting", "contender.id")
-
+def compare(cfg, baseline_id, contender_id):
     if not baseline_id or not contender_id:
         raise exceptions.SystemSetupError("compare needs baseline and a contender")
     race_store = metrics.race_store(cfg)

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -68,7 +68,7 @@ class CompositeTrackProcessor(TrackProcessor):
     def __init__(self, cfg):
         self.track_processors = []
         self.offline = cfg.opts("system", "offline.mode")
-        self.test_mode = cfg.opts("track", "test.mode.enabled")
+        self.test_mode = cfg.opts("track", "test.mode.enabled", mandatory=False, default_value=False)
 
     def register_track_processor(self, processor):
         if hasattr(processor, "downloader"):
@@ -194,7 +194,7 @@ def _load_single_track(cfg, track_repository, track_name):
         track_processor.register_track_processor(TaskFilterTrackProcessor(cfg))
         track_processor.register_track_processor(TestModeTrackProcessor(cfg))
 
-        has_plugins = load_track_plugins(cfg, register_track_processor=track_processor.register_track_processor)
+        has_plugins = load_track_plugins(cfg, track_name, register_track_processor=track_processor.register_track_processor)
         current_track.has_plugins = has_plugins
 
         return track_processor.on_after_load_track(current_track)
@@ -208,6 +208,7 @@ def _load_single_track(cfg, track_repository, track_name):
 
 
 def load_track_plugins(cfg,
+                       track_name,
                        register_runner=None,
                        register_scheduler=None,
                        register_track_processor=None,
@@ -216,6 +217,7 @@ def load_track_plugins(cfg,
     Loads plugins that are defined for the current track (as specified by the configuration).
 
     :param cfg: The config object.
+    :param track_name: Name of the track for which plugins should be loaded.
     :param register_runner: An optional function where runners can be registered.
     :param register_scheduler: An optional function where custom schedulers can be registered.
     :param register_track_processor: An optional function where track processors can be registered.
@@ -224,7 +226,6 @@ def load_track_plugins(cfg,
     :return: True iff this track defines plugins and they have been loaded.
     """
     repo = track_repo(cfg, fetch=force_update, update=force_update)
-    track_name = repo.track_name
     track_plugin_path = repo.track_dir(track_name)
 
     plugin_reader = TrackPluginReader(track_plugin_path, register_runner, register_scheduler, register_track_processor)
@@ -406,7 +407,7 @@ def prepare_track(t, cfg):
         logger.info("Reloading track [%s] to ensure plugins are up-to-date.", t.name)
         # the track might have been loaded on a different machine (the coordinator machine) so we force a track update
         # to ensure we use the latest version of plugins.
-        load_track_plugins(cfg, register_track_processor=tp.register_track_processor, force_update=True)
+        load_track_plugins(cfg, t.name, register_track_processor=tp.register_track_processor, force_update=True)
 
     # register last so user-defined track processors can override the default behavior
     tp.register_track_processor(DefaultTrackPreparator(cfg))
@@ -792,11 +793,14 @@ def render_template_from_file(template_file_name, template_vars, complete_track_
 class TaskFilterTrackProcessor(TrackProcessor):
     def __init__(self, cfg):
         self.logger = logging.getLogger(__name__)
-        if cfg.opts("track", "include.tasks"):
-            filtered_tasks = cfg.opts("track", "include.tasks")
+        include_tasks = cfg.opts("track", "include.tasks", mandatory=False)
+        exclude_tasks = cfg.opts("track", "exclude.tasks", mandatory=False)
+
+        if include_tasks:
+            filtered_tasks = include_tasks
             self.exclude = False
         else:
-            filtered_tasks = cfg.opts("track", "exclude.tasks")
+            filtered_tasks = exclude_tasks
             self.exclude = True
         self.filters = self._filters_from_filtered_tasks(filtered_tasks)
 
@@ -855,7 +859,7 @@ class TaskFilterTrackProcessor(TrackProcessor):
 
 class TestModeTrackProcessor(TrackProcessor):
     def __init__(self, cfg):
-        self.test_mode_enabled = cfg.opts("track", "test.mode.enabled")
+        self.test_mode_enabled = cfg.opts("track", "test.mode.enabled", mandatory=False, default_value=False)
         self.logger = logging.getLogger(__name__)
 
     def on_after_load_track(self, track):
@@ -954,7 +958,7 @@ class TrackFileReader:
         track_schema_file = os.path.join(cfg.opts("node", "rally.root"), "resources", "track-schema.json")
         with open(track_schema_file, mode="rt", encoding="utf-8") as f:
             self.track_schema = json.loads(f.read())
-        self.track_params = cfg.opts("track", "params")
+        self.track_params = cfg.opts("track", "params", mandatory=False)
         self.complete_track_params = CompleteTrackParams(user_specified_track_params=self.track_params)
         self.read_track = TrackSpecificationReader(
             track_params=self.track_params,

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -71,7 +71,7 @@ def rally_es(t):
 
 
 def esrally_command_line_for(cfg, command_line):
-    return f"esrally {command_line} --kill-running-processes --configuration-name='{cfg}'"
+    return f"esrally {command_line} --configuration-name='{cfg}'"
 
 
 def esrally(cfg, command_line):
@@ -87,7 +87,7 @@ def race(cfg, command_line):
     This method should be used for rally invocations of the race command.
     It sets up some defaults for how the integration tests expect to run races.
     """
-    return esrally(cfg, f"race {command_line} --on-error='abort' --enable-assertions")
+    return esrally(cfg, f"race {command_line} --kill-running-processes --on-error='abort' --enable-assertions")
 
 
 def wait_until_port_is_free(port_number=39200, timeout=120):

--- a/it/generate_test.py
+++ b/it/generate_test.py
@@ -1,0 +1,31 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+import it
+
+
+@it.rally_in_mem
+def test_track_info_with_challenge(cfg, tmp_path):
+    cwd = os.path.dirname(__file__)
+    chart_spec_path = os.path.join(cwd, "resources", "sample-race-config.json")
+    output_path = os.path.join(tmp_path, "nightly-charts.ndjson")
+    assert it.esrally(cfg, f"generate charts "
+                           f"--chart-spec-path={chart_spec_path} "
+                           f"--chart-type=time-series "
+                           f"--output-path={output_path}") == 0

--- a/it/resources/sample-race-config.json
+++ b/it/resources/sample-race-config.json
@@ -1,0 +1,30 @@
+[
+  {
+    "track": "geonames",
+    "flavors": [
+      {
+        "name": "default",
+        "licenses": [
+          {
+            "name": "basic",
+            "configurations": [
+              {
+                "name": "geonames-append-4g-3nodes",
+                "label": "add-4g-3nodes",
+                "charts": [
+                  "indexing"
+                ],
+                "challenge": "append-no-conflicts-index-only",
+                "track-params": {
+                  "number_of_replicas": 1
+                },
+                "car": "4gheap",
+                "node-count": 3
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -169,7 +169,6 @@ class ProcessLauncherTests(TestCase):
     def test_daemon_start_stop(self, wait_for_pidfile, chdir, get_size, supports, java_home):
         cfg = config.Config()
         cfg.add(config.Scope.application, "node", "root.dir", "test")
-        cfg.add(config.Scope.application, "mechanic", "keep.running", False)
         cfg.add(config.Scope.application, "mechanic", "runtime.jdk", None)
         cfg.add(config.Scope.application, "telemetry", "devices", [])
         cfg.add(config.Scope.application, "telemetry", "params", None)
@@ -196,7 +195,6 @@ class ProcessLauncherTests(TestCase):
     def test_daemon_stop_with_already_terminated_process(self):
         cfg = config.Config()
         cfg.add(config.Scope.application, "node", "root.dir", "test")
-        cfg.add(config.Scope.application, "mechanic", "keep.running", False)
         cfg.add(config.Scope.application, "telemetry", "devices", [])
         cfg.add(config.Scope.application, "telemetry", "params", None)
         cfg.add(config.Scope.application, "system", "env.name", "test")
@@ -220,7 +218,6 @@ class ProcessLauncherTests(TestCase):
     @mock.patch("esrally.time.sleep")
     def test_env_options_order(self, sleep):
         cfg = config.Config()
-        cfg.add(config.Scope.application, "mechanic", "keep.running", False)
         cfg.add(config.Scope.application, "system", "env.name", "test")
 
         proc_launcher = launcher.ProcessLauncher(cfg)
@@ -239,7 +236,6 @@ class ProcessLauncherTests(TestCase):
 
     def test_bundled_jdk_not_in_path(self):
         cfg = config.Config()
-        cfg.add(config.Scope.application, "mechanic", "keep.running", False)
         cfg.add(config.Scope.application, "system", "env.name", "test")
         os.environ["JAVA_HOME"] = "/path/to/java"
 
@@ -255,7 +251,6 @@ class ProcessLauncherTests(TestCase):
 
     def test_pass_env_vars(self):
         cfg = config.Config()
-        cfg.add(config.Scope.application, "mechanic", "keep.running", False)
         cfg.add(config.Scope.application, "system", "env.name", "test")
         cfg.add(config.Scope.application, "system", "passenv", "JAVA_HOME,FOO1")
         os.environ["JAVA_HOME"] = "/path/to/java"
@@ -274,7 +269,6 @@ class ProcessLauncherTests(TestCase):
 
     def test_pass_java_opts(self):
         cfg = config.Config()
-        cfg.add(config.Scope.application, "mechanic", "keep.running", False)
         cfg.add(config.Scope.application, "system", "env.name", "test")
         cfg.add(config.Scope.application, "system", "passenv", "ES_JAVA_OPTS")
         os.environ["ES_JAVA_OPTS"] = "-XX:-someJunk"

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -62,6 +62,7 @@ def test_finds_available_pipelines():
 
 def test_prevents_running_an_unknown_pipeline():
     cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "system", "race.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
     cfg.add(config.Scope.benchmark, "race", "pipeline", "invalid")
     cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "5.0.0")
 
@@ -73,6 +74,7 @@ def test_prevents_running_an_unknown_pipeline():
 
 def test_passes_benchmark_only_pipeline_in_docker(running_in_docker, benchmark_only_pipeline):
     cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "system", "race.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
     cfg.add(config.Scope.benchmark, "race", "pipeline", "benchmark-only")
 
     racecontrol.run(cfg)
@@ -82,6 +84,7 @@ def test_passes_benchmark_only_pipeline_in_docker(running_in_docker, benchmark_o
 
 def test_fails_without_benchmark_only_pipeline_in_docker(running_in_docker, unittest_pipeline):
     cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "system", "race.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
     cfg.add(config.Scope.benchmark, "race", "pipeline", "unit-test-pipeline")
 
     with pytest.raises(
@@ -97,6 +100,7 @@ def test_fails_without_benchmark_only_pipeline_in_docker(running_in_docker, unit
 
 def test_runs_a_known_pipeline(unittest_pipeline):
     cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "system", "race.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
     cfg.add(config.Scope.benchmark, "race", "pipeline", "unit-test-pipeline")
     cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "")
 


### PR DESCRIPTION
With this commit we remove leniency in subcommand handling and always
require a subcommand. This makes it obvious what command Rally is
executing and as a nice side-effect makes the command line help more
useful as well.

Closes #1142