### PR TITLE
Always rely on source artifact caching

### DIFF
--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -61,10 +61,9 @@ class Pipeline:
 
 
 class Setup:
-    def __init__(self, cfg, sources=False, build=False, distribution=False, external=False, docker=False):
+    def __init__(self, cfg, sources=False, distribution=False, external=False, docker=False):
         self.cfg = cfg
         self.sources = sources
-        self.build = build
         self.distribution = distribution
         self.external = external
         self.docker = docker
@@ -105,7 +104,6 @@ class BenchmarkActor(actor.RallyActor):
                                                       self.coordinator.metrics_store.open_context,
                                                       cluster_settings,
                                                       msg.sources,
-                                                      msg.build,
                                                       msg.distribution,
                                                       msg.external,
                                                       msg.docker))
@@ -234,13 +232,13 @@ class BenchmarkCoordinator:
         self.metrics_store.close()
 
 
-def race(cfg, sources=False, build=False, distribution=False, external=False, docker=False):
+def race(cfg, sources=False, distribution=False, external=False, docker=False):
     logger = logging.getLogger(__name__)
     # at this point an actor system has to run and we should only join
     actor_system = actor.bootstrap_actor_system(try_join=True)
     benchmark_actor = actor_system.createActor(BenchmarkActor, targetActorRequirements={"coordinator": True})
     try:
-        result = actor_system.ask(benchmark_actor, Setup(cfg, sources, build, distribution, external, docker))
+        result = actor_system.ask(benchmark_actor, Setup(cfg, sources, distribution, external, docker))
         if isinstance(result, Success):
             logger.info("Benchmark has finished successfully.")
         # may happen if one of the load generators has detected that the user has cancelled the benchmark.
@@ -276,7 +274,7 @@ def set_default_hosts(cfg, host="127.0.0.1", port=9200):
 def from_sources(cfg):
     port = cfg.opts("provisioning", "node.http.port")
     set_default_hosts(cfg, port=port)
-    return race(cfg, sources=True, build=True)
+    return race(cfg, sources=True)
 
 
 def from_distribution(cfg):

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -246,11 +246,6 @@ def create_arg_parser():
              " The timestamp must be specified as: \"@ts\" where \"ts\" must be a valid ISO 8601 timestamp, "
              "e.g. \"@2013-07-27T10:37:00Z\" (default: current).",
         default="current")  # optimized for local usage, don't fetch sources
-    install_parser.add_argument(
-        "--skip-build",
-        help="Whether Rally should skip rebuilding Elasticsearch (default: false).",
-        default=False,
-        action="store_true")
     # Intentionally undocumented as we do not consider Docker a fully supported option.
     install_parser.add_argument(
         "--build-type",
@@ -789,8 +784,6 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "mechanic", "network.host", args.network_host)
             cfg.add(config.Scope.applicationOverride, "mechanic", "network.http.port", args.http_port)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
-            # TODO: Remove this special treatment and rely on artifact caching (follow-up PR)
-            cfg.add(config.Scope.applicationOverride, "mechanic", "skip.build", args.skip_build)
             cfg.add(config.Scope.applicationOverride, "mechanic", "build.type", args.build_type)
             cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
             cfg.add(config.Scope.applicationOverride, "mechanic", "node.name", args.node_name)


### PR DESCRIPTION
With this commit we remove the undocumented command line parameter
`--skip-build` which was useful before Rally has implemented source
artifact caching. As Rally is aware whether an artifact needs to built,
this flag can be removed.

This is a follow-up from #1175.

Relates #1175