### PR TITLE
Use operation name consistently in metrics samples

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -682,13 +682,13 @@ class SamplePostprocessor:
 
                 self.metrics_store.put_value_cluster_level(name="service_time", value=sample.service_time_ms,
                                                            unit="ms", task=sample.task.name,
-                                                           operation=sample.task.name, operation_type=sample.operation.type,
+                                                           operation=sample.operation.name, operation_type=sample.operation.type,
                                                            sample_type=sample.sample_type, absolute_time=sample.absolute_time,
                                                            relative_time=sample.relative_time, meta_data=meta_data)
 
                 self.metrics_store.put_value_cluster_level(name="processing_time", value=sample.processing_time_ms,
                                                            unit="ms", task=sample.task.name,
-                                                           operation=sample.task.name, operation_type=sample.operation.type,
+                                                           operation=sample.operation.name, operation_type=sample.operation.type,
                                                            sample_type=sample.sample_type, absolute_time=sample.absolute_time,
                                                            relative_time=sample.relative_time, meta_data=meta_data)
 

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -249,7 +249,7 @@ class SamplePostprocessorTests(TestCase):
                          value=value,
                          unit="docs/s",
                          task="index",
-                         operation="index",
+                         operation="index-op",
                          operation_type=track.OperationType.Bulk,
                          sample_type=metrics.SampleType.Normal,
                          absolute_time=absolute_time,
@@ -270,7 +270,7 @@ class SamplePostprocessorTests(TestCase):
                          value=value,
                          unit="ms",
                          task="index",
-                         operation="index",
+                         operation="index-op",
                          operation_type=track.OperationType.Bulk,
                          sample_type=metrics.SampleType.Normal,
                          absolute_time=absolute_time,
@@ -285,7 +285,7 @@ class SamplePostprocessorTests(TestCase):
                                                   challenge_meta_data={})
 
         task = track.Task("index",
-                        track.Operation("index", track.OperationType.Bulk, param_source="driver-test-param-source"))
+                        track.Operation("index-op", track.OperationType.Bulk, param_source="driver-test-param-source"))
         samples = [
             driver.Sample(0, 38598, 24, task, metrics.SampleType.Normal, None, 10, 7, 9, None, 5000, "docs", 1, 1 / 2),
             driver.Sample(0, 38599, 25, task, metrics.SampleType.Normal, None, 10, 7, 9, None, 5000, "docs", 2, 2 / 2),
@@ -309,7 +309,7 @@ class SamplePostprocessorTests(TestCase):
                                                   challenge_meta_data={})
 
         task = track.Task("index",
-                          track.Operation("index", track.OperationType.Bulk, param_source="driver-test-param-source"))
+                          track.Operation("index-op", track.OperationType.Bulk, param_source="driver-test-param-source"))
         samples = [
             driver.Sample(0, 38598, 24, task, metrics.SampleType.Normal, None, 10, 7, 9, None, 5000, "docs", 1, 1 / 2),
             driver.Sample(0, 38599, 25, task, metrics.SampleType.Normal, None, 10, 7, 9, None, 5000, "docs", 2, 2 / 2),


### PR DESCRIPTION
With this commit we align the value that is used for the `operation`
property in request metrics. Previously, only the `latency` samples
contained the correct operation name but `service_time` and
`processing_time` duplicated the task name instead.