### PR TITLE
Fix compare subcommand

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -198,6 +198,10 @@ def create_arg_parser():
         "--report-file",
         help="Write the command line report also to the provided file.",
         default="")
+    compare_parser.add_argument(
+        "--show-in-report",
+        help="Whether to include the comparison in the results file.",
+        default=True)
 
     download_parser = subparsers.add_parser("download", help="Downloads an artifact")
     download_parser.add_argument(


### PR DESCRIPTION
The refactoring in #1175 broken the compare subcommand due to reliance
on the `show-in-report` cli argument. As prior to the PR the subcommand
parsing logic was obscure the problem surfaced now.

This commit defaults the parameter `show-in-report` for the compare
subcommand to True. This parameter could be removed in the future,
the reason for adding it in the past was that some users relied on
parsing the report file and the comparison adds fields
(like percentiles) dynamically.
