### PR TITLE
Avoid ephemeral ports in integration tests

### DIFF
--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -24,21 +24,23 @@ import it
 
 @it.random_rally_config
 def test_tar_distributions(cfg):
+    port = 19200
     for dist in it.DISTRIBUTIONS:
         for track in it.TRACKS:
-            it.wait_until_port_is_free()
+            it.wait_until_port_is_free(port_number=port)
             assert it.race(cfg, f"--distribution-version=\"{dist}\" --track=\"{track}\" "
-                                f"--test-mode --car=4gheap") == 0
+                                f"--test-mode --car=4gheap --target-hosts=127.0.0.1:{port}") == 0
 
 
 @it.random_rally_config
 def test_docker_distribution(cfg):
+    port = 19200
     # only test the most recent Docker distribution
     dist = it.DISTRIBUTIONS[-1]
-    it.wait_until_port_is_free(port_number=19200)
+    it.wait_until_port_is_free(port_number=port)
     assert it.race(cfg, f"--pipeline=\"docker\" --distribution-version=\"{dist}\" "
                         f"--track=\"geonames\" --challenge=\"append-no-conflicts-index-only\" --test-mode "
-                        f"--car=4gheap --target-hosts=127.0.0.1:19200") == 0
+                        f"--car=4gheap --target-hosts=127.0.0.1:{port}") == 0
 
 
 @pytest.fixture(scope="module")
@@ -46,7 +48,7 @@ def test_cluster():
     cluster = it.TestCluster("in-memory-it")
     # test with a recent distribution as eventdata is not available for all versions
     dist = it.DISTRIBUTIONS[-1]
-    port = 49200
+    port = 19200
     race_id = str(uuid.uuid4())
 
     it.wait_until_port_is_free(port_number=port)

--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -20,10 +20,11 @@ import it
 
 @it.random_rally_config
 def test_sources(cfg):
-    it.wait_until_port_is_free()
-    assert it.race(cfg, "--revision=latest --track=geonames --test-mode "
-                        "--challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu") == 0
+    port = 19200
+    it.wait_until_port_is_free(port_number=port)
+    assert it.race(cfg, f"--revision=latest --track=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
+                        f"--challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu") == 0
 
-    it.wait_until_port_is_free()
-    assert it.race(cfg, "--pipeline=from-sources --track=geonames --test-mode "
-                        "--challenge=append-no-conflicts-index-only --car=\"4gheap,ea\"") == 0
+    it.wait_until_port_is_free(port_number=port)
+    assert it.race(cfg, f"--pipeline=from-sources --track=geonames --test-mode --target-hosts=127.0.0.1:{port} "
+                        f"--challenge=append-no-conflicts-index-only --car=\"4gheap,ea\"") == 0

--- a/it/tracker_test.py
+++ b/it/tracker_test.py
@@ -27,7 +27,7 @@ def test_cluster():
     cluster = it.TestCluster("in-memory-it")
     # test with a recent distribution
     dist = it.DISTRIBUTIONS[-1]
-    port = 49200
+    port = 19200
     race_id = str(uuid.uuid4())
 
     it.wait_until_port_is_free(port_number=port)


### PR DESCRIPTION
Previously, some integration tests have spun up clusters in the
ephemeral port range (on Linux this port range usually starts with port
32768) which can negatively influence test stability. With this commit
we bind test clusters in integration tests to ports below the ephemeral
port range to avoid this issue.