### PR TITLE
Remove leftover from resolver cleanup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ setenv =
     # LC_ALL should have priority but to ensure that non-confirming
     # applications behave identically, we also set LANG explicitly.
     LANG=C
-    PIP_USE_FEATURE={env:PIP_USE_FEATURE:2020-resolver}
 commands =
     pytest --junitxml=junit-{envname}.xml
     pytest -s it --junitxml=junit-{envname}-it.xml


### PR DESCRIPTION
With this commit we remove one leftover reference in our tox
configuration which still mentions the 2020-resolver.

Relates #1151