### PR TITLE
improvements to chart generator

### DIFF
--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -19,7 +19,6 @@ import glob
 import json
 import logging
 import uuid
-from datetime import datetime
 
 from esrally import track, config, exceptions
 from esrally.utils import io, console
@@ -1688,12 +1687,11 @@ def generate_dashboard(chart_type, environment, track, charts, flavor=None):
         if col == 0:
             row += 1
 
-    publish_date = datetime.now().strftime("%Y%m%d")
     return {
         "id": str(uuid.uuid4()),
         "type": "dashboard",
         "attributes": {
-            "title": chart_type.format_title(environment, track.name, flavor=flavor, suffix=publish_date),
+            "title": chart_type.format_title(environment, track.name, flavor=flavor),
             "hits": 0,
             "description": "",
             "panelsJSON": json.dumps(panels),

--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -19,6 +19,7 @@ import glob
 import json
 import logging
 import uuid
+from datetime import datetime
 
 from esrally import track, config, exceptions
 from esrally.utils import io, console
@@ -1265,6 +1266,7 @@ class TimeSeriesCharts:
                 ],
                 "show_grid": 1,
                 "drop_last_bucket": 0,
+                "axis_scale": "log",
                 "axis_min": "0"
             },
             "aggs": []
@@ -1686,11 +1688,12 @@ def generate_dashboard(chart_type, environment, track, charts, flavor=None):
         if col == 0:
             row += 1
 
+    publish_date = datetime.now().strftime("%Y%m%d")
     return {
         "id": str(uuid.uuid4()),
         "type": "dashboard",
         "attributes": {
-            "title": chart_type.format_title(environment, track.name, flavor=flavor),
+            "title": chart_type.format_title(environment, track.name, flavor=flavor, suffix=publish_date),
             "hits": 0,
             "description": "",
             "panelsJSON": json.dumps(panels),
@@ -1837,8 +1840,10 @@ def load_race_configs(cfg, chart_type, chart_spec_path=None):
     race_configs = {"oss": [], "default": []}
     if chart_type == BarCharts:
         race_configs = []
-
-    for _track_file in glob.glob(io.normalize_path(chart_spec_path)):
+    chart_specs = glob.glob(io.normalize_path(chart_spec_path))
+    if not chart_specs:
+        raise exceptions.NotFound(f"Chart spec path [{chart_spec_path}] not found.")
+    for _track_file in chart_specs:
         with open(_track_file, mode="rt", encoding="utf-8") as f:
             for item in json.load(f):
                 _track_repository = item.get("track-repository", "default")

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -171,8 +171,6 @@ def create_arg_parser():
         metavar="artifact",
         help="The artifact to create. Possible values are: charts",
         choices=["charts"])
-    # We allow to either have a chart-spec-path *or* define a chart-spec on the fly with track, challenge and car. Convincing
-    # argparse to validate that everything is correct *might* be doable but it is simpler to just do this manually.
     generate_parser.add_argument(
         "--chart-spec-path",
         required=True,

--- a/it/generate_test.py
+++ b/it/generate_test.py
@@ -37,4 +37,4 @@ def test_fails_when_spec_not_found(cfg, tmp_path):
     assert it.esrally(cfg, f"generate charts "
                            f"--chart-spec-path={chart_spec_path} "
                            f"--chart-type=time-series "
-                           f"--output-path={output_path}") == 64
+                           f"--output-path={output_path}") !=0

--- a/it/generate_test.py
+++ b/it/generate_test.py
@@ -29,3 +29,12 @@ def test_track_info_with_challenge(cfg, tmp_path):
                            f"--chart-spec-path={chart_spec_path} "
                            f"--chart-type=time-series "
                            f"--output-path={output_path}") == 0
+
+@it.rally_in_mem
+def test_fails_when_spec_not_found(cfg, tmp_path):
+    chart_spec_path = "/non/existent/path"
+    output_path = os.path.join(tmp_path, "nightly-charts.ndjson")
+    assert it.esrally(cfg, f"generate charts "
+                           f"--chart-spec-path={chart_spec_path} "
+                           f"--chart-type=time-series "
+                           f"--output-path={output_path}") == 64


### PR DESCRIPTION
With this commit we:
* Add a `-yyyymmdd` suffix to generated dashboard names for easier version maintenance
* Set memory-based timeseries charts on a logarithmic scale
* Fail if `--chart-spec-path` is invalid