### PR TITLE
Pin urllib3 version to fix boto dep requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ install_requires = [
     #   jmespath: MIT
     #   s3transfer: Apache 2.0
     "boto3==1.10.32",
+    "urllib3<1.26,>=1.20",
     # License: Apache 2.0
     "yappi==1.2.3",
     # License: BSD


### PR DESCRIPTION
error: urllib3 1.26.3 is installed but urllib3<1.26,>=1.20 is required by {'botocore'}

<!--
Thank you for your interest in and contributing to Rally! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

* Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
* Have you followed the [contributor guidelines](https://github.com/elastic/rally/blob/master/CONTRIBUTING.md)?
* Have you run `make test` and `make it` and both finish without errors?
* Did you choose a [descriptive title and description](https://chris.beams.io/posts/git-commit/) for your PR?
* (Only for maintainers) Did you apply appropriate labels and a milestone?
