### PR TITLE
Include requests when installing google-resumable-media

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ install_requires = [
     # License: Apache 2.0
     # transitive dependencies:
     #   google-crc32c: Apache 2.0
-    "google-resumable-media==1.1.0",
+    "google-resumable-media[requests]==1.1.0",
     # License: Apache 2.0
     "google-auth==1.22.1"
 ]


### PR DESCRIPTION
This commit adds the requests package (which is an extra dependency,
i.e. listed as optional) when installing the
google-resumable-media pip package.

Currently this is missing when installing Rally without development
dependencies and will cause tracks relying on GS hosted private buckets
to fail.

Closes #1269
