### PR TITLE
Collect metrics on composite subtasks

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -76,7 +76,7 @@ A UUID that changes on every invocation of Rally. It is intended to group all sa
 @timestamp
 ~~~~~~~~~~
 
-The timestamp in milliseconds since epoch determined when the sample was taken.
+The timestamp in milliseconds since epoch determined when the sample was taken. For request-related metrics, such as ``latency`` or ``service_time`` this is the timestamp when Rally has issued the request.
 
 relative-time
 ~~~~~~~~~~~~~

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -4,6 +4,11 @@ Migration Guide
 Migrating to Rally 2.1.0
 ------------------------
 
+Semantics of request-related timestamps have changed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When Rally stores metrics in a dedicated metrics store, it records additional meta-data such as the absolute and relative timestamp when a sample has been collected. Previously, these timestamps have represented the point in time when a sample has been collected. For request-related metrics such as ``latency`` and ``service_time`` these timestamps represent now the point in time when a request has been sent by Rally.
+
 Throttling is active from the beginning
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -671,26 +671,34 @@ class SamplePostprocessor:
                 meta_data = self.merge(
                     self.track_meta_data,
                     self.challenge_meta_data,
-                    sample.operation.meta_data,
+                    sample.operation_meta_data,
                     sample.task.meta_data,
                     sample.request_meta_data)
 
-                self.metrics_store.put_value_cluster_level(name="latency", value=sample.latency_ms, unit="ms", task=sample.task.name,
-                                                           operation=sample.operation.name, operation_type=sample.operation.type,
+                self.metrics_store.put_value_cluster_level(name="latency", value=convert.seconds_to_ms(sample.latency),
+                                                           unit="ms", task=sample.task.name,
+                                                           operation=sample.operation_name, operation_type=sample.operation_type,
                                                            sample_type=sample.sample_type, absolute_time=sample.absolute_time,
                                                            relative_time=sample.relative_time, meta_data=meta_data)
 
-                self.metrics_store.put_value_cluster_level(name="service_time", value=sample.service_time_ms,
+                self.metrics_store.put_value_cluster_level(name="service_time", value=convert.seconds_to_ms(sample.service_time),
                                                            unit="ms", task=sample.task.name,
-                                                           operation=sample.operation.name, operation_type=sample.operation.type,
+                                                           operation=sample.operation_name, operation_type=sample.operation_type,
                                                            sample_type=sample.sample_type, absolute_time=sample.absolute_time,
                                                            relative_time=sample.relative_time, meta_data=meta_data)
 
-                self.metrics_store.put_value_cluster_level(name="processing_time", value=sample.processing_time_ms,
+                self.metrics_store.put_value_cluster_level(name="processing_time", value=convert.seconds_to_ms(sample.processing_time),
                                                            unit="ms", task=sample.task.name,
-                                                           operation=sample.operation.name, operation_type=sample.operation.type,
+                                                           operation=sample.operation_name, operation_type=sample.operation_type,
                                                            sample_type=sample.sample_type, absolute_time=sample.absolute_time,
                                                            relative_time=sample.relative_time, meta_data=meta_data)
+
+                for timing in sample.dependent_timings:
+                    self.metrics_store.put_value_cluster_level(name="service_time", value=convert.seconds_to_ms(timing.service_time),
+                                                               unit="ms", task=timing.task.name,
+                                                               operation=timing.operation_name, operation_type=timing.operation_type,
+                                                               sample_type=timing.sample_type, absolute_time=timing.absolute_time,
+                                                               relative_time=timing.relative_time, meta_data=meta_data)
 
         end = time.perf_counter()
         self.logger.debug("Storing latency and service time took [%f] seconds.", (end - start))
@@ -991,12 +999,13 @@ class Sampler:
         self.q = queue.Queue(maxsize=buffer_size)
         self.logger = logging.getLogger(__name__)
 
-    def add(self, task, client_id, sample_type, meta_data, latency, service_time, processing_time, throughput,
-            ops, ops_unit, time_period, percent_completed):
+    def add(self, task, client_id, sample_type, meta_data, absolute_time, request_start, latency, service_time,
+            processing_time, throughput, ops, ops_unit, time_period, percent_completed, dependent_timing=None):
         try:
             self.q.put_nowait(
-                Sample(client_id, time.time(), time.perf_counter() - self.start_timestamp, task, sample_type, meta_data,
-                       latency, service_time, processing_time, throughput, ops, ops_unit, time_period, percent_completed))
+                Sample(client_id, absolute_time, request_start, self.start_timestamp, task, sample_type, meta_data,
+                       latency, service_time, processing_time, throughput, ops, ops_unit, time_period,
+                       percent_completed, dependent_timing))
         except queue.Full:
             self.logger.warning("Dropping sample for [%s] due to a full sampling queue.", task.operation.name)
 
@@ -1012,33 +1021,58 @@ class Sampler:
 
 
 class Sample:
-    def __init__(self, client_id, absolute_time, relative_time, task, sample_type, request_meta_data, latency_ms,
-                 service_time_ms, processing_time_ms, throughput, total_ops, total_ops_unit, time_period,
-                 percent_completed):
+    def __init__(self, client_id, absolute_time, request_start, task_start, task, sample_type, request_meta_data, latency,
+                 service_time, processing_time, throughput, total_ops, total_ops_unit, time_period,
+                 percent_completed, dependent_timing=None, operation_name=None, operation_type=None):
         self.client_id = client_id
         self.absolute_time = absolute_time
-        self.relative_time = relative_time
+        self.request_start = request_start
+        self.task_start = task_start
         self.task = task
         self.sample_type = sample_type
         self.request_meta_data = request_meta_data
-        self.latency_ms = latency_ms
-        self.service_time_ms = service_time_ms
-        self.processing_time_ms = processing_time_ms
+        self.latency = latency
+        self.service_time = service_time
+        self.processing_time = processing_time
         self.throughput = throughput
         self.total_ops = total_ops
         self.total_ops_unit = total_ops_unit
         self.time_period = time_period
+        self._dependent_timing = dependent_timing
+        self._operation_name = operation_name
+        self._operation_type = operation_type
         # may be None for eternal tasks!
         self.percent_completed = percent_completed
 
     @property
-    def operation(self):
-        return self.task.operation
+    def operation_name(self):
+        return self._operation_name if self._operation_name else self.task.operation.name
+
+    @property
+    def operation_type(self):
+        return self._operation_type if self._operation_type else self.task.operation.type
+
+    @property
+    def operation_meta_data(self):
+        return self.task.operation.meta_data
+
+    @property
+    def relative_time(self):
+        return self.request_start - self.task_start
+
+    @property
+    def dependent_timings(self):
+        if self._dependent_timing:
+            for t in self._dependent_timing:
+                yield Sample(self.client_id, t["absolute_time"], t["request_start"], self.task_start, self.task,
+                             self.sample_type, self.request_meta_data, 0, t["service_time"], 0, 0, self.total_ops,
+                             self.total_ops_unit, self.time_period, self.percent_completed, None,
+                             t["operation"], t["operation-type"])
 
     def __repr__(self, *args, **kwargs):
-        return "[%f; %f] [client [%s]] [%s] [%s]: [%f] ms request latency, [%f] ms service time, [%d %s]" % \
-               (self.absolute_time, self.relative_time, self.client_id, self.task, self.sample_type, self.latency_ms, self.service_time_ms,
-                self.total_ops, self.total_ops_unit)
+        return f"[{self.absolute_time}; {self.relative_time}] [client [{self.client_id}]] [{self.task}] " \
+               f"[{self.sample_type}]: [{self.latency}s] request latency, [{self.service_time}s] service time, " \
+               f"[{self.total_ops} {self.total_ops_unit}]"
 
 
 def select_challenge(config, t):
@@ -1358,15 +1392,19 @@ class AsyncExecutor:
                     rest = absolute_expected_schedule_time - time.perf_counter()
                     if rest > 0:
                         await asyncio.sleep(rest)
-                request_context = self.es["default"].init_request_context()
+
+                absolute_processing_start = time.time()
                 processing_start = time.perf_counter()
                 self.schedule_handle.before_request(processing_start)
-                total_ops, total_ops_unit, request_meta_data = await execute_single(runner, self.es, params, self.on_error)
+                async with self.es["default"].new_request_context() as request_context:
+                    total_ops, total_ops_unit, request_meta_data = await execute_single(runner, self.es, params, self.on_error)
+                    request_start = request_context.request_start
+                    request_end = request_context.request_end
+
                 processing_end = time.perf_counter()
+                service_time = request_end - request_start
                 processing_time = processing_end - processing_start
-                stop = request_context["request_end"]
-                service_time = request_context["request_end"] - request_context["request_start"]
-                time_period = stop - total_start
+                time_period = request_end - total_start
                 self.schedule_handle.after_request(processing_end, total_ops, total_ops_unit, request_meta_data)
                 # Allow runners to override the throughput calculation in very specific circumstances. Usually, Rally
                 # assumes that throughput is the "amount of work" (determined by the "weight") per unit of time
@@ -1380,7 +1418,7 @@ class AsyncExecutor:
                 #
                 throughput = request_meta_data.pop("throughput", None)
                 # Do not calculate latency separately when we run unthrottled. This metric is just confusing then.
-                latency = stop - absolute_expected_schedule_time if throughput_throttled else service_time
+                latency = request_end - absolute_expected_schedule_time if throughput_throttled else service_time
                 # If this task completes the parent task we should *not* check for completion by another client but
                 # instead continue until our own runner has completed. We need to do this because the current
                 # worker (process) could run multiple clients that execute the same task. We do not want all clients to
@@ -1397,10 +1435,11 @@ class AsyncExecutor:
                     progress = runner.percent_completed
                 else:
                     progress = percent_completed
+
                 self.sampler.add(self.task, self.client_id, sample_type, request_meta_data,
-                                 convert.seconds_to_ms(latency), convert.seconds_to_ms(service_time),
-                                 convert.seconds_to_ms(processing_time), throughput, total_ops, total_ops_unit,
-                                 time_period, progress)
+                                 absolute_processing_start, request_start,
+                                 latency, service_time, processing_time, throughput, total_ops, total_ops_unit,
+                                 time_period, progress, request_meta_data.pop("dependent_timing", None))
 
                 if completed:
                     self.logger.info("Task [%s] is considered completed due to external event.", self.task)

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -659,17 +659,18 @@ class MetricsStore:
         """
         return self._get(name, task, operation_type, sample_type, node_name, mapper)
 
-    def get_unit(self, name, task=None, node_name=None):
+    def get_unit(self, name, task=None, operation_type=None, node_name=None):
         """
         Gets the unit for the given metric name.
 
         :param name: The metric name to query.
         :param task The task name to query. Optional.
+        :param operation_type The operation type to query. Optional.
         :param node_name The name of the node where this metric was gathered. Optional.
         :return: The corresponding unit for the given metric name or None if no metric record is available.
         """
         # does not make too much sense to ask for a sample type here
-        return self._first_or_none(self._get(name, task, None, None, node_name, lambda doc: doc["unit"]))
+        return self._first_or_none(self._get(name, task, operation_type, None, node_name, lambda doc: doc["unit"]))
 
     def _get(self, name, task, operation_type, sample_type, node_name, mapper):
         raise NotImplementedError("abstract method")
@@ -936,7 +937,7 @@ class EsMetricsStore(MetricsStore):
         if operation_type:
             q["bool"]["filter"].append({
                 "term": {
-                    "operation-type": operation_type.name
+                    "operation-type": operation_type
                 }
             })
         if sample_type:
@@ -1034,7 +1035,7 @@ class InMemoryMetricsStore(MetricsStore):
         for doc in self.docs:
             # we can use any request metrics record (i.e. service time or latency)
             if doc["name"] == "service_time" and doc["task"] == task and \
-                    (operation_type is None or doc["operation-type"] == operation_type.name) and \
+                    (operation_type is None or doc["operation-type"] == operation_type) and \
                     (sample_type is None or doc["sample-type"] == sample_type.name.lower()):
                 total_count += 1
                 if doc["meta"]["success"] is False:
@@ -1063,7 +1064,7 @@ class InMemoryMetricsStore(MetricsStore):
                 for doc in self.docs
                 if doc["name"] == name and
                 (task is None or doc["task"] == task) and
-                (operation_type is None or doc["operation-type"] == operation_type.name) and
+                (operation_type is None or doc["operation-type"] == operation_type) and
                 (sample_type is None or doc["sample-type"] == sample_type.name.lower()) and
                 (node_name is None or doc.get("meta", {}).get("node_name") == node_name)
                 ]
@@ -1520,16 +1521,17 @@ class GlobalStatsCalculator:
         for tasks in self.challenge.schedule:
             for task in tasks:
                 t = task.name
-                error_rate = self.error_rate(t)
+                op_type = task.operation.type
+                error_rate = self.error_rate(t, op_type)
                 if task.operation.include_in_reporting or error_rate > 0:
                     self.logger.debug("Gathering request metrics for [%s].", t)
                     result.add_op_metrics(
                         t,
                         task.operation.name,
-                        self.summary_stats("throughput", t),
-                        self.single_latency(t),
-                        self.single_latency(t, metric_name="service_time"),
-                        self.single_latency(t, metric_name="processing_time"),
+                        self.summary_stats("throughput", t, op_type),
+                        self.single_latency(t, op_type),
+                        self.single_latency(t, op_type, metric_name="service_time"),
+                        self.single_latency(t, op_type, metric_name="processing_time"),
                         error_rate,
                         self.merge(
                             self.track.meta_data,
@@ -1603,11 +1605,11 @@ class GlobalStatsCalculator:
     def one(self, metric_name):
         return self.store.get_one(metric_name)
 
-    def summary_stats(self, metric_name, task_name):
-        mean = self.store.get_mean(metric_name, task=task_name, sample_type=SampleType.Normal)
-        median = self.store.get_median(metric_name, task=task_name, sample_type=SampleType.Normal)
-        unit = self.store.get_unit(metric_name, task=task_name)
-        stats = self.store.get_stats(metric_name, task=task_name, sample_type=SampleType.Normal)
+    def summary_stats(self, metric_name, task_name, operation_type):
+        mean = self.store.get_mean(metric_name, task=task_name, operation_type=operation_type, sample_type=SampleType.Normal)
+        median = self.store.get_median(metric_name, task=task_name, operation_type=operation_type, sample_type=SampleType.Normal)
+        unit = self.store.get_unit(metric_name, task=task_name, operation_type=operation_type)
+        stats = self.store.get_stats(metric_name, task=task_name, operation_type=operation_type, sample_type=SampleType.Normal)
         if mean and median and stats:
             return {
                 "min": stats["min"],
@@ -1668,25 +1670,27 @@ class GlobalStatsCalculator:
                     })
         return result
 
-    def error_rate(self, task_name):
-        return self.store.get_error_rate(task=task_name, sample_type=SampleType.Normal)
+    def error_rate(self, task_name, operation_type):
+        return self.store.get_error_rate(task=task_name, operation_type=operation_type, sample_type=SampleType.Normal)
 
     def median(self, metric_name, task_name=None, operation_type=None, sample_type=None):
         return self.store.get_median(metric_name, task=task_name, operation_type=operation_type, sample_type=sample_type)
 
-    def single_latency(self, task, metric_name="latency"):
+    def single_latency(self, task, operation_type, metric_name="latency"):
         sample_type = SampleType.Normal
-        stats = self.store.get_stats(metric_name, task=task, sample_type=sample_type)
+        stats = self.store.get_stats(metric_name, task=task, operation_type=operation_type, sample_type=sample_type)
         sample_size = stats["count"] if stats else 0
         if sample_size > 0:
             percentiles = self.store.get_percentiles(metric_name,
                                                      task=task,
+                                                     operation_type=operation_type,
                                                      sample_type=sample_type,
                                                      percentiles=percentiles_for_sample_size(sample_size))
             mean = self.store.get_mean(metric_name,
                                        task=task,
+                                       operation_type=operation_type,
                                        sample_type=sample_type)
-            unit = self.store.get_unit(metric_name, task=task)
+            unit = self.store.get_unit(metric_name, task=task, operation_type=operation_type)
             stats = collections.OrderedDict()
             for k, v in percentiles.items():
                 # safely encode so we don't have any dots in field names

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -616,6 +616,11 @@ class EsMetricsTests(TestCase):
                             "term": {
                                 "name": "indexing_throughput"
                             }
+                        },
+                        {
+                            "term": {
+                                "operation-type": "bulk"
+                            }
                         }
                     ]
                 }
@@ -630,7 +635,7 @@ class EsMetricsTests(TestCase):
             }
         }
 
-        actual_mean_throughput = self.metrics_store.get_mean("indexing_throughput")
+        actual_mean_throughput = self.metrics_store.get_mean("indexing_throughput", operation_type="bulk")
 
         self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 
@@ -667,6 +672,11 @@ class EsMetricsTests(TestCase):
                             "term": {
                                 "name": "indexing_throughput"
                             }
+                        },
+                        {
+                            "term": {
+                                "operation-type": "bulk"
+                            }
                         }
                     ]
                 }
@@ -682,7 +692,7 @@ class EsMetricsTests(TestCase):
             }
         }
 
-        actual_median_throughput = self.metrics_store.get_median("indexing_throughput")
+        actual_median_throughput = self.metrics_store.get_median("indexing_throughput", operation_type="bulk")
 
         self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 


### PR DESCRIPTION
Previously, Rally could only measure request timings on top-level
requests. This is usually what is want but we introduced `composite`
tasks recently, which allow to issue multiple concurrent requests in the
context of one task. It was not possible to measure the service time of
these requests so far.

With this commit we introduce a notion of "dependent timings" that can
be attached to measurement samples of a task. These are stored as
additional service time samples in the metrics store and can be used to
analyze behavior in more detail.

We also introduce a slight change in how "absolute time" and "relative
time" need to be interpreted. Previously, these times represented the
absolute and relative point in time when the request sample has been
created (which happens *after* a response has been received). Now, these
represent the point in time when the request has been sent to
Elasticsearch which is more meaningful and also simplifies correlating
timestamps from other tools such as tcpdump.

Closes #1173