### PR TITLE
Consolidate and improve track/team repo revision logic docs

### DIFF
--- a/docs/car.rst
+++ b/docs/car.rst
@@ -121,7 +121,7 @@ Rally provides a default team repository that is hosted on `Github <https://gith
 * The `master` branch needs to work with the latest `master` branch of Elasticsearch.
 * All other branches need to match the version scheme of Elasticsearch, i.e. ``MAJOR.MINOR.PATCH-SUFFIX`` where all parts except ``MAJOR`` are optional.
 
-Rally implements a fallback logic similar to the one used for :ref:`track-repositories <track-repositories-fall-back-logic>`.
+Rally implements a branch matching logic similar to the one used for :ref:`track-repositories <track-repositories-branch-logic>`.
 
 Creating a new team repository
 """"""""""""""""""""""""""""""

--- a/docs/elasticsearch_plugins.rst
+++ b/docs/elasticsearch_plugins.rst
@@ -228,4 +228,4 @@ Now you can run benchmarks with the custom Elasticsearch plugin, e.g. with ``esr
 For this to work you need ensure two things:
 
 1. The plugin needs to be available for the version that you want to benchmark (7.12.0 in the example above).
-2. Rally will choose the most appropriate branch in the team repository before starting the benchmark. See the documentation on :ref:`how branches are mapped to Elasticsearch versions <track-repositories-fall-back-logic>`.
+2. Rally will choose the most appropriate branch in the team repository before starting the benchmark. See the documentation on :ref:`how branches are mapped to Elasticsearch versions <track-repositories-branch-logic>`.

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -42,7 +42,7 @@ Alternatively, you can store Rally tracks also in a dedicated git repository whi
 
 When a track repository has several branches, Rally will pick the most appropriate branch, depending on the Elasticsearch version to be benchmarked, using a match logic in the following order:
 
-#. *Exact match major.minor.patch-extension_label* (e.g. ``7.0.0-beta1``)
+#. *Exact match major.minor.patch-SUFFIX* (e.g. ``7.0.0-beta1``)
 #. *Exact match major.minor.patch* (e.g. ``7.10.2``, ``6.7.0``)
 #. *Exact match major.minor* (e.g. ``7.10``)
 #. *Nearest prior minor branch*


### PR DESCRIPTION
Currently the repository version matching logic for Rally tracks/teams
is duplicated in Rally docs as well as README files in in our standard
tracks/teams repositories.

Update docs consolidating existing documentation from
elastic/rally-tracks and elastic/rally-teams

Relates:

- https://github.com/elastic/rally-tracks/issues/162
- https://github.com/elastic/rally-teams/issues/62
