### PR TITLE
Add pyenv shims to PATH

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -44,6 +44,7 @@ function build {
   export LC_ALL=en_US.UTF-8
   update_pyenv
   eval "$(pyenv init -)"
+  # ensure pyenv shims are added to PATH, see https://github.com/pyenv/pyenv/issues/1906
   eval "$(pyenv init --path)"
   eval "$(pyenv virtualenv-init -)"
 
@@ -59,6 +60,7 @@ function license-scan {
 
   export PATH="$HOME/.pyenv/bin:$PATH"
   eval "$(pyenv init -)"
+  # ensure pyenv shims are added to PATH, see https://github.com/pyenv/pyenv/issues/1906
   eval "$(pyenv init --path)"
   eval "$(pyenv virtualenv-init -)"
 

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -44,6 +44,7 @@ function build {
   export LC_ALL=en_US.UTF-8
   update_pyenv
   eval "$(pyenv init -)"
+  eval "$(pyenv init --path)"
   eval "$(pyenv virtualenv-init -)"
 
   make prereq
@@ -58,6 +59,7 @@ function license-scan {
 
   export PATH="$HOME/.pyenv/bin:$PATH"
   eval "$(pyenv init -)"
+  eval "$(pyenv init --path)"
   eval "$(pyenv virtualenv-init -)"
 
   make prereq

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VENV_ACTIVATE = . $(VENV_ACTIVATE_FILE)
 VEPYTHON = $(VENV_NAME)/bin/$(PY_BIN)
 VEPYLINT = $(VENV_NAME)/bin/pylint
 PYENV_ERROR = "\033[0;31mIMPORTANT\033[0m: Please install pyenv.\n"
-PYENV_PREREQ_HELP = "\033[0;31mIMPORTANT\033[0m: please add \033[0;31meval \"\$$(pyenv init -)\"\033[0m and \033[0;31meval \"\$$(pyenv init --path)\"\033[0m to your bash profile and restart your terminal before proceeding any further.\n"
+PYENV_PREREQ_HELP = "\033[0;31mIMPORTANT\033[0m: please type \033[0;31mpyenv init\033[0m, follow the instructions there and restart your terminal before proceeding any further.\n"
 VE_MISSING_HELP = "\033[0;31mIMPORTANT\033[0m: Couldn't find $(PWD)/$(VENV_NAME); have you executed make venv-create?\033[0m\n"
 
 prereq:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VENV_ACTIVATE = . $(VENV_ACTIVATE_FILE)
 VEPYTHON = $(VENV_NAME)/bin/$(PY_BIN)
 VEPYLINT = $(VENV_NAME)/bin/pylint
 PYENV_ERROR = "\033[0;31mIMPORTANT\033[0m: Please install pyenv.\n"
-PYENV_PREREQ_HELP = "\033[0;31mIMPORTANT\033[0m: please add \033[0;31meval \"\$$(pyenv init -)\"\033[0m to your bash profile and restart your terminal before proceeding any further.\n"
+PYENV_PREREQ_HELP = "\033[0;31mIMPORTANT\033[0m: please add \033[0;31meval \"\$$(pyenv init -)\"\033[0m and \033[0;31meval \"\$$(pyenv init --path)\"\033[0m to your bash profile and restart your terminal before proceeding any further.\n"
 VE_MISSING_HELP = "\033[0;31mIMPORTANT\033[0m: Couldn't find $(PWD)/$(VENV_NAME); have you executed make venv-create?\033[0m\n"
 
 prereq:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ VENV_ACTIVATE = . $(VENV_ACTIVATE_FILE)
 VEPYTHON = $(VENV_NAME)/bin/$(PY_BIN)
 VEPYLINT = $(VENV_NAME)/bin/pylint
 PYENV_ERROR = "\033[0;31mIMPORTANT\033[0m: Please install pyenv.\n"
-PYENV_PATH_ERROR = "\033[0;31mIMPORTANT\033[0m: Please add $(HOME)/$(PYENV_REGEX) to your PATH env.\n"
 PYENV_PREREQ_HELP = "\033[0;31mIMPORTANT\033[0m: please add \033[0;31meval \"\$$(pyenv init -)\"\033[0m to your bash profile and restart your terminal before proceeding any further.\n"
 VE_MISSING_HELP = "\033[0;31mIMPORTANT\033[0m: Couldn't find $(PWD)/$(VENV_NAME); have you executed make venv-create?\033[0m\n"
 
@@ -46,12 +45,8 @@ venv-create:
 		printf $(PYENV_ERROR); \
 		exit 1; \
 	fi;
-	@if [[ ! "$(PATH)" =~ $(PYENV_REGEX) ]]; then \
-		printf $(PYENV_PATH_ERROR); \
-		exit 1; \
-	fi;
 	@if [[ ! -f $(VENV_ACTIVATE_FILE) ]]; then \
-		eval "$$(pyenv init -)" && $(PY_BIN) -mvenv $(VENV_NAME); \
+		eval "$$(pyenv init -)" && eval "$$(pyenv init --path)" && $(PY_BIN) -mvenv $(VENV_NAME); \
 		printf "Created python3 venv under $(PWD)/$(VENV_NAME).\n"; \
 	fi;
 

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -6,7 +6,7 @@ Prerequisites
 
 Install the following software packages:
 
-* Pyenv installed and ``eval "$(pyenv init -)"`` is added to the shell configuration file. For more details please refer to the PyEnv `installation instructions <https://github.com/pyenv/pyenv#installation>`_.
+* Pyenv installed, ``eval "$(pyenv init -)"`` and ``eval "$(pyenv init --path)"`` is added to the shell configuration file. For more details please refer to the PyEnv `installation instructions <https://github.com/pyenv/pyenv#installation>`_.
 * JDK version required to build Elasticsearch. Please refer to the `build setup requirements <https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-to-the-elasticsearch-codebase>`_.
 * `Docker <https://docs.docker.com/install/>`_ and on Linux additionally `docker-compose <https://docs.docker.com/compose/install/>`_.
 * git 1.9 or better

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -6,7 +6,7 @@ Prerequisites
 
 Install the following software packages:
 
-* Pyenv installed, ``eval "$(pyenv init -)"`` and ``eval "$(pyenv init --path)"`` is added to the shell configuration file. For more details please refer to the PyEnv `installation instructions <https://github.com/pyenv/pyenv#installation>`_.
+* Pyenv installed, Follow the instructions in the output of ``pyenv init`` to setup your shell and then restart it before proceeding. For more details please refer to the PyEnv `installation instructions <https://github.com/pyenv/pyenv#installation>`_.
 * JDK version required to build Elasticsearch. Please refer to the `build setup requirements <https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-to-the-elasticsearch-codebase>`_.
 * `Docker <https://docs.docker.com/install/>`_ and on Linux additionally `docker-compose <https://docs.docker.com/compose/install/>`_.
 * git 1.9 or better


### PR DESCRIPTION
Recently the pyenv init command does not add pyenv shims to the `PATH`
anymore. This needs to be done now explicitly with a new command. We add
the command in build scripts and our documentation to make sure shims
are available.