### PR TITLE
Consider new API calls in static response example

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -716,6 +716,13 @@ Here we define the necessary responses for a track that bulk-indexes data::
         "body-encoding": "json"
       },
       {
+        "path": "/_cluster/settings",
+        "body": {
+          "transient": {}
+        },
+        "body-encoding": "json"
+      },
+      {
         "path": "/_all/_stats/_all",
         "body": {
           "_all": {

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -718,6 +718,7 @@ Here we define the necessary responses for a track that bulk-indexes data::
       {
         "path": "/_cluster/settings",
         "body": {
+          "persistent": {},
           "transient": {}
         },
         "body-encoding": "json"


### PR DESCRIPTION
With this commit we amend the example response file in our documentation
to also include a static response for the cluster settings API. This is
needed because Rally issues this call to determine the value of
`action.destructive_requires_name` prior to issuing a delete index
request.

Relates #1243