### PR TITLE
assert developers have block storage dependencies installed

### DIFF
--- a/tests/utils/net_test.py
+++ b/tests/utils/net_test.py
@@ -91,3 +91,13 @@ class TestNetUtils:
         mock_progress.reset_mock()
         progress(42, None)
         assert mock_progress.print.called
+
+    def test_s3_dependency(self):
+        #pylint: disable=import-outside-toplevel,unused-import
+        import boto3
+        assert True
+
+    def test_gcs_dependency(self):
+        #pylint: disable=import-outside-toplevel,unused-import
+        import google.auth
+        assert True


### PR DESCRIPTION
While reviewing #1252, we found boto3 got de-referenced for the developer's environment (in other words, when invoking `make install` in a clean environment).  With this commit we assert with tests that the proper dependencies are in place