### PR TITLE
Add searchable-snapshots-stats telemetry device 

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -16,16 +16,18 @@ You probably want to gain additional insights from a race. Therefore, we have ad
 
    Available telemetry devices:
 
-   Command         Name                   Description
-   --------------  ---------------------  --------------------------------------------------------------------
-   jit              JIT Compiler Profiler  Enables JIT compiler logs.
-   gc               GC log                 Enables GC logs.
-   jfr              Flight Recorder        Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
-   heapdump         Heap Dump              Captures a heap dump.
-   node-stats       Node Stats             Regularly samples node stats
-   recovery-stats   Recovery Stats         Regularly samples shard recovery stats
-   ccr-stats        CCR Stats              Regularly samples Cross Cluster Replication (CCR) related stats
-   transform-stats  Transform Stats        Regularly samples transform stats
+    Command                     Name                        Description
+    --------------------------  --------------------------  --------------------------------------------------------------------
+    jit                         JIT Compiler Profiler       Enables JIT compiler logs.
+    gc                          GC log                      Enables GC logs.
+    jfr                         Flight Recorder             Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
+    heapdump                    Heap Dump                   Captures a heap dump.
+    node-stats                  Node Stats                  Regularly samples node stats
+    recovery-stats              Recovery Stats              Regularly samples shard recovery stats
+    ccr-stats                   CCR Stats                   Regularly samples Cross Cluster Replication (CCR) related stats
+    segment-stats               Segment Stats               Determines segment stats at the end of the benchmark.
+    transform-stats             Transform Stats             Regularly samples transform stats
+    searchable-snapshots-stats  Searchable Snapshots Stats  Regularly samples searchable snapshots stats
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 
@@ -146,3 +148,15 @@ Supported telemetry parameters:
 
 * ``transform-stats-transforms`` (default: all transforms): A list of transforms per cluster for which transform stats should be checked.
 * ``transform-stats-sample-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.
+
+searchable-snapshots-stats
+--------------------------
+
+The searchable-snapshots-stats telemetry device regularly calls the low level `searchable snapshots stats API <https://www.elastic.co/guide/en/elasticsearch/reference/7.11/searchable-snapshots-api-stats.html>` and records one metrics document per file extension.
+
+As the API is currently undocumented, there are no guarantees about future compatibility or completeness of metrics captured.
+
+Supported telemetry parameters:
+
+* ``searchable-snapshots-stats-indices`` (default: None): A string with the index/index pattern, or list of strings/index patterns that searchable snapshots stats should additionally be collected from.
+* ``searchable-snapshots-stats-sample-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -16,18 +16,18 @@ You probably want to gain additional insights from a race. Therefore, we have ad
 
    Available telemetry devices:
 
-    Command                     Name                        Description
-    --------------------------  --------------------------  --------------------------------------------------------------------
-    jit                         JIT Compiler Profiler       Enables JIT compiler logs.
-    gc                          GC log                      Enables GC logs.
-    jfr                         Flight Recorder             Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
-    heapdump                    Heap Dump                   Captures a heap dump.
-    node-stats                  Node Stats                  Regularly samples node stats
-    recovery-stats              Recovery Stats              Regularly samples shard recovery stats
-    ccr-stats                   CCR Stats                   Regularly samples Cross Cluster Replication (CCR) related stats
-    segment-stats               Segment Stats               Determines segment stats at the end of the benchmark.
-    transform-stats             Transform Stats             Regularly samples transform stats
-    searchable-snapshots-stats  Searchable Snapshots Stats  Regularly samples searchable snapshots stats
+   Command                     Name                        Description
+   --------------------------  --------------------------  --------------------------------------------------------------------
+   jit                         JIT Compiler Profiler       Enables JIT compiler logs.
+   gc                          GC log                      Enables GC logs.
+   jfr                         Flight Recorder             Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
+   heapdump                    Heap Dump                   Captures a heap dump.
+   node-stats                  Node Stats                  Regularly samples node stats
+   recovery-stats              Recovery Stats              Regularly samples shard recovery stats
+   ccr-stats                   CCR Stats                   Regularly samples Cross Cluster Replication (CCR) related stats
+   segment-stats               Segment Stats               Determines segment stats at the end of the benchmark.
+   transform-stats             Transform Stats             Regularly samples transform stats
+   searchable-snapshots-stats  Searchable Snapshots Stats  Regularly samples searchable snapshots stats
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 
@@ -142,7 +142,7 @@ Supported telemetry parameters:
 transform-stats
 ---------------
 
-The transform-stats telemetry device regularly calls the `transform stats API <https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html>` and records one metrics document per transform.
+The transform-stats telemetry device regularly calls the `transform stats API <https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html>`_ and records one metrics document per transform.
 
 Supported telemetry parameters:
 
@@ -152,11 +152,11 @@ Supported telemetry parameters:
 searchable-snapshots-stats
 --------------------------
 
-The searchable-snapshots-stats telemetry device regularly calls the low level `searchable snapshots stats API <https://www.elastic.co/guide/en/elasticsearch/reference/7.11/searchable-snapshots-api-stats.html>` and records one metrics document per file extension.
+The searchable-snapshots-stats telemetry device regularly calls the low level `searchable snapshots stats API <https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-stats.html>`_ and records one metrics document per file extension.
 
 As the API is currently undocumented, there are no guarantees about future compatibility or completeness of metrics captured.
 
 Supported telemetry parameters:
 
-* ``searchable-snapshots-stats-indices`` (default: None): A string with the index/index pattern, or list of strings/index patterns that searchable snapshots stats should additionally be collected from.
+* ``searchable-snapshots-stats-indices`` (default: None): A string with the index/index pattern, or list of indices/index patterns that searchable snapshots stats should additionally be collected from.
 * ``searchable-snapshots-stats-sample-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -158,5 +158,5 @@ As the API is currently undocumented, there are no guarantees about future compa
 
 Supported telemetry parameters:
 
-* ``searchable-snapshots-stats-indices`` (default: None): A string with the index/index pattern, or list of indices/index patterns that searchable snapshots stats should additionally be collected from.
+* ``searchable-snapshots-stats-indices`` (default: None): A string with the index/index pattern, or list of indices/index patterns that searchable snapshots stats should additionally be collected from. If unset, only cluster level stats will be collected.
 * ``searchable-snapshots-stats-sample-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -415,7 +415,8 @@ class Driver:
             telemetry.SegmentStats(log_root, es_default),
             telemetry.CcrStats(telemetry_params, es, self.metrics_store),
             telemetry.RecoveryStats(telemetry_params, es, self.metrics_store),
-            telemetry.TransformStats(telemetry_params, es, self.metrics_store)
+            telemetry.TransformStats(telemetry_params, es, self.metrics_store),
+            telemetry.SearchableSnapshotsStats(telemetry_params, es, self.metrics_store)
         ])
 
     def wait_for_rest_api(self, es):

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -990,7 +990,7 @@ class SearchableSnapshotsStats(TelemetryDevice):
                 f"The telemetry parameter 'searchable-snapshots-stats-sample-interval' must be greater than zero "
                 f"but was {self.sample_interval}.")
         self.specified_cluster_names = self.clients.keys()
-        indices_per_cluster = self.telemetry_params.get("searchable-snapshots-stats-indices", False)
+        indices_per_cluster = self.telemetry_params.get("searchable-snapshots-stats-indices", None)
         # allow the user to specify either an index pattern as string or as a JSON object
         if isinstance(indices_per_cluster, str):
             self.indices_per_cluster = {opts.TargetHosts.DEFAULT: [indices_per_cluster]}
@@ -1073,11 +1073,9 @@ class SearchableSnapshotsStatsRecorder:
                 # allow collection, indices might be mounted later on
                 return
         except elasticsearch.TransportError:
-            msg = f"A transport error occurred while collecting searchable snapshots stats on cluster " \
-                  f"[{self.cluster_name}]"
-
-            self.logger.exception(msg)
-            raise exceptions.RallyError(msg)
+            raise exceptions.RallyError(
+                f"A transport error occurred while collecting searchable snapshots stats on cluster "
+                f"[{self.cluster_name}]") from None
 
         total_stats = stats.get("total", [])
         for lucene_file_stats in total_stats:

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1095,7 +1095,7 @@ class SearchableSnapshotsStatsRecorder:
         doc = {
             "name": "searchable-snapshots-stats",
             # be lenient as the API is still WiP
-            "lucene_file": stats.get("file_ext"),
+            "lucene_file_type": stats.get("file_ext"),
             "stats": stats,
         }
 

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -1318,7 +1318,7 @@ class TestSearchableSnapshotsStats:
         expected_calls = [
             call({
                 "name": "searchable-snapshots-stats",
-                "lucene_file": stat["file_ext"],
+                "lucene_file_type": stat["file_ext"],
                 "stats": stat},
                 level=MetaInfoScope.cluster,
                 meta_data={
@@ -1355,7 +1355,7 @@ class TestSearchableSnapshotsStats:
         expected_calls = [
             call({
                 "name": "searchable-snapshots-stats",
-                "lucene_file": stat["file_ext"],
+                "lucene_file_type": stat["file_ext"],
                 "stats": stat},
                 level=MetaInfoScope.cluster,
                 meta_data={
@@ -1365,7 +1365,7 @@ class TestSearchableSnapshotsStats:
         expected_calls.extend([
             call({
                 "name": "searchable-snapshots-stats",
-                "lucene_file": stat["file_ext"],
+                "lucene_file_type": stat["file_ext"],
                 "stats": stat,
                 "index": "elasticlogs-2020-01-01"
                 },

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import collections
+import copy
 import logging
 import random
 import unittest.mock as mock
@@ -882,8 +883,378 @@ class RecoveryStatsTests(TestCase):
 
 
 class TestSearchableSnapshotsStats:
+    response_fragment_total = [
+            {
+                "file_ext": "fnm",
+                "num_files": 50,
+                "total_size": 279900,
+                "open_count": 274,
+                "close_count": 274,
+                "contiguous_bytes_read": {
+                    "count": 1644,
+                    "sum": 1533852,
+                    "min": 478,
+                    "max": 1024
+                },
+                "non_contiguous_bytes_read": {
+                    "count": 0,
+                    "sum": 0,
+                    "min": 0,
+                    "max": 0
+                },
+                "cached_bytes_read": {
+                    "count": 1613,
+                    "sum": 1502108,
+                    "min": 478,
+                    "max": 1024
+                },
+                "index_cache_bytes_read": {
+                    "count": 31,
+                    "sum": 173538,
+                    "min": 0,
+                    "max": 5598
+                },
+                "cached_bytes_written": {
+                    "count": 81,
+                    "sum": 453438,
+                    "min": 5598,
+                    "max": 5598,
+                    "time": "1.6s",
+                    "time_in_nanos": 1607457548
+                },
+                "direct_bytes_read": {
+                    "count": 0,
+                    "sum": 0,
+                    "min": 0,
+                    "max": 0,
+                    "time": "0s",
+                    "time_in_nanos": 0
+                },
+                "optimized_bytes_read": {
+                    "count": 0,
+                    "sum": 0,
+                    "min": 0,
+                    "max": 0,
+                    "time": "0s",
+                    "time_in_nanos": 0
+                },
+                "forward_seeks": {
+                    "small": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0
+                    },
+                    "large": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0
+                    }
+                },
+                "backward_seeks": {
+                    "small": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0
+                    },
+                    "large": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0
+                    }
+                },
+                "blob_store_bytes_requested": {
+                    "count": 50,
+                    "sum": 279900,
+                    "min": 5598,
+                    "max": 5598
+                },
+                "current_index_cache_fills": 0
+            },
+            {
+                "file_ext": "kdd",
+                "num_files": 50,
+                "total_size": 356841728759,
+                "open_count": 174,
+                "close_count": 174,
+                "contiguous_bytes_read": {
+                    "count": 184852,
+                    "sum": 189288448,
+                    "min": 1024,
+                    "max": 1024
+                },
+                "non_contiguous_bytes_read": {
+                    "count": 2228,
+                    "sum": 2281472,
+                    "min": 0,
+                    "max": 1024
+                },
+                "cached_bytes_read": {
+                    "count": 187049,
+                    "sum": 191538176,
+                    "min": 1024,
+                    "max": 1024
+                },
+                "index_cache_bytes_read": {
+                    "count": 31,
+                    "sum": 31744,
+                    "min": 0,
+                    "max": 1024
+                },
+                "cached_bytes_written": {
+                    "count": 122,
+                    "sum": 274173997,
+                    "min": 1024,
+                    "max": 7942949,
+                    "time": "22.2s",
+                    "time_in_nanos": 22277973991
+                },
+                "direct_bytes_read": {
+                    "count": 0,
+                    "sum": 0,
+                    "min": 0,
+                    "max": 0,
+                    "time": "0s",
+                    "time_in_nanos": 0
+                },
+                "optimized_bytes_read": {
+                    "count": 0,
+                    "sum": 0,
+                    "min": 0,
+                    "max": 0,
+                    "time": "0s",
+                    "time_in_nanos": 0
+                },
+                "forward_seeks": {
+                    "small": {
+                        "count": 2114,
+                        "sum": 11467,
+                        "min": 0,
+                        "max": 10
+                    },
+                    "large": {
+                        "count": 174,
+                        "sum": 1241804830245,
+                        "min": 7134354745,
+                        "max": 7139204589
+                    }
+                },
+                "backward_seeks": {
+                    "small": {
+                        "count": 114,
+                        "sum": 192303474,
+                        "min": 0,
+                        "max": 1689340
+                    },
+                    "large": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0
+                    }
+                },
+                "blob_store_bytes_requested": {
+                    "count": 91,
+                    "sum": 274142253,
+                    "min": 131072,
+                    "max": 7942949
+                },
+                "current_index_cache_fills": 0
+            }
+        ]
+
+    response_fragment_indices = {
+        "elasticlogs-2020-01-01": {
+                                      "total": [
+                                          {
+                                              "file_ext": "fnm",
+                                              "num_files": 5,
+                                              "total_size": 27990,
+                                              "open_count": 20,
+                                              "close_count": 20,
+                                              "contiguous_bytes_read": {
+                                                  "count": 120,
+                                                  "sum": 111960,
+                                                  "min": 478,
+                                                  "max": 1024
+                                              },
+                                              "non_contiguous_bytes_read": {
+                                                  "count": 0,
+                                                  "sum": 0,
+                                                  "min": 0,
+                                                  "max": 0
+                                              },
+                                              "cached_bytes_read": {
+                                                  "count": 120,
+                                                  "sum": 111960,
+                                                  "min": 478,
+                                                  "max": 1024
+                                              },
+                                              "index_cache_bytes_read": {
+                                                  "count": 0,
+                                                  "sum": 0,
+                                                  "min": 0,
+                                                  "max": 0
+                                              },
+                                              "cached_bytes_written": {
+                                                  "count": 5,
+                                                  "sum": 27990,
+                                                  "min": 5598,
+                                                  "max": 5598,
+                                                  "time": "193.9ms",
+                                                  "time_in_nanos": 193930007
+                                              },
+                                              "direct_bytes_read": {
+                                                  "count": 0,
+                                                  "sum": 0,
+                                                  "min": 0,
+                                                  "max": 0,
+                                                  "time": "0s",
+                                                  "time_in_nanos": 0
+                                              },
+                                              "optimized_bytes_read": {
+                                                  "count": 0,
+                                                  "sum": 0,
+                                                  "min": 0,
+                                                  "max": 0,
+                                                  "time": "0s",
+                                                  "time_in_nanos": 0
+                                              },
+                                              "forward_seeks": {
+                                                  "small": {
+                                                      "count": 0,
+                                                      "sum": 0,
+                                                      "min": 0,
+                                                      "max": 0
+                                                  },
+                                                  "large": {
+                                                      "count": 0,
+                                                      "sum": 0,
+                                                      "min": 0,
+                                                      "max": 0
+                                                  }
+                                              },
+                                              "backward_seeks": {
+                                                  "small": {
+                                                      "count": 0,
+                                                      "sum": 0,
+                                                      "min": 0,
+                                                      "max": 0
+                                                  },
+                                                  "large": {
+                                                      "count": 0,
+                                                      "sum": 0,
+                                                      "min": 0,
+                                                      "max": 0
+                                                  }
+                                              },
+                                              "blob_store_bytes_requested": {
+                                                  "count": 5,
+                                                  "sum": 27990,
+                                                  "min": 5598,
+                                                  "max": 5598
+                                              },
+                                              "current_index_cache_fills": 0
+                                          },
+                                          {
+                                              "file_ext": "kdd",
+                                              "num_files": 5,
+                                              "total_size": 35672988421,
+                                              "open_count": 10,
+                                              "close_count": 10,
+                                              "contiguous_bytes_read": {
+                                                  "count": 10,
+                                                  "sum": 10240,
+                                                  "min": 1024,
+                                                  "max": 1024
+                                              },
+                                              "non_contiguous_bytes_read": {
+                                                  "count": 0,
+                                                  "sum": 0,
+                                                  "min": 0,
+                                                  "max": 0
+                                              },
+                                              "cached_bytes_read": {
+                                                  "count": 10,
+                                                  "sum": 10240,
+                                                  "min": 1024,
+                                                  "max": 1024
+                                              },
+                                              "index_cache_bytes_read": {
+                                                  "count": 0,
+                                                  "sum": 0,
+                                                  "min": 0,
+                                                  "max": 0
+                                              },
+                                              "cached_bytes_written": {
+                                                  "count": 5,
+                                                  "sum": 655360,
+                                                  "min": 131072,
+                                                  "max": 131072,
+                                                  "time": "414.4ms",
+                                                  "time_in_nanos": 414455967
+                                              },
+                                              "direct_bytes_read": {
+                                                  "count": 0,
+                                                  "sum": 0,
+                                                  "min": 0,
+                                                  "max": 0,
+                                                  "time": "0s",
+                                                  "time_in_nanos": 0
+                                              },
+                                              "optimized_bytes_read": {
+                                                  "count": 0,
+                                                  "sum": 0,
+                                                  "min": 0,
+                                                  "max": 0,
+                                                  "time": "0s",
+                                                  "time_in_nanos": 0
+                                              },
+                                              "forward_seeks": {
+                                                  "small": {
+                                                      "count": 0,
+                                                      "sum": 0,
+                                                      "min": 0,
+                                                      "max": 0
+                                                  },
+                                                  "large": {
+                                                      "count": 10,
+                                                      "sum": 71345966442,
+                                                      "min": 7134354745,
+                                                      "max": 7134854030
+                                                  }
+                                              },
+                                              "backward_seeks": {
+                                                  "small": {
+                                                      "count": 0,
+                                                      "sum": 0,
+                                                      "min": 0,
+                                                      "max": 0
+                                                  },
+                                                  "large": {
+                                                      "count": 0,
+                                                      "sum": 0,
+                                                      "min": 0,
+                                                      "max": 0
+                                                  }
+                                              },
+                                              "blob_store_bytes_requested": {
+                                                  "count": 5,
+                                                  "sum": 655360,
+                                                  "min": 131072,
+                                                  "max": 131072
+                                              },
+                                              "current_index_cache_fills": 0
+                                          }
+                                          ]
+                                  }
+    }
+
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
-    def test_empty_metrics_if_empty_searchable_snapshots_stats(self, metrics_store_put_doc):
+    def test_no_metrics_if_empty_searchable_snapshots_stats(self, metrics_store_put_doc):
         response = {}
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
@@ -897,14 +1268,10 @@ class TestSearchableSnapshotsStats:
 
         recorder.record()
 
-        metrics_store_put_doc.assert_called_once_with(
-            {'name': 'searchable-snapshots-stats', 'total': None},
-            level=MetaInfoScope.cluster,
-            meta_data={'cluster': 'default', 'level': 'cluster'})
+        assert metrics_store_put_doc.call_count == 0
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_no_metrics_if_no_searchable_snapshots_stats(self, metrics_store_put_doc):
-        response = {}
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         client = Client(transport_client=TransportClient(
@@ -928,204 +1295,88 @@ class TestSearchableSnapshotsStats:
                 "Unable to find valid indices while collecting searchable snapshots stats on cluster [default]"
             )
 
-        assert 0 == metrics_store_put_doc.call_count
+        assert metrics_store_put_doc.call_count == 0
 
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
-    def test_stores_single_shard_stats(self, metrics_store_put_doc):
+    def test_stores_total_stats(self, metrics_store_put_doc):
         response = {
-            "index1": {
-                "shards": [{
-                    "id": 0,
-                    "type": "STORE",
-                    "stage": "DONE",
-                    "primary": True,
-                    "start_time": "2014-02-24T12:38:06.349",
-                    "start_time_in_millis": "1393245486349",
-                    "stop_time": "2014-02-24T12:38:08.464",
-                    "stop_time_in_millis": "1393245488464",
-                    "total_time": "2.1s",
-                    "total_time_in_millis": 2115,
-                    "source": {
-                        "id": "RGMdRc-yQWWKIBM4DGvwqQ",
-                        "host": "my.fqdn",
-                        "transport_address": "my.fqdn",
-                        "ip": "10.0.1.7",
-                        "name": "my_es_node"
-                    },
-                    "target": {
-                        "id": "RGMdRc-yQWWKIBM4DGvwqQ",
-                        "host": "my.fqdn",
-                        "transport_address": "my.fqdn",
-                        "ip": "10.0.1.7",
-                        "name": "my_es_node"
-                    },
-                    "index": {
-                        "size": {
-                            "total": "24.7mb",
-                            "total_in_bytes": 26001617,
-                            "reused": "24.7mb",
-                            "reused_in_bytes": 26001617,
-                            "recovered": "0b",
-                            "recovered_in_bytes": 0,
-                            "percent": "100.0%"
-                        },
-                        "files": {
-                            "total": 26,
-                            "reused": 26,
-                            "recovered": 0,
-                            "percent": "100.0%"
-                        },
-                        "total_time": "2ms",
-                        "total_time_in_millis": 2,
-                        "source_throttle_time": "0s",
-                        "source_throttle_time_in_millis": 0,
-                        "target_throttle_time": "0s",
-                        "target_throttle_time_in_millis": 0
-                    },
-                    "translog": {
-                        "recovered": 71,
-                        "total": 0,
-                        "percent": "100.0%",
-                        "total_on_start": 0,
-                        "total_time": "2.0s",
-                        "total_time_in_millis": 2025
-                    },
-                    "verify_index": {
-                        "check_index_time": 0,
-                        "check_index_time_in_millis": 0,
-                        "total_time": "88ms",
-                        "total_time_in_millis": 88
-                    }
-                }
-                ]
-            }
+            "total": copy.deepcopy(TestSearchableSnapshotsStats.response_fragment_total)
         }
 
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        client = Client(indices=SubClient(recovery=response))
-        recorder = telemetry.RecoveryStatsRecorder(cluster_name="leader",
-                                                   client=client,
-                                                   metrics_store=metrics_store,
-                                                   sample_interval=1,
-                                                   indices=["index1"])
+        client = Client(transport_client=TransportClient(response=response))
+
+        recorder = telemetry.SearchableSnapshotsStatsRecorder(
+            cluster_name="leader",
+            client=client,
+            metrics_store=metrics_store,
+            sample_interval=1)
         recorder.record()
 
-        shard_metadata = {
-            "cluster": "leader",
-            "index": "index1",
-            "shard": 0
-        }
+        expected_calls = [
+            call({
+                "name": "searchable-snapshots-stats",
+                "lucene_file": stat["file_ext"],
+                "stats": stat},
+                level=MetaInfoScope.cluster,
+                meta_data={
+                    "cluster": "leader", "level": "cluster"})
+            for stat in TestSearchableSnapshotsStats.response_fragment_total]
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index1"]["shards"][0]
-            }, level=MetaInfoScope.cluster, meta_data=shard_metadata)
-        ],  any_order=True)
+        metrics_store_put_doc.assert_has_calls(expected_calls, any_order=True)
 
+    @pytest.mark.parametrize("seed", range(40))
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
-    def test_stores_multi_index_multi_shard_stats(self, metrics_store_put_doc):
+    def test_stores_index_stats(self, metrics_store_put_doc, seed):
+        random.seed(seed)
         response = {
-            "index1": {
-                "shards": [
-                    {
-                        # for the test we only assume a subset of the fields
-                        "id": 0,
-                        "type": "STORE",
-                        "stage": "DONE",
-                        "primary": True,
-                        "total_time_in_millis": 100
-                    },
-                    {
-                        "id": 1,
-                        "type": "STORE",
-                        "stage": "DONE",
-                        "primary": True,
-                        "total_time_in_millis": 200
-                    }
-                ]
-            },
-            "index2": {
-                "shards": [
-                    {
-                        "id": 0,
-                        "type": "STORE",
-                        "stage": "DONE",
-                        "primary": True,
-                        "total_time_in_millis": 300
-                    },
-                    {
-                        "id": 1,
-                        "type": "STORE",
-                        "stage": "DONE",
-                        "primary": True,
-                        "total_time_in_millis": 400
-                    },
-                    {
-                        "id": 2,
-                        "type": "STORE",
-                        "stage": "DONE",
-                        "primary": True,
-                        "total_time_in_millis": 500
-                    }
-                ]
-            }
+            "total": copy.deepcopy(TestSearchableSnapshotsStats.response_fragment_total),
+            "indices": copy.deepcopy(TestSearchableSnapshotsStats.response_fragment_indices)
         }
 
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        client = Client(indices=SubClient(recovery=response))
-        recorder = telemetry.RecoveryStatsRecorder(cluster_name="leader",
-                                                   client=client,
-                                                   metrics_store=metrics_store,
-                                                   sample_interval=1,
-                                                   indices=["index1", "index2"])
+        client = Client(transport_client=TransportClient(response=response))
+
+        recorder = telemetry.SearchableSnapshotsStatsRecorder(
+            cluster_name="default",
+            client=client,
+            metrics_store=metrics_store,
+            sample_interval=1,
+            indices=random.choice([
+                ["elasticlogs*"],
+                "elasticlogs-2020-01-01",
+                "elasticlogs*",
+                ["elasticlogs-2020-01-01"]
+            ])
+        )
         recorder.record()
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index1"]["shards"][0]
-            }, level=MetaInfoScope.cluster, meta_data={
-                "cluster": "leader",
-                "index": "index1",
-                "shard": 0
-            }),
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index1"]["shards"][1]
-            }, level=MetaInfoScope.cluster, meta_data={
-                "cluster": "leader",
-                "index": "index1",
-                "shard": 1
-            }),
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index2"]["shards"][0]
-            }, level=MetaInfoScope.cluster, meta_data={
-                "cluster": "leader",
-                "index": "index2",
-                "shard": 0
-            }),
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index2"]["shards"][1]
-            }, level=MetaInfoScope.cluster, meta_data={
-                "cluster": "leader",
-                "index": "index2",
-                "shard": 1
-            }),
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index2"]["shards"][2]
-            }, level=MetaInfoScope.cluster, meta_data={
-                "cluster": "leader",
-                "index": "index2",
-                "shard": 2
-            }),
-        ],  any_order=True)
+        expected_calls = [
+            call({
+                "name": "searchable-snapshots-stats",
+                "lucene_file": stat["file_ext"],
+                "stats": stat},
+                level=MetaInfoScope.cluster,
+                meta_data={
+                    "cluster": "default", "level": "cluster"})
+            for stat in TestSearchableSnapshotsStats.response_fragment_total]
+
+        expected_calls.extend([
+            call({
+                "name": "searchable-snapshots-stats",
+                "lucene_file": stat["file_ext"],
+                "stats": stat,
+                "index": "elasticlogs-2020-01-01"
+                },
+                level=MetaInfoScope.cluster,
+                meta_data={
+                    "cluster": "default", "level": "index"})
+            for stat in TestSearchableSnapshotsStats.response_fragment_indices["elasticlogs-2020-01-01"]["total"]])
+
+        metrics_store_put_doc.assert_has_calls(expected_calls, any_order=True)
 
 
 class NodeStatsTests(TestCase):

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -1292,7 +1292,7 @@ class TestSearchableSnapshotsStats:
         with mock.patch.object(logger, "info") as mocked_info:
             recorder.record()
             mocked_info.assert_called_once_with(
-                "Unable to find valid indices while collecting searchable snapshots stats on cluster [default]"
+                "Unable to find valid indices while collecting searchable snapshots stats on cluster [%s]", "default"
             )
 
         assert metrics_store_put_doc.call_count == 0
@@ -1347,8 +1347,6 @@ class TestSearchableSnapshotsStats:
             sample_interval=1,
             indices=random.choice([
                 ["elasticlogs*"],
-                "elasticlogs-2020-01-01",
-                "elasticlogs*",
                 ["elasticlogs-2020-01-01"]
             ])
         )


### PR DESCRIPTION
This commit adds a new telemetry device called
`searchable-snapshots-stats` which can be used to retrieve various
useful statistics about searchable snapshots while running a benchmark.
