### PR TITLE
Switch to pytest asserts

### DIFF
--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from unittest import TestCase
 
 import elasticsearch
+import pytest
 
 from esrally import metrics, track, exceptions, config
 from esrally.driver import driver, runner, scheduler
@@ -142,7 +143,7 @@ class DriverTests(TestCase):
         ])
 
         # Did we start all load generators? There is no specific mock assert for this...
-        self.assertEqual(4, target.start_worker.call_count)
+        assert target.start_worker.call_count == 4
 
     def test_assign_drivers_round_robin(self):
         target = self.create_test_driver_target()
@@ -162,7 +163,7 @@ class DriverTests(TestCase):
         ])
 
         # Did we start all load generators? There is no specific mock assert for this...
-        self.assertEqual(4, target.start_worker.call_count)
+        assert target.start_worker.call_count == 4
 
     def test_client_reaches_join_point_others_still_executing(self):
         target = self.create_test_driver_target()
@@ -171,16 +172,16 @@ class DriverTests(TestCase):
         d.prepare_benchmark(t=self.track)
         d.start_benchmark()
 
-        self.assertEqual(0, len(d.workers_completed_current_step))
+        assert len(d.workers_completed_current_step) == 0
 
         d.joinpoint_reached(worker_id=0,
                             worker_local_timestamp=10,
                             task_allocations=[driver.ClientAllocation(client_id=0, task=driver.JoinPoint(id=0))])
 
-        self.assertEqual(1, len(d.workers_completed_current_step))
+        assert len(d.workers_completed_current_step) == 1
 
-        self.assertEqual(0, target.on_task_finished.call_count)
-        self.assertEqual(0, target.drive_at.call_count)
+        assert target.on_task_finished.call_count == 0
+        assert target.drive_at.call_count == 0
 
     def test_client_reaches_join_point_which_completes_parent(self):
         target = self.create_test_driver_target()
@@ -189,7 +190,7 @@ class DriverTests(TestCase):
         d.prepare_benchmark(t=self.track)
         d.start_benchmark()
 
-        self.assertEqual(0, len(d.workers_completed_current_step))
+        assert len(d.workers_completed_current_step) == 0
 
         d.joinpoint_reached(worker_id=0,
                             worker_local_timestamp=10,
@@ -198,10 +199,10 @@ class DriverTests(TestCase):
                                                         task=driver.JoinPoint(id=0,
                                                                               clients_executing_completing_task=[0]))])
 
-        self.assertEqual(-1, d.current_step)
-        self.assertEqual(1, len(d.workers_completed_current_step))
+        assert d.current_step == -1
+        assert len(d.workers_completed_current_step) == 1
         # notified all drivers that they should complete the current task ASAP
-        self.assertEqual(4, target.complete_current_task.call_count)
+        assert target.complete_current_task.call_count == 4
 
         # awaiting responses of other clients
         d.joinpoint_reached(worker_id=1,
@@ -211,8 +212,8 @@ class DriverTests(TestCase):
                                                         task=driver.JoinPoint(id=0,
                                                                               clients_executing_completing_task=[0]))])
 
-        self.assertEqual(-1, d.current_step)
-        self.assertEqual(2, len(d.workers_completed_current_step))
+        assert d.current_step == -1
+        assert len(d.workers_completed_current_step) == 2
 
         d.joinpoint_reached(worker_id=2,
                             worker_local_timestamp=12,
@@ -220,8 +221,8 @@ class DriverTests(TestCase):
                                 driver.ClientAllocation(client_id=2,
                                                         task=driver.JoinPoint(id=0,
                                                                               clients_executing_completing_task=[0]))])
-        self.assertEqual(-1, d.current_step)
-        self.assertEqual(3, len(d.workers_completed_current_step))
+        assert d.current_step == -1
+        assert len(d.workers_completed_current_step) == 3
 
         d.joinpoint_reached(worker_id=3,
                             worker_local_timestamp=13,
@@ -231,13 +232,13 @@ class DriverTests(TestCase):
                                                                               clients_executing_completing_task=[0]))])
 
         # by now the previous step should be considered completed and we are at the next one
-        self.assertEqual(0, d.current_step)
-        self.assertEqual(0, len(d.workers_completed_current_step))
+        assert d.current_step == 0
+        assert len(d.workers_completed_current_step) == 0
 
         # this requires at least Python 3.6
         # target.on_task_finished.assert_called_once()
-        self.assertEqual(1, target.on_task_finished.call_count)
-        self.assertEqual(4, target.drive_at.call_count)
+        assert target.on_task_finished.call_count == 1
+        assert target.drive_at.call_count == 4
 
 
 def op(name, operation_type):
@@ -374,7 +375,7 @@ class WorkerAssignmentTests(TestCase):
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=4)
 
-        self.assertEqual([
+        assert assignments == [
             {
                 "host": "localhost",
                 "workers": [
@@ -384,7 +385,7 @@ class WorkerAssignmentTests(TestCase):
                     [3]
                 ]
             }
-        ], assignments)
+        ]
 
     def test_single_host_assignment_more_clients_than_cores(self):
         host_configs = [{
@@ -394,7 +395,7 @@ class WorkerAssignmentTests(TestCase):
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=6)
 
-        self.assertEqual([
+        assert assignments == [
             {
                 "host": "localhost",
                 "workers": [
@@ -404,7 +405,7 @@ class WorkerAssignmentTests(TestCase):
                     [5]
                 ]
             }
-        ], assignments)
+        ]
 
     def test_single_host_assignment_less_clients_than_cores(self):
         host_configs = [{
@@ -414,7 +415,7 @@ class WorkerAssignmentTests(TestCase):
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=2)
 
-        self.assertEqual([
+        assert assignments == [
             {
                 "host": "localhost",
                 "workers": [
@@ -424,7 +425,7 @@ class WorkerAssignmentTests(TestCase):
                     []
                 ]
             }
-        ], assignments)
+        ]
 
     def test_multiple_host_assignment_more_clients_than_cores(self):
         host_configs = [
@@ -440,7 +441,7 @@ class WorkerAssignmentTests(TestCase):
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=16)
 
-        self.assertEqual([
+        assert assignments == [
             {
                 "host": "host-a",
                 "workers": [
@@ -459,7 +460,7 @@ class WorkerAssignmentTests(TestCase):
                     [14, 15]
                 ]
             }
-        ], assignments)
+        ]
 
     def test_multiple_host_assignment_less_clients_than_cores(self):
         host_configs = [
@@ -475,7 +476,7 @@ class WorkerAssignmentTests(TestCase):
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=4)
 
-        self.assertEqual([
+        assert assignments == [
             {
                 "host": "host-a",
                 "workers": [
@@ -494,7 +495,7 @@ class WorkerAssignmentTests(TestCase):
                     []
                 ]
             }
-        ], assignments)
+        ]
 
     def test_uneven_assignment_across_hosts(self):
         host_configs = [
@@ -514,7 +515,7 @@ class WorkerAssignmentTests(TestCase):
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=17)
 
-        self.assertEqual([
+        assert assignments == [
             {
                 "host": "host-a",
                 "workers": [
@@ -542,7 +543,7 @@ class WorkerAssignmentTests(TestCase):
                     [16]
                 ]
             }
-        ], assignments)
+        ]
 
 
 class AllocatorTests(TestCase):
@@ -560,35 +561,35 @@ class AllocatorTests(TestCase):
 
         allocator = driver.Allocator([task])
 
-        self.assertEqual(1, allocator.clients)
-        self.assertEqual(3, len(allocator.allocations[0]))
-        self.assertEqual(2, len(allocator.join_points))
-        self.assertEqual([{task}], allocator.tasks_per_joinpoint)
+        assert allocator.clients == 1
+        assert len(allocator.allocations[0]) == 3
+        assert len(allocator.join_points) == 2
+        assert allocator.tasks_per_joinpoint == [{task}]
 
     def test_allocates_two_serial_tasks(self):
         task = track.Task("index", op("index", track.OperationType.Bulk))
 
         allocator = driver.Allocator([task, task])
 
-        self.assertEqual(1, allocator.clients)
+        assert allocator.clients == 1
         # we have two operations and three join points
-        self.assertEqual(5, len(allocator.allocations[0]))
-        self.assertEqual(3, len(allocator.join_points))
-        self.assertEqual([{task}, {task}], allocator.tasks_per_joinpoint)
+        assert len(allocator.allocations[0]) == 5
+        assert len(allocator.join_points) == 3
+        assert allocator.tasks_per_joinpoint == [{task}, {task}]
 
     def test_allocates_two_parallel_tasks(self):
         task = track.Task("index", op("index", track.OperationType.Bulk))
 
         allocator = driver.Allocator([track.Parallel([task, task])])
 
-        self.assertEqual(2, allocator.clients)
-        self.assertEqual(3, len(allocator.allocations[0]))
-        self.assertEqual(3, len(allocator.allocations[1]))
-        self.assertEqual(2, len(allocator.join_points))
-        self.assertEqual([{task}], allocator.tasks_per_joinpoint)
+        assert allocator.clients == 2
+        assert len(allocator.allocations[0]) == 3
+        assert len(allocator.allocations[1]) == 3
+        assert len(allocator.join_points) == 2
+        assert allocator.tasks_per_joinpoint == [{task}]
         for join_point in allocator.join_points:
-            self.assertFalse(join_point.preceding_task_completes_parent)
-            self.assertEqual(0, join_point.num_clients_executing_completing_task)
+            assert not join_point.preceding_task_completes_parent
+            assert join_point.num_clients_executing_completing_task == 0
 
     def test_a_task_completes_the_parallel_structure(self):
         taskA = track.Task("index-completing", op("index", track.OperationType.Bulk), completes_parent=True)
@@ -596,15 +597,15 @@ class AllocatorTests(TestCase):
 
         allocator = driver.Allocator([track.Parallel([taskA, taskB])])
 
-        self.assertEqual(2, allocator.clients)
-        self.assertEqual(3, len(allocator.allocations[0]))
-        self.assertEqual(3, len(allocator.allocations[1]))
-        self.assertEqual(2, len(allocator.join_points))
-        self.assertEqual([{taskA, taskB}], allocator.tasks_per_joinpoint)
+        assert allocator.clients == 2
+        assert len(allocator.allocations[0]) == 3
+        assert len(allocator.allocations[1]) == 3
+        assert len(allocator.join_points) == 2
+        assert allocator.tasks_per_joinpoint == [{taskA, taskB}]
         final_join_point = allocator.join_points[1]
-        self.assertTrue(final_join_point.preceding_task_completes_parent)
-        self.assertEqual(1, final_join_point.num_clients_executing_completing_task)
-        self.assertEqual([0], final_join_point.clients_executing_completing_task)
+        assert final_join_point.preceding_task_completes_parent
+        assert final_join_point.num_clients_executing_completing_task == 1
+        assert final_join_point.clients_executing_completing_task == [0]
 
     def test_allocates_mixed_tasks(self):
         index = track.Task("index", op("index", track.OperationType.Bulk))
@@ -617,17 +618,17 @@ class AllocatorTests(TestCase):
                                       index,
                                       track.Parallel([search, search, search])])
 
-        self.assertEqual(3, allocator.clients)
+        assert allocator.clients == 3
 
         # 1 join point, 1 op, 1 jp, 1 (parallel) op, 1 jp, 1 op, 1 jp, 1 op, 1 jp, 1 (parallel) op, 1 jp
-        self.assertEqual(11, len(allocator.allocations[0]))
-        self.assertEqual(11, len(allocator.allocations[1]))
-        self.assertEqual(11, len(allocator.allocations[2]))
-        self.assertEqual(6, len(allocator.join_points))
-        self.assertEqual([{index}, {index, stats}, {index}, {index}, {search}], allocator.tasks_per_joinpoint)
+        assert len(allocator.allocations[0]) == 11
+        assert len(allocator.allocations[1]) == 11
+        assert len(allocator.allocations[2]) == 11
+        assert len(allocator.join_points) == 6
+        assert allocator.tasks_per_joinpoint == [{index}, {index, stats}, {index}, {index}, {search}]
         for join_point in allocator.join_points:
-            self.assertFalse(join_point.preceding_task_completes_parent)
-            self.assertEqual(0, join_point.num_clients_executing_completing_task)
+            assert not join_point.preceding_task_completes_parent
+            assert join_point.num_clients_executing_completing_task == 0
 
     # TODO (follow-up PR): We should probably forbid this
     def test_allocates_more_tasks_than_clients(self):
@@ -639,38 +640,38 @@ class AllocatorTests(TestCase):
 
         allocator = driver.Allocator([track.Parallel(tasks=[index_a, index_b, index_c, index_d, index_e], clients=2)])
 
-        self.assertEqual(2, allocator.clients)
+        assert allocator.clients == 2
 
         allocations = allocator.allocations
 
         # 2 clients
-        self.assertEqual(2, len(allocations))
+        assert len(allocations) == 2
         # join_point, index_a, index_c, index_e, join_point
-        self.assertEqual(5, len(allocations[0]))
+        assert len(allocations[0]) == 5
         # we really have no chance to extract the join point so we just take what is there...
-        self.assertEqual([
+        assert allocations[0] == [
             allocations[0][0],
             self.ta(index_a, client_index_in_task=0, global_client_index=0, total_clients=2),
             self.ta(index_c, client_index_in_task=0, global_client_index=2, total_clients=2),
             self.ta(index_e, client_index_in_task=0, global_client_index=4, total_clients=2),
             allocations[0][4]
-        ], allocations[0])
+        ]
         # join_point, index_a, index_c, None, join_point
-        self.assertEqual(5, len(allocator.allocations[1]))
-        self.assertEqual([
+        assert len(allocator.allocations[1]) == 5
+        assert allocations[1] == [
             allocations[1][0],
             self.ta(index_b, client_index_in_task=0, global_client_index=1, total_clients=2),
             self.ta(index_d, client_index_in_task=0, global_client_index=3, total_clients=2),
             None,
             allocations[1][4]
-        ], allocations[1])
+        ]
 
-        self.assertEqual([{index_a, index_b, index_c, index_d, index_e}], allocator.tasks_per_joinpoint)
-        self.assertEqual(2, len(allocator.join_points))
+        assert allocator.tasks_per_joinpoint == [{index_a, index_b, index_c, index_d, index_e}]
+        assert len(allocator.join_points) == 2
         final_join_point = allocator.join_points[1]
-        self.assertTrue(final_join_point.preceding_task_completes_parent)
-        self.assertEqual(1, final_join_point.num_clients_executing_completing_task)
-        self.assertEqual([1], final_join_point.clients_executing_completing_task)
+        assert final_join_point.preceding_task_completes_parent
+        assert final_join_point.num_clients_executing_completing_task == 1
+        assert final_join_point.clients_executing_completing_task == [1]
 
     # TODO (follow-up PR): We should probably forbid this
     def test_considers_number_of_clients_per_subtask(self):
@@ -680,51 +681,51 @@ class AllocatorTests(TestCase):
 
         allocator = driver.Allocator([track.Parallel(tasks=[index_a, index_b, index_c], clients=3)])
 
-        self.assertEqual(3, allocator.clients)
+        assert allocator.clients == 3
 
         allocations = allocator.allocations
 
         # 3 clients
-        self.assertEqual(3, len(allocations))
+        assert len(allocations) == 3
 
         # tasks that client 0 will execute:
         # join_point, index_a, index_c, join_point
-        self.assertEqual(4, len(allocations[0]))
+        assert len(allocations[0]) == 4
         # we really have no chance to extract the join point so we just take what is there...
-        self.assertEqual([
+        assert allocations[0] == [
             allocations[0][0],
             self.ta(index_a, client_index_in_task=0, global_client_index=0, total_clients=3),
             self.ta(index_c, client_index_in_task=1, global_client_index=3, total_clients=3),
             allocations[0][3]
-        ], allocations[0])
+        ]
 
         # task that client 1 will execute:
         # join_point, index_b, None, join_point
-        self.assertEqual(4, len(allocator.allocations[1]))
-        self.assertEqual([
+        assert len(allocator.allocations[1]) == 4
+        assert allocations[1] == [
             allocations[1][0],
             self.ta(index_b, client_index_in_task=0, global_client_index=1, total_clients=3),
             None,
             allocations[1][3]
-        ], allocations[1])
+        ]
 
         # tasks that client 2 will execute:
-        self.assertEqual(4, len(allocator.allocations[2]))
-        self.assertEqual([
+        assert len(allocator.allocations[2]) == 4
+        assert allocations[2] == [
             allocations[2][0],
             self.ta(index_c, client_index_in_task=0, global_client_index=2, total_clients=3),
             None,
             allocations[2][3]
-        ], allocations[2])
+        ]
 
-        self.assertEqual([{index_a, index_b, index_c}], allocator.tasks_per_joinpoint)
+        assert allocator.tasks_per_joinpoint == [{index_a, index_b, index_c}]
 
-        self.assertEqual(2, len(allocator.join_points))
+        assert len(allocator.join_points) == 2
         final_join_point = allocator.join_points[1]
-        self.assertTrue(final_join_point.preceding_task_completes_parent)
+        assert final_join_point.preceding_task_completes_parent
         # task index_c has two clients, hence we have to wait for two clients to finish
-        self.assertEqual(2, final_join_point.num_clients_executing_completing_task)
-        self.assertEqual([2, 0], final_join_point.clients_executing_completing_task)
+        assert final_join_point.num_clients_executing_completing_task == 2
+        assert final_join_point.clients_executing_completing_task == [2, 0]
 
 
 class MetricsAggregationTests(TestCase):
@@ -741,13 +742,13 @@ class MetricsAggregationTests(TestCase):
 
         aggregated = self.calculate_global_throughput(samples)
 
-        self.assertIn(op, aggregated)
-        self.assertEqual(1, len(aggregated))
+        assert op in aggregated
+        assert len(aggregated) == 1
 
         throughput = aggregated[op]
-        self.assertEqual(2, len(throughput))
-        self.assertEqual((1470838595, 21, metrics.SampleType.Warmup, 3000, "docs/s"), throughput[0])
-        self.assertEqual((1470838595.5, 21.5, metrics.SampleType.Normal, 3666.6666666666665, "docs/s"), throughput[1])
+        assert len(throughput) == 2
+        assert throughput[0] == (1470838595, 21, metrics.SampleType.Warmup, 3000, "docs/s")
+        assert throughput[1] == (1470838595.5, 21.5, metrics.SampleType.Normal, 3666.6666666666665, "docs/s")
 
     def test_single_metrics_aggregation(self):
         op = track.Operation("index", track.OperationType.Bulk, param_source="driver-test-param-source")
@@ -766,17 +767,17 @@ class MetricsAggregationTests(TestCase):
 
         aggregated = self.calculate_global_throughput(samples)
 
-        self.assertIn(op, aggregated)
-        self.assertEqual(1, len(aggregated))
+        assert op in aggregated
+        assert len(aggregated) == 1
 
         throughput = aggregated[op]
-        self.assertEqual(6, len(throughput))
-        self.assertEqual((38595, 21, metrics.SampleType.Normal, 5000, "docs/s"), throughput[0])
-        self.assertEqual((38596, 22, metrics.SampleType.Normal, 5000, "docs/s"), throughput[1])
-        self.assertEqual((38597, 23, metrics.SampleType.Normal, 5000, "docs/s"), throughput[2])
-        self.assertEqual((38598, 24, metrics.SampleType.Normal, 5000, "docs/s"), throughput[3])
-        self.assertEqual((38599, 25, metrics.SampleType.Normal, 6000, "docs/s"), throughput[4])
-        self.assertEqual((38600, 26, metrics.SampleType.Normal, 6666.666666666667, "docs/s"), throughput[5])
+        assert len(throughput) == 6
+        assert throughput[0] == (38595, 21, metrics.SampleType.Normal, 5000, "docs/s")
+        assert throughput[1] == (38596, 22, metrics.SampleType.Normal, 5000, "docs/s")
+        assert throughput[2] == (38597, 23, metrics.SampleType.Normal, 5000, "docs/s")
+        assert throughput[3] == (38598, 24, metrics.SampleType.Normal, 5000, "docs/s")
+        assert throughput[4] == (38599, 25, metrics.SampleType.Normal, 6000, "docs/s")
+        assert throughput[5] == (38600, 26, metrics.SampleType.Normal, 6666.666666666667, "docs/s")
         # self.assertEqual((1470838600.5, 26.5, metrics.SampleType.Normal, 10000), throughput[6])
 
     def test_use_provided_throughput(self):
@@ -791,14 +792,14 @@ class MetricsAggregationTests(TestCase):
 
         aggregated = self.calculate_global_throughput(samples)
 
-        self.assertIn(op, aggregated)
-        self.assertEqual(1, len(aggregated))
+        assert op in aggregated
+        assert len(aggregated) == 1
 
         throughput = aggregated[op]
-        self.assertEqual(3, len(throughput))
-        self.assertEqual((38595, 21, metrics.SampleType.Normal, 8000, "byte/s"), throughput[0])
-        self.assertEqual((38596, 22, metrics.SampleType.Normal, 8000, "byte/s"), throughput[1])
-        self.assertEqual((38597, 23, metrics.SampleType.Normal, 8000, "byte/s"), throughput[2])
+        assert len(throughput) == 3
+        assert throughput[0] == (38595, 21, metrics.SampleType.Normal, 8000, "byte/s")
+        assert throughput[1] == (38596, 22, metrics.SampleType.Normal, 8000, "byte/s")
+        assert throughput[2] == (38597, 23, metrics.SampleType.Normal, 8000, "byte/s")
 
     def calculate_global_throughput(self, samples):
         return driver.ThroughputCalculator().calculate(samples)
@@ -841,11 +842,11 @@ class SchedulerTests(TestCase):
         async for invocation_time, sample_type, progress_percent, runner, params in schedule_handle():
             schedule_handle.before_request(now=idx)
             exp_invocation_time, exp_sample_type, exp_progress_percent, exp_params = expected_schedule[idx]
-            self.assertAlmostEqual(exp_invocation_time, invocation_time, msg="Invocation time for sample at index %d does not match" % idx)
-            self.assertEqual(exp_sample_type, sample_type, "Sample type for sample at index %d does not match" % idx)
-            self.assertEqual(exp_progress_percent, progress_percent, "Current progress for sample at index %d does not match" % idx)
-            self.assertIsNotNone(runner, "runner must be defined")
-            self.assertEqual(exp_params, params, "Parameters do not match")
+            assert round(abs(exp_invocation_time-invocation_time), 7) == 0, "Invocation time for sample at index %d does not match" % idx
+            assert sample_type == exp_sample_type, "Sample type for sample at index %d does not match" % idx
+            assert progress_percent == exp_progress_percent, "Current progress for sample at index %d does not match" % idx
+            assert runner is not None, "runner must be defined"
+            assert params == exp_params, "Parameters do not match"
             idx += 1
             # for infinite schedules we only check the first few elements
             if infinite_schedule and idx == len(expected_schedule):
@@ -853,7 +854,7 @@ class SchedulerTests(TestCase):
             # simulate that the request is done - we only support throttling based on request count (ops).
             schedule_handle.after_request(now=idx, weight=1, unit="ops", request_meta_data=None)
         if not infinite_schedule:
-            self.assertEqual(len(expected_schedule), idx, msg="Number of elements in the schedules do not match")
+            assert idx == len(expected_schedule), "Number of elements in the schedules do not match"
 
     def setUp(self):
         self.test_track = track.Track(name="unittest")
@@ -887,8 +888,8 @@ class SchedulerTests(TestCase):
         param_source = track.operation_parameters(self.test_track, task)
         schedule = driver.schedule_for(task_allocation, param_source)
 
-        self.assertIsNotNone(schedule.sched.parameter_source, "Parameter source has not been injected into scheduler")
-        self.assertEqual(param_source, schedule.sched.parameter_source)
+        assert schedule.sched.parameter_source is not None, "Parameter source has not been injected into scheduler"
+        assert schedule.sched.parameter_source == param_source
 
     @run_async
     async def test_search_task_one_client(self):
@@ -1111,24 +1112,24 @@ class SchedulerTests(TestCase):
         schedule_handle = driver.schedule_for(task_allocation, param_source)
         schedule_handle.start()
         # first client does not wait
-        self.assertEqual(0.0, schedule_handle.ramp_up_wait_time)
+        assert schedule_handle.ramp_up_wait_time == 0.0
         schedule = schedule_handle()
 
         last_progress = -1
 
         async for invocation_time, sample_type, progress_percent, runner, params in schedule:
             # we're not throughput throttled
-            self.assertEqual(0, invocation_time)
+            assert invocation_time == 0
             if progress_percent <= 0.5:
-                self.assertEqual(metrics.SampleType.Warmup, sample_type)
+                assert sample_type == metrics.SampleType.Warmup
             else:
-                self.assertEqual(metrics.SampleType.Normal, sample_type)
-            self.assertTrue(last_progress < progress_percent)
+                assert sample_type == metrics.SampleType.Normal
+            assert last_progress < progress_percent
             last_progress = progress_percent
-            self.assertTrue(round(progress_percent, 2) >= 0.0, "progress should be >= 0.0 but was [%f]" % progress_percent)
-            self.assertTrue(round(progress_percent, 2) <= 1.0, "progress should be <= 1.0 but was [%f]" % progress_percent)
-            self.assertIsNotNone(runner, "runner must be defined")
-            self.assertEqual({"body": ["a"], "size": 11}, params)
+            assert round(progress_percent, 2) >= 0.0, "progress should be >= 0.0 but was [%f]" % progress_percent
+            assert round(progress_percent, 2) <= 1.0, "progress should be <= 1.0 but was [%f]" % progress_percent
+            assert runner is not None, "runner must be defined"
+            assert params == {"body": ["a"], "size": 11}
 
     @run_async
     async def test_schedule_for_time_based_with_multiple_clients(self):
@@ -1150,24 +1151,24 @@ class SchedulerTests(TestCase):
         schedule_handle = driver.schedule_for(task_allocation, param_source)
         schedule_handle.start()
         # client number 4 out of 8 -> 0.1 * (4 / 8) = 0.05
-        self.assertEqual(0.05, schedule_handle.ramp_up_wait_time)
+        assert schedule_handle.ramp_up_wait_time == 0.05
         schedule = schedule_handle()
 
         last_progress = -1
 
         async for invocation_time, sample_type, progress_percent, runner, params in schedule:
             # we're not throughput throttled
-            self.assertEqual(0, invocation_time)
+            assert invocation_time == 0
             if progress_percent <= 0.5:
-                self.assertEqual(metrics.SampleType.Warmup, sample_type)
+                assert sample_type == metrics.SampleType.Warmup
             else:
-                self.assertEqual(metrics.SampleType.Normal, sample_type)
-            self.assertTrue(last_progress < progress_percent)
+                assert sample_type == metrics.SampleType.Normal
+            assert last_progress < progress_percent
             last_progress = progress_percent
-            self.assertTrue(round(progress_percent, 2) >= 0.0, "progress should be >= 0.0 but was [%f]" % progress_percent)
-            self.assertTrue(round(progress_percent, 2) <= 1.0, "progress should be <= 1.0 but was [%f]" % progress_percent)
-            self.assertIsNotNone(runner, "runner must be defined")
-            self.assertEqual({"body": ["a"], "size": 11}, params)
+            assert round(progress_percent, 2) >= 0.0, "progress should be >= 0.0 but was [%f]" % progress_percent
+            assert round(progress_percent, 2) <= 1.0, "progress should be <= 1.0 but was [%f]" % progress_percent
+            assert runner is not None, "runner must be defined"
+            assert params == {"body": ["a"], "size": 11}
 
 
 
@@ -1299,23 +1300,23 @@ class AsyncExecutorTests(TestCase):
 
         samples = sampler.samples
 
-        self.assertTrue(len(samples) > 0)
-        self.assertFalse(complete.is_set(), "Executor should not auto-complete a normal task")
+        assert len(samples) > 0
+        assert not complete.is_set(), "Executor should not auto-complete a normal task"
         previous_absolute_time = -1.0
         previous_relative_time = -1.0
         for sample in samples:
-            self.assertEqual(2, sample.client_id)
-            self.assertEqual(task, sample.task)
-            self.assertLess(previous_absolute_time, sample.absolute_time)
+            assert sample.client_id == 2
+            assert sample.task == task
+            assert previous_absolute_time < sample.absolute_time
             previous_absolute_time = sample.absolute_time
-            self.assertLess(previous_relative_time, sample.relative_time)
+            assert previous_relative_time < sample.relative_time
             previous_relative_time = sample.relative_time
             # we don't have any warmup time period
-            self.assertEqual(metrics.SampleType.Normal, sample.sample_type)
+            assert sample.sample_type == metrics.SampleType.Normal
             # latency equals service time in throughput mode
-            self.assertEqual(sample.latency, sample.service_time)
-            self.assertEqual(1, sample.total_ops)
-            self.assertEqual("docs", sample.total_ops_unit)
+            assert sample.service_time == sample.latency
+            assert sample.total_ops == 1
+            assert sample.total_ops_unit == "docs"
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -1358,27 +1359,27 @@ class AsyncExecutorTests(TestCase):
 
         samples = sampler.samples
 
-        self.assertEqual(5, len(samples))
-        self.assertTrue(self.runner_with_progress.completed)
-        self.assertEqual(1.0, self.runner_with_progress.percent_completed)
-        self.assertFalse(complete.is_set(), "Executor should not auto-complete a normal task")
+        assert len(samples) == 5
+        assert self.runner_with_progress.completed
+        assert self.runner_with_progress.percent_completed == 1.0
+        assert not complete.is_set(), "Executor should not auto-complete a normal task"
         previous_absolute_time = -1.0
         previous_relative_time = -1.0
         for sample in samples:
-            self.assertEqual(2, sample.client_id)
-            self.assertEqual(task, sample.task)
-            self.assertLess(previous_absolute_time, sample.absolute_time)
+            assert sample.client_id == 2
+            assert sample.task == task
+            assert previous_absolute_time < sample.absolute_time
             previous_absolute_time = sample.absolute_time
-            self.assertLess(previous_relative_time, sample.relative_time)
+            assert previous_relative_time < sample.relative_time
             previous_relative_time = sample.relative_time
             # we don't have any warmup time period
-            self.assertEqual(metrics.SampleType.Normal, sample.sample_type)
+            assert sample.sample_type == metrics.SampleType.Normal
             # throughput is not overridden and will be calculated later
-            self.assertIsNone(sample.throughput)
+            assert sample.throughput is None
             # latency equals service time in throughput mode
-            self.assertEqual(sample.latency, sample.service_time)
-            self.assertEqual(1, sample.total_ops)
-            self.assertEqual("ops", sample.total_ops_unit)
+            assert sample.service_time == sample.latency
+            assert sample.total_ops == 1
+            assert sample.total_ops_unit == "ops"
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -1424,19 +1425,19 @@ class AsyncExecutorTests(TestCase):
 
         samples = sampler.samples
 
-        self.assertFalse(complete.is_set(), "Executor should not auto-complete a normal task")
-        self.assertEqual(1, len(samples))
+        assert not complete.is_set(), "Executor should not auto-complete a normal task"
+        assert len(samples) == 1
         sample = samples[0]
-        self.assertEqual(0, sample.client_id)
-        self.assertEqual(task, sample.task)
+        assert sample.client_id == 0
+        assert sample.task == task
         # we don't have any warmup samples
-        self.assertEqual(metrics.SampleType.Normal, sample.sample_type)
-        self.assertEqual(sample.latency, sample.service_time)
-        self.assertEqual(1, sample.total_ops)
-        self.assertEqual("ops", sample.total_ops_unit)
-        self.assertEqual(1.23, sample.throughput)
-        self.assertIsNotNone(sample.service_time)
-        self.assertIsNotNone(sample.time_period)
+        assert sample.sample_type == metrics.SampleType.Normal
+        assert sample.service_time == sample.latency
+        assert sample.total_ops == 1
+        assert sample.total_ops_unit == "ops"
+        assert sample.throughput == 1.23
+        assert sample.service_time is not None
+        assert sample.time_period is not None
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -1501,9 +1502,9 @@ class AsyncExecutorTests(TestCase):
             sample_size = len(samples)
             lower_bound = bounds[0]
             upper_bound = bounds[1]
-            self.assertTrue(lower_bound <= sample_size <= upper_bound,
-                            msg="Expected sample size to be between %d and %d but was %d" % (lower_bound, upper_bound, sample_size))
-            self.assertTrue(complete.is_set(), "Executor should auto-complete a task that terminates its parent")
+            assert lower_bound <= sample_size <= upper_bound, \
+                            "Expected sample size to be between %d and %d but was %d" % (lower_bound, upper_bound, sample_size)
+            assert complete.is_set(), "Executor should auto-complete a task that terminates its parent"
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -1559,7 +1560,7 @@ class AsyncExecutorTests(TestCase):
             samples = sampler.samples
 
             sample_size = len(samples)
-            self.assertEqual(0, sample_size)
+            assert sample_size == 0
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -1610,10 +1611,10 @@ class AsyncExecutorTests(TestCase):
                                                 complete=complete,
                                                 on_error="continue")
 
-        with self.assertRaisesRegex(exceptions.RallyError, r"Cannot run task \[no-op\]: expected unit test exception"):
+        with pytest.raises(exceptions.RallyError, match=r"Cannot run task \[no-op\]: expected unit test exception"):
             await execute_schedule()
 
-        self.assertEqual(0, es.call_count)
+        assert es.call_count == 0
 
     @run_async
     async def test_execute_single_no_return_value(self):
@@ -1624,9 +1625,9 @@ class AsyncExecutorTests(TestCase):
 
         ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
 
-        self.assertEqual(1, ops)
-        self.assertEqual("ops", unit)
-        self.assertEqual({"success": True}, request_meta_data)
+        assert ops == 1
+        assert unit == "ops"
+        assert request_meta_data == {"success": True}
 
     @run_async
     async def test_execute_single_tuple(self):
@@ -1637,9 +1638,9 @@ class AsyncExecutorTests(TestCase):
 
         ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
 
-        self.assertEqual(500, ops)
-        self.assertEqual("MB", unit)
-        self.assertEqual({"success": True}, request_meta_data)
+        assert ops == 500
+        assert unit == "MB"
+        assert request_meta_data == {"success": True}
 
     @run_async
     async def test_execute_single_dict(self):
@@ -1655,13 +1656,13 @@ class AsyncExecutorTests(TestCase):
 
         ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
 
-        self.assertEqual(50, ops)
-        self.assertEqual("docs", unit)
-        self.assertEqual({
+        assert ops == 50
+        assert unit == "docs"
+        assert request_meta_data == {
             "some-custom-meta-data": "valid",
             "http-status": 200,
             "success": True
-        }, request_meta_data)
+        }
 
     @run_async
     async def test_execute_single_with_connection_error_always_aborts(self):
@@ -1672,11 +1673,10 @@ class AsyncExecutorTests(TestCase):
                 # ES client uses pseudo-status "N/A" in this case...
                 runner = mock.Mock(side_effect=as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host", None)))
 
-                with self.assertRaises(exceptions.RallyAssertionError) as ctx:
+                with pytest.raises(exceptions.RallyAssertionError) as ctx:
                     await driver.execute_single(self.context_managed(runner), es, params, on_error=on_error)
-                self.assertEqual(
-                    "Request returned an error. Error type: transport, Description: no route to host",
-                    ctx.exception.args[0])
+                assert ctx.value.args[0] == \
+                    "Request returned an error. Error type: transport, Description: no route to host"
 
     @run_async
     async def test_execute_single_with_http_400_aborts_when_specified(self):
@@ -1685,11 +1685,10 @@ class AsyncExecutorTests(TestCase):
         runner = mock.Mock(side_effect=
                            as_future(exception=elasticsearch.NotFoundError(404, "not found", "the requested document could not be found")))
 
-        with self.assertRaises(exceptions.RallyAssertionError) as ctx:
+        with pytest.raises(exceptions.RallyAssertionError) as ctx:
             await driver.execute_single(self.context_managed(runner), es, params, on_error="abort")
-        self.assertEqual(
-            "Request returned an error. Error type: transport, Description: not found (the requested document could not be found)",
-            ctx.exception.args[0])
+        assert ctx.value.args[0] == \
+            "Request returned an error. Error type: transport, Description: not found (the requested document could not be found)"
 
 
     @run_async
@@ -1702,14 +1701,14 @@ class AsyncExecutorTests(TestCase):
         ops, unit, request_meta_data = await driver.execute_single(
             self.context_managed(runner), es, params, on_error="continue")
 
-        self.assertEqual(0, ops)
-        self.assertEqual("ops", unit)
-        self.assertEqual({
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data == {
             "http-status": 404,
             "error-type": "transport",
             "error-description": "not found (the requested document could not be found)",
             "success": False
-        }, request_meta_data)
+        }
 
     @run_async
     async def test_execute_single_with_http_413(self):
@@ -1721,14 +1720,14 @@ class AsyncExecutorTests(TestCase):
         ops, unit, request_meta_data = await driver.execute_single(
             self.context_managed(runner), es, params, on_error="continue")
 
-        self.assertEqual(0, ops)
-        self.assertEqual("ops", unit)
-        self.assertEqual({
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data == {
             "http-status": 413,
             "error-type": "transport",
             "error-description": "",
             "success": False
-        }, request_meta_data)
+        }
 
     @run_async
     async def test_execute_single_with_key_error(self):
@@ -1746,11 +1745,10 @@ class AsyncExecutorTests(TestCase):
         params["mode"] = "append"
         runner = FailingRunner()
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
-        self.assertEqual(
-            "Cannot execute [failing_mock_runner]. Provided parameters are: ['bulk', 'mode']. Error: ['bulk-size missing'].",
-            ctx.exception.args[0])
+        assert ctx.value.args[0] == \
+            "Cannot execute [failing_mock_runner]. Provided parameters are: ['bulk', 'mode']. Error: ['bulk-size missing']."
 
 
 class AsyncProfilerTests(TestCase):
@@ -1765,6 +1763,6 @@ class AsyncProfilerTests(TestCase):
         # this should take roughly 1 second and should return something
         return_value = await profiler(1)
         end = time.perf_counter()
-        self.assertEqual(2, return_value)
+        assert return_value == 2
         duration = end - start
-        self.assertTrue(0.9 <= duration <= 1.2, "Should sleep for roughly 1 second but took [%.2f] seconds." % duration)
+        assert 0.9 <= duration <= 1.2, "Should sleep for roughly 1 second but took [%.2f] seconds." % duration

--- a/tests/mechanic/java_resolver_test.py
+++ b/tests/mechanic/java_resolver_test.py
@@ -18,6 +18,8 @@
 import unittest.mock as mock
 from unittest import TestCase
 
+import pytest
+
 from esrally import exceptions
 from esrally.mechanic import java_resolver
 
@@ -30,8 +32,8 @@ class JavaResolverTests(TestCase):
                                                    specified_runtime_jdk=None,
                                                    provides_bundled_jdk=True)
 
-        self.assertEqual(major, 12)
-        self.assertEqual(java_home, "/opt/jdk12")
+        assert major == 12
+        assert java_home == "/opt/jdk12"
 
     @mock.patch("esrally.utils.jvm.resolve_path")
     def test_resolves_java_home_for_specific_runtime_jdk(self, resolve_jvm_path):
@@ -40,8 +42,8 @@ class JavaResolverTests(TestCase):
                                                    specified_runtime_jdk=8,
                                                    provides_bundled_jdk=True)
 
-        self.assertEqual(major, 8)
-        self.assertEqual(java_home, "/opt/jdk8")
+        assert major == 8
+        assert java_home == "/opt/jdk8"
         resolve_jvm_path.assert_called_with([8])
 
     def test_resolves_java_home_for_bundled_jdk(self):
@@ -50,12 +52,11 @@ class JavaResolverTests(TestCase):
                                                    provides_bundled_jdk=True)
 
         # assumes most recent JDK
-        self.assertEqual(major, 12)
+        assert major == 12
         # does not set JAVA_HOME for the bundled JDK
-        self.assertEqual(java_home, None)
+        assert java_home is None
 
     def test_disallowed_bundled_jdk(self):
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             java_resolver.java_home("12,11,10,9,8", specified_runtime_jdk="bundled")
-        self.assertEqual("This Elasticsearch version does not contain a bundled JDK. Please specify a different runtime JDK.",
-                         ctx.exception.args[0])
+        assert ctx.value.args[0] == "This Elasticsearch version does not contain a bundled JDK. Please specify a different runtime JDK."

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -21,6 +21,8 @@ import tempfile
 import unittest.mock as mock
 from unittest import TestCase
 
+import pytest
+
 from esrally import exceptions
 from esrally.mechanic import provisioner, team
 
@@ -57,16 +59,16 @@ class BareProvisionerTests(TestCase):
                                         apply_config=null_apply_config)
 
         node_config = p.prepare({"elasticsearch": "/opt/elasticsearch-5.0.0.tar.gz"})
-        self.assertEqual("8", node_config.car_runtime_jdks)
-        self.assertEqual("/opt/elasticsearch-5.0.0", node_config.binary_path)
-        self.assertEqual(["/opt/elasticsearch-5.0.0/data"], node_config.data_paths)
+        assert node_config.car_runtime_jdks == "8"
+        assert node_config.binary_path == "/opt/elasticsearch-5.0.0"
+        assert node_config.data_paths == ["/opt/elasticsearch-5.0.0/data"]
 
-        self.assertEqual(1, len(apply_config_calls))
+        assert len(apply_config_calls) == 1
         source_root_path, target_root_path, config_vars = apply_config_calls[0]
 
-        self.assertEqual(HOME_DIR + "/.rally/benchmarks/teams/default/my-car", source_root_path)
-        self.assertEqual("/opt/elasticsearch-5.0.0", target_root_path)
-        self.assertEqual({
+        assert source_root_path == HOME_DIR + "/.rally/benchmarks/teams/default/my-car"
+        assert target_root_path == "/opt/elasticsearch-5.0.0"
+        assert config_vars == {
             "cluster_settings": {
             },
             "heap": "4g",
@@ -85,7 +87,7 @@ class BareProvisionerTests(TestCase):
             "all_node_names": "[\"rally-node-0\",\"rally-node-1\"]",
             "minimum_master_nodes": 2,
             "install_root_path": "/opt/elasticsearch-5.0.0"
-        }, config_vars)
+        }
 
     class NoopHookHandler:
         def __init__(self, plugin):
@@ -168,19 +170,19 @@ class BareProvisionerTests(TestCase):
                                         apply_config=null_apply_config)
 
         node_config = p.prepare({"elasticsearch": "/opt/elasticsearch-5.0.0.tar.gz"})
-        self.assertEqual("8", node_config.car_runtime_jdks)
-        self.assertEqual("/opt/elasticsearch-5.0.0", node_config.binary_path)
-        self.assertEqual(["/opt/elasticsearch-5.0.0/data"], node_config.data_paths)
+        assert node_config.car_runtime_jdks == "8"
+        assert node_config.binary_path == "/opt/elasticsearch-5.0.0"
+        assert node_config.data_paths == ["/opt/elasticsearch-5.0.0/data"]
 
-        self.assertEqual(1, len(apply_config_calls))
+        assert len(apply_config_calls) == 1
         source_root_path, target_root_path, config_vars = apply_config_calls[0]
 
-        self.assertEqual(HOME_DIR + "/.rally/benchmarks/teams/default/my-car", source_root_path)
-        self.assertEqual("/opt/elasticsearch-5.0.0", target_root_path)
+        assert source_root_path == HOME_DIR + "/.rally/benchmarks/teams/default/my-car"
+        assert target_root_path == "/opt/elasticsearch-5.0.0"
 
         self.maxDiff = None
 
-        self.assertEqual({
+        assert config_vars == {
             "cluster_settings": {
                 "plugin.mandatory": ["x-pack-security"]
             },
@@ -203,7 +205,7 @@ class BareProvisionerTests(TestCase):
             "plugin_name": "x-pack-security",
             "xpack_security_enabled": True
 
-        }, config_vars)
+        }
 
     @mock.patch("glob.glob", lambda p: ["/opt/elasticsearch-6.3.0"])
     @mock.patch("esrally.utils.io.decompress")
@@ -246,19 +248,19 @@ class BareProvisionerTests(TestCase):
                                         apply_config=null_apply_config)
 
         node_config = p.prepare({"elasticsearch": "/opt/elasticsearch-6.3.0.tar.gz"})
-        self.assertEqual("8", node_config.car_runtime_jdks)
-        self.assertEqual("/opt/elasticsearch-6.3.0", node_config.binary_path)
-        self.assertEqual(["/opt/elasticsearch-6.3.0/data"], node_config.data_paths)
+        assert node_config.car_runtime_jdks == "8"
+        assert node_config.binary_path == "/opt/elasticsearch-6.3.0"
+        assert node_config.data_paths == ["/opt/elasticsearch-6.3.0/data"]
 
-        self.assertEqual(1, len(apply_config_calls))
+        assert len(apply_config_calls) == 1
         source_root_path, target_root_path, config_vars = apply_config_calls[0]
 
-        self.assertEqual(HOME_DIR + "/.rally/benchmarks/teams/default/my-car", source_root_path)
-        self.assertEqual("/opt/elasticsearch-6.3.0", target_root_path)
+        assert source_root_path == HOME_DIR + "/.rally/benchmarks/teams/default/my-car"
+        assert target_root_path == "/opt/elasticsearch-6.3.0"
 
         self.maxDiff = None
 
-        self.assertEqual({
+        assert config_vars == {
             "cluster_settings": {
                 "plugin.mandatory": ["x-pack"]
             },
@@ -281,7 +283,7 @@ class BareProvisionerTests(TestCase):
             "plugin_name": "x-pack-security",
             "xpack_security_enabled": True
 
-        }, config_vars)
+        }
 
 
 class NoopHookHandler:
@@ -316,9 +318,9 @@ class ElasticsearchInstallerTests(TestCase):
                                                        node_root_dir=HOME_DIR + "/.rally/benchmarks/races/unittest")
 
         installer.install("/data/builds/distributions")
-        self.assertEqual(installer.es_home_path, "/install/elasticsearch-5.0.0-SNAPSHOT")
+        assert installer.es_home_path == "/install/elasticsearch-5.0.0-SNAPSHOT"
 
-        self.assertEqual({
+        assert installer.variables == {
             "cluster_name": "rally-benchmark",
             "node_name": "rally-node-0",
             "data_paths": ["/install/elasticsearch-5.0.0-SNAPSHOT/data"],
@@ -332,9 +334,9 @@ class ElasticsearchInstallerTests(TestCase):
             "all_node_names": "[\"rally-node-0\",\"rally-node-1\"]",
             "minimum_master_nodes": 2,
             "install_root_path": "/install/elasticsearch-5.0.0-SNAPSHOT"
-        }, installer.variables)
+        }
 
-        self.assertEqual(installer.data_paths, ["/install/elasticsearch-5.0.0-SNAPSHOT/data"])
+        assert installer.data_paths == ["/install/elasticsearch-5.0.0-SNAPSHOT/data"]
 
     @mock.patch("glob.glob", lambda p: ["/install/elasticsearch-5.0.0-SNAPSHOT"])
     @mock.patch("esrally.utils.io.decompress")
@@ -354,9 +356,9 @@ class ElasticsearchInstallerTests(TestCase):
                                                        node_root_dir="~/.rally/benchmarks/races/unittest")
 
         installer.install("/data/builds/distributions")
-        self.assertEqual(installer.es_home_path, "/install/elasticsearch-5.0.0-SNAPSHOT")
+        assert installer.es_home_path == "/install/elasticsearch-5.0.0-SNAPSHOT"
 
-        self.assertEqual({
+        assert installer.variables == {
             "cluster_name": "rally-benchmark",
             "node_name": "rally-node-0",
             "data_paths": ["/tmp/some/data-path-dir"],
@@ -370,9 +372,9 @@ class ElasticsearchInstallerTests(TestCase):
             "all_node_names": "[\"rally-node-0\",\"rally-node-1\"]",
             "minimum_master_nodes": 2,
             "install_root_path": "/install/elasticsearch-5.0.0-SNAPSHOT"
-        }, installer.variables)
+        }
 
-        self.assertEqual(installer.data_paths, ["/tmp/some/data-path-dir"])
+        assert installer.data_paths == ["/tmp/some/data-path-dir"]
 
     def test_invokes_hook_with_java_home(self):
         installer = provisioner.ElasticsearchInstaller(car=team.Car(names="defaults",
@@ -388,12 +390,11 @@ class ElasticsearchInstallerTests(TestCase):
                                                        node_root_dir="~/.rally/benchmarks/races/unittest",
                                                        hook_handler_class=NoopHookHandler)
 
-        self.assertEqual(0, len(installer.hook_handler.hook_calls))
+        assert len(installer.hook_handler.hook_calls) == 0
         installer.invoke_install_hook(team.BootstrapPhase.post_install, {"foo": "bar"})
-        self.assertEqual(1, len(installer.hook_handler.hook_calls))
-        self.assertEqual({"foo": "bar"}, installer.hook_handler.hook_calls["post_install"]["variables"])
-        self.assertEqual({"env": {"JAVA_HOME": "/usr/local/javas/java8"}},
-                         installer.hook_handler.hook_calls["post_install"]["kwargs"])
+        assert len(installer.hook_handler.hook_calls) == 1
+        assert installer.hook_handler.hook_calls["post_install"]["variables"] == {"foo": "bar"}
+        assert installer.hook_handler.hook_calls["post_install"]["kwargs"] == {"env": {"JAVA_HOME": "/usr/local/javas/java8"}}
 
     def test_invokes_hook_no_java_home(self):
         installer = provisioner.ElasticsearchInstaller(car=team.Car(names="defaults",
@@ -409,11 +410,11 @@ class ElasticsearchInstallerTests(TestCase):
                                                        node_root_dir="~/.rally/benchmarks/races/unittest",
                                                        hook_handler_class=NoopHookHandler)
 
-        self.assertEqual(0, len(installer.hook_handler.hook_calls))
+        assert len(installer.hook_handler.hook_calls) == 0
         installer.invoke_install_hook(team.BootstrapPhase.post_install, {"foo": "bar"})
-        self.assertEqual(1, len(installer.hook_handler.hook_calls))
-        self.assertEqual({"foo": "bar"}, installer.hook_handler.hook_calls["post_install"]["variables"])
-        self.assertEqual({"env": {}}, installer.hook_handler.hook_calls["post_install"]["kwargs"])
+        assert len(installer.hook_handler.hook_calls) == 1
+        assert installer.hook_handler.hook_calls["post_install"]["variables"] == {"foo": "bar"}
+        assert installer.hook_handler.hook_calls["post_install"]["kwargs"] == {"env": {}}
 
 
 class PluginInstallerTests(TestCase):
@@ -458,9 +459,9 @@ class PluginInstallerTests(TestCase):
                                                 java_home="/usr/local/javas/java8",
                                                 hook_handler_class=NoopHookHandler)
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             installer.install(es_home_path="/opt/elasticsearch")
-        self.assertEqual("Unknown plugin [unknown]", ctx.exception.args[0])
+        assert ctx.value.args[0] == "Unknown plugin [unknown]"
 
         installer_subprocess.assert_called_with(
             '/opt/elasticsearch/bin/elasticsearch-plugin install --batch "unknown"',
@@ -476,9 +477,9 @@ class PluginInstallerTests(TestCase):
                                                 java_home="/usr/local/javas/java8",
                                                 hook_handler_class=NoopHookHandler)
 
-        with self.assertRaises(exceptions.SupplyError) as ctx:
+        with pytest.raises(exceptions.SupplyError) as ctx:
             installer.install(es_home_path="/opt/elasticsearch")
-        self.assertEqual("I/O error while trying to install [simple]", ctx.exception.args[0])
+        assert ctx.value.args[0] == "I/O error while trying to install [simple]"
 
         installer_subprocess.assert_called_with(
             '/opt/elasticsearch/bin/elasticsearch-plugin install --batch "simple"',
@@ -494,10 +495,9 @@ class PluginInstallerTests(TestCase):
                                                 java_home="/usr/local/javas/java8",
                                                 hook_handler_class=NoopHookHandler)
 
-        with self.assertRaises(exceptions.RallyError) as ctx:
+        with pytest.raises(exceptions.RallyError) as ctx:
             installer.install(es_home_path="/opt/elasticsearch")
-        self.assertEqual("Unknown error while trying to install [simple] (installer return code [12987]). Please check the logs.",
-                         ctx.exception.args[0])
+        assert ctx.value.args[0] == "Unknown error while trying to install [simple] (installer return code [12987]). Please check the logs."
 
         installer_subprocess.assert_called_with(
             '/opt/elasticsearch/bin/elasticsearch-plugin install --batch "simple"',
@@ -512,9 +512,9 @@ class PluginInstallerTests(TestCase):
                                                 java_home="/usr/local/javas/java8",
                                                 hook_handler_class=NoopHookHandler)
 
-        self.assertEqual("unit-test-plugin", installer.plugin_name)
-        self.assertEqual({"active": True}, installer.variables)
-        self.assertEqual(["/etc/plugin"], installer.config_source_paths)
+        assert installer.plugin_name == "unit-test-plugin"
+        assert installer.variables == {"active": True}
+        assert installer.config_source_paths == ["/etc/plugin"]
 
     def test_invokes_hook_with_java_home(self):
         plugin = team.PluginDescriptor(name="unit-test-plugin",
@@ -525,12 +525,11 @@ class PluginInstallerTests(TestCase):
                                                 java_home="/usr/local/javas/java8",
                                                 hook_handler_class=NoopHookHandler)
 
-        self.assertEqual(0, len(installer.hook_handler.hook_calls))
+        assert len(installer.hook_handler.hook_calls) == 0
         installer.invoke_install_hook(team.BootstrapPhase.post_install, {"foo": "bar"})
-        self.assertEqual(1, len(installer.hook_handler.hook_calls))
-        self.assertEqual({"foo": "bar"}, installer.hook_handler.hook_calls["post_install"]["variables"])
-        self.assertEqual({"env": {"JAVA_HOME": "/usr/local/javas/java8"}},
-                         installer.hook_handler.hook_calls["post_install"]["kwargs"])
+        assert len(installer.hook_handler.hook_calls) == 1
+        assert installer.hook_handler.hook_calls["post_install"]["variables"] == {"foo": "bar"}
+        assert installer.hook_handler.hook_calls["post_install"]["kwargs"] == {"env": {"JAVA_HOME": "/usr/local/javas/java8"}}
 
     def test_invokes_hook_no_java_home(self):
         plugin = team.PluginDescriptor(name="unit-test-plugin",
@@ -541,11 +540,11 @@ class PluginInstallerTests(TestCase):
                                                 java_home=None,
                                                 hook_handler_class=NoopHookHandler)
 
-        self.assertEqual(0, len(installer.hook_handler.hook_calls))
+        assert len(installer.hook_handler.hook_calls) == 0
         installer.invoke_install_hook(team.BootstrapPhase.post_install, {"foo": "bar"})
-        self.assertEqual(1, len(installer.hook_handler.hook_calls))
-        self.assertEqual({"foo": "bar"}, installer.hook_handler.hook_calls["post_install"]["variables"])
-        self.assertEqual({"env": {}}, installer.hook_handler.hook_calls["post_install"]["kwargs"])
+        assert len(installer.hook_handler.hook_calls) == 1
+        assert installer.hook_handler.hook_calls["post_install"]["variables"] == {"foo": "bar"}
+        assert installer.hook_handler.hook_calls["post_install"]["kwargs"] == {"env": {}}
 
 
 class DockerProvisionerTests(TestCase):
@@ -571,7 +570,7 @@ class DockerProvisionerTests(TestCase):
                                                distribution_version="6.3.0",
                                                rally_root=rally_root)
 
-        self.assertDictEqual({
+        assert docker.config_vars == {
             "cluster_name": "rally-benchmark",
             "node_name": "rally-node-0",
             "install_root_path": "/usr/share/elasticsearch",
@@ -585,9 +584,9 @@ class DockerProvisionerTests(TestCase):
             "cluster_settings": {
             },
             "docker_image": "docker.elastic.co/elasticsearch/elasticsearch-oss"
-        }, docker.config_vars)
+        }
 
-        self.assertDictEqual({
+        assert docker.docker_vars(mounts={}) == {
             "es_data_dir": data_dir,
             "es_log_dir": log_dir,
             "es_heap_dump_dir": heap_dump_dir,
@@ -595,11 +594,11 @@ class DockerProvisionerTests(TestCase):
             "docker_image": "docker.elastic.co/elasticsearch/elasticsearch-oss",
             "http_port": 39200,
             "mounts": {}
-        }, docker.docker_vars(mounts={}))
+        }
 
         docker_cfg = docker._render_template_from_file(docker.docker_vars(mounts={}))
 
-        self.assertEqual(
+        assert docker_cfg == \
 """version: '2.2'
 services:
   elasticsearch1:
@@ -623,7 +622,7 @@ services:
       test: nc -z 127.0.0.1 39200
       interval: 5s
       timeout: 2s
-      retries: 10""" % (data_dir, log_dir, heap_dump_dir), docker_cfg)
+      retries: 10""" % (data_dir, log_dir, heap_dump_dir)
 
     @mock.patch("uuid.uuid4")
     def test_provisioning_with_variables(self, uuid4):
@@ -651,7 +650,7 @@ services:
 
         docker_cfg = docker._render_template_from_file(docker.docker_vars(mounts={}))
 
-        self.assertEqual(
+        assert docker_cfg == \
 """version: '2.2'
 services:
   elasticsearch1:
@@ -677,7 +676,7 @@ services:
       test: nc -z 127.0.0.1 39200
       interval: 5s
       timeout: 2s
-      retries: 10""" % (data_dir, log_dir, heap_dump_dir), docker_cfg)
+      retries: 10""" % (data_dir, log_dir, heap_dump_dir)
 
 
 class CleanupTests(TestCase):
@@ -688,8 +687,8 @@ class CleanupTests(TestCase):
 
         provisioner.cleanup(preserve=True, install_dir="./rally/races/install", data_paths=["./rally/races/data"])
 
-        self.assertEqual(mock_path_exists.call_count, 0)
-        self.assertEqual(mock_rm.call_count, 0)
+        assert mock_path_exists.call_count == 0
+        assert mock_rm.call_count == 0
 
     @mock.patch("shutil.rmtree")
     @mock.patch("os.path.exists")

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -21,25 +21,25 @@ import datetime
 import unittest.mock as mock
 from unittest import TestCase
 
+import pytest
+
 from esrally import exceptions, config
 from esrally.mechanic import supplier, team
 
 
 class RevisionExtractorTests(TestCase):
     def test_single_revision(self):
-        self.assertDictEqual({"elasticsearch": "67c2f42", "all": "67c2f42"}, supplier._extract_revisions("67c2f42"))
-        self.assertDictEqual({"elasticsearch": "current", "all": "current"}, supplier._extract_revisions("current"))
-        self.assertDictEqual({"elasticsearch": "@2015-01-01-01:00:00", "all": "@2015-01-01-01:00:00"},
-                             supplier._extract_revisions("@2015-01-01-01:00:00"))
+        assert supplier._extract_revisions("67c2f42") == {"elasticsearch": "67c2f42", "all": "67c2f42"}
+        assert supplier._extract_revisions("current") == {"elasticsearch": "current", "all": "current"}
+        assert supplier._extract_revisions("@2015-01-01-01:00:00") == {"elasticsearch": "@2015-01-01-01:00:00", "all": "@2015-01-01-01:00:00"}
 
     def test_multiple_revisions(self):
-        self.assertDictEqual({"elasticsearch": "67c2f42", "x-pack": "@2015-01-01-01:00:00", "some-plugin": "current"},
-                             supplier._extract_revisions("elasticsearch:67c2f42,x-pack:@2015-01-01-01:00:00,some-plugin:current"))
+        assert supplier._extract_revisions("elasticsearch:67c2f42,x-pack:@2015-01-01-01:00:00,some-plugin:current") == {"elasticsearch": "67c2f42", "x-pack": "@2015-01-01-01:00:00", "some-plugin": "current"}
 
     def test_invalid_revisions(self):
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             supplier._extract_revisions("elasticsearch 67c2f42,x-pack:current")
-        self.assertEqual("Revision [elasticsearch 67c2f42] does not match expected format [name:revision].", ctx.exception.args[0])
+        assert ctx.value.args[0] == "Revision [elasticsearch 67c2f42] does not match expected format [name:revision]."
 
 
 class SourceRepositoryTests(TestCase):
@@ -72,8 +72,8 @@ class SourceRepositoryTests(TestCase):
         s.fetch("current")
 
         mock_is_working_copy.assert_called_with("/src")
-        self.assertEqual(0, mock_clone.call_count)
-        self.assertEqual(0, mock_pull.call_count)
+        assert mock_clone.call_count == 0
+        assert mock_pull.call_count == 0
         mock_head_revision.assert_called_with("/src")\
 
 
@@ -91,8 +91,8 @@ class SourceRepositoryTests(TestCase):
         s.fetch("67c2f42")
 
         mock_is_working_copy.assert_called_with("/src")
-        self.assertEqual(0, mock_clone.call_count)
-        self.assertEqual(0, mock_pull.call_count)
+        assert mock_clone.call_count == 0
+        assert mock_pull.call_count == 0
         mock_checkout.assert_called_with("/src", "67c2f42")
         mock_head_revision.assert_called_with("/src")
 
@@ -125,12 +125,12 @@ class SourceRepositoryTests(TestCase):
         mock_head_revision.assert_called_with("/src")
 
     def test_is_commit_hash(self):
-        self.assertTrue(supplier.SourceRepository.is_commit_hash("67c2f42"))
+        assert supplier.SourceRepository.is_commit_hash("67c2f42")
 
     def test_is_not_commit_hash(self):
-        self.assertFalse(supplier.SourceRepository.is_commit_hash("latest"))
-        self.assertFalse(supplier.SourceRepository.is_commit_hash("current"))
-        self.assertFalse(supplier.SourceRepository.is_commit_hash("@2015-01-01-01:00:00"))
+        assert not supplier.SourceRepository.is_commit_hash("latest")
+        assert not supplier.SourceRepository.is_commit_hash("current")
+        assert not supplier.SourceRepository.is_commit_hash("@2015-01-01-01:00:00")
 
 
 class BuilderTests(TestCase):
@@ -174,15 +174,13 @@ class BuilderTests(TestCase):
 class TemplateRendererTests(TestCase):
     def test_uses_provided_values(self):
         renderer = supplier.TemplateRenderer(version="1.2.3", os_name="Windows", arch="arm7")
-        self.assertEqual("This is version 1.2.3 on Windows with a arm7 CPU.",
-                         renderer.render("This is version {{VERSION}} on {{OSNAME}} with a {{ARCH}} CPU."))
+        assert renderer.render("This is version {{VERSION}} on {{OSNAME}} with a {{ARCH}} CPU.") == "This is version 1.2.3 on Windows with a arm7 CPU."
 
     @mock.patch("esrally.utils.sysstats.os_name", return_value="Linux")
     @mock.patch("esrally.utils.sysstats.cpu_arch", return_value="X86_64")
     def test_uses_derived_values(self, os_name, cpu_arch):
         renderer = supplier.TemplateRenderer(version="1.2.3")
-        self.assertEqual("This is version 1.2.3 on linux with a x86_64 CPU.",
-                         renderer.render("This is version {{VERSION}} on {{OSNAME}} with a {{ARCH}} CPU."))
+        assert renderer.render("This is version {{VERSION}} on {{OSNAME}} with a {{ARCH}} CPU.") == "This is version 1.2.3 on linux with a x86_64 CPU."
 
 
 class CachedElasticsearchSourceSupplierTests(TestCase):
@@ -218,10 +216,10 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
 
         cached_supplier.add(binaries)
 
-        self.assertEqual(0, copy.call_count)
-        self.assertFalse(cached_supplier.cached)
-        self.assertIn("elasticsearch", binaries)
-        self.assertEqual("/path/to/artifact.tar.gz", binaries["elasticsearch"])
+        assert copy.call_count == 0
+        assert not cached_supplier.cached
+        assert "elasticsearch" in binaries
+        assert binaries["elasticsearch"] == "/path/to/artifact.tar.gz"
 
     @mock.patch("os.path.exists")
     @mock.patch("esrally.mechanic.supplier.ElasticsearchSourceSupplier")
@@ -249,12 +247,12 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
 
         cached_supplier.add(binaries)
 
-        self.assertEqual(0, es.fetch.call_count)
-        self.assertEqual(0, es.prepare.call_count)
-        self.assertEqual(0, es.add.call_count)
-        self.assertTrue(cached_supplier.cached)
-        self.assertIn("elasticsearch", binaries)
-        self.assertEqual("/tmp/elasticsearch-abc123-linux-x86_64.tar.gz", binaries["elasticsearch"])
+        assert es.fetch.call_count == 0
+        assert es.prepare.call_count == 0
+        assert es.add.call_count == 0
+        assert cached_supplier.cached
+        assert "elasticsearch" in binaries
+        assert binaries["elasticsearch"] == "/tmp/elasticsearch-abc123-linux-x86_64.tar.gz"
 
     @mock.patch("esrally.utils.io.ensure_dir")
     @mock.patch("os.path.exists")
@@ -291,10 +289,10 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
         # path is cached now
         path_exists.return_value = True
 
-        self.assertEqual(1, copy.call_count, "artifact has been copied")
-        self.assertEqual(1, es.add.call_count, "artifact has been added by internal supplier")
-        self.assertTrue(cached_supplier.cached)
-        self.assertIn("elasticsearch", binaries)
+        assert copy.call_count == 1, "artifact has been copied"
+        assert es.add.call_count == 1, "artifact has been added by internal supplier"
+        assert cached_supplier.cached
+        assert "elasticsearch" in binaries
 
         # simulate a second attempt
         cached_supplier.fetch()
@@ -303,10 +301,10 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
         binaries = {}
         cached_supplier.add(binaries)
 
-        self.assertEqual(1, copy.call_count, "artifact has not been copied twice")
+        assert copy.call_count == 1, "artifact has not been copied twice"
         # the internal supplier did not get called again as we reuse the cached artifact
-        self.assertEqual(1, es.add.call_count, "internal supplier is not called again")
-        self.assertTrue(cached_supplier.cached)
+        assert es.add.call_count == 1, "internal supplier is not called again"
+        assert cached_supplier.cached
 
     @mock.patch("esrally.utils.io.ensure_dir")
     @mock.patch("os.path.exists")
@@ -342,12 +340,12 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
 
         cached_supplier.add(binaries)
 
-        self.assertEqual(1, copy.call_count, "artifact has been copied")
-        self.assertEqual(1, es.add.call_count, "artifact has been added by internal supplier")
-        self.assertFalse(cached_supplier.cached)
-        self.assertIn("elasticsearch", binaries)
+        assert copy.call_count == 1, "artifact has been copied"
+        assert es.add.call_count == 1, "artifact has been added by internal supplier"
+        assert not cached_supplier.cached
+        assert "elasticsearch" in binaries
         # still the uncached artifact
-        self.assertEqual("/path/to/artifact.tar.gz", binaries["elasticsearch"])
+        assert binaries["elasticsearch"] == "/path/to/artifact.tar.gz"
 
 
 class ElasticsearchFileNameResolverTests(TestCase):
@@ -367,18 +365,18 @@ class ElasticsearchFileNameResolverTests(TestCase):
 
     def test_resolve(self):
         self.resolver.revision = "abc123"
-        self.assertEqual("elasticsearch-abc123-linux-x86_64.tar.gz", self.resolver.file_name)
+        assert self.resolver.file_name == "elasticsearch-abc123-linux-x86_64.tar.gz"
 
     def test_artifact_key(self):
-        self.assertEqual("elasticsearch", self.resolver.artifact_key)
+        assert self.resolver.artifact_key == "elasticsearch"
 
     def test_to_artifact_path(self):
         file_system_path = "/tmp/test"
-        self.assertEqual(file_system_path, self.resolver.to_artifact_path(file_system_path))
+        assert self.resolver.to_artifact_path(file_system_path) == file_system_path
 
     def test_to_file_system_path(self):
         artifact_path = "/tmp/test"
-        self.assertEqual(artifact_path, self.resolver.to_file_system_path(artifact_path))
+        assert self.resolver.to_file_system_path(artifact_path) == artifact_path
 
 
 class PluginFileNameResolverTests(TestCase):
@@ -388,18 +386,18 @@ class PluginFileNameResolverTests(TestCase):
 
     def test_resolve(self):
         self.resolver.revision = "abc123"
-        self.assertEqual("test-plugin-abc123.zip", self.resolver.file_name)
+        assert self.resolver.file_name == "test-plugin-abc123.zip"
 
     def test_artifact_key(self):
-        self.assertEqual("test-plugin", self.resolver.artifact_key)
+        assert self.resolver.artifact_key == "test-plugin"
 
     def test_to_artifact_path(self):
         file_system_path = "/tmp/test"
-        self.assertEqual(f"file://{file_system_path}", self.resolver.to_artifact_path(file_system_path))
+        assert self.resolver.to_artifact_path(file_system_path) == f"file://{file_system_path}"
 
     def test_to_file_system_path(self):
         file_system_path = "/tmp/test"
-        self.assertEqual(file_system_path, self.resolver.to_file_system_path(f"file://{file_system_path}"))
+        assert self.resolver.to_file_system_path(f"file://{file_system_path}") == file_system_path
 
 
 class PruneTests(TestCase):
@@ -415,7 +413,7 @@ class PruneTests(TestCase):
 
         supplier._prune(root_path="/tmp/test", max_age_days=7)
 
-        self.assertEqual(0, listdir.call_count, "attempted to list a non-existing directory")
+        assert listdir.call_count == 0, "attempted to list a non-existing directory"
 
     @mock.patch("os.path.exists")
     @mock.patch("os.listdir")
@@ -489,11 +487,10 @@ class ElasticsearchSourceSupplierTests(TestCase):
                                                   car=car,
                                                   builder=builder,
                                                   template_renderer=renderer)
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    "Car \"default\" requires config key \"system.build_command\""):
+        with pytest.raises(exceptions.SystemSetupError, match="Car \"default\" requires config key \"system.build_command\""):
             es.prepare()
 
-        self.assertEqual(0, builder.build.call_count)
+        assert builder.build.call_count == 0
 
     @mock.patch("glob.glob", lambda p: ["elasticsearch.tar.gz"])
     def test_add_elasticsearch_binary(self):
@@ -511,7 +508,7 @@ class ElasticsearchSourceSupplierTests(TestCase):
                                                   template_renderer=renderer)
         binaries = {}
         es.add(binaries=binaries)
-        self.assertEqual(binaries, {"elasticsearch": "elasticsearch.tar.gz"})
+        assert {"elasticsearch": "elasticsearch.tar.gz"} == binaries
 
 
 class ExternalPluginSourceSupplierTests(TestCase):
@@ -542,8 +539,7 @@ class ExternalPluginSourceSupplierTests(TestCase):
                                                                 builder=None)
 
     def test_invalid_config_no_source(self):
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    "Neither plugin.some-plugin.src.dir nor plugin.some-plugin.src.subdir are set for plugin some-plugin."):
+        with pytest.raises(exceptions.SystemSetupError, match="Neither plugin.some-plugin.src.dir nor plugin.some-plugin.src.subdir are set for plugin some-plugin."):
             supplier.ExternalPluginSourceSupplier(plugin=team.PluginDescriptor("some-plugin", core_plugin=False),
                                                   revision="abc",
                                                   # built separately
@@ -556,8 +552,7 @@ class ExternalPluginSourceSupplierTests(TestCase):
                                                   builder=None)
 
     def test_invalid_config_duplicate_source(self):
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    "Can only specify one of plugin.duplicate.src.dir and plugin.duplicate.src.subdir but both are set."):
+        with pytest.raises(exceptions.SystemSetupError, match="Can only specify one of plugin.duplicate.src.dir and plugin.duplicate.src.subdir but both are set."):
             supplier.ExternalPluginSourceSupplier(plugin=team.PluginDescriptor("duplicate", core_plugin=False),
                                                   revision="abc",
                                                   src_dir=None,
@@ -569,24 +564,22 @@ class ExternalPluginSourceSupplierTests(TestCase):
                                                   builder=None)
 
     def test_standalone_plugin_overrides_build_dir(self):
-        self.assertEqual("/Projects/src/some-plugin", self.standalone.override_build_dir)
+        assert self.standalone.override_build_dir == "/Projects/src/some-plugin"
 
     def test_along_es_plugin_keeps_build_dir(self):
-        self.assertIsNone(self.along_es.override_build_dir)
+        assert self.along_es.override_build_dir is None
 
     @mock.patch("glob.glob", lambda p: ["/src/elasticsearch-extra/some-plugin/plugin/build/distributions/some-plugin.zip"])
     def test_add_binary_built_along_elasticsearch(self):
         binaries = {}
         self.along_es.add(binaries)
-        self.assertDictEqual(binaries,
-                             {"some-plugin": "file:///src/elasticsearch-extra/some-plugin/plugin/build/distributions/some-plugin.zip"})
+        assert {"some-plugin": "file:///src/elasticsearch-extra/some-plugin/plugin/build/distributions/some-plugin.zip"} == binaries
 
     @mock.patch("glob.glob", lambda p: ["/Projects/src/some-plugin/build/distributions/some-plugin.zip"])
     def test_resolve_plugin_binary_built_standalone(self):
         binaries = {}
         self.along_es.add(binaries)
-        self.assertDictEqual(binaries,
-                             {"some-plugin": "file:///Projects/src/some-plugin/build/distributions/some-plugin.zip"})
+        assert {"some-plugin": "file:///Projects/src/some-plugin/build/distributions/some-plugin.zip"} == binaries
 
 
 class CorePluginSourceSupplierTests(TestCase):
@@ -598,7 +591,7 @@ class CorePluginSourceSupplierTests(TestCase):
                                               builder=None)
         binaries = {}
         s.add(binaries)
-        self.assertDictEqual(binaries, {"core-plugin": "file:///src/elasticsearch/core-plugin/build/distributions/core-plugin.zip"})
+        assert {"core-plugin": "file:///src/elasticsearch/core-plugin/build/distributions/core-plugin.zip"} == binaries
 
 
 class PluginDistributionSupplierTests(TestCase):
@@ -611,7 +604,7 @@ class PluginDistributionSupplierTests(TestCase):
                                                 plugin=team.PluginDescriptor("custom-analyzer"))
         binaries = {}
         s.add(binaries)
-        self.assertDictEqual(binaries, {"custom-analyzer": "http://example.org/elasticearch/custom-analyzer-6.3.0.zip"})
+        assert {"custom-analyzer": "http://example.org/elasticearch/custom-analyzer-6.3.0.zip"} == binaries
 
 
 class CreateSupplierTests(TestCase):
@@ -619,13 +612,13 @@ class CreateSupplierTests(TestCase):
         # corresponds to --revision="abc"
         requirements = supplier._supply_requirements(
             sources=True, distribution=False, plugins=[], revisions={"elasticsearch": "abc"}, distribution_version=None)
-        self.assertDictEqual({"elasticsearch": ("source", "abc", True)}, requirements)
+        assert requirements == {"elasticsearch": ("source", "abc", True)}
 
     def test_derive_supply_requirements_es_distribution(self):
         # corresponds to --distribution-version=6.0.0
         requirements = supplier._supply_requirements(
             sources=False, distribution=True, plugins=[], revisions={}, distribution_version="6.0.0")
-        self.assertDictEqual({"elasticsearch": ("distribution", "6.0.0", False)}, requirements)
+        assert requirements == {"elasticsearch": ("distribution", "6.0.0", False)}
 
     def test_derive_supply_requirements_es_and_plugin_source_build(self):
         # corresponds to --revision="elasticsearch:abc,community-plugin:effab"
@@ -635,12 +628,12 @@ class CreateSupplierTests(TestCase):
         requirements = supplier._supply_requirements(sources=True, distribution=False, plugins=[core_plugin, external_plugin],
                                                      revisions={"elasticsearch": "abc", "all": "abc", "community-plugin": "effab"},
                                                      distribution_version=None)
-        self.assertDictEqual({
+        assert requirements == {
             "elasticsearch": ("source", "abc", True),
             # core plugin configuration is forced to be derived from ES
             "analysis-icu": ("source", "abc", True),
             "community-plugin": ("source", "effab", True),
-        }, requirements)
+        }
 
     def test_derive_supply_requirements_es_distribution_and_plugin_source_build(self):
         # corresponds to --revision="community-plugin:effab" --distribution-version="6.0.0"
@@ -651,12 +644,12 @@ class CreateSupplierTests(TestCase):
                                                      revisions={"community-plugin": "effab"},
                                                      distribution_version="6.0.0")
         # core plugin is not contained, its configured is forced to be derived by ES
-        self.assertDictEqual({
+        assert requirements == {
             "elasticsearch": ("distribution", "6.0.0", False),
             # core plugin configuration is forced to be derived from ES
             "analysis-icu": ("distribution", "6.0.0", False),
             "community-plugin": ("source", "effab", True),
-        }, requirements)
+        }
 
     def test_create_suppliers_for_es_only_config(self):
         cfg = config.Config()
@@ -673,8 +666,8 @@ class CreateSupplierTests(TestCase):
 
         composite_supplier = supplier.create(cfg, sources=False, distribution=True, car=car)
 
-        self.assertEqual(1, len(composite_supplier.suppliers))
-        self.assertIsInstance(composite_supplier.suppliers[0], supplier.ElasticsearchDistributionSupplier)
+        assert len(composite_supplier.suppliers) == 1
+        assert isinstance(composite_supplier.suppliers[0], supplier.ElasticsearchDistributionSupplier)
 
     @mock.patch("esrally.utils.jvm.resolve_path", lambda v: (v, "/opt/java/java{}".format(v)))
     def test_create_suppliers_for_es_distribution_plugin_source_build(self):
@@ -701,13 +694,13 @@ class CreateSupplierTests(TestCase):
             external_plugin
         ])
 
-        self.assertEqual(3, len(composite_supplier.suppliers))
-        self.assertIsInstance(composite_supplier.suppliers[0], supplier.ElasticsearchDistributionSupplier)
-        self.assertIsInstance(composite_supplier.suppliers[1], supplier.PluginDistributionSupplier)
-        self.assertEqual(core_plugin, composite_supplier.suppliers[1].plugin)
-        self.assertIsInstance(composite_supplier.suppliers[2].source_supplier, supplier.ExternalPluginSourceSupplier)
-        self.assertEqual(external_plugin, composite_supplier.suppliers[2].source_supplier.plugin)
-        self.assertIsNotNone(composite_supplier.suppliers[2].source_supplier.builder)
+        assert len(composite_supplier.suppliers) == 3
+        assert isinstance(composite_supplier.suppliers[0], supplier.ElasticsearchDistributionSupplier)
+        assert isinstance(composite_supplier.suppliers[1], supplier.PluginDistributionSupplier)
+        assert composite_supplier.suppliers[1].plugin == core_plugin
+        assert isinstance(composite_supplier.suppliers[2].source_supplier, supplier.ExternalPluginSourceSupplier)
+        assert composite_supplier.suppliers[2].source_supplier.plugin == external_plugin
+        assert composite_supplier.suppliers[2].source_supplier.builder is not None
 
     @mock.patch("esrally.utils.jvm.resolve_path", lambda v: (v, "/opt/java/java{}".format(v)))
     def test_create_suppliers_for_es_and_plugin_source_build(self):
@@ -737,13 +730,13 @@ class CreateSupplierTests(TestCase):
             external_plugin
         ])
 
-        self.assertEqual(3, len(composite_supplier.suppliers))
-        self.assertIsInstance(composite_supplier.suppliers[0].source_supplier, supplier.ElasticsearchSourceSupplier)
-        self.assertIsInstance(composite_supplier.suppliers[1].source_supplier, supplier.CorePluginSourceSupplier)
-        self.assertEqual(core_plugin, composite_supplier.suppliers[1].source_supplier.plugin)
-        self.assertIsInstance(composite_supplier.suppliers[2].source_supplier, supplier.ExternalPluginSourceSupplier)
-        self.assertEqual(external_plugin, composite_supplier.suppliers[2].source_supplier.plugin)
-        self.assertIsNotNone(composite_supplier.suppliers[2].source_supplier.builder)
+        assert len(composite_supplier.suppliers) == 3
+        assert isinstance(composite_supplier.suppliers[0].source_supplier, supplier.ElasticsearchSourceSupplier)
+        assert isinstance(composite_supplier.suppliers[1].source_supplier, supplier.CorePluginSourceSupplier)
+        assert composite_supplier.suppliers[1].source_supplier.plugin == core_plugin
+        assert isinstance(composite_supplier.suppliers[2].source_supplier, supplier.ExternalPluginSourceSupplier)
+        assert composite_supplier.suppliers[2].source_supplier.plugin == external_plugin
+        assert composite_supplier.suppliers[2].source_supplier.builder is not None
 
 
 class DistributionRepositoryTests(TestCase):
@@ -757,9 +750,9 @@ class DistributionRepositoryTests(TestCase):
                 "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz",
             "release.cache": "true"
         }, template_renderer=renderer)
-        self.assertEqual("https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.3.2-linux-x86_64.tar.gz", repo.download_url)
-        self.assertEqual("elasticsearch-7.3.2-linux-x86_64.tar.gz", repo.file_name)
-        self.assertTrue(repo.cache)
+        assert repo.download_url == "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.3.2-linux-x86_64.tar.gz"
+        assert repo.file_name == "elasticsearch-7.3.2-linux-x86_64.tar.gz"
+        assert repo.cache
 
     def test_release_repo_config_with_user_url(self):
         renderer = supplier.TemplateRenderer(version="2.4.3")
@@ -770,9 +763,9 @@ class DistributionRepositoryTests(TestCase):
             "release.url": "https://es-mirror.example.org/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
             "release.cache": "false"
         }, template_renderer=renderer)
-        self.assertEqual("https://es-mirror.example.org/downloads/elasticsearch/elasticsearch-2.4.3.tar.gz", repo.download_url)
-        self.assertEqual("elasticsearch-2.4.3.tar.gz", repo.file_name)
-        self.assertFalse(repo.cache)
+        assert repo.download_url == "https://es-mirror.example.org/downloads/elasticsearch/elasticsearch-2.4.3.tar.gz"
+        assert repo.file_name == "elasticsearch-2.4.3.tar.gz"
+        assert not repo.cache
 
     def test_missing_url(self):
         renderer = supplier.TemplateRenderer(version="2.4.3")
@@ -781,11 +774,11 @@ class DistributionRepositoryTests(TestCase):
             "runtime.jdk.bundled": "false",
             "release.cache": "true"
         }, template_renderer=renderer)
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             # pylint: disable=pointless-statement
             # noinspection PyStatementEffect
             repo.download_url
-        self.assertEqual("Neither config key [miss.url] nor [jdk.unbundled.miss_url] is defined.", ctx.exception.args[0])
+        assert ctx.value.args[0] == "Neither config key [miss.url] nor [jdk.unbundled.miss_url] is defined."
 
     def test_missing_cache(self):
         renderer = supplier.TemplateRenderer(version="2.4.3")
@@ -793,11 +786,11 @@ class DistributionRepositoryTests(TestCase):
             "jdk.unbundled.release.url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
             "runtime.jdk.bundled": "false"
         }, template_renderer=renderer)
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             # pylint: disable=pointless-statement
             # noinspection PyStatementEffect
             repo.cache
-        self.assertEqual("Mandatory config key [release.cache] is undefined.", ctx.exception.args[0])
+        assert ctx.value.args[0] == "Mandatory config key [release.cache] is undefined."
 
     def test_invalid_cache_value(self):
         renderer = supplier.TemplateRenderer(version="2.4.3")
@@ -806,11 +799,11 @@ class DistributionRepositoryTests(TestCase):
             "runtime.jdk.bundled": "false",
             "release.cache": "Invalid"
         }, template_renderer=renderer)
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             # pylint: disable=pointless-statement
             # noinspection PyStatementEffect
             repo.cache
-        self.assertEqual("Value [Invalid] for config key [release.cache] is not a valid boolean value.", ctx.exception.args[0])
+        assert ctx.value.args[0] == "Value [Invalid] for config key [release.cache] is not a valid boolean value."
 
     def test_plugin_config_with_default_url(self):
         renderer = supplier.TemplateRenderer(version="5.5.0")
@@ -818,7 +811,7 @@ class DistributionRepositoryTests(TestCase):
             "runtime.jdk.bundled": "false",
             "plugin_example_release_url": "https://artifacts.example.org/downloads/plugins/example-{{VERSION}}.zip"
         }, template_renderer=renderer)
-        self.assertEqual("https://artifacts.example.org/downloads/plugins/example-5.5.0.zip", repo.plugin_download_url("example"))
+        assert repo.plugin_download_url("example") == "https://artifacts.example.org/downloads/plugins/example-5.5.0.zip"
 
     def test_plugin_config_with_user_url(self):
         renderer = supplier.TemplateRenderer(version="5.5.0")
@@ -828,11 +821,11 @@ class DistributionRepositoryTests(TestCase):
             # user override
             "plugin.example.release.url": "https://mirror.example.org/downloads/plugins/example-{{VERSION}}.zip"
         }, template_renderer=renderer)
-        self.assertEqual("https://mirror.example.org/downloads/plugins/example-5.5.0.zip", repo.plugin_download_url("example"))
+        assert repo.plugin_download_url("example") == "https://mirror.example.org/downloads/plugins/example-5.5.0.zip"
 
     def test_missing_plugin_config(self):
         renderer = supplier.TemplateRenderer(version="5.5.0")
         repo = supplier.DistributionRepository(name="release", distribution_config={
             "runtime.jdk.bundled": "false",
         }, template_renderer=renderer)
-        self.assertIsNone(repo.plugin_download_url("not existing"))
+        assert repo.plugin_download_url("not existing") is None

--- a/tests/reporter_test.py
+++ b/tests/reporter_test.py
@@ -36,17 +36,17 @@ class FormatterTests(TestCase):
     def test_formats_as_markdown(self):
         formatted = reporter.format_as_markdown(self.empty_header, self.empty_data, self.numbers_align)
         # 1 header line, 1 separation line + 0 data lines
-        self.assertEqual(1 + 1 + 0, len(formatted.splitlines()))
+        assert len(formatted.splitlines()) == 1 + 1 + 0
 
         formatted = reporter.format_as_markdown(self.metrics_header, self.metrics_data, self.numbers_align)
         # 1 header line, 1 separation line + 3 data lines
-        self.assertEqual(1 + 1 + 3, len(formatted.splitlines()))
+        assert len(formatted.splitlines()) == 1 + 1 + 3
 
     def test_formats_as_csv(self):
         formatted = reporter.format_as_csv(self.empty_header, self.empty_data)
         # 1 header line, no separation line + 0 data lines
-        self.assertEqual(1 + 0, len(formatted.splitlines()))
+        assert len(formatted.splitlines()) == 1 + 0
 
         formatted = reporter.format_as_csv(self.metrics_header, self.metrics_data)
         # 1 header line, no separation line + 3 data lines
-        self.assertEqual(1 + 3, len(formatted.splitlines()))
+        assert len(formatted.splitlines()) == 1 + 3

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -78,9 +78,9 @@ class TelemetryTests(TestCase):
 
         opts = t.instrument_candidate_java_opts()
 
-        self.assertIsNotNone(opts)
-        self.assertEqual(len(opts), 3)
-        self.assertEqual(["-Xms256M", "-Xmx512M", "-Des.network.host=127.0.0.1"], opts)
+        assert opts is not None
+        assert len(opts) == 3
+        assert opts == ["-Xms256M", "-Xmx512M", "-Des.network.host=127.0.0.1"]
 
 
 class StartupTimeTests(TestCase):
@@ -172,79 +172,77 @@ class JfrTests(TestCase):
     def test_sets_options_for_pre_java_9_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(0, 8))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
+        assert java_opts == ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
                           "-XX:+FlightRecorder", "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,"
-                          "dumponexitpath=/var/log/test-recording.jfr", "-XX:StartFlightRecording=defaultrecording=true"], java_opts)
+                          "dumponexitpath=/var/log/test-recording.jfr", "-XX:StartFlightRecording=defaultrecording=true"]
 
     def test_sets_options_for_java_9_or_10_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(9, 10))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
+        assert java_opts == ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
                           "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,"
-                          "dumponexit=true,filename=/var/log/test-recording.jfr"], java_opts)
+                          "dumponexit=true,filename=/var/log/test-recording.jfr"]
 
     def test_sets_options_for_java_11_or_above_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(11, 999))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints",
+        assert java_opts == ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints",
                           "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,"
-                          "dumponexit=true,filename=/var/log/test-recording.jfr"], java_opts)
+                          "dumponexit=true,filename=/var/log/test-recording.jfr"]
 
     def test_sets_options_for_pre_java_9_custom_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={"recording-template": "profile"},
                                        log_root="/var/log",
                                        java_major_version=random.randint(0, 8))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
+        assert java_opts == ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
                           "-XX:+FlightRecorder", "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,"
                           "dumponexitpath=/var/log/test-recording.jfr",
-                          "-XX:StartFlightRecording=defaultrecording=true,settings=profile"], java_opts)
+                          "-XX:StartFlightRecording=defaultrecording=true,settings=profile"]
 
     def test_sets_options_for_java_9_or_10_custom_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={"recording-template": "profile"},
                                        log_root="/var/log",
                                        java_major_version=random.randint(9, 10))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
+        assert java_opts == ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
                           "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
-                          "filename=/var/log/test-recording.jfr,settings=profile"], java_opts)
+                          "filename=/var/log/test-recording.jfr,settings=profile"]
 
     def test_sets_options_for_java_11_or_above_custom_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={"recording-template": "profile"},
                                        log_root="/var/log",
                                        java_major_version=random.randint(11, 999))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints",
+        assert java_opts == ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints",
                           "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
-                          "filename=/var/log/test-recording.jfr,settings=profile"], java_opts)
+                          "filename=/var/log/test-recording.jfr,settings=profile"]
 
 
 class GcTests(TestCase):
     def test_sets_options_for_pre_java_9(self):
         gc = telemetry.Gc(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(0, 8))
         gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
-        self.assertEqual(7, len(gc_java_opts))
-        self.assertEqual(["-Xloggc:/var/log/defaults-node-0.gc.log", "-XX:+PrintGCDetails", "-XX:+PrintGCDateStamps",
+        assert len(gc_java_opts) == 7
+        assert gc_java_opts == ["-Xloggc:/var/log/defaults-node-0.gc.log", "-XX:+PrintGCDetails", "-XX:+PrintGCDateStamps",
                           "-XX:+PrintGCTimeStamps", "-XX:+PrintGCApplicationStoppedTime", "-XX:+PrintGCApplicationConcurrentTime",
-                          "-XX:+PrintTenuringDistribution"], gc_java_opts)
+                          "-XX:+PrintTenuringDistribution"]
 
     def test_sets_options_for_java_9_or_above(self):
         gc = telemetry.Gc(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(9, 999))
         gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
-        self.assertEqual(1, len(gc_java_opts))
-        self.assertEqual(
-            ["-Xlog:gc*=info,safepoint=info,age*=trace:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"],
-            gc_java_opts)
+        assert len(gc_java_opts) == 1
+        assert gc_java_opts == \
+            ["-Xlog:gc*=info,safepoint=info,age*=trace:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"]
 
     def test_can_override_options_for_java_9_or_above(self):
         gc = telemetry.Gc(telemetry_params={"gc-log-config": "gc,safepoint"},
                           log_root="/var/log",
                           java_major_version=random.randint(9, 999))
         gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
-        self.assertEqual(1, len(gc_java_opts))
-        self.assertEqual(
-            ["-Xlog:gc,safepoint:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"],
-            gc_java_opts)
+        assert len(gc_java_opts) == 1
+        assert gc_java_opts == \
+            ["-Xlog:gc,safepoint:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"]
 
 
 class HeapdumpTests(TestCase):
@@ -290,8 +288,7 @@ class CcrStatsTests(TestCase):
         telemetry_params = {
             "ccr-stats-sample-interval": -1 * random.random()
         }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    r"The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was .*\."):
+        with pytest.raises(exceptions.SystemSetupError, match=r"The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was .*\."):
             telemetry.CcrStats(telemetry_params, clients, metrics_store)
 
     def test_wrong_cluster_name_in_ccr_stats_indices_forbidden(self):
@@ -304,11 +301,9 @@ class CcrStatsTests(TestCase):
                 "wrong_cluster_name": ["follower"]
             }
         }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    r"The telemetry parameter 'ccr-stats-indices' must be a JSON Object with keys matching "
+        with pytest.raises(exceptions.SystemSetupError, match=r"The telemetry parameter 'ccr-stats-indices' must be a JSON Object with keys matching "
                                     r"the cluster names \[{}] specified in --target-hosts "
-                                    r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys())))
-                                    ):
+                                    r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys())))):
             telemetry.CcrStats(telemetry_params, clients, metrics_store)
 
 
@@ -319,8 +314,7 @@ class CcrStatsRecorderTests(TestCase):
         client = Client(transport_client=TransportClient(response={}, force_error=True))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        with self.assertRaisesRegex(exceptions.RallyError,
-                                    r"A transport error occurred while collecting CCR stats from the endpoint "
+        with pytest.raises(exceptions.RallyError, match=r"A transport error occurred while collecting CCR stats from the endpoint "
                                     r"\[/_ccr/stats\?filter_path=follow_stats\] on "
                                     r"cluster \[remote\]"):
             telemetry.CcrStatsRecorder(cluster_name="remote", client=client, metrics_store=metrics_store, sample_interval=1).record()
@@ -683,7 +677,7 @@ class RecoveryStatsTests(TestCase):
                                                    indices=["index1"])
         recorder.record()
 
-        self.assertEqual(0, metrics_store_put_doc.call_count)
+        assert metrics_store_put_doc.call_count == 0
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_single_shard_stats(self, metrics_store_put_doc):
@@ -1878,8 +1872,7 @@ class NodeStatsRecorderTests(TestCase):
         telemetry_params = {
             "node-stats-sample-interval": -1 * random.random()
         }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    r"The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was .*\."):
+        with pytest.raises(exceptions.SystemSetupError, match=r"The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was .*\."):
             telemetry.NodeStatsRecorder(telemetry_params, cluster_name="default", client=client, metrics_store=metrics_store)
 
     def test_flatten_indices_fields(self):
@@ -1892,7 +1885,7 @@ class NodeStatsRecorderTests(TestCase):
             prefix="indices",
             stats=NodeStatsRecorderTests.node_stats_response["nodes"]["Zbl_e8EyRXmiR47gbHgPfg"]["indices"]
         )
-        self.assertDictEqual(NodeStatsRecorderTests.indices_stats_response_flattened, flattened_fields)
+        assert flattened_fields == NodeStatsRecorderTests.indices_stats_response_flattened
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_default_nodes_stats(self, metrics_store_put_doc):
@@ -2522,8 +2515,7 @@ class NodeStatsRecorderTests(TestCase):
         telemetry_params = {
             "node-stats-include-indices-metrics": {"bad": "input"}
         }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    "The telemetry parameter 'node-stats-include-indices-metrics' must be "
+        with pytest.raises(exceptions.SystemSetupError, match="The telemetry parameter 'node-stats-include-indices-metrics' must be "
                                     "a comma-separated string but was <class 'dict'>"):
             telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
 
@@ -2536,8 +2528,7 @@ class TransformStatsTests(TestCase):
         telemetry_params = {
             "transform-stats-sample-interval": -1 * random.random()
         }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    r"The telemetry parameter 'transform-stats-sample-interval' must be greater than zero but was .*\."):
+        with pytest.raises(exceptions.SystemSetupError, match=r"The telemetry parameter 'transform-stats-sample-interval' must be greater than zero but was .*\."):
             telemetry.TransformStats(telemetry_params, clients, metrics_store)
 
     def test_wrong_cluster_name_in_transform_stats_indices_forbidden(self):
@@ -2550,11 +2541,9 @@ class TransformStatsTests(TestCase):
                 "wrong_cluster_name": ["follower"]
             }
         }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    r"The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys matching "
+        with pytest.raises(exceptions.SystemSetupError, match=r"The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys matching "
                                     r"the cluster names \[{}] specified in --target-hosts "
-                                    r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys())))
-                                    ):
+                                    r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys())))):
             telemetry.TransformStats(telemetry_params, clients, metrics_store)
 
 
@@ -2730,7 +2719,7 @@ class ClusterEnvironmentInfoTests(TestCase):
         t = telemetry.Telemetry(cfg, devices=[env_device])
         t.on_benchmark_start()
 
-        self.assertEqual(0, metrics_store_add_meta_info.call_count)
+        assert metrics_store_add_meta_info.call_count == 0
 
 
 class NodeEnvironmentInfoTests(TestCase):
@@ -2899,7 +2888,7 @@ class ExternalEnvironmentInfoTests(TestCase):
         t = telemetry.Telemetry(self.cfg, devices=[env_device])
         t.on_benchmark_start()
 
-        self.assertEqual(0, metrics_store_add_meta_info.call_count)
+        assert metrics_store_add_meta_info.call_count == 0
 
 
 class DiskIoTests(TestCase):
@@ -3374,7 +3363,7 @@ class MlBucketProcessingTimeTests(TestCase):
         t = telemetry.Telemetry(cfg, devices=[device])
         t.on_benchmark_stop()
 
-        self.assertEqual(0, metrics_store_put_doc.call_count)
+        assert metrics_store_put_doc.call_count == 0
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("elasticsearch.Elasticsearch")
@@ -3392,7 +3381,7 @@ class MlBucketProcessingTimeTests(TestCase):
         t = telemetry.Telemetry(cfg, devices=[device])
         t.on_benchmark_stop()
 
-        self.assertEqual(0, metrics_store_put_doc.call_count)
+        assert metrics_store_put_doc.call_count == 0
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("elasticsearch.Elasticsearch")
@@ -3511,6 +3500,6 @@ class IndexSizeTests(TestCase):
         t.detach_from_node(node, running=False)
         t.store_system_metrics(node, metrics_store)
 
-        self.assertEqual(0, run_subprocess.call_count)
-        self.assertEqual(0, metrics_store_cluster_value.call_count)
-        self.assertEqual(0, get_size.call_count)
+        assert run_subprocess.call_count == 0
+        assert metrics_store_cluster_value.call_count == 0
+        assert get_size.call_count == 0

--- a/tests/test_async_connection.py
+++ b/tests/test_async_connection.py
@@ -52,4 +52,4 @@ class ResponseMatcherTests(TestCase):
 
     def assert_response_type(self, matcher, path, expected_response_type):
         response = json.loads(matcher.response(path))
-        self.assertEqual(response["response-type"], expected_response_type)
+        assert expected_response_type == response["response-type"]

--- a/tests/time_test.py
+++ b/tests/time_test.py
@@ -31,11 +31,11 @@ class TimeTests(TestCase):
         for _ in range(3):
             time.sleep(wait_period_seconds)
             split_time = stop_watch.split_time()
-            self.assertLess(prev_split_time, split_time)
+            assert prev_split_time < split_time
             prev_split_time = split_time
         stop_watch.stop()
         total_time = stop_watch.total_time()
-        self.assertLessEqual(prev_split_time, total_time)
+        assert prev_split_time <= total_time
 
     def test_total_time_roughly_in_expected_range(self):
         wait_period_seconds = 0.05
@@ -48,8 +48,8 @@ class TimeTests(TestCase):
 
         interval = stop_watch.total_time()
         # depending on scheduling accuracy we should end up somewhere in that range
-        self.assertGreaterEqual(interval, wait_period_seconds - acceptable_delta_seconds)
-        self.assertLessEqual(interval, wait_period_seconds + acceptable_delta_seconds)
+        assert interval >= wait_period_seconds - acceptable_delta_seconds
+        assert interval <= wait_period_seconds + acceptable_delta_seconds
 
     def test_millis_conversion_roughly_in_expected_range(self):
         wait_period_millis = 50
@@ -62,5 +62,5 @@ class TimeTests(TestCase):
         interval_millis = end - start
 
         # depending on scheduling accuracy we should end up somewhere in that range
-        self.assertGreaterEqual(interval_millis, wait_period_millis - acceptable_delta_millis)
-        self.assertLessEqual(interval_millis, wait_period_millis + acceptable_delta_millis)
+        assert interval_millis >= wait_period_millis - acceptable_delta_millis
+        assert interval_millis <= wait_period_millis + acceptable_delta_millis

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -17,6 +17,8 @@
 
 from unittest import TestCase
 
+import pytest
+
 from esrally import exceptions
 from esrally.track import track
 
@@ -26,80 +28,77 @@ class TrackTests(TestCase):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        self.assertEqual(default_challenge,
-                         track.Track(name="unittest",
+        assert track.Track(name="unittest",
                                      description="unittest track",
-                                     challenges=[another_challenge, default_challenge])
-                         .default_challenge)
+                                     challenges=[another_challenge, default_challenge]) \
+                         .default_challenge == default_challenge
 
     def test_default_challenge_none_if_no_challenges(self):
-        self.assertIsNone(track.Track(name="unittest",
+        assert track.Track(name="unittest",
                                       description="unittest track",
-                                      challenges=[])
-                          .default_challenge)
+                                      challenges=[]) \
+                          .default_challenge is None
 
     def test_finds_challenge_by_name(self):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        self.assertEqual(another_challenge,
-                         track.Track(name="unittest",
+        assert track.Track(name="unittest",
                                      description="unittest track",
-                                     challenges=[another_challenge, default_challenge])
-                         .find_challenge_or_default("other"))
+                                     challenges=[another_challenge, default_challenge]) \
+                         .find_challenge_or_default("other") == another_challenge
 
     def test_uses_default_challenge_if_no_name_given(self):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        self.assertEqual(default_challenge,
-                         track.Track(name="unittest",
+        assert track.Track(name="unittest",
                                      description="unittest track",
-                                     challenges=[another_challenge, default_challenge])
-                         .find_challenge_or_default(""))
+                                     challenges=[another_challenge, default_challenge]) \
+                         .find_challenge_or_default("") == default_challenge
 
     def test_does_not_find_unknown_challenge(self):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        with self.assertRaises(exceptions.InvalidName) as ctx:
+        with pytest.raises(exceptions.InvalidName) as ctx:
             track.Track(name="unittest",
                         description="unittest track",
                         challenges=[another_challenge, default_challenge]).find_challenge_or_default("unknown-name")
 
-        self.assertEqual("Unknown challenge [unknown-name] for track [unittest]", ctx.exception.args[0])
+        assert ctx.value.args[0] == "Unknown challenge [unknown-name] for track [unittest]"
 
 
 class IndexTests(TestCase):
     def test_matches_exactly(self):
-        self.assertTrue(track.Index("test").matches("test"))
-        self.assertFalse(track.Index("test").matches(" test"))
+        assert track.Index("test").matches("test")
+        assert not track.Index("test").matches(" test")
 
     def test_matches_if_no_pattern_is_defined(self):
-        self.assertTrue(track.Index("test").matches(pattern=None))
+        assert track.Index("test").matches(pattern=None)
 
     def test_matches_if_catch_all_pattern_is_defined(self):
-        self.assertTrue(track.Index("test").matches(pattern="*"))
-        self.assertTrue(track.Index("test").matches(pattern="_all"))
+        assert track.Index("test").matches(pattern="*")
+        assert track.Index("test").matches(pattern="_all")
 
     def test_str(self):
-        self.assertEqual("test", str(track.Index("test")))
+        assert str(track.Index("test")) == "test"
 
 
 class DataStreamTests(TestCase):
     def test_matches_exactly(self):
-        self.assertTrue(track.DataStream("test").matches("test"))
-        self.assertFalse(track.DataStream("test").matches(" test"))
+        assert track.DataStream("test").matches("test")
+        assert not track.DataStream("test").matches(" test")
 
     def test_matches_if_no_pattern_is_defined(self):
-        self.assertTrue(track.DataStream("test").matches(pattern=None))
+        assert track.DataStream("test").matches(pattern=None)
 
     def test_matches_if_catch_all_pattern_is_defined(self):
-        self.assertTrue(track.DataStream("test").matches(pattern="*"))
-        self.assertTrue(track.DataStream("test").matches(pattern="_all"))
+        assert track.DataStream("test").matches(pattern="*")
+        assert track.DataStream("test").matches(pattern="_all")
 
     def test_str(self):
-        self.assertEqual("test", str(track.DataStream("test")))
+        assert str(track.DataStream("test")) == "test"
 
 
 class DocumentCorpusTests(TestCase):
@@ -115,9 +114,9 @@ class DocumentCorpusTests(TestCase):
 
         filtered_corpus = corpus.filter()
 
-        self.assertEqual(corpus.name, filtered_corpus.name)
-        self.assertListEqual(corpus.documents, filtered_corpus.documents)
-        self.assertDictEqual(corpus.meta_data, filtered_corpus.meta_data)
+        assert filtered_corpus.name == corpus.name
+        assert filtered_corpus.documents == corpus.documents
+        assert filtered_corpus.meta_data == corpus.meta_data
 
     def test_filter_documents_by_format(self):
         corpus = track.DocumentCorpus("test", documents=[
@@ -129,10 +128,10 @@ class DocumentCorpusTests(TestCase):
 
         filtered_corpus = corpus.filter(source_format=track.Documents.SOURCE_FORMAT_BULK)
 
-        self.assertEqual("test", filtered_corpus.name)
-        self.assertEqual(2, len(filtered_corpus.documents))
-        self.assertEqual("logs-01", filtered_corpus.documents[0].target_index)
-        self.assertEqual("logs-03", filtered_corpus.documents[1].target_index)
+        assert filtered_corpus.name == "test"
+        assert len(filtered_corpus.documents) == 2
+        assert filtered_corpus.documents[0].target_index == "logs-01"
+        assert filtered_corpus.documents[1].target_index == "logs-03"
 
     def test_filter_documents_by_indices(self):
         corpus = track.DocumentCorpus("test", documents=[
@@ -144,9 +143,9 @@ class DocumentCorpusTests(TestCase):
 
         filtered_corpus = corpus.filter(target_indices=["logs-02"])
 
-        self.assertEqual("test", filtered_corpus.name)
-        self.assertEqual(1, len(filtered_corpus.documents))
-        self.assertEqual("logs-02", filtered_corpus.documents[0].target_index)
+        assert filtered_corpus.name == "test"
+        assert len(filtered_corpus.documents) == 1
+        assert filtered_corpus.documents[0].target_index == "logs-02"
 
     def test_filter_documents_by_data_streams(self):
         corpus = track.DocumentCorpus("test", documents=[
@@ -159,9 +158,9 @@ class DocumentCorpusTests(TestCase):
         ])
 
         filtered_corpus = corpus.filter(target_data_streams=["logs-02"])
-        self.assertEqual("test", filtered_corpus.name)
-        self.assertEqual(1, len(filtered_corpus.documents))
-        self.assertEqual("logs-02", filtered_corpus.documents[0].target_data_stream)
+        assert filtered_corpus.name == "test"
+        assert len(filtered_corpus.documents) == 1
+        assert filtered_corpus.documents[0].target_data_stream == "logs-02"
 
     def test_filter_documents_by_format_and_indices(self):
         corpus = track.DocumentCorpus("test", documents=[
@@ -173,10 +172,10 @@ class DocumentCorpusTests(TestCase):
 
         filtered_corpus = corpus.filter(source_format=track.Documents.SOURCE_FORMAT_BULK, target_indices=["logs-01", "logs-02"])
 
-        self.assertEqual("test", filtered_corpus.name)
-        self.assertEqual(2, len(filtered_corpus.documents))
-        self.assertEqual("logs-01", filtered_corpus.documents[0].target_index)
-        self.assertEqual("logs-02", filtered_corpus.documents[1].target_index)
+        assert filtered_corpus.name == "test"
+        assert len(filtered_corpus.documents) == 2
+        assert filtered_corpus.documents[0].target_index == "logs-01"
+        assert filtered_corpus.documents[1].target_index == "logs-02"
 
     def test_union_document_corpus_is_reflexive(self):
         corpus = track.DocumentCorpus("test", documents=[
@@ -185,7 +184,7 @@ class DocumentCorpusTests(TestCase):
             track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
             track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=8, target_index=None)
         ])
-        self.assertTrue(corpus.union(corpus) is corpus)
+        assert corpus.union(corpus) is corpus
 
     def test_union_document_corpora_is_symmetric(self):
         a = track.DocumentCorpus("test", documents=[
@@ -194,8 +193,8 @@ class DocumentCorpusTests(TestCase):
         b = track.DocumentCorpus("test", documents=[
             track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-02"),
         ])
-        self.assertEqual(b.union(a), a.union(b))
-        self.assertEqual(2, len(a.union(b).documents))
+        assert a.union(b) == b.union(a)
+        assert len(a.union(b).documents) == 2
 
     def test_cannot_union_mixed_document_corpora_by_name(self):
         a = track.DocumentCorpus("test", documents=[
@@ -204,9 +203,9 @@ class DocumentCorpusTests(TestCase):
         b = track.DocumentCorpus("other", documents=[
             track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-02"),
         ])
-        with self.assertRaises(exceptions.RallyAssertionError) as ae:
+        with pytest.raises(exceptions.RallyAssertionError) as ae:
             a.union(b)
-        self.assertEqual(ae.exception.message, "Corpora names differ: [test] and [other].")
+        assert ae.value.message == "Corpora names differ: [test] and [other]."
 
     def test_cannot_union_mixed_document_corpora_by_meta_data(self):
         a = track.DocumentCorpus("test", documents=[
@@ -219,16 +218,15 @@ class DocumentCorpusTests(TestCase):
         ], meta_data={
             "with-metadata": True
         })
-        with self.assertRaises(exceptions.RallyAssertionError) as ae:
+        with pytest.raises(exceptions.RallyAssertionError) as ae:
             a.union(b)
-        self.assertEqual(ae.exception.message,
-                         "Corpora meta-data differ: [{'with-metadata': False}] and [{'with-metadata': True}].")
+        assert ae.value.message == "Corpora meta-data differ: [{'with-metadata': False}] and [{'with-metadata': True}]."
 
 
 class OperationTypeTests(TestCase):
     def test_string_hyphenation_is_symmetric(self):
         for op_type in track.OperationType:
-            self.assertEqual(op_type, track.OperationType.from_hyphenated_string(op_type.to_hyphenated_string()))
+            assert track.OperationType.from_hyphenated_string(op_type.to_hyphenated_string()) == op_type
 
 
 class TaskFilterTests(TestCase):
@@ -246,18 +244,18 @@ class TaskFilterTests(TestCase):
 
     def test_task_name_filter(self):
         f = track.TaskNameFilter("create-index-task")
-        self.assertTrue(f.matches(self.create_index_task()))
-        self.assertFalse(f.matches(self.search_task()))
+        assert f.matches(self.create_index_task())
+        assert not f.matches(self.search_task())
 
     def test_task_op_type_filter(self):
         f = track.TaskOpTypeFilter(track.OperationType.CreateIndex.to_hyphenated_string())
-        self.assertTrue(f.matches(self.create_index_task()))
-        self.assertFalse(f.matches(self.search_task()))
+        assert f.matches(self.create_index_task())
+        assert not f.matches(self.search_task())
 
     def test_task_tag_filter(self):
         f = track.TaskTagFilter(tag_name="write-op")
-        self.assertTrue(f.matches(self.create_index_task()))
-        self.assertFalse(f.matches(self.search_task()))
+        assert f.matches(self.create_index_task())
+        assert not f.matches(self.search_task())
 
 
 class TaskTests(TestCase):
@@ -274,61 +272,61 @@ class TaskTests(TestCase):
 
     def test_unthrottled_task(self):
         task = self.task()
-        self.assertIsNone(task.target_throughput)
+        assert task.target_throughput is None
 
     def test_target_interval_zero_treated_as_unthrottled(self):
         task = self.task(target_interval=0)
-        self.assertIsNone(task.target_throughput)
+        assert task.target_throughput is None
 
     def test_valid_throughput_with_unit(self):
         task = self.task(target_throughput="5 MB/s")
-        self.assertEqual(track.Throughput(5.0, "MB/s"), task.target_throughput)
+        assert task.target_throughput == track.Throughput(5.0, "MB/s")
 
     def test_valid_throughput_numeric(self):
         task = self.task(target_throughput=3.2)
-        self.assertEqual(track.Throughput(3.2, "ops/s"), task.target_throughput)
+        assert task.target_throughput == track.Throughput(3.2, "ops/s")
 
     def test_invalid_throughput_format_is_rejected(self):
         task = self.task(target_throughput="3.2 docs")
-        with self.assertRaises(exceptions.InvalidSyntax) as e:
+        with pytest.raises(exceptions.InvalidSyntax) as e:
             # pylint: disable=pointless-statement
             task.target_throughput
-        self.assertEqual("Task [test] specifies invalid target throughput [3.2 docs].", e.exception.args[0])
+        assert e.value.args[0] == "Task [test] specifies invalid target throughput [3.2 docs]."
 
     def test_invalid_throughput_type_is_rejected(self):
         task = self.task(target_throughput=True)
-        with self.assertRaises(exceptions.InvalidSyntax) as e:
+        with pytest.raises(exceptions.InvalidSyntax) as e:
             # pylint: disable=pointless-statement
             task.target_throughput
-        self.assertEqual("Target throughput [True] for task [test] must be string or numeric.", e.exception.args[0])
+        assert e.value.args[0] == "Target throughput [True] for task [test] must be string or numeric."
 
     def test_interval_and_throughput_is_rejected(self):
         task = self.task(target_throughput=1, target_interval=1)
-        with self.assertRaises(exceptions.InvalidSyntax) as e:
+        with pytest.raises(exceptions.InvalidSyntax) as e:
             # pylint: disable=pointless-statement
             task.target_throughput
-        self.assertEqual("Task [test] specifies target-interval [1] and target-throughput [1] but only one "
-                         "of them is allowed.", e.exception.args[0])
+        assert e.value.args[0] == "Task [test] specifies target-interval [1] and target-throughput [1] but only one " \
+                         "of them is allowed."
 
     def test_invalid_ignore_response_error_level_is_rejected(self):
         task = self.task(ignore_response_error_level="invalid-value")
-        with self.assertRaises(exceptions.InvalidSyntax) as e:
+        with pytest.raises(exceptions.InvalidSyntax) as e:
             # pylint: disable=pointless-statement
             task.ignore_response_error_level
-        self.assertEqual("Task [test] specifies ignore-response-error-level to [invalid-value] but "
-                         "the only allowed values are [non-fatal].", e.exception.args[0])
+        assert e.value.args[0] == "Task [test] specifies ignore-response-error-level to [invalid-value] but " \
+                         "the only allowed values are [non-fatal]."
 
     def test_task_continues_with_global_continue(self):
         task = self.task()
         effective_on_error = task.error_behavior(default_error_behavior="continue")
-        self.assertEqual(effective_on_error, "continue")
+        assert effective_on_error == "continue"
 
     def test_task_continues_with_global_abort_and_task_override(self):
         task = self.task(ignore_response_error_level="non-fatal")
         effective_on_error = task.error_behavior(default_error_behavior="abort")
-        self.assertEqual(effective_on_error, "continue")
+        assert effective_on_error == "continue"
 
     def test_task_aborts_with_global_abort(self):
         task = self.task()
         effective_on_error = task.error_behavior(default_error_behavior="abort")
-        self.assertEqual(effective_on_error, "abort")
+        assert effective_on_error == "abort"

--- a/tests/utils/collections_test.py
+++ b/tests/utils/collections_test.py
@@ -18,7 +18,7 @@
 import random
 from typing import Any, Mapping
 
-import pytest  # type: ignore
+import pytest
 
 from esrally.utils import collections
 

--- a/tests/utils/console_test.py
+++ b/tests/utils/console_test.py
@@ -45,17 +45,17 @@ class ConsoleFunctionTests(TestCase):
     @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": random.choice(["false", "False", "FALSE", ""])})
     def test_global_rally_running_in_docker_is_false(self):
         console.init()
-        self.assertEqual(False, console.RALLY_RUNNING_IN_DOCKER)
+        assert console.RALLY_RUNNING_IN_DOCKER is False
 
     @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": ""})
     def test_global_rally_running_in_docker_is_false_if_unset(self):
         console.init()
-        self.assertEqual(False, console.RALLY_RUNNING_IN_DOCKER)
+        assert console.RALLY_RUNNING_IN_DOCKER is False
 
     @mock.patch.dict(os.environ, {"RALLY_RUNNING_IN_DOCKER": random.choice(["True", "true", "TRUE"])})
     def test_global_rally_running_in_docker_is_true(self):
         console.init()
-        self.assertEqual(True, console.RALLY_RUNNING_IN_DOCKER)
+        assert console.RALLY_RUNNING_IN_DOCKER is True
 
     @mock.patch("sys.stdout.isatty")
     @mock.patch("builtins.print")

--- a/tests/utils/convert_test.py
+++ b/tests/utils/convert_test.py
@@ -17,6 +17,8 @@
 
 from unittest import TestCase
 
+import pytest
+
 from esrally.utils import convert
 
 
@@ -24,16 +26,16 @@ class ToBoolTests(TestCase):
     def test_convert_to_true(self):
         values = ["True", "true", "Yes", "yes", "t", "y", "1", True]
         for value in values:
-            self.assertTrue(convert.to_bool(value), msg="Expect [%s] of type [%s] to be converted to True." % (str(value), type(value)))
+            assert convert.to_bool(value), "Expect [%s] of type [%s] to be converted to True." % (str(value), type(value))
 
     def test_convert_to_false(self):
         values = ["False", "false", "No", "no", "f", "n", "0", False]
         for value in values:
-            self.assertFalse(convert.to_bool(value), msg="Expect [%s] of type [%s] to be converted to False." % (str(value), type(value)))
+            assert not convert.to_bool(value), "Expect [%s] of type [%s] to be converted to False." % (str(value), type(value))
 
     def test_cannot_convert_invalid_value(self):
         values = ["Invalid", None, []]
         for value in values:
-            with self.assertRaises(ValueError, msg="Expect [%s] of type [%s] to fail to be converted." % (str(value), type(value))) as ctx:
+            with pytest.raises(ValueError) as ctx:
                 convert.to_bool(value)
-            self.assertEqual("Cannot convert [%s] to bool." % value, ctx.exception.args[0])
+            assert ctx.value.args[0] == "Cannot convert [%s] to bool." % value

--- a/tests/utils/io_test.py
+++ b/tests/utils/io_test.py
@@ -47,24 +47,24 @@ def mock_red_hat(path):
 
 class IoTests(TestCase):
     def test_normalize_path(self):
-        self.assertEqual("/already/a/normalized/path", io.normalize_path("/already/a/normalized/path"))
-        self.assertEqual("/not/normalized", io.normalize_path("/not/normalized/path/../"))
-        self.assertEqual(os.path.expanduser("~"), io.normalize_path("~/Documents/.."))
+        assert io.normalize_path("/already/a/normalized/path") == "/already/a/normalized/path"
+        assert io.normalize_path("/not/normalized/path/../") == "/not/normalized"
+        assert io.normalize_path("~/Documents/..") == os.path.expanduser("~")
 
     def test_archive(self):
-        self.assertTrue(io.is_archive("/tmp/some-archive.tar.gz"))
-        self.assertTrue(io.is_archive("/tmp/some-archive.tgz"))
+        assert io.is_archive("/tmp/some-archive.tar.gz")
+        assert io.is_archive("/tmp/some-archive.tgz")
         # Rally does not recognize .7z
-        self.assertFalse(io.is_archive("/tmp/some-archive.7z"))
-        self.assertFalse(io.is_archive("/tmp/some.log"))
-        self.assertFalse(io.is_archive("some.log"))
+        assert not io.is_archive("/tmp/some-archive.7z")
+        assert not io.is_archive("/tmp/some.log")
+        assert not io.is_archive("some.log")
 
     def test_has_extension(self):
-        self.assertTrue(io.has_extension("/tmp/some-archive.tar.gz", ".tar.gz"))
-        self.assertFalse(io.has_extension("/tmp/some-archive.tar.gz", ".gz"))
-        self.assertTrue(io.has_extension("/tmp/text.txt", ".txt"))
+        assert io.has_extension("/tmp/some-archive.tar.gz", ".tar.gz")
+        assert not io.has_extension("/tmp/some-archive.tar.gz", ".gz")
+        assert io.has_extension("/tmp/text.txt", ".txt")
         # no extension whatsoever
-        self.assertFalse(io.has_extension("/tmp/README", "README"))
+        assert not io.has_extension("/tmp/README", "README")
 
 
 class TestDecompression:

--- a/tests/utils/jvm_test.py
+++ b/tests/utils/jvm_test.py
@@ -18,28 +18,30 @@
 import unittest.mock as mock
 from unittest import TestCase
 
+import pytest
+
 from esrally import exceptions
 from esrally.utils import jvm
 
 
 class JvmTests(TestCase):
     def test_extract_major_version_7(self):
-        self.assertEqual(7, jvm.major_version("1.7", lambda x, y: x))
+        assert jvm.major_version("1.7", lambda x, y: x) == 7
 
     def test_extract_major_version_8(self):
-        self.assertEqual(8, jvm.major_version("1.8", lambda x, y: x))
+        assert jvm.major_version("1.8", lambda x, y: x) == 8
 
     def test_extract_major_version_9(self):
-        self.assertEqual(9, jvm.major_version("9", lambda x, y: x))
+        assert jvm.major_version("9", lambda x, y: x) == 9
 
     def test_extract_major_version_10(self):
-        self.assertEqual(10, jvm.major_version("10", lambda x, y: x))
+        assert jvm.major_version("10", lambda x, y: x) == 10
 
     def test_ea_release(self):
-        self.assertTrue(jvm.is_early_access_release("Oracle Corporation,9-ea", self.prop_version_reader))
+        assert jvm.is_early_access_release("Oracle Corporation,9-ea", self.prop_version_reader)
 
     def test_ga_release(self):
-        self.assertFalse(jvm.is_early_access_release("Oracle Corporation,9", self.prop_version_reader))
+        assert not jvm.is_early_access_release("Oracle Corporation,9", self.prop_version_reader)
 
     def prop_version_reader(self, java_home, prop):
         props = java_home.split(",")
@@ -56,8 +58,8 @@ class JvmTests(TestCase):
         getenv.side_effect = [None, "/opt/jdks/jdk/1.8"]
 
         major, resolved_path = jvm.resolve_path(majors=8, sysprop_reader=self.path_based_prop_version_reader)
-        self.assertEqual(8, major)
-        self.assertEqual("/opt/jdks/jdk/1.8", resolved_path)
+        assert major == 8
+        assert resolved_path == "/opt/jdks/jdk/1.8"
 
     @mock.patch("os.getenv")
     def test_resolve_path_for_one_version_via_java_x_home(self, getenv):
@@ -65,24 +67,22 @@ class JvmTests(TestCase):
         getenv.side_effect = ["/opt/jdks/jdk/1.8", None]
 
         major, resolved_path = jvm.resolve_path(majors=8, sysprop_reader=self.path_based_prop_version_reader)
-        self.assertEqual(8, major)
-        self.assertEqual("/opt/jdks/jdk/1.8", resolved_path)
+        assert major == 8
+        assert resolved_path == "/opt/jdks/jdk/1.8"
 
     @mock.patch("os.getenv")
     def test_resolve_path_for_one_version_no_matching_version(self, getenv):
         # JAVA8_HOME, JAVA_HOME
         getenv.side_effect = [None, "/opt/jdks/jdk/1.7"]
 
-        with self.assertRaisesRegex(expected_exception=exceptions.SystemSetupError,
-                                    expected_regex="JAVA_HOME points to JDK 7 but it should point to JDK 8."):
+        with pytest.raises(exceptions.SystemSetupError, match="JAVA_HOME points to JDK 7 but it should point to JDK 8."):
             jvm.resolve_path(majors=8, sysprop_reader=self.path_based_prop_version_reader)
 
     @mock.patch("os.getenv")
     def test_resolve_path_for_one_version_no_env_vars_defined(self, getenv):
         getenv.return_value = None
 
-        with self.assertRaisesRegex(expected_exception=exceptions.SystemSetupError,
-                                    expected_regex="Neither JAVA8_HOME nor JAVA_HOME point to a JDK 8 installation."):
+        with pytest.raises(exceptions.SystemSetupError, match="Neither JAVA8_HOME nor JAVA_HOME point to a JDK 8 installation."):
             jvm.resolve_path(majors=8, sysprop_reader=self.path_based_prop_version_reader)
 
     @mock.patch("os.getenv")
@@ -106,5 +106,5 @@ class JvmTests(TestCase):
             "/opt/jdks/jdk/1.8",
         ]
         major, resolved_path = jvm.resolve_path(majors=[11, 10, 9, 8], sysprop_reader=self.path_based_prop_version_reader)
-        self.assertEqual(9, major)
-        self.assertEqual("/opt/jdks/jdk/9", resolved_path)
+        assert major == 9
+        assert resolved_path == "/opt/jdks/jdk/9"

--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -23,37 +23,32 @@ from esrally.utils import opts
 
 class ConfigHelperFunctionTests(TestCase):
     def test_csv_to_list(self):
-        self.assertEqual([], opts.csv_to_list(""))
-        self.assertEqual(["a", "b", "c", "d"], opts.csv_to_list("    a,b,c   , d"))
-        self.assertEqual(["a-;d", "b", "c", "d"], opts.csv_to_list("    a-;d    ,b,c   , d"))
+        assert opts.csv_to_list("") == []
+        assert opts.csv_to_list("    a,b,c   , d") == ["a", "b", "c", "d"]
+        assert opts.csv_to_list("    a-;d    ,b,c   , d") == ["a-;d", "b", "c", "d"]
 
     def test_kv_to_map(self):
-        self.assertEqual({}, opts.kv_to_map([]))
+        assert opts.kv_to_map([]) == {}
         # explicit treatment as string
-        self.assertEqual({"k": "3"}, opts.kv_to_map(["k:'3'"]))
-        self.assertEqual({"k": 3}, opts.kv_to_map(["k:3"]))
+        assert opts.kv_to_map(["k:'3'"]) == {"k": "3"}
+        assert opts.kv_to_map(["k:3"]) == {"k": 3}
         # implicit treatment as string
-        self.assertEqual({"k": "v"}, opts.kv_to_map(["k:v"]))
-        self.assertEqual({"k": "v", "size": 4, "empty": False, "temperature": 0.5},
-                         opts.kv_to_map(["k:'v'", "size:4", "empty:false", "temperature:0.5"]))
+        assert opts.kv_to_map(["k:v"]) == {"k": "v"}
+        assert opts.kv_to_map(["k:'v'", "size:4", "empty:false", "temperature:0.5"]) == {"k": "v", "size": 4, "empty": False, "temperature": 0.5}
 
 
 class GenericHelperFunctionTests(TestCase):
     def test_list_as_bulleted_list(self):
         src_list = ["param-1", "param-2", "a_longer-parameter"]
 
-        self.assertEqual(
-            ["- param-1", "- param-2", "- a_longer-parameter"],
-            opts.bulleted_list_of(src_list)
-        )
+        assert opts.bulleted_list_of(src_list) == \
+            ["- param-1", "- param-2", "- a_longer-parameter"]
 
     def test_list_as_double_quoted_list(self):
         src_list = ["oneitem", "_another-weird_item", "param-3"]
 
-        self.assertEqual(
-            opts.double_quoted_list_of(src_list),
-            ['"oneitem"', '"_another-weird_item"', '"param-3"']
-        )
+        assert ['"oneitem"', '"_another-weird_item"', '"param-3"'] == \
+            opts.double_quoted_list_of(src_list)
 
     def test_make_list_of_close_matches(self):
         word_list = [
@@ -108,7 +103,7 @@ class GenericHelperFunctionTests(TestCase):
             "target_throughput",
             "translog_sync"]
 
-        self.assertEqual(
+        assert opts.make_list_of_close_matches(word_list, available_word_list) == \
             ['bulk_indexing_clients',
              'bulk_indexing_iterations',
              'target_throughput',
@@ -116,64 +111,51 @@ class GenericHelperFunctionTests(TestCase):
              # number_of-shards had a typo
              'number_of_shards',
              'number_of_replicas',
-             'index_refresh_interval'],
-            opts.make_list_of_close_matches(word_list, available_word_list)
-        )
+             'index_refresh_interval']
 
     def test_make_list_of_close_matches_returns_with_empty_word_list(self):
-        self.assertEqual(
-            [],
-            opts.make_list_of_close_matches([], ["number_of_shards"])
-        )
+        assert opts.make_list_of_close_matches([], ["number_of_shards"]) == \
+            []
 
     def test_make_list_of_close_matches_returns_empty_list_with_no_close_matches(self):
-        self.assertEqual(
-            [],
-            opts.make_list_of_close_matches(
+        assert opts.make_list_of_close_matches(
                 ["number_of_shards", "number_of-replicas"],
-                [])
-        )
+                []) == \
+            []
 
 
 class TestTargetHosts(TestCase):
     def test_empty_arg_parses_as_empty_list(self):
-        self.assertEqual([], opts.TargetHosts('').default)
-        self.assertEqual({'default': []}, opts.TargetHosts('').all_hosts)
+        assert opts.TargetHosts('').default == []
+        assert opts.TargetHosts('').all_hosts == {'default': []}
 
     def test_csv_hosts_parses(self):
         target_hosts = '127.0.0.1:9200,10.17.0.5:19200'
 
-        self.assertEqual(
-            {'default': [{'host': '127.0.0.1', 'port': 9200},{'host': '10.17.0.5', 'port': 19200}]},
-            opts.TargetHosts(target_hosts).all_hosts
-        )
+        assert opts.TargetHosts(target_hosts).all_hosts == \
+            {'default': [{'host': '127.0.0.1', 'port': 9200},{'host': '10.17.0.5', 'port': 19200}]}
 
-        self.assertEqual(
-            [{'host': '127.0.0.1', 'port': 9200},{'host': '10.17.0.5', 'port': 19200}],
-            opts.TargetHosts(target_hosts).default
-        )
+        assert opts.TargetHosts(target_hosts).default == \
+            [{'host': '127.0.0.1', 'port': 9200},{'host': '10.17.0.5', 'port': 19200}]
 
-        self.assertEqual(
-            [{'host': '127.0.0.1', 'port': 9200},{'host': '10.17.0.5', 'port': 19200}],
-            opts.TargetHosts(target_hosts).default)
+        assert opts.TargetHosts(target_hosts).default == \
+            [{'host': '127.0.0.1', 'port': 9200},{'host': '10.17.0.5', 'port': 19200}]
 
     def test_jsonstring_parses_as_dict_of_clusters(self):
         target_hosts = ('{"default": ["127.0.0.1:9200","10.17.0.5:19200"],'
                         ' "remote_1": ["88.33.22.15:19200"],'
                         ' "remote_2": ["10.18.0.6:19200","10.18.0.7:19201"]}')
 
-        self.assertEqual(
+        assert opts.TargetHosts(target_hosts).all_hosts == \
             {'default': ['127.0.0.1:9200','10.17.0.5:19200'],
              'remote_1': ['88.33.22.15:19200'],
-             'remote_2': ['10.18.0.6:19200','10.18.0.7:19201']},
-            opts.TargetHosts(target_hosts).all_hosts)
+             'remote_2': ['10.18.0.6:19200','10.18.0.7:19201']}
 
     def test_json_file_parameter_parses(self):
-        self.assertEqual(
-            {"default": ["127.0.0.1:9200","10.127.0.3:19200"] },
-            opts.TargetHosts(os.path.join(os.path.dirname(__file__), "resources", "target_hosts_1.json")).all_hosts)
+        assert opts.TargetHosts(os.path.join(os.path.dirname(__file__), "resources", "target_hosts_1.json")).all_hosts == \
+            {"default": ["127.0.0.1:9200","10.127.0.3:19200"] }
 
-        self.assertEqual(
+        assert opts.TargetHosts(os.path.join(os.path.dirname(__file__), "resources", "target_hosts_2.json")).all_hosts == \
             {
               "default": [
                 {"host": "127.0.0.1", "port": 9200},
@@ -186,106 +168,87 @@ class TestTargetHosts(TestCase):
               "remote_2":[
                 {"host": "88.33.27.15", "port": 39200}
               ]
-            },
-            opts.TargetHosts(os.path.join(os.path.dirname(__file__), "resources", "target_hosts_2.json")).all_hosts)
+            }
 
 
 class TestClientOptions(TestCase):
     def test_csv_client_options_parses(self):
         client_options_string = "use_ssl:true,verify_certs:true,ca_certs:'/path/to/cacert.pem'"
 
-        self.assertEqual(
-            {'use_ssl': True, 'verify_certs': True, 'ca_certs': '/path/to/cacert.pem'},
-            opts.ClientOptions(client_options_string).default)
+        assert opts.ClientOptions(client_options_string).default == \
+            {'use_ssl': True, 'verify_certs': True, 'ca_certs': '/path/to/cacert.pem'}
 
-        self.assertEqual(
-            {'use_ssl': True, 'verify_certs': True, 'ca_certs': '/path/to/cacert.pem'},
-            opts.ClientOptions(client_options_string).default
-        )
+        assert opts.ClientOptions(client_options_string).default == \
+            {'use_ssl': True, 'verify_certs': True, 'ca_certs': '/path/to/cacert.pem'}
 
-        self.assertEqual(
-            {'default': {'use_ssl': True, 'verify_certs': True, 'ca_certs': '/path/to/cacert.pem'}},
-            opts.ClientOptions(client_options_string).all_client_options
-        )
+        assert opts.ClientOptions(client_options_string).all_client_options == \
+            {'default': {'use_ssl': True, 'verify_certs': True, 'ca_certs': '/path/to/cacert.pem'}}
 
     def test_jsonstring_client_options_parses(self):
         client_options_string = '{"default": {"timeout": 60},' \
             '"remote_1": {"use_ssl":true,"verify_certs":true,"basic_auth_user": "elastic", "basic_auth_password": "changeme"},'\
             '"remote_2": {"use_ssl":true,"verify_certs":true,"ca_certs":"/path/to/cacert.pem"}}'
 
-        self.assertEqual(
-            {'timeout': 60},
-            opts.ClientOptions(client_options_string).default)
+        assert opts.ClientOptions(client_options_string).default == \
+            {'timeout': 60}
 
-        self.assertEqual(
-            {'timeout': 60},
-            opts.ClientOptions(client_options_string).default)
+        assert opts.ClientOptions(client_options_string).default == \
+            {'timeout': 60}
 
-        self.assertEqual(
+        assert opts.ClientOptions(client_options_string).all_client_options == \
             {'default': {'timeout':60},
              'remote_1': {'use_ssl': True,'verify_certs': True,'basic_auth_user':'elastic','basic_auth_password':'changeme'},
-             'remote_2': {'use_ssl': True,'verify_certs': True, 'ca_certs':'/path/to/cacert.pem'}},
-            opts.ClientOptions(client_options_string).all_client_options)
+             'remote_2': {'use_ssl': True,'verify_certs': True, 'ca_certs':'/path/to/cacert.pem'}}
 
     def test_json_file_parameter_parses(self):
-        self.assertEqual(
+        assert opts.ClientOptions(os.path.join(os.path.dirname(__file__), "resources", "client_options_1.json")).all_client_options == \
             {'default': {'timeout':60},
              'remote_1': {'use_ssl': True,'verify_certs': True,'basic_auth_user':'elastic','basic_auth_password':'changeme'},
-             'remote_2': {'use_ssl': True,'verify_certs': True, 'ca_certs':'/path/to/cacert.pem'}},
-            opts.ClientOptions(os.path.join(os.path.dirname(__file__), "resources", "client_options_1.json")).all_client_options)
+             'remote_2': {'use_ssl': True,'verify_certs': True, 'ca_certs':'/path/to/cacert.pem'}}
 
-        self.assertEqual(
-            {'default': {'timeout':60}},
-            opts.ClientOptions(os.path.join(os.path.dirname(__file__), "resources", "client_options_2.json")).all_client_options)
+        assert opts.ClientOptions(os.path.join(os.path.dirname(__file__), "resources", "client_options_2.json")).all_client_options == \
+            {'default': {'timeout':60}}
 
     def test_no_client_option_parses_to_default(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = None
 
-        self.assertEqual(
-            {"timeout": 60},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).default)
+        assert opts.ClientOptions(client_options_string,
+                                 target_hosts=target_hosts).default == \
+            {"timeout": 60}
 
-        self.assertEqual(
-            {"default": {"timeout": 60}},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).all_client_options)
+        assert opts.ClientOptions(client_options_string,
+                                 target_hosts=target_hosts).all_client_options == \
+            {"default": {"timeout": 60}}
 
-        self.assertEqual(
-            {"timeout": 60},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).default)
+        assert opts.ClientOptions(client_options_string,
+                                 target_hosts=target_hosts).default == \
+            {"timeout": 60}
 
     def test_no_client_option_parses_to_default_with_multicluster(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = opts.TargetHosts('{"default": ["127.0.0.1:9200,10.17.0.5:19200"], "remote": ["88.33.22.15:19200"]}')
 
-        self.assertEqual(
-            {"timeout": 60},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).default)
+        assert opts.ClientOptions(client_options_string,
+                                 target_hosts=target_hosts).default == \
+            {"timeout": 60}
 
-        self.assertEqual(
-            {"default": {"timeout": 60}, "remote": {"timeout": 60}},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).all_client_options)
+        assert opts.ClientOptions(client_options_string,
+                                 target_hosts=target_hosts).all_client_options == \
+            {"default": {"timeout": 60}, "remote": {"timeout": 60}}
 
-        self.assertEqual(
-            {"timeout": 60},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).default)
+        assert opts.ClientOptions(client_options_string,
+                                 target_hosts=target_hosts).default == \
+            {"timeout": 60}
 
     def test_amends_with_max_connections(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = opts.TargetHosts('{"default": ["10.17.0.5:9200"], "remote": ["88.33.22.15:9200"]}')
-        self.assertEqual(
-            {"default": {"timeout": 60, "max_connections": 128}, "remote": {"timeout": 60, "max_connections": 128}},
-            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(128))
+        assert opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(128) == \
+            {"default": {"timeout": 60, "max_connections": 128}, "remote": {"timeout": 60, "max_connections": 128}}
 
     def test_keeps_already_specified_max_connections(self):
         client_options_string = '{"default": {"timeout":60,"max_connections":5}, "remote": {"timeout":60}}'
         target_hosts = opts.TargetHosts('{"default": ["10.17.0.5:9200"], "remote": ["88.33.22.15:9200"]}')
-        self.assertEqual(
-            {"default": {"timeout": 60, "max_connections": 5}, "remote": {"timeout": 60, "max_connections": 32}},
-            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(32))
+        assert opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(32) == \
+            {"default": {"timeout": 60, "max_connections": 5}, "remote": {"timeout": 60, "max_connections": 32}}

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -82,8 +82,7 @@ class ProcessTests(TestCase):
             night_rally_process,
         ]
 
-        self.assertEqual([rally_process_p, rally_process_r, rally_process_e, rally_process_mac],
-                         process.find_all_other_rally_processes())
+        assert process.find_all_other_rally_processes() == [rally_process_p, rally_process_r, rally_process_e, rally_process_mac]
 
     @mock.patch("psutil.process_iter")
     def test_find_no_other_rally_process_running(self, process_iter):
@@ -94,7 +93,7 @@ class ProcessTests(TestCase):
 
         process_iter.return_value = [ metrics_store_process, random_python]
 
-        self.assertEqual(0, len(process.find_all_other_rally_processes()))
+        assert len(process.find_all_other_rally_processes()) == 0
 
     @mock.patch("psutil.process_iter")
     def test_kills_only_rally_processes(self, process_iter):
@@ -133,14 +132,14 @@ class ProcessTests(TestCase):
 
         process.kill_running_rally_instances()
 
-        self.assertFalse(rally_es_5_process.killed)
-        self.assertFalse(rally_es_1_process.killed)
-        self.assertFalse(metrics_store_process.killed)
-        self.assertFalse(random_python.killed)
-        self.assertFalse(other_process.killed)
-        self.assertTrue(rally_process_p.killed)
-        self.assertTrue(rally_process_r.killed)
-        self.assertTrue(rally_process_e.killed)
-        self.assertTrue(rally_process_mac.killed)
-        self.assertFalse(own_rally_process.killed)
-        self.assertFalse(night_rally_process.killed)
+        assert not rally_es_5_process.killed
+        assert not rally_es_1_process.killed
+        assert not metrics_store_process.killed
+        assert not random_python.killed
+        assert not other_process.killed
+        assert rally_process_p.killed
+        assert rally_process_r.killed
+        assert rally_process_e.killed
+        assert rally_process_mac.killed
+        assert not own_rally_process.killed
+        assert not night_rally_process.killed


### PR DESCRIPTION
They're easier to read and produce better error messages. This was done mostly automatically with the `self_assert` unittest2pytest fix. (I had to modify unittest2pytest to use fissix instead of lib2to3 as the latter choked on various files.)

I also had to change many lines from `assert 0 == value` to `assert value == 0` to please pytest. This isn't a useful pattern in Python because `assert 0 = value` is a syntax error anyway.

I may have some pylint issues left to fix, but wanted to hear about the general idea first.