### PR TITLE
Re-introduce relative-time property

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -15,6 +15,7 @@ Here is a typical metrics record::
           "race-id": "6ebc6e53-ee20-4b0c-99b4-09697987e9f4",
           "@timestamp": 1461213093093,
           "relative-time-ms": 10507.328,
+          "relative-time": 10507.328,
           "track": "geonames",
           "track-params": {
             "shard-count": 3
@@ -83,8 +84,13 @@ relative-time-ms
 
 .. warning::
 
-    This property is introduced for a transition period between Rally 2.1.0 and Rally 2.4.0. It will be deprecated with Rally 2.3.0 and removed in Rally 2.4.0.
+    This property has been introduced for a transition period between Rally 2.1.0 and Rally 2.3.0. It is deprecated with Rally 2.2.1 and will be removed in Rally 2.3.0. Use ``relative-time`` instead.
 
+
+The relative time in milliseconds since the start of the benchmark. This is useful for comparing time-series graphs over multiple races, e.g. you might want to compare the indexing throughput over time across multiple races. As they should always start at the same (relative) point in time, absolute timestamps are not helpful.
+
+relative-time
+~~~~~~~~~~~~~
 
 The relative time in milliseconds since the start of the benchmark. This is useful for comparing time-series graphs over multiple races, e.g. you might want to compare the indexing throughput over time across multiple races. As they should always start at the same (relative) point in time, absolute timestamps are not helpful.
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,18 @@
 Migration Guide
 ===============
 
+Migrating to Rally 2.2.1
+------------------------
+
+``relative-time-ms`` is deprecated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+    This deprecation is only relevant if you have configured an Elasticsearch metrics store for Rally.
+
+The property ``relative-time-ms`` has been deprecated in Rally 2.2.1. Use the re-introduced property ``relative-time`` instead to retrieve the same metric. ``relative-time-ms`` will be dropped in Rally 2.3.0.
+
 Migrating to Rally 2.2.0
 ------------------------
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -271,6 +271,7 @@ The number of hits from queries can also be investigated if you have configured 
 	{
 	  "@timestamp" : 1597681313435,
 	  "relative-time-ms" : 130273.374,
+	  "relative-time" : 130273.374,
 	  "race-id" : "452ad9d7-9c21-4828-848e-89974af3230e",
 	  "race-timestamp" : "20200817T160412Z",
 	  "environment" : "Personal",

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -521,7 +521,9 @@ class MetricsStore:
 
         doc = {
             "@timestamp": time.to_epoch_millis(absolute_time),
+            # deprecated
             "relative-time-ms": convert.seconds_to_ms(relative_time),
+            "relative-time": convert.seconds_to_ms(relative_time),
             "race-id": self._race_id,
             "race-timestamp": self._race_timestamp,
             "environment": self._environment_name,
@@ -578,7 +580,9 @@ class MetricsStore:
 
         doc.update({
             "@timestamp": time.to_epoch_millis(absolute_time),
+            # deprecated
             "relative-time-ms": convert.seconds_to_ms(relative_time),
+            "relative-time": convert.seconds_to_ms(relative_time),
             "race-id": self._race_id,
             "race-timestamp": self._race_timestamp,
             "environment": self._environment_name,
@@ -1713,8 +1717,8 @@ class GlobalStatsCalculator:
         return self.store.get_error_rate(task=task_name, operation_type=operation_type, sample_type=SampleType.Normal)
 
     def duration(self, task_name):
-        return self.store.get_one("service_time", task=task_name, mapper=lambda doc: doc["relative-time-ms"],
-                                  sort_key="relative-time-ms", sort_reverse=True)
+        return self.store.get_one("service_time", task=task_name, mapper=lambda doc: doc["relative-time"],
+                                  sort_key="relative-time", sort_reverse=True)
 
     def median(self, metric_name, task_name=None, operation_type=None, sample_type=None):
         return self.store.get_median(metric_name, task=task_name, operation_type=operation_type, sample_type=sample_type)

--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -31,6 +31,9 @@
         "relative-time-ms": {
           "type": "float"
         },
+        "relative-time": {
+          "type": "float"
+        },
         "race-id": {
           "type": "keyword"
         },

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -315,6 +315,7 @@ class EsMetricsTests(TestCase):
             "race-id": EsMetricsTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time-ms": 0,
+            "relative-time": 0,
             "environment": "unittest",
             "sample-type": "normal",
             "track": "test",
@@ -344,6 +345,7 @@ class EsMetricsTests(TestCase):
             "race-id": EsMetricsTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time-ms": 10000,
+            "relative-time": 10000,
             "environment": "unittest",
             "sample-type": "normal",
             "track": "test",
@@ -382,6 +384,7 @@ class EsMetricsTests(TestCase):
             "race-id": EsMetricsTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time-ms": 0,
+            "relative-time": 0,
             "environment": "unittest",
             "sample-type": "normal",
             "track": "test",
@@ -420,6 +423,7 @@ class EsMetricsTests(TestCase):
             "race-id": EsMetricsTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time-ms": 0,
+            "relative-time": 0,
             "environment": "unittest",
             "track": "test",
             "track-params": {
@@ -465,6 +469,7 @@ class EsMetricsTests(TestCase):
             "race-id": EsMetricsTests.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time-ms": 0,
+            "relative-time": 0,
             "environment": "unittest",
             "track": "test",
             "track-params": {
@@ -498,13 +503,13 @@ class EsMetricsTests(TestCase):
                 "hits": [
                     {
                         "_source": {
-                            "relative-time-ms": duration,
+                            "relative-time": duration,
                             "value": 500
                         }
                     },
                     {
                         "_source": {
-                            "relative-time-ms": duration-200,
+                            "relative-time": duration-200,
                             "value": 700
                         }
                     },
@@ -539,12 +544,15 @@ class EsMetricsTests(TestCase):
             },
             "size": 1,
             "sort": [
-                {"relative-time-ms": {"order": "desc" }}
+                {"relative-time": {"order": "desc" }}
                 ]
         }
 
-        actual_duration = self.metrics_store.get_one("service_time", task="task1", mapper=lambda doc: doc["relative-time-ms"],
-                                                         sort_key="relative-time-ms", sort_reverse=True)
+        actual_duration = self.metrics_store.get_one("service_time",
+                                                     task="task1",
+                                                     mapper=lambda doc: doc["relative-time"],
+                                                     sort_key="relative-time",
+                                                     sort_reverse=True)
 
         self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 
@@ -1410,8 +1418,11 @@ class InMemoryMetricsStoreTests(TestCase):
         self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults")
 
-        actual_duration = self.metrics_store.get_one("service_time", task="task1", mapper=lambda doc: doc["relative-time-ms"],
-                                                         sort_key="relative-time-ms", sort_reverse=True)
+        actual_duration = self.metrics_store.get_one("service_time",
+                                                     task="task1",
+                                                     mapper=lambda doc: doc["relative-time"],
+                                                     sort_key="relative-time",
+                                                     sort_reverse=True)
 
         self.assertEqual(duration * 1000, actual_duration)
 
@@ -1426,8 +1437,11 @@ class InMemoryMetricsStoreTests(TestCase):
         self.metrics_store.open(InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP,
                                 "test", "append-no-conflicts", "defaults")
 
-        actual_duration = self.metrics_store.get_one("service_time", task="task1", mapper=lambda doc: doc["relative-time-ms"],
-                                                     sort_key="relative-time-ms", sort_reverse=True)
+        actual_duration = self.metrics_store.get_one("service_time",
+                                                     task="task1",
+                                                     mapper=lambda doc: doc["relative-time"],
+                                                     sort_key="relative-time",
+                                                     sort_reverse=True)
 
         self.assertIsNone(actual_duration)
 
@@ -1809,6 +1823,7 @@ class GlobalStatsCalculatorTests(TestCase):
                                 "test", "append-fast-with-conflicts", "defaults", create=True)
         self.metrics_store.put_doc(doc={"@timestamp": 1595896761994,
                                         "relative-time-ms": 283.382,
+                                        "relative-time": 283.382,
                                         "race-id": "fb26018b-428d-4528-b36b-cf8c54a303ec",
                                         "race-timestamp": "20200728T003905Z", "environment": "local",
                                         "track": "geonames", "challenge": "append-fast-with-conflicts",


### PR DESCRIPTION
With this commit we introduce the property `relative-time` for metrics
documents again. Contrary to Rally versions prior to 2.1.0, this
property contains the relative time since Rally started execution of a
task denoted in milliseconds, instead of microseconds. We also
deprecate the ancillary property `relative-time-ms` which will be
dropped in the next minor release in favor of `relative-time`.

Relates #1198