### PR TITLE
Fix Issue #1222: esrally CLI should always return 130 when cancelled

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -933,7 +933,7 @@ def main():
             sys.exit(64)
     except KeyboardInterrupt:
         console.println("")
-        console.info("FAILURE (took %d seconds)" % (end - start), overline="-", underline="-")
+        console.info("ABORTED (took %d seconds)" % (end - start), overline="-", underline="-")
         print("\nRally has detected KeyboardInterrupt. Shutting down...", file=sys.stderr)
         sys.exit(130)
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -923,13 +923,19 @@ def main():
     success = dispatch_sub_command(arg_parser, args, cfg)
 
     end = time.time()
-    if success:
-        console.println("")
-        console.info("SUCCESS (took %d seconds)" % (end - start), overline="-", underline="-")
-    else:
+    try:
+        if success:
+            console.println("")
+            console.info("SUCCESS (took %d seconds)" % (end - start), overline="-", underline="-")
+        else:
+            console.println("")
+            console.info("FAILURE (took %d seconds)" % (end - start), overline="-", underline="-")
+            sys.exit(64)
+    except KeyboardInterrupt:
         console.println("")
         console.info("FAILURE (took %d seconds)" % (end - start), overline="-", underline="-")
-        sys.exit(64)
+        print("\nRally has detected KeyboardInterrupt. Shutting down...", file=sys.stderr)
+        sys.exit(130)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/rally/blob/master/CONTRIBUTING.md)?
- [x] Have you run `make test` and `make it` and both finish without errors?
- [x] Did you choose a [descriptive title and description](https://chris.beams.io/posts/git-commit/) for your PR?
- [ ] (Only for maintainers) Did you apply appropriate labels and a milestone?

## Description
Previously a sigterm recieved from keyboard interrupt would result in the exit code being 0 and success status being reached, this behaviour was undesired. This PR adds a `try and except` statement around the possible area of interest and makes the exit status 130 in case of a keyboard interrupt and provides the verbose logging to user.

Fixes Issue #1222 

Changes:
- Error code changed to 130 for keyboard interrupt
- Abort message is displayed
- Acknowledgement for keyboard interrupt received is displayed