### PR TITLE
Update community resources videos

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -1,10 +1,10 @@
 Community Resources
 ===================
 
-Below are a few community resources about Rally. If you find an interesting article, talk or custom tracks, `raise an issue <https://github.com/elastic/rally/issues>`_  or `open a pull request <https://github.com/elastic/rally/pulls>`_.
+Below are a few community resources about Rally. If you find an interesting article, talk, or custom tracks, `raise an issue <https://github.com/elastic/rally/issues>`_  or `open a pull request <https://github.com/elastic/rally/pulls>`_.
 
-Talks
------
+Videos
+------
 
 .. raw:: html
 
@@ -12,7 +12,11 @@ Talks
 
 .. raw:: html
 
-   <iframe width="560" height="315" src="https://www.youtube.com/embed/Fm7fxE4kxPI" frameborder="0" allowfullscreen></iframe>
+   <iframe width="560" height="315" src="https://www.youtube.com/embed/-jgmnpG_P-Y" frameborder="0" allowfullscreen></iframe>
+
+.. raw:: html
+
+   <iframe width="560" height="315" src="https://www.youtube.com/embed/T0tRDNDjHcI" frameborder="0" allowfullscreen></iframe>
 
 Articles
 --------


### PR DESCRIPTION
In [the docs](https://esrally.readthedocs.io/en/stable/community.html) we have an embedded video that is marked `private` and not viewable.  Here we remove that and add two more recent videos, including one from the recent ElasticCC event. 
