### PR TITLE
Ensure stable mappings for metrics

### DIFF
--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -8,6 +8,7 @@
   },
   "mappings": {
     "_doc": {
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings": {

--- a/esrally/resources/races-template.json
+++ b/esrally/resources/races-template.json
@@ -8,6 +8,7 @@
   },
   "mappings": {
     "_doc": {
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings": {

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -8,6 +8,7 @@
   },
   "mappings": {
     "_doc": {
+      "date_detection": false,
       "dynamic_templates": [
         {
           "strings": {


### PR DESCRIPTION
With this commit we disable dynamic detection of dates for documents in
the metrics store. By disabling this feature, any dynamic values (like
track parameters or user tags) that look like dates are mapped as
keywords instead of as dates. These values should only be treated as
keywords and are not meant to be used e.g. in range queries.

Furthermore, this ensures that we don't cause trouble when date formats
conflict in such dynamic values. Note that properties that are
explicitly mapped as dates (e.g. `@timestamp`) are not affected by this
change and will still be mapped as dates.