### PR TITLE
Format code with black and isort

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate to black and isort
+6ec0d1cddc8202775f2e1a5f68ed78393f20107e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,16 +54,22 @@ Once your changes and tests are ready to submit for review:
 
     Run the test suite to make sure that nothing is broken: `python3 setup.py test`.
 
-2. Sign the Contributor License Agreement
+2. Format your changes
+
+    Also make sure that lint is passing by running `make lint`. To format your code, run `make format`.
+
+    Consider using editor integrations to do it automatically: you'll need to configure [black](https://black.readthedocs.io/en/stable/integrations/editors.html) and [isort](https://github.com/PyCQA/isort/wiki/isort-Plugins).
+
+3. Sign the Contributor License Agreement
 
     Please make sure you have signed our [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
 
-3. Rebase your changes
+4. Rebase your changes
 
     Update your local repository with the most recent code from the main Rally repository, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits.  This makes them easier to review.  As a final step before merging we will either ask you to squash all commits yourself or we'll do it for you.
 
 
-4. Submit a pull request
+5. Submit a pull request
 
     Push your local changes to your forked copy of the repository and [submit a pull request](https://help.github.com/articles/using-pull-requests). In the pull request, choose a title which sums up the changes that you have made, and in the body provide more details about what your changes do. Also mention the number of the issue where discussion has taken place, eg "Closes #123".
 
@@ -90,7 +96,7 @@ We require the following license header on all source code files:
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,13 @@ tox-env-clean:
 	rm -rf .tox
 
 lint: check-venv
-	@find esrally benchmarks scripts tests it -name "*.py" -exec $(VEPYLINT) -j0 -rn --load-plugins pylint_quotes --rcfile=$(CURDIR)/.pylintrc \{\} +
+	@find esrally benchmarks scripts tests it -name "*.py" -exec $(VEPYLINT) -j0 -rn --rcfile=$(CURDIR)/.pylintrc \{\} +
+	@. $(VENV_ACTIVATE_FILE); black --check esrally benchmarks scripts tests it
+	@. $(VENV_ACTIVATE_FILE); isort --check esrally benchmarks scripts tests it
+
+format: check-venv
+	@. $(VENV_ACTIVATE_FILE); black esrally benchmarks scripts tests it
+	@. $(VENV_ACTIVATE_FILE); isort esrally benchmarks scripts tests it
 
 docs: check-venv
 	@. $(VENV_ACTIVATE_FILE); cd docs && $(MAKE) html

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/benchmarks/driver/__init__.py
+++ b/benchmarks/driver/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/benchmarks/driver/parsing_test.py
+++ b/benchmarks/driver/parsing_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -25,48 +25,54 @@ import ujson
 
 from esrally.driver import runner
 
+
 @pytest.mark.benchmark(
     group="parse",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_sort_reverse_and_regexp_small(benchmark):
     benchmark(sort_parsing_candidate_reverse_and_regexp, ParsingBenchmarks.small_page)
+
 
 @pytest.mark.benchmark(
     group="parse_large",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_sort_reverse_and_regexp_large(benchmark):
     benchmark(sort_parsing_candidate_reverse_and_regexp, ParsingBenchmarks.large_page)
+
 
 def sort_parsing_candidate_reverse_and_regexp(response):
     reversed_response = response[::-1]
     sort_pattern = r"(\][^\]]*?\[):\"tros\""
     x = re.search(sort_pattern, reversed_response)
     # return json.loads(x.group(1)[::-1]) # mean 3.6 ms
-    return ujson.loads(x.group(1)[::-1]) # mean 1.7 ms
+    return ujson.loads(x.group(1)[::-1])  # mean 1.7 ms
+
 
 @pytest.mark.benchmark(
     group="parse",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_sort_rfind_and_regexp_small(benchmark):
     benchmark(sort_parsing_candidate_rfind_and_regexp, ParsingBenchmarks.small_page)
+
 
 @pytest.mark.benchmark(
     group="parse_large",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_sort_rfind_and_regexp_large(benchmark):
     benchmark(sort_parsing_candidate_rfind_and_regexp, ParsingBenchmarks.large_page)
+
 
 def sort_parsing_candidate_rfind_and_regexp(response):
     index_of_last_sort = response.rfind('"sort"')
@@ -75,23 +81,26 @@ def sort_parsing_candidate_rfind_and_regexp(response):
     # return json.loads(x.group(1)[::-1])
     return ujson.loads(x.group(1))
 
+
 @pytest.mark.benchmark(
     group="parse",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_sort_end_anchor_regexp(benchmark):
     benchmark(sort_parsing_candidate_end_anchor_regexp, ParsingBenchmarks.small_page)
+
 
 @pytest.mark.benchmark(
     group="parse_large",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_sort_end_anchor_regexp_large(benchmark):
     benchmark(sort_parsing_candidate_end_anchor_regexp, ParsingBenchmarks.large_page)
+
 
 def sort_parsing_candidate_end_anchor_regexp(response):
     # predictably, no difference in using a literal lookahead vs just a surrounding pattern.  room for improvement?
@@ -99,71 +108,80 @@ def sort_parsing_candidate_end_anchor_regexp(response):
     x = re.search(sort_pattern, response)
     # return ast.literal_eval(x.group(1)) # mean 8.6 ms
     # return json.loads(x.group(1)) # mean 3.2 ms
-    return ujson.loads(x.group(1)) # mean 1.5 ms
+    return ujson.loads(x.group(1))  # mean 1.5 ms
+
 
 @pytest.mark.benchmark(
     group="parse",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_sort_find_all_regexp_small(benchmark):
     benchmark(sort_parsing_candidate_find_all, ParsingBenchmarks.small_page)
+
 
 @pytest.mark.benchmark(
     group="parse_large",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_sort_find_all_regexp_large(benchmark):
     benchmark(sort_parsing_candidate_find_all, ParsingBenchmarks.large_page)
+
 
 def sort_parsing_candidate_find_all(response):
     sort_pattern = r"\"sort\":([^\]]+])"
     x = re.findall(sort_pattern, response)
     return ujson.loads(x[-1])
 
+
 @pytest.mark.benchmark(
     group="parse",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_pit_id_regexp_small(benchmark):
     benchmark(pit_id_parsing_candidate_regexp, ParsingBenchmarks.small_page)
 
+
 @pytest.mark.benchmark(
     group="parse_large",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_pit_id_regexp_large(benchmark):
     benchmark(pit_id_parsing_candidate_regexp, ParsingBenchmarks.large_page)
 
+
 def pit_id_parsing_candidate_regexp(response):
-    pit_id_pattern = r'"pit_id":"([^"]*)"' # 0.9 ms
+    pit_id_pattern = r'"pit_id":"([^"]*)"'  # 0.9 ms
     x = re.search(pit_id_pattern, response)
     return x.group(1)
+
 
 @pytest.mark.benchmark(
     group="parse",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_combined_json_small(benchmark):
     benchmark(combined_parsing_candidate_json_loads, ParsingBenchmarks.small_page)
+
 
 @pytest.mark.benchmark(
     group="parse_large",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_combined_json_large(benchmark):
     benchmark(combined_parsing_candidate_json_loads, ParsingBenchmarks.large_page)
+
 
 def combined_parsing_candidate_json_loads(response):
     parsed_response = json.loads(response)
@@ -171,23 +189,26 @@ def combined_parsing_candidate_json_loads(response):
     sort = parsed_response.get("hits").get("hits")[-1].get("sort")
     return pit_id, sort
 
+
 @pytest.mark.benchmark(
     group="parse_large",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_combined_ijson_large(benchmark):
     benchmark(combined_parsing_candidate_json_loads, ParsingBenchmarks.large_page)
+
 
 @pytest.mark.benchmark(
     group="parse",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_combined_ijson_small(benchmark):
     benchmark(combined_parsing_candidate_json_loads, ParsingBenchmarks.small_page)
+
 
 def combined_parsing_candidate_ijson_loads(response):
     parsed_response = ujson.loads(response)
@@ -195,25 +216,28 @@ def combined_parsing_candidate_ijson_loads(response):
     sort = parsed_response.get("hits").get("hits")[-1].get("sort")
     return pit_id, sort
 
+
 @pytest.mark.benchmark(
     group="parse",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_pit_id_parse_small(benchmark):
     page = ParsingBenchmarks.small_page.encode()
     benchmark(pit_id_parsing_candidate_runner_parse, page)
 
+
 @pytest.mark.benchmark(
     group="parse_large",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_pit_id_parse_large(benchmark):
     page = ParsingBenchmarks.large_page.encode()
     benchmark(pit_id_parsing_candidate_runner_parse, page)
+
 
 def pit_id_parsing_candidate_runner_parse(response):
     response_bytes = io.BytesIO(response)
@@ -223,7 +247,6 @@ def pit_id_parsing_candidate_runner_parse(response):
 
 
 class ParsingBenchmarks(TestCase):
-
     def test_all_candidates(self):
         """
         Quick utility test to ensure all benchmark cases are correct
@@ -233,16 +256,16 @@ class ParsingBenchmarks(TestCase):
         self.assertEqual("fedcba9876543210", pit_id)
 
         sort = sort_parsing_candidate_reverse_and_regexp(self.small_page)
-        self.assertEqual([1609780186,"2"], sort)
+        self.assertEqual([1609780186, "2"], sort)
 
         sort = sort_parsing_candidate_rfind_and_regexp(self.large_page)
         self.assertEqual([1609780186, "2"], sort)
 
         sort = sort_parsing_candidate_end_anchor_regexp(self.small_page)
-        self.assertEqual([1609780186,"2"], sort)
+        self.assertEqual([1609780186, "2"], sort)
 
         sort = sort_parsing_candidate_find_all(self.large_page)
-        self.assertEqual([1609780186,"2"], sort)
+        self.assertEqual([1609780186, "2"], sort)
 
         pit_id = pit_id_parsing_candidate_regexp(self.large_page)
         self.assertEqual("fedcba9876543210", pit_id)
@@ -272,21 +295,30 @@ class ParsingBenchmarks(TestCase):
                 ]
             }
         }
-    """.replace("\n", "").replace(" ", "") # assume client never calls ?pretty :)
+    """.replace(
+        "\n", ""
+    ).replace(
+        " ", ""
+    )  # assume client never calls ?pretty :)
 
-    large_page = ("""
+    large_page = (
+        (
+            """
         {
             "pit_id": "fedcba9876543210",
             "took": 10,
             "timed_out": false,
             "hits": {
                 "total": 2,
-                "hits": [""" + """
+                "hits": ["""
+            + """
                     {
                         "_id": "1",
                          "timestamp": 1609780186,
                          "sort": [1609780186, "1"]
-                    },""" * 100 + """
+                    },"""
+            * 100
+            + """
                     {
                         "_id": "2",
                          "timestamp": 1609780186,
@@ -295,4 +327,8 @@ class ParsingBenchmarks(TestCase):
                 ]
             }
         }
-    """).replace("\n", "").replace(" ", "")
+    """
+        )
+        .replace("\n", "")
+        .replace(" ", "")
+    )

--- a/benchmarks/driver/runner_test.py
+++ b/benchmarks/driver/runner_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -26,29 +26,23 @@ BULK_SIZE = 5000
 
 class ElasticsearchMock:
     def __init__(self, bulk_size):
-        self.no_errors = {
-            "took": 500,
-            "errors": False,
-            "items": []
-        }
+        self.no_errors = {"took": 500, "errors": False, "items": []}
         for idx in range(0, bulk_size):
-            self.no_errors["items"].append({
-                "index": {
-                    "_index": "test",
-                    "_type": "type1",
-                    "_id": str(idx),
-                    "_version": 1,
-                    "result": "created",
-                    "_shards": {
-                        "total": 2,
-                        "successful": 1,
-                        "failed": 0
-                    },
-                    "created": True,
-                    "status": 201,
-                    "_seq_no": 0
+            self.no_errors["items"].append(
+                {
+                    "index": {
+                        "_index": "test",
+                        "_type": "type1",
+                        "_id": str(idx),
+                        "_version": 1,
+                        "result": "created",
+                        "_shards": {"total": 2, "successful": 1, "failed": 0},
+                        "created": True,
+                        "status": 201,
+                        "_seq_no": 0,
+                    }
                 }
-            })
+            )
 
     def bulk(self, body=None, index=None, doc_type=None, params=None):
         return self.no_errors
@@ -61,26 +55,17 @@ es = ElasticsearchMock(bulk_size=BULK_SIZE)
     group="bulk-runner",
     warmup="on",
     warmup_iterations=10000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_bulk_runner_without_errors_no_detailed_results(benchmark):
-    benchmark(bulk_index, es, {
-        "action-metadata-present": True,
-        "body": "bulk API body",
-        "bulk-size": BULK_SIZE
-    })
+    benchmark(bulk_index, es, {"action-metadata-present": True, "body": "bulk API body", "bulk-size": BULK_SIZE})
 
 
 @pytest.mark.benchmark(
     group="bulk-runner",
     warmup="on",
     warmup_iterations=1000,
-    disable_gc=True
+    disable_gc=True,
 )
 def test_bulk_runner_without_errors_with_detailed_results(benchmark):
-    benchmark(bulk_index, es, {
-        "action-metadata-present": True,
-        "body": "bulk API body",
-        "bulk-size": BULK_SIZE,
-        "detailed-results": True
-    })
+    benchmark(bulk_index, es, {"action-metadata-present": True, "body": "bulk API body", "bulk-size": BULK_SIZE, "detailed-results": True})

--- a/benchmarks/track/__init__.py
+++ b/benchmarks/track/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/benchmarks/track/bulk_params_test.py
+++ b/benchmarks/track/bulk_params_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -68,13 +68,15 @@ def create_reader(bulk_size):
     metadata = params.GenerateActionMetaData(index_name="test-idx", type_name=None)
 
     source = params.Slice(StaticSource, 0, sys.maxsize)
-    reader = params.MetadataIndexDataReader(data_file="bogus",
-                                            batch_size=bulk_size,
-                                            bulk_size=bulk_size,
-                                            file_source=source,
-                                            action_metadata=metadata,
-                                            index_name="test-idx",
-                                            type_name=None)
+    reader = params.MetadataIndexDataReader(
+        data_file="bogus",
+        batch_size=bulk_size,
+        bulk_size=bulk_size,
+        file_source=source,
+        action_metadata=metadata,
+        index_name="test-idx",
+        type_name=None,
+    )
     return reader
 
 

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -27,6 +27,13 @@ Installation Instructions for Development
     source .venv/bin/activate
     ./rally
 
+IDE Setup
+---------
+
+Rally uses automatic code formatters. They're enforced by ``make lint`` and you can apply then by running ``make format``.
+
+However, consider using editor integrations to do it automatically: you'll need to configure `black <https://black.readthedocs.io/en/stable/integrations/editors.html>`_ and `isort <https://github.com/PyCQA/isort/wiki/isort-Plugins>`_.
+
 Known Issues
 ~~~~~~~~~~~~
 

--- a/esrally/__init__.py
+++ b/esrally/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/esrally/__init__.py
+++ b/esrally/__init__.py
@@ -44,7 +44,6 @@ BANNER = r"""
 """
 
 
-# pylint: disable=C4002
 SKULL = '''
                  uuuuuuu
              uu$$$$$$$$$$$uu

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -29,6 +29,7 @@ class BenchmarkFailure:
     """
     Indicates a failure in the benchmark execution due to an exception
     """
+
     def __init__(self, message, cause=None):
         self.message = message
         self.cause = cause
@@ -47,10 +48,13 @@ def parametrized(decorator):
 
     :param decorator: The decorator that should accept parameters.
     """
+
     def inner(*args, **kwargs):
         def g(f):
             return decorator(f, *args, **kwargs)
+
         return g
+
     return inner
 
 
@@ -80,6 +84,7 @@ def no_retry(f, actor_name):
     :param f: The message handler. Does not need to passed directly, this is handled by the decorator infrastructure.
     :param actor_name: A human readable name of the current actor that should be used in the exception message.
     """
+
     def guard(self, msg, sender):
         try:
             return f(self, msg, sender)
@@ -90,6 +95,7 @@ def no_retry(f, actor_name):
             # don't forward the exception as is because the main process might not have this class available on the load path
             # and will fail then while deserializing the cause.
             self.send(sender, BenchmarkFailure("{} ({})".format(msg, str(e))))
+
     return guard
 
 
@@ -133,22 +139,30 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
             response_count = len(self.received_responses)
             expected_count = len(self.children)
 
-            self.logger.debug("[%d] of [%d] child actors have responded for transition from [%s] to [%s].",
-                              response_count, expected_count, self.status, new_status)
+            self.logger.debug(
+                "[%d] of [%d] child actors have responded for transition from [%s] to [%s].",
+                response_count,
+                expected_count,
+                self.status,
+                new_status,
+            )
             if response_count == expected_count:
-                self.logger.debug("All [%d] child actors have responded. Transitioning now from [%s] to [%s].",
-                                  expected_count, self.status, new_status)
+                self.logger.debug(
+                    "All [%d] child actors have responded. Transitioning now from [%s] to [%s].", expected_count, self.status, new_status
+                )
                 # all nodes have responded, change status
                 self.status = new_status
                 self.received_responses = []
                 transition()
             elif response_count > expected_count:
                 raise exceptions.RallyAssertionError(
-                    "Received [%d] responses but only [%d] were expected to transition from [%s] to [%s]. The responses are: %s" %
-                    (response_count, expected_count, self.status, new_status, self.received_responses))
+                    "Received [%d] responses but only [%d] were expected to transition from [%s] to [%s]. The responses are: %s"
+                    % (response_count, expected_count, self.status, new_status, self.received_responses)
+                )
         else:
-            raise exceptions.RallyAssertionError("Received [%s] from [%s] but we are in status [%s] instead of [%s]." %
-                                                 (type(msg), sender, self.status, expected_status))
+            raise exceptions.RallyAssertionError(
+                "Received [%s] from [%s] but we are in status [%s] instead of [%s]." % (type(msg), sender, self.status, expected_status)
+            )
 
     def send_to_children_and_transition(self, sender, msg, expected_status, new_status):
         """
@@ -166,8 +180,9 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
             for m in filter(None, self.children):
                 self.send(m, msg)
         else:
-            raise exceptions.RallyAssertionError("Received [%s] from [%s] but we are in status [%s] instead of [%s]." %
-                                                 (type(msg), sender, self.status, expected_status))
+            raise exceptions.RallyAssertionError(
+                "Received [%s] from [%s] but we are in status [%s] instead of [%s]." % (type(msg), sender, self.status, expected_status)
+            )
 
     def is_current_status_expected(self, expected_status):
         # if we don't expect anything, we're always in the right status
@@ -244,9 +259,7 @@ def bootstrap_actor_system(try_join=False, prefer_local_only=False, local_ip=Non
             # Make the coordinator node the convention leader
             capabilities["Convention Address.IPv4"] = "%s:1900" % coordinator_ip
         logger.info("Starting actor system with system base [%s] and capabilities [%s].", system_base, capabilities)
-        return thespian.actors.ActorSystem(system_base,
-                                           logDefs=log.load_configuration(),
-                                           capabilities=capabilities)
+        return thespian.actors.ActorSystem(system_base, logDefs=log.load_configuration(), capabilities=capabilities)
     except thespian.actors.ActorSystemException:
         logger.exception("Could not initialize internal actor system.")
         raise

--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -20,8 +20,8 @@ import json
 import logging
 import uuid
 
-from esrally import track, config, exceptions
-from esrally.utils import io, console
+from esrally import config, exceptions, track
+from esrally.utils import console, io
 
 color_scheme_rgba = [
     # #00BFB3
@@ -55,12 +55,8 @@ def index_label(race_config):
 
 class BarCharts:
     UI_STATE_JSON = json.dumps(
-        {
-            "vis": {
-                "colors": dict(
-                    zip(["bare-oss", "bare-basic", "bare-trial-security", "docker-basic", "ear-basic"], color_scheme_rgba))
-            }
-        })
+        {"vis": {"colors": dict(zip(["bare-oss", "bare-basic", "bare-trial-security", "docker-basic", "ear-basic"], color_scheme_rgba))}}
+    )
 
     @staticmethod
     # flavor's unused but we need the same signature used by the corresponding method in TimeSeriesCharts
@@ -75,10 +71,12 @@ class BarCharts:
     @staticmethod
     def filter_string(environment, race_config):
         if race_config.name:
-            return f"environment:\"{environment}\" AND active:true AND user-tags.name:\"{race_config.name}\""
+            return f'environment:"{environment}" AND active:true AND user-tags.name:"{race_config.name}"'
         else:
-            return f"environment:\"{environment}\" AND active:true AND track:\"{race_config.track}\""\
-                   f" AND challenge:\"{race_config.challenge}\" AND car:\"{race_config.car}\" AND node-count:{race_config.node_count}"
+            return (
+                f'environment:"{environment}" AND active:true AND track:"{race_config.track}"'
+                f' AND challenge:"{race_config.challenge}" AND car:"{race_config.car}" AND node-count:{race_config.node_count}'
+            )
 
     @staticmethod
     def gc(title, environment, race_config):
@@ -92,46 +90,31 @@ class BarCharts:
                 "categoryAxes": [
                     {
                         "id": "CategoryAxis-1",
-                        "labels": {
-                            "show": True,
-                            "truncate": 100
-                        },
+                        "labels": {"show": True, "truncate": 100},
                         "position": "bottom",
-                        "scale": {
-                            "type": "linear"
-                        },
+                        "scale": {"type": "linear"},
                         "show": True,
                         "style": {},
-                        "title": {
-                            "text": "filters"
-                        },
-                        "type": "category"
+                        "title": {"text": "filters"},
+                        "type": "category",
                     }
                 ],
                 "defaultYExtents": False,
                 "drawLinesBetweenPoints": True,
-                "grid": {
-                    "categoryLines": False,
-                    "style": {
-                        "color": "#eee"
-                    }
-                },
+                "grid": {"categoryLines": False, "style": {"color": "#eee"}},
                 "interpolate": "linear",
                 "legendPosition": "right",
                 "radiusRatio": 9,
                 "scale": "linear",
                 "seriesParams": [
                     {
-                        "data": {
-                            "id": "1",
-                            "label": "Total GC Duration [ms]"
-                        },
+                        "data": {"id": "1", "label": "Total GC Duration [ms]"},
                         "drawLinesBetweenPoints": True,
                         "mode": "normal",
                         "show": "True",
                         "showCircles": True,
                         "type": "histogram",
-                        "valueAxis": "ValueAxis-1"
+                        "valueAxis": "ValueAxis-1",
                     }
                 ],
                 "setYExtents": False,
@@ -140,26 +123,16 @@ class BarCharts:
                 "valueAxes": [
                     {
                         "id": "ValueAxis-1",
-                        "labels": {
-                            "filter": False,
-                            "rotate": 0,
-                            "show": True,
-                            "truncate": 100
-                        },
+                        "labels": {"filter": False, "rotate": 0, "show": True, "truncate": 100},
                         "name": "LeftAxis-1",
                         "position": "left",
-                        "scale": {
-                            "mode": "normal",
-                            "type": "linear"
-                        },
+                        "scale": {"mode": "normal", "type": "linear"},
                         "show": True,
                         "style": {},
-                        "title": {
-                            "text": "Total GC Duration [ms]"
-                        },
-                        "type": "value"
+                        "title": {"text": "Total GC Duration [ms]"},
+                        "type": "value",
                     }
-                ]
+                ],
             },
             "aggs": [
                 {
@@ -167,13 +140,7 @@ class BarCharts:
                     "enabled": True,
                     "type": "median",
                     "schema": "metric",
-                    "params": {
-                        "field": "value.single",
-                        "percents": [
-                            50
-                        ],
-                        "customLabel": "Total GC Duration [ms]"
-                    }
+                    "params": {"field": "value.single", "percents": [50], "customLabel": "Total GC Duration [ms]"},
                 },
                 {
                     "id": "2",
@@ -183,68 +150,38 @@ class BarCharts:
                     "params": {
                         "filters": [
                             {
-                                "input": {
-                                    "query": {
-                                        "query_string": {
-                                            "query": "name:young_gc_time",
-                                            "analyze_wildcard": True
-                                        }
-                                    }
-                                },
-                                "label": "Young GC"
+                                "input": {"query": {"query_string": {"query": "name:young_gc_time", "analyze_wildcard": True}}},
+                                "label": "Young GC",
                             },
                             {
-                                "input": {
-                                    "query": {
-                                        "query_string": {
-                                            "query": "name:old_gc_time",
-                                            "analyze_wildcard": True
-                                        }
-                                    }
-                                },
-                                "label": "Old GC"
-                            }
+                                "input": {"query": {"query_string": {"query": "name:old_gc_time", "analyze_wildcard": True}}},
+                                "label": "Old GC",
+                            },
                         ]
-                    }
+                    },
                 },
                 {
                     "id": "3",
                     "enabled": True,
                     "type": "terms",
                     "schema": "split",
-                    "params": {
-                        "field": "distribution-version",
-                        "size": 10,
-                        "order": "asc",
-                        "orderBy": "_term",
-                        "row": False
-                    }
+                    "params": {"field": "distribution-version", "size": 10, "order": "asc", "orderBy": "_term", "row": False},
                 },
                 {
                     "id": "4",
                     "enabled": True,
                     "type": "terms",
                     "schema": "group",
-                    "params": {
-                        "field": "user-tags.setup",
-                        "size": 5,
-                        "order": "desc",
-                        "orderBy": "_term"
-                    }
-                }
+                    "params": {"field": "user-tags.setup", "size": 5, "order": "desc", "orderBy": "_term"},
+                },
             ],
-            "listeners": {}
+            "listeners": {},
         }
 
         search_source = {
             "index": "rally-results-*",
-            "query": {
-                "query_string": {
-                    "query": BarCharts.filter_string(environment, race_config),
-                    "analyze_wildcard": True
-                }
-            },
-            "filter": []
+            "query": {"query_string": {"query": BarCharts.filter_string(environment, race_config), "analyze_wildcard": True}},
+            "filter": [],
         }
 
         return {
@@ -256,10 +193,8 @@ class BarCharts:
                 "uiStateJSON": BarCharts.UI_STATE_JSON,
                 "description": "gc",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": json.dumps(search_source)
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": json.dumps(search_source)},
+            },
         }
 
     @staticmethod
@@ -274,46 +209,31 @@ class BarCharts:
                 "categoryAxes": [
                     {
                         "id": "CategoryAxis-1",
-                        "labels": {
-                            "show": True,
-                            "truncate": 100
-                        },
+                        "labels": {"show": True, "truncate": 100},
                         "position": "bottom",
-                        "scale": {
-                            "type": "linear"
-                        },
+                        "scale": {"type": "linear"},
                         "show": True,
                         "style": {},
-                        "title": {
-                            "text": "filters"
-                        },
-                        "type": "category"
+                        "title": {"text": "filters"},
+                        "type": "category",
                     }
                 ],
                 "defaultYExtents": False,
                 "drawLinesBetweenPoints": True,
-                "grid": {
-                    "categoryLines": False,
-                    "style": {
-                        "color": "#eee"
-                    }
-                },
+                "grid": {"categoryLines": False, "style": {"color": "#eee"}},
                 "interpolate": "linear",
                 "legendPosition": "right",
                 "radiusRatio": 9,
                 "scale": "linear",
                 "seriesParams": [
                     {
-                        "data": {
-                            "id": "1",
-                            "label": "[Bytes]"
-                        },
+                        "data": {"id": "1", "label": "[Bytes]"},
                         "drawLinesBetweenPoints": True,
                         "mode": "normal",
                         "show": "True",
                         "showCircles": True,
                         "type": "histogram",
-                        "valueAxis": "ValueAxis-1"
+                        "valueAxis": "ValueAxis-1",
                     }
                 ],
                 "setYExtents": False,
@@ -322,26 +242,16 @@ class BarCharts:
                 "valueAxes": [
                     {
                         "id": "ValueAxis-1",
-                        "labels": {
-                            "filter": False,
-                            "rotate": 0,
-                            "show": True,
-                            "truncate": 100
-                        },
+                        "labels": {"filter": False, "rotate": 0, "show": True, "truncate": 100},
                         "name": "LeftAxis-1",
                         "position": "left",
-                        "scale": {
-                            "mode": "normal",
-                            "type": "linear"
-                        },
+                        "scale": {"mode": "normal", "type": "linear"},
                         "show": True,
                         "style": {},
-                        "title": {
-                            "text": "[Bytes]"
-                        },
-                        "type": "value"
+                        "title": {"text": "[Bytes]"},
+                        "type": "value",
                     }
-                ]
+                ],
             },
             "aggs": [
                 {
@@ -349,10 +259,7 @@ class BarCharts:
                     "enabled": True,
                     "type": "sum",
                     "schema": "metric",
-                    "params": {
-                        "field": "value.single",
-                        "customLabel": "[Bytes]"
-                    }
+                    "params": {"field": "value.single", "customLabel": "[Bytes]"},
                 },
                 {
                     "id": "2",
@@ -362,68 +269,38 @@ class BarCharts:
                     "params": {
                         "filters": [
                             {
-                                "input": {
-                                    "query": {
-                                        "query_string": {
-                                            "analyze_wildcard": True,
-                                            "query": "name:index_size"
-                                        }
-                                    }
-                                },
-                                "label": "Index size"
+                                "input": {"query": {"query_string": {"analyze_wildcard": True, "query": "name:index_size"}}},
+                                "label": "Index size",
                             },
                             {
-                                "input": {
-                                    "query": {
-                                        "query_string": {
-                                            "analyze_wildcard": True,
-                                            "query": "name:bytes_written"
-                                        }
-                                    }
-                                },
-                                "label": "Bytes written"
-                            }
+                                "input": {"query": {"query_string": {"analyze_wildcard": True, "query": "name:bytes_written"}}},
+                                "label": "Bytes written",
+                            },
                         ]
-                    }
+                    },
                 },
                 {
                     "id": "3",
                     "enabled": True,
                     "type": "terms",
                     "schema": "split",
-                    "params": {
-                        "field": "distribution-version",
-                        "size": 10,
-                        "order": "asc",
-                        "orderBy": "_term",
-                        "row": False
-                    }
+                    "params": {"field": "distribution-version", "size": 10, "order": "asc", "orderBy": "_term", "row": False},
                 },
                 {
                     "id": "4",
                     "enabled": True,
                     "type": "terms",
                     "schema": "group",
-                    "params": {
-                        "field": "user-tags.setup",
-                        "size": 5,
-                        "order": "desc",
-                        "orderBy": "_term"
-                    }
-                }
+                    "params": {"field": "user-tags.setup", "size": 5, "order": "desc", "orderBy": "_term"},
+                },
             ],
-            "listeners": {}
+            "listeners": {},
         }
 
         search_source = {
             "index": "rally-results-*",
-            "query": {
-                "query_string": {
-                    "query": BarCharts.filter_string(environment, race_config),
-                    "analyze_wildcard": True
-                }
-            },
-            "filter": []
+            "query": {"query_string": {"query": BarCharts.filter_string(environment, race_config), "analyze_wildcard": True}},
+            "filter": [],
         }
 
         return {
@@ -435,10 +312,8 @@ class BarCharts:
                 "uiStateJSON": BarCharts.UI_STATE_JSON,
                 "description": "io",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": json.dumps(search_source)
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": json.dumps(search_source)},
+            },
         }
 
     @staticmethod
@@ -458,10 +333,10 @@ class BarCharts:
         metric = "service_time"
         if iterations < 100:
             prefix = "p90"
-            field= "value.90_0"
+            field = "value.90_0"
         else:
             prefix = "p99"
-            field= "value.99_0"
+            field = "value.99_0"
 
         title = BarCharts.format_title(environment, race_config.track, suffix=f"{race_config.label}-{q}-{prefix}-{metric}")
         label = "Query Service Time [ms]"
@@ -476,46 +351,31 @@ class BarCharts:
                 "categoryAxes": [
                     {
                         "id": "CategoryAxis-1",
-                        "labels": {
-                            "show": True,
-                            "truncate": 100
-                        },
+                        "labels": {"show": True, "truncate": 100},
                         "position": "bottom",
-                        "scale": {
-                            "type": "linear"
-                        },
+                        "scale": {"type": "linear"},
                         "show": True,
                         "style": {},
-                        "title": {
-                            "text": "distribution-version: Ascending"
-                        },
-                        "type": "category"
+                        "title": {"text": "distribution-version: Ascending"},
+                        "type": "category",
                     }
                 ],
                 "defaultYExtents": False,
                 "drawLinesBetweenPoints": True,
-                "grid": {
-                    "categoryLines": False,
-                    "style": {
-                        "color": "#eee"
-                    }
-                },
+                "grid": {"categoryLines": False, "style": {"color": "#eee"}},
                 "interpolate": "linear",
                 "legendPosition": "right",
                 "radiusRatio": 9,
                 "scale": "linear",
                 "seriesParams": [
                     {
-                        "data": {
-                            "id": "1",
-                            "label": label
-                        },
+                        "data": {"id": "1", "label": label},
                         "drawLinesBetweenPoints": True,
                         "mode": "normal",
                         "show": "True",
                         "showCircles": True,
                         "type": "histogram",
-                        "valueAxis": "ValueAxis-1"
+                        "valueAxis": "ValueAxis-1",
                     }
                 ],
                 "setYExtents": False,
@@ -524,26 +384,16 @@ class BarCharts:
                 "valueAxes": [
                     {
                         "id": "ValueAxis-1",
-                        "labels": {
-                            "filter": False,
-                            "rotate": 0,
-                            "show": True,
-                            "truncate": 100
-                        },
+                        "labels": {"filter": False, "rotate": 0, "show": True, "truncate": 100},
                         "name": "LeftAxis-1",
                         "position": "left",
-                        "scale": {
-                            "mode": "normal",
-                            "type": "linear"
-                        },
+                        "scale": {"mode": "normal", "type": "linear"},
                         "show": True,
                         "style": {},
-                        "title": {
-                            "text": label
-                        },
-                        "type": "value"
+                        "title": {"text": label},
+                        "type": "value",
                     }
-                ]
+                ],
             },
             "aggs": [
                 {
@@ -551,51 +401,35 @@ class BarCharts:
                     "enabled": True,
                     "type": "median",
                     "schema": "metric",
-                    "params": {
-                        "field": field,
-                        "percents": [
-                            50
-                        ],
-                        "customLabel": label
-                    }
+                    "params": {"field": field, "percents": [50], "customLabel": label},
                 },
                 {
                     "id": "2",
                     "enabled": True,
                     "type": "terms",
                     "schema": "segment",
-                    "params": {
-                        "field": "distribution-version",
-                        "size": 10,
-                        "order": "asc",
-                        "orderBy": "_term"
-                    }
+                    "params": {"field": "distribution-version", "size": 10, "order": "asc", "orderBy": "_term"},
                 },
                 {
                     "id": "3",
                     "enabled": True,
                     "type": "terms",
                     "schema": "group",
-                    "params": {
-                        "field": "user-tags.setup",
-                        "size": 10,
-                        "order": "desc",
-                        "orderBy": "_term"
-                    }
-                }
+                    "params": {"field": "user-tags.setup", "size": 10, "order": "desc", "orderBy": "_term"},
+                },
             ],
-            "listeners": {}
+            "listeners": {},
         }
 
         search_source = {
             "index": "rally-results-*",
             "query": {
                 "query_string": {
-                    "query": "name:\"%s\" AND task:\"%s\" AND %s" % (metric, q, BarCharts.filter_string(environment, race_config)),
-                    "analyze_wildcard": True
+                    "query": 'name:"%s" AND task:"%s" AND %s' % (metric, q, BarCharts.filter_string(environment, race_config)),
+                    "analyze_wildcard": True,
                 }
             },
-            "filter": []
+            "filter": [],
         }
 
         return {
@@ -607,10 +441,8 @@ class BarCharts:
                 "uiStateJSON": BarCharts.UI_STATE_JSON,
                 "description": "query",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": json.dumps(search_source)
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": json.dumps(search_source)},
+            },
         }
 
     @staticmethod
@@ -620,66 +452,44 @@ class BarCharts:
             label = index_label(race_config)
             # the assumption is that we only have one bulk task
             for bulk_task in race_config.bulk_tasks:
-                filters.append({
-                    "input": {
-                        "query": {
-                            "query_string": {
-                                "analyze_wildcard": True,
-                                "query": "task:\"%s\" AND %s" % (bulk_task, BarCharts.filter_string(environment, race_config))
+                filters.append(
+                    {
+                        "input": {
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": True,
+                                    "query": 'task:"%s" AND %s' % (bulk_task, BarCharts.filter_string(environment, race_config)),
+                                }
                             }
-                        }
-                    },
-                    "label": label
-                })
+                        },
+                        "label": label,
+                    }
+                )
 
         vis_state = {
             "aggs": [
                 {
                     "enabled": True,
                     "id": "1",
-                    "params": {
-                        "customLabel": "Median Indexing Throughput [docs/s]",
-                        "field": "value.median",
-                        "percents": [
-                            50
-                        ]
-                    },
+                    "params": {"customLabel": "Median Indexing Throughput [docs/s]", "field": "value.median", "percents": [50]},
                     "schema": "metric",
-                    "type": "median"
+                    "type": "median",
                 },
                 {
                     "enabled": True,
                     "id": "2",
-                    "params": {
-                        "field": "distribution-version",
-                        "order": "asc",
-                        "orderBy": "_term",
-                        "size": 10
-                    },
+                    "params": {"field": "distribution-version", "order": "asc", "orderBy": "_term", "size": 10},
                     "schema": "segment",
-                    "type": "terms"
+                    "type": "terms",
                 },
                 {
                     "enabled": True,
                     "id": "3",
-                    "params": {
-                        "field": "user-tags.setup",
-                        "order": "desc",
-                        "orderBy": "_term",
-                        "size": 10
-                    },
+                    "params": {"field": "user-tags.setup", "order": "desc", "orderBy": "_term", "size": 10},
                     "schema": "group",
-                    "type": "terms"
+                    "type": "terms",
                 },
-                {
-                    "enabled": True,
-                    "id": "4",
-                    "params": {
-                        "filters": filters
-                    },
-                    "schema": "split",
-                    "type": "filters"
-                }
+                {"enabled": True, "id": "4", "params": {"filters": filters}, "schema": "split", "type": "filters"},
             ],
             "listeners": {},
             "params": {
@@ -689,46 +499,31 @@ class BarCharts:
                 "categoryAxes": [
                     {
                         "id": "CategoryAxis-1",
-                        "labels": {
-                            "show": True,
-                            "truncate": 100
-                        },
+                        "labels": {"show": True, "truncate": 100},
                         "position": "bottom",
-                        "scale": {
-                            "type": "linear"
-                        },
+                        "scale": {"type": "linear"},
                         "show": True,
                         "style": {},
-                        "title": {
-                            "text": "distribution-version: Ascending"
-                        },
-                        "type": "category"
+                        "title": {"text": "distribution-version: Ascending"},
+                        "type": "category",
                     }
                 ],
                 "defaultYExtents": False,
                 "drawLinesBetweenPoints": True,
-                "grid": {
-                    "categoryLines": False,
-                    "style": {
-                        "color": "#eee"
-                    }
-                },
+                "grid": {"categoryLines": False, "style": {"color": "#eee"}},
                 "interpolate": "linear",
                 "legendPosition": "right",
                 "radiusRatio": 9,
                 "scale": "linear",
                 "seriesParams": [
                     {
-                        "data": {
-                            "id": "1",
-                            "label": "Median Indexing Throughput [docs/s]"
-                        },
+                        "data": {"id": "1", "label": "Median Indexing Throughput [docs/s]"},
                         "drawLinesBetweenPoints": True,
                         "mode": "normal",
                         "show": "True",
                         "showCircles": True,
                         "type": "histogram",
-                        "valueAxis": "ValueAxis-1"
+                        "valueAxis": "ValueAxis-1",
                     }
                 ],
                 "setYExtents": False,
@@ -737,41 +532,28 @@ class BarCharts:
                 "valueAxes": [
                     {
                         "id": "ValueAxis-1",
-                        "labels": {
-                            "filter": False,
-                            "rotate": 0,
-                            "show": True,
-                            "truncate": 100
-                        },
+                        "labels": {"filter": False, "rotate": 0, "show": True, "truncate": 100},
                         "name": "LeftAxis-1",
                         "position": "left",
-                        "scale": {
-                            "mode": "normal",
-                            "type": "linear"
-                        },
+                        "scale": {"mode": "normal", "type": "linear"},
                         "show": True,
                         "style": {},
-                        "title": {
-                            "text": "Median Indexing Throughput [docs/s]"
-                        },
-                        "type": "value"
+                        "title": {"text": "Median Indexing Throughput [docs/s]"},
+                        "type": "value",
                     }
                 ],
-                "row": True
+                "row": True,
             },
             "title": title,
-            "type": "histogram"
+            "type": "histogram",
         }
 
         search_source = {
             "index": "rally-results-*",
             "query": {
-                "query_string": {
-                    "analyze_wildcard": True,
-                    "query": "environment:\"%s\" AND active:true AND name:\"throughput\"" % environment
-                }
+                "query_string": {"analyze_wildcard": True, "query": 'environment:"%s" AND active:true AND name:"throughput"' % environment}
             },
-            "filter": []
+            "filter": [],
         }
 
         return {
@@ -783,10 +565,8 @@ class BarCharts:
                 "uiStateJSON": BarCharts.UI_STATE_JSON,
                 "description": "index",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": json.dumps(search_source)
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": json.dumps(search_source)},
+            },
         }
 
 
@@ -798,8 +578,7 @@ class TimeSeriesCharts:
         elif es_license:
             title = [environment, es_license, str(track_name)]
         elif flavor and es_license:
-            raise exceptions.RallyAssertionError(
-                f"Specify either flavor [{flavor}] or license [{es_license}] but not both")
+            raise exceptions.RallyAssertionError(f"Specify either flavor [{flavor}] or license [{es_license}] but not both")
         else:
             title = [environment, str(track_name)]
         if suffix:
@@ -812,12 +591,14 @@ class TimeSeriesCharts:
         nightly_extra_filter = ""
         if race_config.es_license:
             # Time series charts need to support different licenses and produce customized titles.
-            nightly_extra_filter = f" AND user-tags.license:\"{race_config.es_license}\""
+            nightly_extra_filter = f' AND user-tags.license:"{race_config.es_license}"'
         if race_config.name:
-            return f"environment:\"{environment}\" AND active:true AND user-tags.name:\"{race_config.name}\"{nightly_extra_filter}"
+            return f'environment:"{environment}" AND active:true AND user-tags.name:"{race_config.name}"{nightly_extra_filter}'
         else:
-            return f"environment:\"{environment}\" AND active:true AND track:\"{race_config.track}\""\
-                   f" AND challenge:\"{race_config.challenge}\" AND car:\"{race_config.car}\" AND node-count:{race_config.node_count}"
+            return (
+                f'environment:"{environment}" AND active:true AND track:"{race_config.track}"'
+                f' AND challenge:"{race_config.challenge}" AND car:"{race_config.car}" AND node-count:{race_config.node_count}'
+            )
 
     @staticmethod
     def gc(title, environment, race_config):
@@ -839,13 +620,7 @@ class TimeSeriesCharts:
                         "formatter": "number",
                         "id": str(uuid.uuid4()),
                         "line_width": "1",
-                        "metrics": [
-                            {
-                                "id": str(uuid.uuid4()),
-                                "type": "avg",
-                                "field": "value.single"
-                            }
-                        ],
+                        "metrics": [{"id": str(uuid.uuid4()), "type": "avg", "field": "value.single"}],
                         "point_size": "3",
                         "seperate_axis": 1,
                         "split_mode": "filters",
@@ -856,18 +631,18 @@ class TimeSeriesCharts:
                                 "filter": "young_gc_time",
                                 "label": "Young Gen GC time",
                                 "color": "rgba(0,191,179,1)",
-                                "id": str(uuid.uuid4())
+                                "id": str(uuid.uuid4()),
                             },
                             {
                                 "filter": "old_gc_time",
                                 "label": "Old Gen GC time",
                                 "color": "rgba(254,209,10,1)",
-                                "id": str(uuid.uuid4())
-                            }
+                                "id": str(uuid.uuid4()),
+                            },
                         ],
                         "label": "GC Times",
                         "value_template": "{{value}} ms",
-                        "steps": 0
+                        "steps": 0,
                     }
                 ],
                 "show_legend": 1,
@@ -881,19 +656,19 @@ class TimeSeriesCharts:
                         "fields": "message",
                         "template": "{{message}}",
                         "index_pattern": "rally-annotations",
-                        "query_string": f"((NOT _exists_:track) OR track:\"{race_config.track}\") AND ((NOT _exists_:chart) OR chart:gc) "
-                                        f"AND ((NOT _exists_:chart-name) OR chart-name:\"{title}\") AND environment:\"{environment}\"",
+                        "query_string": f'((NOT _exists_:track) OR track:"{race_config.track}") AND ((NOT _exists_:chart) OR chart:gc) '
+                        f'AND ((NOT _exists_:chart-name) OR chart-name:"{title}") AND environment:"{environment}"',
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
                         "time_field": "race-timestamp",
                         "icon": "fa-tag",
-                        "ignore_panel_filters": 1
+                        "ignore_panel_filters": 1,
                     }
                 ],
-                "axis_min": "0"
+                "axis_min": "0",
             },
             "aggs": [],
-            "listeners": {}
+            "listeners": {},
         }
 
         return {
@@ -905,10 +680,8 @@ class TimeSeriesCharts:
                 "uiStateJSON": "{}",
                 "description": "gc",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": "{\"query\":\"*\",\"filter\":[]}"
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": '{"query":"*","filter":[]}'},
+            },
         }
 
     @staticmethod
@@ -931,13 +704,7 @@ class TimeSeriesCharts:
                         "formatter": "number",
                         "id": str(uuid.uuid4()),
                         "line_width": "1",
-                        "metrics": [
-                            {
-                                "id": str(uuid.uuid4()),
-                                "type": "avg",
-                                "field": "value.single"
-                            }
-                        ],
+                        "metrics": [{"id": str(uuid.uuid4()), "type": "avg", "field": "value.single"}],
                         "point_size": "3",
                         "seperate_axis": 1,
                         "split_mode": "filters",
@@ -948,18 +715,18 @@ class TimeSeriesCharts:
                                 "filter": "merge_time",
                                 "label": "Cumulative merge time",
                                 "color": "rgba(0,191,179,1)",
-                                "id": str(uuid.uuid4())
+                                "id": str(uuid.uuid4()),
                             },
                             {
                                 "filter": "merge_throttle_time",
                                 "label": "Cumulative merge throttle time",
                                 "color": "rgba(254,209,10,1)",
-                                "id": str(uuid.uuid4())
-                            }
+                                "id": str(uuid.uuid4()),
+                            },
                         ],
                         "label": "Merge Times",
                         "value_template": "{{value}} ms",
-                        "steps": 0
+                        "steps": 0,
                     }
                 ],
                 "show_legend": 1,
@@ -973,20 +740,20 @@ class TimeSeriesCharts:
                         "fields": "message",
                         "template": "{{message}}",
                         "index_pattern": "rally-annotations",
-                        "query_string": f"((NOT _exists_:track) OR track:\"{race_config.track}\") "
-                                        f"AND ((NOT _exists_:chart) OR chart:merge_times) "
-                                        f"AND ((NOT _exists_:chart-name) OR chart-name:\"{title}\") AND environment:\"{environment}\"",
+                        "query_string": f'((NOT _exists_:track) OR track:"{race_config.track}") '
+                        f"AND ((NOT _exists_:chart) OR chart:merge_times) "
+                        f'AND ((NOT _exists_:chart-name) OR chart-name:"{title}") AND environment:"{environment}"',
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
                         "time_field": "race-timestamp",
                         "icon": "fa-tag",
-                        "ignore_panel_filters": 1
+                        "ignore_panel_filters": 1,
                     }
                 ],
-                "axis_min": "0"
+                "axis_min": "0",
             },
             "aggs": [],
-            "listeners": {}
+            "listeners": {},
         }
 
         return {
@@ -998,10 +765,8 @@ class TimeSeriesCharts:
                 "uiStateJSON": "{}",
                 "description": "merge_times",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": "{\"query\":\"*\",\"filter\":[]}"
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": '{"query":"*","filter":[]}'},
+            },
         }
 
     @staticmethod
@@ -1024,13 +789,7 @@ class TimeSeriesCharts:
                         "formatter": "number",
                         "id": str(uuid.uuid4()),
                         "line_width": "1",
-                        "metrics": [
-                            {
-                                "id": str(uuid.uuid4()),
-                                "type": "avg",
-                                "field": "value.single"
-                            }
-                        ],
+                        "metrics": [{"id": str(uuid.uuid4()), "type": "avg", "field": "value.single"}],
                         "point_size": "3",
                         "seperate_axis": 1,
                         "split_mode": "filters",
@@ -1041,12 +800,12 @@ class TimeSeriesCharts:
                                 "filter": "merge_count",
                                 "label": "Cumulative merge count",
                                 "color": "rgba(0,191,179,1)",
-                                "id": str(uuid.uuid4())
+                                "id": str(uuid.uuid4()),
                             }
                         ],
                         "label": "Merge Count",
                         "value_template": "{{value}}",
-                        "steps": 0
+                        "steps": 0,
                     }
                 ],
                 "show_legend": 1,
@@ -1060,20 +819,20 @@ class TimeSeriesCharts:
                         "fields": "message",
                         "template": "{{message}}",
                         "index_pattern": "rally-annotations",
-                        "query_string": f"((NOT _exists_:track) OR track:\"{race_config.track}\") "
-                                        f"AND ((NOT _exists_:chart) OR chart:merge_count) "
-                                        f"AND ((NOT _exists_:chart-name) OR chart-name:\"{title}\") AND environment:\"{environment}\"",
+                        "query_string": f'((NOT _exists_:track) OR track:"{race_config.track}") '
+                        f"AND ((NOT _exists_:chart) OR chart:merge_count) "
+                        f'AND ((NOT _exists_:chart-name) OR chart-name:"{title}") AND environment:"{environment}"',
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
                         "time_field": "race-timestamp",
                         "icon": "fa-tag",
-                        "ignore_panel_filters": 1
+                        "ignore_panel_filters": 1,
                     }
                 ],
-                "axis_min": "0"
+                "axis_min": "0",
             },
             "aggs": [],
-            "listeners": {}
+            "listeners": {},
         }
 
         return {
@@ -1085,10 +844,8 @@ class TimeSeriesCharts:
                 "uiStateJSON": "{}",
                 "description": "merge_count",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": "{\"query\":\"*\",\"filter\":[]}"
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": '{"query":"*","filter":[]}'},
+            },
         }
 
     @staticmethod
@@ -1111,13 +868,7 @@ class TimeSeriesCharts:
                         "formatter": "number",
                         "id": str(uuid.uuid4()),
                         "line_width": "1",
-                        "metrics": [
-                            {
-                                "id": str(uuid.uuid4()),
-                                "type": "avg",
-                                "field": "value.max"
-                            }
-                        ],
+                        "metrics": [{"id": str(uuid.uuid4()), "type": "avg", "field": "value.max"}],
                         "point_size": "3",
                         "seperate_axis": 1,
                         "split_mode": "filters",
@@ -1128,12 +879,12 @@ class TimeSeriesCharts:
                                 "filter": "ml_processing_time",
                                 "label": "Maximum ML processing time",
                                 "color": "rgba(0,191,179,1)",
-                                "id": str(uuid.uuid4())
+                                "id": str(uuid.uuid4()),
                             }
                         ],
                         "label": "ML Time",
                         "value_template": "{{value}}",
-                        "steps": 0
+                        "steps": 0,
                     }
                 ],
                 "show_legend": 1,
@@ -1147,20 +898,20 @@ class TimeSeriesCharts:
                         "fields": "message",
                         "template": "{{message}}",
                         "index_pattern": "rally-annotations",
-                        "query_string": f"((NOT _exists_:track) OR track:\"{race_config.track}\") "
-                                        f"AND ((NOT _exists_:chart) OR chart:ml_processing_time) "
-                                        f"AND ((NOT _exists_:chart-name) OR chart-name:\"{title}\") AND environment:\"{environment}\"",
+                        "query_string": f'((NOT _exists_:track) OR track:"{race_config.track}") '
+                        f"AND ((NOT _exists_:chart) OR chart:ml_processing_time) "
+                        f'AND ((NOT _exists_:chart-name) OR chart-name:"{title}") AND environment:"{environment}"',
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
                         "time_field": "race-timestamp",
                         "icon": "fa-tag",
-                        "ignore_panel_filters": 1
+                        "ignore_panel_filters": 1,
                     }
                 ],
-                "axis_min": "0"
+                "axis_min": "0",
             },
             "aggs": [],
-            "listeners": {}
+            "listeners": {},
         }
 
         return {
@@ -1172,10 +923,8 @@ class TimeSeriesCharts:
                 "uiStateJSON": "{}",
                 "description": "ml_processing_time",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": "{\"query\":\"*\",\"filter\":[]}"
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": '{"query":"*","filter":[]}'},
+            },
         }
 
     @staticmethod
@@ -1198,13 +947,7 @@ class TimeSeriesCharts:
                         "formatter": "bytes",
                         "id": str(uuid.uuid4()),
                         "line_width": "1",
-                        "metrics": [
-                            {
-                                "id": str(uuid.uuid4()),
-                                "type": "sum",
-                                "field": "value.single"
-                            }
-                        ],
+                        "metrics": [{"id": str(uuid.uuid4()), "type": "sum", "field": "value.single"}],
                         "point_size": "3",
                         "seperate_axis": 1,
                         "split_mode": "filters",
@@ -1215,18 +958,18 @@ class TimeSeriesCharts:
                                 "filter": "name:index_size",
                                 "label": "Index Size",
                                 "color": "rgba(0,191,179,1)",
-                                "id": str(uuid.uuid4())
+                                "id": str(uuid.uuid4()),
                             },
                             {
                                 "filter": "name:bytes_written",
                                 "label": "Written",
                                 "color": "rgba(254,209,10,1)",
-                                "id": str(uuid.uuid4())
-                            }
+                                "id": str(uuid.uuid4()),
+                            },
                         ],
                         "label": "Disk IO",
                         "value_template": "{{value}}",
-                        "steps": 0
+                        "steps": 0,
                     }
                 ],
                 "show_legend": 1,
@@ -1240,19 +983,19 @@ class TimeSeriesCharts:
                         "fields": "message",
                         "template": "{{message}}",
                         "index_pattern": "rally-annotations",
-                        "query_string": f"((NOT _exists_:track) OR track:\"{race_config.track}\") AND ((NOT _exists_:chart) OR chart:io) "
-                                        f"AND ((NOT _exists_:chart-name) OR chart-name:\"{title}\") AND environment:\"{environment}\"",
+                        "query_string": f'((NOT _exists_:track) OR track:"{race_config.track}") AND ((NOT _exists_:chart) OR chart:io) '
+                        f'AND ((NOT _exists_:chart-name) OR chart-name:"{title}") AND environment:"{environment}"',
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
                         "time_field": "race-timestamp",
                         "icon": "fa-tag",
-                        "ignore_panel_filters": 1
+                        "ignore_panel_filters": 1,
                     }
                 ],
-                "axis_min": "0"
+                "axis_min": "0",
             },
             "aggs": [],
-            "listeners": {}
+            "listeners": {},
         }
 
         return {
@@ -1264,17 +1007,16 @@ class TimeSeriesCharts:
                 "uiStateJSON": "{}",
                 "description": "io",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": "{\"query\":\"*\",\"filter\":[]}"
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": '{"query":"*","filter":[]}'},
+            },
         }
 
     @staticmethod
     def query(environment, race_config, q, iterations):
         metric = "latency"
-        title = TimeSeriesCharts.format_title(environment, race_config.track, es_license=race_config.es_license,
-                                              suffix="%s-%s-%s" % (race_config.label, q, metric))
+        title = TimeSeriesCharts.format_title(
+            environment, race_config.track, es_license=race_config.es_license, suffix="%s-%s-%s" % (race_config.label, q, metric)
+        )
 
         vis_state = {
             "title": title,
@@ -1288,13 +1030,7 @@ class TimeSeriesCharts:
                         "color": color_scheme_rgba[0],
                         "split_mode": "everything",
                         "label": "50th percentile",
-                        "metrics": [
-                            {
-                                "id": str(uuid.uuid4()),
-                                "type": "avg",
-                                "field": "value.50_0"
-                            }
-                        ],
+                        "metrics": [{"id": str(uuid.uuid4()), "type": "avg", "field": "value.50_0"}],
                         "seperate_axis": 0,
                         "axis_position": "right",
                         "formatter": "number",
@@ -1312,13 +1048,7 @@ class TimeSeriesCharts:
                         "color": color_scheme_rgba[1],
                         "split_mode": "everything",
                         "label": "90th percentile",
-                        "metrics": [
-                            {
-                                "id": str(uuid.uuid4()),
-                                "type": "avg",
-                                "field": "value.90_0"
-                            }
-                        ],
+                        "metrics": [{"id": str(uuid.uuid4()), "type": "avg", "field": "value.90_0"}],
                         "seperate_axis": 0,
                         "axis_position": "right",
                         "formatter": "number",
@@ -1336,13 +1066,7 @@ class TimeSeriesCharts:
                         "color": color_scheme_rgba[2],
                         "split_mode": "everything",
                         "label": "99th percentile",
-                        "metrics": [
-                            {
-                                "id": str(uuid.uuid4()),
-                                "type": "avg",
-                                "field": "value.99_0"
-                            }
-                        ],
+                        "metrics": [{"id": str(uuid.uuid4()), "type": "avg", "field": "value.99_0"}],
                         "seperate_axis": 0,
                         "axis_position": "right",
                         "formatter": "number",
@@ -1360,13 +1084,7 @@ class TimeSeriesCharts:
                         "color": color_scheme_rgba[3],
                         "split_mode": "everything",
                         "label": "100th percentile",
-                        "metrics": [
-                            {
-                                "id": str(uuid.uuid4()),
-                                "type": "avg",
-                                "field": "value.100_0"
-                            }
-                        ],
+                        "metrics": [{"id": str(uuid.uuid4()), "type": "avg", "field": "value.100_0"}],
                         "seperate_axis": 0,
                         "axis_position": "right",
                         "formatter": "number",
@@ -1378,7 +1096,7 @@ class TimeSeriesCharts:
                         "split_color_mode": "gradient",
                         "series_drop_last_bucket": 0,
                         "value_template": "{{value}} ms",
-                    }
+                    },
                 ],
                 "time_field": "race-timestamp",
                 "index_pattern": "rally-results-*",
@@ -1388,31 +1106,26 @@ class TimeSeriesCharts:
                 "show_legend": 1,
                 "show_grid": 1,
                 "drop_last_bucket": 0,
-                "background_color_rules": [
-                    {
-                        "id": str(uuid.uuid4())
-                    }
-                ],
-                "filter": "task:\"%s\" AND name:\"%s\" AND %s" % (q, metric, TimeSeriesCharts.filter_string(
-                    environment, race_config)),
+                "background_color_rules": [{"id": str(uuid.uuid4())}],
+                "filter": 'task:"%s" AND name:"%s" AND %s' % (q, metric, TimeSeriesCharts.filter_string(environment, race_config)),
                 "annotations": [
                     {
                         "fields": "message",
                         "template": "{{message}}",
                         "index_pattern": "rally-annotations",
-                        "query_string": f"((NOT _exists_:track) OR track:\"{race_config.track}\") "
-                                        f"AND ((NOT _exists_:chart) OR chart:query) "
-                                        f"AND ((NOT _exists_:chart-name) OR chart-name:\"{title}\") AND environment:\"{environment}\"",
+                        "query_string": f'((NOT _exists_:track) OR track:"{race_config.track}") '
+                        f"AND ((NOT _exists_:chart) OR chart:query) "
+                        f'AND ((NOT _exists_:chart-name) OR chart-name:"{title}") AND environment:"{environment}"',
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
                         "time_field": "race-timestamp",
                         "icon": "fa-tag",
-                        "ignore_panel_filters": 1
+                        "ignore_panel_filters": 1,
                     }
-                ]
+                ],
             },
             "aggs": [],
-            "listeners": {}
+            "listeners": {},
         }
 
         return {
@@ -1424,10 +1137,8 @@ class TimeSeriesCharts:
                 "uiStateJSON": "{}",
                 "description": "query",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": "{\"query\":\"*\",\"filter\":[]}"
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": '{"query":"*","filter":[]}'},
+            },
         }
 
     @staticmethod
@@ -1440,10 +1151,10 @@ class TimeSeriesCharts:
             for bulk_task in race_config.bulk_tasks:
                 filters.append(
                     {
-                        "filter": "task:\"%s\" AND %s" % (bulk_task, TimeSeriesCharts.filter_string(environment, race_config)),
+                        "filter": 'task:"%s" AND %s' % (bulk_task, TimeSeriesCharts.filter_string(environment, race_config)),
                         "label": label,
                         "color": color_scheme_rgba[idx % len(color_scheme_rgba)],
-                        "id": str(uuid.uuid4())
+                        "id": str(uuid.uuid4()),
                     }
                 )
 
@@ -1465,22 +1176,16 @@ class TimeSeriesCharts:
                         "formatter": "number",
                         "id": str(uuid.uuid4()),
                         "line_width": "1",
-                        "metrics": [
-                            {
-                                "id": str(uuid.uuid4()),
-                                "type": "avg",
-                                "field": "value.median"
-                            }
-                        ],
+                        "metrics": [{"id": str(uuid.uuid4()), "type": "avg", "field": "value.median"}],
                         "point_size": "3",
                         "seperate_axis": 1,
                         "split_mode": "filters",
                         "stacked": "none",
-                        "filter": "environment:\"%s\" AND track:\"%s\"" % (environment, t),
+                        "filter": 'environment:"%s" AND track:"%s"' % (environment, t),
                         "split_filters": filters,
                         "label": "Indexing Throughput",
                         "value_template": "{{value}} docs/s",
-                        "steps": 0
+                        "steps": 0,
                     }
                 ],
                 "show_legend": 1,
@@ -1488,26 +1193,26 @@ class TimeSeriesCharts:
                 "drop_last_bucket": 0,
                 "time_field": "race-timestamp",
                 "type": "timeseries",
-                "filter": "environment:\"%s\" AND track:\"%s\" AND name:\"throughput\" AND active:true" % (environment, t),
+                "filter": 'environment:"%s" AND track:"%s" AND name:"throughput" AND active:true' % (environment, t),
                 "annotations": [
                     {
                         "fields": "message",
                         "template": "{{message}}",
                         "index_pattern": "rally-annotations",
-                        "query_string": f"((NOT _exists_:track) OR track:\"{t}\") "
-                                        f"AND ((NOT _exists_:chart) OR chart:indexing) "
-                                        f"AND ((NOT _exists_:chart-name) OR chart-name:\"{title}\") AND environment:\"{environment}\"",
+                        "query_string": f'((NOT _exists_:track) OR track:"{t}") '
+                        f"AND ((NOT _exists_:chart) OR chart:indexing) "
+                        f'AND ((NOT _exists_:chart-name) OR chart-name:"{title}") AND environment:"{environment}"',
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
                         "time_field": "race-timestamp",
                         "icon": "fa-tag",
-                        "ignore_panel_filters": 1
+                        "ignore_panel_filters": 1,
                     }
                 ],
-                "axis_min": "0"
+                "axis_min": "0",
             },
             "aggs": [],
-            "listeners": {}
+            "listeners": {},
         }
         return {
             "id": str(uuid.uuid4()),
@@ -1518,10 +1223,8 @@ class TimeSeriesCharts:
                 "uiStateJSON": "{}",
                 "description": "index",
                 "version": 1,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": "{\"query\":\"*\",\"filter\":[]}"
-                }
-            }
+                "kibanaSavedObjectMeta": {"searchSourceJSON": '{"query":"*","filter":[]}'},
+            },
         }
 
 
@@ -1556,8 +1259,13 @@ class RaceConfigTrack:
 def generate_index_ops(chart_type, race_configs, environment, logger):
     idx_race_configs = list(filter(lambda c: "indexing" in c.charts, race_configs))
     for race_conf in idx_race_configs:
-        logger.debug("Gen index visualization for race config with name:[%s] / label:[%s] / flavor: [%s] / license: [%s]",
-                     race_conf.name, race_conf.label, race_conf.flavor, race_conf.es_license)
+        logger.debug(
+            "Gen index visualization for race config with name:[%s] / label:[%s] / flavor: [%s] / license: [%s]",
+            race_conf.name,
+            race_conf.label,
+            race_conf.flavor,
+            race_conf.es_license,
+        )
     charts = []
 
     if idx_race_configs:
@@ -1573,7 +1281,7 @@ def generate_queries(chart_type, race_configs, environment):
     for race_config in race_configs:
         if "query" in race_config.charts:
             for q in race_config.throttled_tasks:
-                structures.append(chart_type.query(environment, race_config, q.name, q.params.get('iterations', 100)))
+                structures.append(chart_type.query(environment, race_config, q.name, q.params.get("iterations", 100)))
     return structures
 
 
@@ -1582,8 +1290,9 @@ def generate_io(chart_type, race_configs, environment):
     structures = []
     for race_config in race_configs:
         if "io" in race_config.charts:
-            title = chart_type.format_title(environment, race_config.track, es_license=race_config.es_license,
-                                            suffix="%s-io" % race_config.label)
+            title = chart_type.format_title(
+                environment, race_config.track, es_license=race_config.es_license, suffix="%s-io" % race_config.label
+            )
             structures.append(chart_type.io(title, environment, race_config))
 
     return structures
@@ -1593,8 +1302,9 @@ def generate_gc(chart_type, race_configs, environment):
     structures = []
     for race_config in race_configs:
         if "gc" in race_config.charts:
-            title = chart_type.format_title(environment, race_config.track, es_license=race_config.es_license,
-                                            suffix="%s-gc" % race_config.label)
+            title = chart_type.format_title(
+                environment, race_config.track, es_license=race_config.es_license, suffix="%s-gc" % race_config.label
+            )
             structures.append(chart_type.gc(title, environment, race_config))
 
     return structures
@@ -1606,8 +1316,9 @@ def generate_merge_time(chart_type, race_configs, environment):
         return structures
     for race_config in race_configs:
         if "merge_times" in race_config.charts:
-            title = chart_type.format_title(environment, race_config.track, es_license=race_config.es_license,
-                                            suffix=f"{race_config.label}-merge-times")
+            title = chart_type.format_title(
+                environment, race_config.track, es_license=race_config.es_license, suffix=f"{race_config.label}-merge-times"
+            )
             chart = chart_type.merge_time(title, environment, race_config)
             if chart is not None:
                 structures.append(chart)
@@ -1619,8 +1330,9 @@ def generate_ml_processing_time(chart_type, race_configs, environment):
     structures = []
     for race_config in race_configs:
         if "ml_processing_time" in race_config.charts:
-            title = chart_type.format_title(environment, race_config.track, es_license=race_config.es_license,
-                                            suffix=f"{race_config.label}-ml-processing-time")
+            title = chart_type.format_title(
+                environment, race_config.track, es_license=race_config.es_license, suffix=f"{race_config.label}-ml-processing-time"
+            )
             chart = chart_type.ml_processing_time(title, environment, race_config)
             if chart is not None:
                 structures.append(chart)
@@ -1632,8 +1344,9 @@ def generate_merge_count(chart_type, race_configs, environment):
     structures = []
     for race_config in race_configs:
         if "merge_count" in race_config.charts:
-            title = chart_type.format_title(environment, race_config.track, es_license=race_config.es_license,
-                                            suffix=f"{race_config.label}-merge-count")
+            title = chart_type.format_title(
+                environment, race_config.track, es_license=race_config.es_license, suffix=f"{race_config.label}-merge-count"
+            )
             chart = chart_type.merge_count(title, environment, race_config)
             if chart is not None:
                 structures.append(chart)
@@ -1665,15 +1378,9 @@ def generate_dashboard(chart_type, environment, track, charts, flavor=None):
         panel = {
             "id": chart["id"],
             "panelIndex": panelIndex,
-            "gridData": {
-                "x": (col * chart_width),
-                "y": (row * height),
-                "w": chart_width,
-                "h": height,
-                "i": str(panelIndex)
-            },
+            "gridData": {"x": (col * chart_width), "y": (row * height), "w": chart_width, "h": height, "i": str(panelIndex)},
             "type": "visualization",
-            "version": "7.10.2"
+            "version": "7.10.2",
         }
         panels.append(panel)
         col = next_col
@@ -1688,29 +1395,20 @@ def generate_dashboard(chart_type, environment, track, charts, flavor=None):
             "hits": 0,
             "description": "",
             "panelsJSON": json.dumps(panels),
-            "optionsJSON": "{\"darkTheme\":false}",
+            "optionsJSON": '{"darkTheme":false}',
             "uiStateJSON": "{}",
             "version": 1,
             "timeRestore": False,
             "kibanaSavedObjectMeta": {
                 "searchSourceJSON": json.dumps(
                     {
-                        "filter": [
-                            {
-                                "query": {
-                                    "query_string": {
-                                        "analyze_wildcard": True,
-                                        "query": "*"
-                                    }
-                                }
-                            }
-                        ],
+                        "filter": [{"query": {"query_string": {"analyze_wildcard": True, "query": "*"}}}],
                         "highlightAll": True,
-                        "version": True
+                        "version": True,
                     }
                 )
-            }
-        }
+            },
+        },
     }
 
 
@@ -1722,12 +1420,7 @@ class RaceConfig:
             self.configuration["flavor"] = flavor
             self.configuration["es_license"] = es_license
         else:
-            self.configuration = {
-                "charts": charts,
-                "challenge": challenge,
-                "car": car,
-                "node-count": node_count
-            }
+            self.configuration = {"charts": charts, "challenge": challenge, "car": car, "node-count": node_count}
 
     @property
     def name(self):
@@ -1775,8 +1468,11 @@ class RaceConfig:
                 # Doing a lenient match to allow for that.
                 if track.OperationType.Bulk.to_hyphenated_string() in sub_task.operation.type:
                     if track.OperationType.Bulk.to_hyphenated_string() != sub_task.operation.type:
-                        console.info(f"Found [{sub_task.name}] of type [{sub_task.operation.type}] in "\
-                                     f"[{self.challenge}], adding it to indexing dashboard.\n", flush=True)
+                        console.info(
+                            f"Found [{sub_task.name}] of type [{sub_task.operation.type}] in "
+                            f"[{self.challenge}], adding it to indexing dashboard.\n",
+                            flush=True,
+                        )
                     task_names.append(sub_task.name)
         return task_names
 
@@ -1793,8 +1489,11 @@ class RaceConfig:
                 #
                 # We should refactor the chart generator to make this classification logic more flexible so the user can specify
                 # which tasks / or types of operations should be used for which chart types.
-                if sub_task.operation.type in ["search", "composite", "eql", "paginated-search", "scroll-search"]\
-                    or "target-throughput" in sub_task.params or "target-interval" in sub_task.params:
+                if (
+                    sub_task.operation.type in ["search", "composite", "eql", "paginated-search", "scroll-search"]
+                    or "target-throughput" in sub_task.params
+                    or "target-interval" in sub_task.params
+                ):
                     task_names.append(sub_task)
         return task_names
 
@@ -1807,12 +1506,14 @@ def load_race_configs(cfg, chart_type, chart_spec_path=None):
             if "exclude-tasks" in race_config:
                 excluded_tasks = race_config.get("exclude-tasks").split(",")
             configs_per_lic.append(
-                RaceConfig(track=race_config_track.get_track(cfg, name=track_name,
-                                                             params=race_config.get("track-params", {}),
-                                                             excluded_tasks=excluded_tasks),
-                           cfg=race_config,
-                           flavor=flavor_name,
-                           es_license=lic)
+                RaceConfig(
+                    track=race_config_track.get_track(
+                        cfg, name=track_name, params=race_config.get("track-params", {}), excluded_tasks=excluded_tasks
+                    ),
+                    cfg=race_config,
+                    flavor=flavor_name,
+                    es_license=lic,
+                )
             )
         return configs_per_lic
 
@@ -1824,10 +1525,7 @@ def load_race_configs(cfg, chart_type, chart_spec_path=None):
                 race_configs_per_track.extend(add_configs(_lic_conf[0], track_name=track_name))
         else:
             for lic_config in license_configs:
-                race_configs_per_track.extend(add_configs(lic_config["configurations"],
-                                                          flavor_name,
-                                                          lic_config["name"],
-                                                          track_name))
+                race_configs_per_track.extend(add_configs(lic_config["configurations"], flavor_name, lic_config["name"], track_name))
 
     race_configs = {"oss": [], "default": []}
     if chart_type == BarCharts:
@@ -1855,13 +1553,15 @@ def load_race_configs(cfg, chart_type, chart_spec_path=None):
 
 
 def gen_charts_per_track_configs(race_configs, chart_type, env, flavor=None, logger=None):
-    charts = generate_index_ops(chart_type, race_configs, env, logger) + \
-             generate_io(chart_type, race_configs, env) + \
-             generate_gc(chart_type, race_configs, env) + \
-             generate_merge_time(chart_type, race_configs, env) + \
-             generate_merge_count(chart_type, race_configs, env) + \
-             generate_ml_processing_time(chart_type, race_configs, env) + \
-             generate_queries(chart_type, race_configs, env)
+    charts = (
+        generate_index_ops(chart_type, race_configs, env, logger)
+        + generate_io(chart_type, race_configs, env)
+        + generate_gc(chart_type, race_configs, env)
+        + generate_merge_time(chart_type, race_configs, env)
+        + generate_merge_count(chart_type, race_configs, env)
+        + generate_ml_processing_time(chart_type, race_configs, env)
+        + generate_queries(chart_type, race_configs, env)
+    )
 
     dashboard = generate_dashboard(chart_type, env, race_configs[0].track, charts, flavor)
 
@@ -1882,8 +1582,7 @@ def gen_charts_from_track_combinations(race_configs, chart_type, env, logger):
     structures = []
     for flavor, race_configs_per_flavor in race_configs.items():
         for race_configs_per_track in race_configs_per_flavor:
-            logger.debug("Generating charts for race_configs with name:[%s]/flavor:[%s]",
-                         race_configs_per_track[0].name, flavor)
+            logger.debug("Generating charts for race_configs with name:[%s]/flavor:[%s]", race_configs_per_track[0].name, flavor)
             charts, dashboard = gen_charts_per_track_configs(race_configs_per_track, chart_type, env, flavor, logger)
 
             structures.extend(charts)

--- a/esrally/config.py
+++ b/esrally/config.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -244,7 +244,6 @@ class Config:
             (Scope.application, "provisioning", "node.http.port"): 39200,
             (Scope.application, "mechanic", "team.repository.dir"): "teams",
             (Scope.application, "mechanic", "team.default.repository"): "default",
-
         }
 
     def _fill_from_config_file(self, config):
@@ -284,14 +283,18 @@ def migrate(config_file, current_version, target_version, out=print, i=input):
         logger.info("Config file is already at version [%s]. Skipping migration.", target_version)
         return
     if current_version < Config.EARLIEST_SUPPORTED_VERSION:
-        raise exceptions.ConfigError(f"The config file in {config_file.location} is too old. Please delete it "
-                                     f"and reconfigure Rally from scratch with {PROGRAM_NAME} configure.")
+        raise exceptions.ConfigError(
+            f"The config file in {config_file.location} is too old. Please delete it "
+            f"and reconfigure Rally from scratch with {PROGRAM_NAME} configure."
+        )
 
     logger.info("Upgrading configuration from version [%s] to [%s].", current_version, target_version)
     # Something is really fishy. We don't want to downgrade the configuration.
     if current_version >= target_version:
-        raise exceptions.ConfigError(f"The existing config file is available in a later version already. "
-                                     f"Expected version <= [{target_version}] but found [{current_version}]")
+        raise exceptions.ConfigError(
+            f"The existing config file is available in a later version already. "
+            f"Expected version <= [{target_version}] but found [{current_version}]"
+        )
     # but first a backup...
     config_file.backup()
     config = config_file.load()

--- a/esrally/driver/__init__.py
+++ b/esrally/driver/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -16,4 +16,11 @@
 # under the License.
 
 # expose only the minimum API
-from .driver import DriverActor, PrepareBenchmark, PreparationComplete, StartBenchmark, BenchmarkComplete, TaskFinished
+from .driver import (
+    BenchmarkComplete,
+    DriverActor,
+    PreparationComplete,
+    PrepareBenchmark,
+    StartBenchmark,
+    TaskFinished,
+)

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -20,17 +20,17 @@ import contextvars
 import json
 import logging
 import random
+import re
 import sys
 import time
 import types
-import re
 from collections import Counter, OrderedDict
 from copy import deepcopy
 from enum import Enum
 from functools import total_ordering
+from io import BytesIO
 from os.path import commonprefix
 from typing import List, Optional
-from io import BytesIO
 
 import ijson
 
@@ -121,7 +121,8 @@ def register_runner(operation_type, runner, **kwargs):
 
     if not async_runner:
         raise exceptions.RallyAssertionError(
-            "Runner [{}] must be implemented as async runner and registered with async_runner=True.".format(str(runner)))
+            "Runner [{}] must be implemented as async runner and registered with async_runner=True.".format(str(runner))
+        )
 
     if getattr(runner, "multi_cluster", False):
         if "__aenter__" in dir(runner) and "__aexit__" in dir(runner):
@@ -191,7 +192,7 @@ class Runner:
             "params": "request-params",
             "request_timeout": "request-timeout",
         }
-        full_result =  {k: params.get(v) for (k, v) in kw_dict.items()}
+        full_result = {k: params.get(v) for (k, v) in kw_dict.items()}
         # filter Nones
         return dict(filter(lambda kv: kv[1] is not None, full_result.items()))
 
@@ -211,6 +212,7 @@ class Delegator:
     """
     Mixin to unify delegate handling
     """
+
     def __init__(self, delegate, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.delegate = delegate
@@ -387,8 +389,7 @@ class AssertingRunner(Runner, Delegator):
                 for assertion in params["assertions"]:
                     self.check_assertion(op_name, assertion, return_value)
             else:
-                self.logger.debug("Skipping assertion check in [%s] as [%s] does not return a dict.",
-                                  op_name, repr(self.delegate))
+                self.logger.debug("Skipping assertion check in [%s] as [%s] does not return a dict.", op_name, repr(self.delegate))
         return return_value
 
     def __repr__(self, *args, **kwargs):
@@ -408,14 +409,15 @@ def mandatory(params, key, op):
     except KeyError:
         raise exceptions.DataError(
             f"Parameter source for operation '{str(op)}' did not provide the mandatory parameter '{key}'. "
-            f"Add it to your parameter source and try again.")
+            f"Add it to your parameter source and try again."
+        )
 
 
 # TODO: remove and use https://docs.python.org/3/library/stdtypes.html#str.removeprefix
 #  once Python 3.9 becomes the minimum version
 def remove_prefix(string, prefix):
     if string.startswith(prefix):
-        return string[len(prefix):]
+        return string[len(prefix) :]
     return string
 
 
@@ -521,7 +523,7 @@ class BulkIndex(Runner):
             raise exceptions.DataError("bulk body is neither string nor list")
 
         for line_number, data in enumerate(bulk_lines):
-            line_size = len(data.encode('utf-8'))
+            line_size = len(data.encode("utf-8"))
             if with_action_metadata:
                 if line_number % 2 == 1:
                     total_document_size_bytes += line_size
@@ -543,10 +545,7 @@ class BulkIndex(Runner):
                 s = data["_shards"]
                 sk = "%d-%d-%d" % (s["total"], s["successful"], s["failed"])
                 if sk not in shards_histogram:
-                    shards_histogram[sk] = {
-                        "item-count": 0,
-                        "shards": s
-                    }
+                    shards_histogram[sk] = {"item-count": 0, "shards": s}
                 shards_histogram[sk]["item-count"] += 1
             if data["status"] > 299 or ("_shards" in data and data["_shards"]["failed"] > 0):
                 bulk_error_count += 1
@@ -561,7 +560,7 @@ class BulkIndex(Runner):
             "ops": ops,
             "shards_histogram": list(shards_histogram.values()),
             "bulk-request-size-bytes": bulk_request_size_bytes,
-            "total-document-size-bytes": total_document_size_bytes
+            "total-document-size-bytes": total_document_size_bytes,
         }
         if bulk_error_count > 0:
             stats["error-type"] = "bulk"
@@ -585,7 +584,7 @@ class BulkIndex(Runner):
             parsed_response = json.loads(response.getvalue())
             for item in parsed_response["items"]:
                 data = next(iter(item.values()))
-                if data["status"] > 299 or ('_shards' in data and data["_shards"]["failed"] > 0):
+                if data["status"] > 299 or ("_shards" in data and data["_shards"]["failed"] > 0):
                     bulk_error_count += 1
                     self.extract_error_details(error_details, data)
                 else:
@@ -594,7 +593,7 @@ class BulkIndex(Runner):
             "took": props.get("took"),
             "success": bulk_error_count == 0,
             "success-count": bulk_success_count,
-            "error-count": bulk_error_count
+            "error-count": bulk_error_count,
         }
         if bulk_error_count > 0:
             stats["error-type"] = "bulk"
@@ -630,6 +629,7 @@ class ForceMerge(Runner):
     async def __call__(self, es, params):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
+
         max_num_segments = params.get("max-num-segments")
         mode = params.get("mode")
         merge_params = self._default_kw_params(params)
@@ -687,16 +687,16 @@ class IndicesStats(Runner):
                     "path": path,
                     # avoid mapping issues in the ES metrics store by always rendering values as strings
                     "actual-value": self._safe_string(actual_value),
-                    "expected-value": self._safe_string(expected_value)
+                    "expected-value": self._safe_string(expected_value),
                 },
                 # currently we only support "==" as a predicate but that might change in the future
-                "success": actual_value == expected_value
+                "success": actual_value == expected_value,
             }
         else:
             return {
                 "weight": 1,
                 "unit": "ops",
-                "success": True
+                "success": True,
             }
 
     def __repr__(self, *args, **kwargs):
@@ -834,7 +834,7 @@ class Query(Runner):
                 "unit": "pages",
                 "success": True,
                 "timed_out": False,
-                "took": 0
+                "took": 0,
             }
             if pit_op:
                 # these are disallowed as they are encoded in the pit_id
@@ -846,8 +846,7 @@ class Query(Runner):
             for page in range(1, total_pages + 1):
                 if pit_op:
                     pit_id = CompositeContext.get(pit_op)
-                    body["pit"] = {"id": pit_id,
-                                   "keep_alive": "1m" }
+                    body["pit"] = {"id": pit_id, "keep_alive": "1m"}
 
                 response = await self._raw_search(es, doc_type=None, index=index, body=body.copy(), params=request_params, headers=headers)
                 parsed, last_sort = self._extractor(response, bool(pit_op), results.get("hits"))
@@ -893,13 +892,13 @@ class Query(Runner):
                     "hits": hits_total,
                     "hits_relation": hits_relation,
                     "timed_out": timed_out,
-                    "took": took
+                    "took": took,
                 }
             else:
                 return {
                     "weight": 1,
                     "unit": "ops",
-                    "success": True
+                    "success": True,
                 }
 
         async def _scroll_query(es, params):
@@ -923,8 +922,9 @@ class Query(Runner):
                         params["size"] = size
                         r = await self._raw_search(es, doc_type, index, body, params, headers=headers)
 
-                        props = parse(r, ["_scroll_id", "hits.total", "hits.total.value", "hits.total.relation",
-                                          "timed_out", "took"], ["hits.hits"])
+                        props = parse(
+                            r, ["_scroll_id", "hits.total", "hits.total.value", "hits.total.relation", "timed_out", "took"], ["hits.hits"]
+                        )
                         scroll_id = props.get("_scroll_id")
                         hits = props.get("hits.total.value", props.get("hits.total", 0))
                         hits_relation = props.get("hits.total.relation", "eq")
@@ -932,16 +932,15 @@ class Query(Runner):
                         took = props.get("took", 0)
                         all_results_collected = (size is not None and hits < size) or hits == 0
                     else:
-                        r = await es.transport.perform_request("GET", "/_search/scroll",
-                                                               body={"scroll_id": scroll_id, "scroll": "10s"},
-                                                               params=request_params,
-                                                               headers=headers)
+                        r = await es.transport.perform_request(
+                            "GET", "/_search/scroll", body={"scroll_id": scroll_id, "scroll": "10s"}, params=request_params, headers=headers
+                        )
                         props = parse(r, ["timed_out", "took"], ["hits.hits"])
                         timed_out = timed_out or props.get("timed_out", False)
                         took += props.get("took", 0)
                         # is the list of hits empty?
                         all_results_collected = props.get("hits.hits", False)
-                    retrieved_pages +=1
+                    retrieved_pages += 1
                     if all_results_collected:
                         break
             finally:
@@ -950,8 +949,11 @@ class Query(Runner):
                     try:
                         await es.clear_scroll(body={"scroll_id": [scroll_id]})
                     except BaseException:
-                        self.logger.exception("Could not clear scroll [%s]. This will lead to excessive resource usage in "
-                                              "Elasticsearch and will skew your benchmark results.", scroll_id)
+                        self.logger.exception(
+                            "Could not clear scroll [%s]. This will lead to excessive resource usage in "
+                            "Elasticsearch and will skew your benchmark results.",
+                            scroll_id,
+                        )
 
             return {
                 "weight": retrieved_pages,
@@ -960,7 +962,7 @@ class Query(Runner):
                 "hits_relation": hits_relation,
                 "unit": "pages",
                 "timed_out": timed_out,
-                "took": took
+                "took": took,
             }
 
         search_method = params.get("operation-type")
@@ -969,8 +971,10 @@ class Query(Runner):
         elif search_method == "scroll-search":
             return await _scroll_query(es, params)
         elif "pages" in params:
-            logging.getLogger(__name__).warning("Invoking a scroll search with the 'search' operation is deprecated "
-                                                "and will be removed in a future release. Use 'scroll-search' instead.")
+            logging.getLogger(__name__).warning(
+                "Invoking a scroll search with the 'search' operation is deprecated "
+                "and will be removed in a future release. Use 'scroll-search' instead."
+            )
             return await _scroll_query(es, params)
         else:
             return await _request_body_query(es, params)
@@ -1013,8 +1017,7 @@ class SearchAfterExtractor:
         parsed = parse(response, properties)
 
         if get_point_in_time and not parsed.get("pit_id"):
-            raise exceptions.RallyAssertionError("Paginated query failure: "
-                                                 "pit_id was expected but not found in the response.")
+            raise exceptions.RallyAssertionError("Paginated query failure: pit_id was expected but not found in the response.")
         # standardize these before returning...
         parsed["hits.total.value"] = parsed.pop("hits.total.value", parsed.pop("hits.total", hits_total))
         parsed["hits.total.relation"] = parsed.get("hits.total.relation", "eq")
@@ -1078,10 +1081,16 @@ class ClusterHealth(Runner):
             "unit": "ops",
             "success": status(cluster_status) >= status(expected_cluster_status) and relocating_shards <= expected_relocating_shards,
             "cluster-status": cluster_status,
-            "relocating-shards": relocating_shards
+            "relocating-shards": relocating_shards,
         }
-        self.logger.info("%s: expected status=[%s], actual status=[%s], relocating shards=[%d], success=[%s].",
-                         repr(self), expected_cluster_status, cluster_status, relocating_shards, result["success"])
+        self.logger.info(
+            "%s: expected status=[%s], actual status=[%s], relocating shards=[%d], success=[%s].",
+            repr(self),
+            expected_cluster_status,
+            cluster_status,
+            relocating_shards,
+            result["success"],
+        )
         return result
 
     def __repr__(self, *args, **kwargs):
@@ -1094,11 +1103,12 @@ class PutPipeline(Runner):
     """
 
     async def __call__(self, es, params):
-        await es.ingest.put_pipeline(id=mandatory(params, "id", self),
-                                     body=mandatory(params, "body", self),
-                                     master_timeout=params.get("master-timeout"),
-                                     timeout=params.get("timeout"),
-                                     )
+        await es.ingest.put_pipeline(
+            id=mandatory(params, "id", self),
+            body=mandatory(params, "body", self),
+            master_timeout=params.get("master-timeout"),
+            timeout=params.get("timeout"),
+        )
 
     def __repr__(self, *args, **kwargs):
         return "put-pipeline"
@@ -1132,7 +1142,7 @@ class CreateIndex(Runner):
         return {
             "weight": len(indices),
             "unit": "ops",
-            "success": True
+            "success": True,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1152,7 +1162,7 @@ class CreateDataStream(Runner):
         return {
             "weight": len(data_streams),
             "unit": "ops",
-            "success": True
+            "success": True,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1169,8 +1179,8 @@ async def set_destructive_requires_name(es, value):
     prior_value = all_settings.get("transient").get("action.destructive_requires_name")
     settings_body = {
         "transient": {
-            "action.destructive_requires_name": value
-        }
+            "action.destructive_requires_name": value,
+        },
     }
     await es.cluster.put_settings(body=settings_body)
     return prior_value
@@ -1202,7 +1212,7 @@ class DeleteIndex(Runner):
         return {
             "weight": ops,
             "unit": "ops",
-            "success": True
+            "success": True,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1233,7 +1243,7 @@ class DeleteDataStream(Runner):
         return {
             "weight": ops,
             "unit": "ops",
-            "success": True
+            "success": True,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1250,12 +1260,11 @@ class CreateComponentTemplate(Runner):
         templates = mandatory(params, "templates", self)
         request_params = mandatory(params, "request-params", self)
         for template, body in templates:
-            await es.cluster.put_component_template(name=template, body=body,
-                                                    params=request_params)
+            await es.cluster.put_component_template(name=template, body=body, params=request_params)
         return {
             "weight": len(templates),
             "unit": "ops",
-            "success": True
+            "success": True,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1276,10 +1285,9 @@ class DeleteComponentTemplate(Runner):
         async def _exists(name):
             # pylint: disable=import-outside-toplevel
             from elasticsearch.client import _make_path
+
             # currently not supported by client and hence custom request
-            return await es.transport.perform_request(
-                "HEAD", _make_path("_component_template", name)
-            )
+            return await es.transport.perform_request("HEAD", _make_path("_component_template", name))
 
         ops_count = 0
         for template_name in template_names:
@@ -1293,9 +1301,8 @@ class DeleteComponentTemplate(Runner):
         return {
             "weight": ops_count,
             "unit": "ops",
-            "success": True
+            "success": True,
         }
-
 
     def __repr__(self, *args, **kwargs):
         return "delete-component-template"
@@ -1315,7 +1322,7 @@ class CreateComposableTemplate(Runner):
         return {
             "weight": len(templates),
             "unit": "ops",
-            "success": True
+            "success": True,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1349,7 +1356,7 @@ class DeleteComposableTemplate(Runner):
         return {
             "weight": ops_count,
             "unit": "ops",
-            "success": True
+            "success": True,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1365,13 +1372,11 @@ class CreateIndexTemplate(Runner):
         templates = mandatory(params, "templates", self)
         request_params = params.get("request-params", {})
         for template, body in templates:
-            await es.indices.put_template(name=template,
-                                          body=body,
-                                          params=request_params)
+            await es.indices.put_template(name=template, body=body, params=request_params)
         return {
             "weight": len(templates),
             "unit": "ops",
-            "success": True
+            "success": True,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1406,7 +1411,7 @@ class DeleteIndexTemplate(Runner):
         return {
             "weight": ops_count,
             "unit": "ops",
-            "success": True
+            "success": True,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1427,13 +1432,9 @@ class ShrinkIndex(Runner):
     async def _wait_for(self, es, idx, description):
         # wait a little bit before the first check
         await asyncio.sleep(3)
-        result = await self.cluster_health(es, params={
-            "index": idx,
-            "retries": sys.maxsize,
-            "request-params": {
-                "wait_for_no_relocating_shards": "true"
-            }
-        })
+        result = await self.cluster_health(
+            es, params={"index": idx, "retries": sys.maxsize, "request-params": {"wait_for_no_relocating_shards": "true"}}
+        )
         if not result["success"]:
             raise exceptions.RallyAssertionError("Failed to wait for [{}].".format(description))
 
@@ -1467,14 +1468,11 @@ class ShrinkIndex(Runner):
             self.logger.info("Preparing [%s] for shrinking.", source_index)
 
             # prepare index for shrinking
-            await es.indices.put_settings(index=source_index,
-                                          body={
-                                              "settings": {
-                                                  "index.routing.allocation.require._name": shrink_node,
-                                                  "index.blocks.write": "true"
-                                              }
-                                          },
-                                          preserve_existing=True)
+            await es.indices.put_settings(
+                index=source_index,
+                body={"settings": {"index.routing.allocation.require._name": shrink_node, "index.blocks.write": "true"}},
+                preserve_existing=True,
+            )
 
             self.logger.info("Waiting for relocation to finish for index [%s] ...", source_index)
             await self._wait_for(es, source_index, f"shard relocation for index [{source_index}]")
@@ -1485,7 +1483,7 @@ class ShrinkIndex(Runner):
             target_body["settings"]["index.blocks.write"] = None
             # kick off the shrink operation
             index_suffix = remove_prefix(source_index, source_indices_stem)
-            final_target_index = target_index if len(index_suffix) == 0 else target_index+index_suffix
+            final_target_index = target_index if len(index_suffix) == 0 else target_index + index_suffix
             await es.indices.shrink(index=source_index, target=final_target_index, body=target_body)
 
             self.logger.info("Waiting for shrink to finish for index [%s] ...", source_index)
@@ -1495,7 +1493,7 @@ class ShrinkIndex(Runner):
         return {
             "weight": len(source_indices),
             "unit": "ops",
-            "success": True
+            "success": True,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1510,6 +1508,7 @@ class CreateMlDatafeed(Runner):
     async def __call__(self, es, params):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
+
         datafeed_id = mandatory(params, "datafeed-id", self)
         body = mandatory(params, "body", self)
         try:
@@ -1537,6 +1536,7 @@ class DeleteMlDatafeed(Runner):
     async def __call__(self, es, params):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
+
         datafeed_id = mandatory(params, "datafeed-id", self)
         force = params.get("force", False)
         try:
@@ -1548,10 +1548,7 @@ class DeleteMlDatafeed(Runner):
                 await es.transport.perform_request(
                     "DELETE",
                     f"/_xpack/ml/datafeeds/{datafeed_id}",
-                    params={
-                        "force": escape(force),
-                        "ignore": 404
-                    },
+                    params={"force": escape(force), "ignore": 404},
                 )
             else:
                 raise e
@@ -1568,6 +1565,7 @@ class StartMlDatafeed(Runner):
     async def __call__(self, es, params):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
+
         datafeed_id = mandatory(params, "datafeed-id", self)
         body = params.get("body")
         start = params.get("start")
@@ -1598,6 +1596,7 @@ class StopMlDatafeed(Runner):
     async def __call__(self, es, params):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
+
         datafeed_id = mandatory(params, "datafeed-id", self)
         force = params.get("force", False)
         timeout = params.get("timeout")
@@ -1611,11 +1610,7 @@ class StopMlDatafeed(Runner):
                 }
                 if timeout:
                     request_params["timeout"] = escape(timeout)
-                await es.transport.perform_request(
-                    "POST",
-                    f"/_xpack/ml/datafeeds/{datafeed_id}/_stop",
-                    params=request_params
-                )
+                await es.transport.perform_request("POST", f"/_xpack/ml/datafeeds/{datafeed_id}/_stop", params=request_params)
             else:
                 raise e
 
@@ -1631,6 +1626,7 @@ class CreateMlJob(Runner):
     async def __call__(self, es, params):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
+
         job_id = mandatory(params, "job-id", self)
         body = mandatory(params, "body", self)
         try:
@@ -1658,6 +1654,7 @@ class DeleteMlJob(Runner):
     async def __call__(self, es, params):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
+
         job_id = mandatory(params, "job-id", self)
         force = params.get("force", False)
         # we don't want to fail if a job does not exist, thus we ignore 404s.
@@ -1669,10 +1666,7 @@ class DeleteMlJob(Runner):
                 await es.transport.perform_request(
                     "DELETE",
                     f"/_xpack/ml/anomaly_detectors/{job_id}",
-                    params={
-                        "force": escape(force),
-                        "ignore": 404
-                    },
+                    params={"force": escape(force), "ignore": 404},
                 )
             else:
                 raise e
@@ -1689,6 +1683,7 @@ class OpenMlJob(Runner):
     async def __call__(self, es, params):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
+
         job_id = mandatory(params, "job-id", self)
         try:
             await es.xpack.ml.open_job(job_id=job_id)
@@ -1714,6 +1709,7 @@ class CloseMlJob(Runner):
     async def __call__(self, es, params):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
+
         job_id = mandatory(params, "job-id", self)
         force = params.get("force", False)
         timeout = params.get("timeout")
@@ -1750,14 +1746,12 @@ class RawRequest(Runner):
             self.logger.error("RawRequest failed. Path parameter: [%s] must begin with a '/'.", path)
             raise exceptions.RallyAssertionError(f"RawRequest [{path}] failed. Path parameter must begin with a '/'.")
         if not bool(headers):
-            #counter-intuitive, but preserves prior behavior
+            # counter-intuitive, but preserves prior behavior
             headers = None
 
-        await es.transport.perform_request(method=params.get("method", "GET"),
-                                           url=path,
-                                           headers=headers,
-                                           body=params.get("body"),
-                                           params=request_params)
+        await es.transport.perform_request(
+            method=params.get("method", "GET"), url=path, headers=headers, body=params.get("body"), params=request_params
+        )
 
     def __repr__(self, *args, **kwargs):
         return "raw-request"
@@ -1783,6 +1777,7 @@ class DeleteSnapshotRepository(Runner):
     """
     Deletes a snapshot repository
     """
+
     async def __call__(self, es, params):
         await es.snapshot.delete_repository(repository=mandatory(params, "repository", repr(self)))
 
@@ -1794,11 +1789,12 @@ class CreateSnapshotRepository(Runner):
     """
     Creates a new snapshot repository
     """
+
     async def __call__(self, es, params):
         request_params = params.get("request-params", {})
-        await es.snapshot.create_repository(repository=mandatory(params, "repository", repr(self)),
-                                            body=mandatory(params, "body", repr(self)),
-                                            params=request_params)
+        await es.snapshot.create_repository(
+            repository=mandatory(params, "repository", repr(self)), body=mandatory(params, "body", repr(self)), params=request_params
+        )
 
     def __repr__(self, *args, **kwargs):
         return "create-snapshot-repository"
@@ -1808,6 +1804,7 @@ class CreateSnapshot(Runner):
     """
     Creates a new snapshot repository
     """
+
     async def __call__(self, es, params):
         wait_for_completion = params.get("wait-for-completion", False)
         repository = mandatory(params, "repository", repr(self))
@@ -1815,10 +1812,7 @@ class CreateSnapshot(Runner):
         # just assert, gets set in _default_kw_params
         mandatory(params, "body", repr(self))
         api_kwargs = self._default_kw_params(params)
-        await es.snapshot.create(repository=repository,
-                                 snapshot=snapshot,
-                                 wait_for_completion=wait_for_completion,
-                                 **api_kwargs)
+        await es.snapshot.create(repository=repository, snapshot=snapshot, wait_for_completion=wait_for_completion, **api_kwargs)
 
     def __repr__(self, *args, **kwargs):
         return "create-snapshot"
@@ -1834,9 +1828,7 @@ class WaitForSnapshotCreate(Runner):
         stats = {}
 
         while not snapshot_done:
-            response = await es.snapshot.status(repository=repository,
-                                                snapshot=snapshot,
-                                                ignore_unavailable=True)
+            response = await es.snapshot.status(repository=repository, snapshot=snapshot, ignore_unavailable=True)
 
             if "snapshots" in response:
                 response_state = response["snapshots"][0]["state"]
@@ -1865,7 +1857,7 @@ class WaitForSnapshotCreate(Runner):
             "start_time_millis": start_time_in_millis,
             "stop_time_millis": start_time_in_millis + duration_in_millis,
             "duration": duration_in_millis,
-            "file_count": file_count
+            "file_count": file_count,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1876,12 +1868,15 @@ class RestoreSnapshot(Runner):
     """
     Restores a snapshot from an already registered repository
     """
+
     async def __call__(self, es, params):
         api_kwargs = self._default_kw_params(params)
-        await es.snapshot.restore(repository=mandatory(params, "repository", repr(self)),
-                                  snapshot=mandatory(params, "snapshot", repr(self)),
-                                  wait_for_completion=params.get("wait-for-completion", False),
-                                  **api_kwargs)
+        await es.snapshot.restore(
+            repository=mandatory(params, "repository", repr(self)),
+            snapshot=mandatory(params, "snapshot", repr(self)),
+            wait_for_completion=params.get("wait-for-completion", False),
+            **api_kwargs,
+        )
 
     def __repr__(self, *args, **kwargs):
         return "restore-snapshot"
@@ -1933,7 +1928,7 @@ class IndicesRecovery(Runner):
             "success": True,
             "throughput": total_recovered / response_time_in_seconds,
             "start_time_millis": total_start_millis,
-            "stop_time_millis": total_end_millis
+            "stop_time_millis": total_end_millis,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -1945,6 +1940,7 @@ class PutSettings(Runner):
     Updates cluster settings with the
     `cluster settings API <http://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html>_.
     """
+
     async def __call__(self, es, params):
         await es.cluster.put_settings(body=mandatory(params, "body", repr(self)))
 
@@ -2037,11 +2033,9 @@ class WaitForTransform(Runner):
 
         if not self._start_time:
             self._start_time = time.monotonic()
-            await es.transform.stop_transform(transform_id=transform_id,
-                                              force=force,
-                                              timeout=timeout,
-                                              wait_for_completion=False,
-                                              wait_for_checkpoint=wait_for_checkpoint)
+            await es.transform.stop_transform(
+                transform_id=transform_id, force=force, timeout=timeout, wait_for_completion=False, wait_for_checkpoint=wait_for_checkpoint
+            )
 
         while True:
             stats_response = await es.transform.get_transform_stats(transform_id=transform_id)
@@ -2051,18 +2045,24 @@ class WaitForTransform(Runner):
             if (time.monotonic() - self._start_time) > transform_timeout:
                 raise exceptions.RallyAssertionError(
                     f"Transform [{transform_id}] timed out after [{transform_timeout}] seconds. "
-                    "Please consider increasing the timeout in the track.")
+                    "Please consider increasing the timeout in the track."
+                )
 
             if state == "failed":
                 failure_reason = stats_response["transforms"][0].get("reason", "unknown")
-                raise exceptions.RallyAssertionError(
-                    f"Transform [{transform_id}] failed with [{failure_reason}].")
+                raise exceptions.RallyAssertionError(f"Transform [{transform_id}] failed with [{failure_reason}].")
             elif state == "stopped" or wait_for_completion is False:
                 self._completed = True
                 self._percent_completed = 1.0
             else:
-                self._percent_completed = stats_response["transforms"][0].get("checkpointing", {}).get("next", {}).get(
-                    "checkpoint_progress", {}).get("percent_complete", 0.0) / 100.0
+                self._percent_completed = (
+                    stats_response["transforms"][0]
+                    .get("checkpointing", {})
+                    .get("next", {})
+                    .get("checkpoint_progress", {})
+                    .get("percent_complete", 0.0)
+                    / 100.0
+                )
 
             documents_processed = transform_stats.get("documents_processed", 0)
             processing_time = transform_stats.get("search_time_in_ms", 0)
@@ -2077,7 +2077,7 @@ class WaitForTransform(Runner):
                     "transform-id": transform_id,
                     "weight": transform_stats.get("documents_processed", 0),
                     "unit": "docs",
-                    "success": True
+                    "success": True,
                 }
 
                 throughput = 0
@@ -2151,16 +2151,16 @@ class TransformStats(Runner):
                     "path": path,
                     # avoid mapping issues in the ES metrics store by always rendering values as strings
                     "actual-value": self._safe_string(actual_value),
-                    "expected-value": self._safe_string(expected_value)
+                    "expected-value": self._safe_string(expected_value),
                 },
                 # currently we only support "==" as a predicate but that might change in the future
-                "success": actual_value == expected_value
+                "success": actual_value == expected_value,
             }
         else:
             return {
                 "weight": 1,
                 "unit": "ops",
-                "success": True
+                "success": True,
             }
 
     def __repr__(self, *args, **kwargs):
@@ -2170,9 +2170,7 @@ class TransformStats(Runner):
 class SubmitAsyncSearch(Runner):
     async def __call__(self, es, params):
         request_params = params.get("request-params", {})
-        response = await es.async_search.submit(body=mandatory(params, "body", self),
-                                                index=params.get("index"),
-                                                params=request_params)
+        response = await es.async_search.submit(body=mandatory(params, "body", self), index=params.get("index"), params=request_params)
 
         op_name = mandatory(params, "name", self)
         # id may be None if the operation has already returned
@@ -2199,8 +2197,7 @@ class GetAsyncSearch(Runner):
         request_params = params.get("request-params", {})
         stats = {}
         for search_id, search in async_search_ids(searches):
-            response = await es.async_search.get(id=search_id,
-                                                 params=request_params)
+            response = await es.async_search.get(id=search_id, params=request_params)
             is_running = response["is_running"]
             success = success and not is_running
             if not is_running:
@@ -2208,7 +2205,7 @@ class GetAsyncSearch(Runner):
                     "hits": response["response"]["hits"]["total"]["value"],
                     "hits_relation": response["response"]["hits"]["total"]["relation"],
                     "timed_out": response["response"]["timed_out"],
-                    "took": response["response"]["took"]
+                    "took": response["response"]["took"],
                 }
 
         return {
@@ -2216,7 +2213,7 @@ class GetAsyncSearch(Runner):
             "weight": len(stats),
             "unit": "ops",
             "success": success,
-            "stats": stats
+            "stats": stats,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -2239,9 +2236,7 @@ class OpenPointInTime(Runner):
         op_name = mandatory(params, "name", self)
         index = mandatory(params, "index", self)
         keep_alive = params.get("keep-alive", "1m")
-        response = await es.open_point_in_time(index=index,
-                                         params=params.get("request-params"),
-                                         keep_alive=keep_alive)
+        response = await es.open_point_in_time(index=index, params=params.get("request-params"), keep_alive=keep_alive)
         id = response.get("id")
         CompositeContext.put(op_name, id)
 
@@ -2285,16 +2280,18 @@ class CompositeContext:
         try:
             return CompositeContext._ctx()[key]
         except KeyError:
-            raise KeyError(f"Unknown property [{key}]. Currently recognized "
-                           f"properties are [{', '.join(CompositeContext._ctx().keys())}].") from None
+            raise KeyError(
+                f"Unknown property [{key}]. Currently recognized properties are [{', '.join(CompositeContext._ctx().keys())}]."
+            ) from None
 
     @staticmethod
     def remove(key):
         try:
             CompositeContext._ctx().pop(key)
         except KeyError:
-            raise KeyError(f"Unknown property [{key}]. Currently recognized "
-                           f"properties are [{', '.join(CompositeContext._ctx().keys())}].") from None
+            raise KeyError(
+                f"Unknown property [{key}]. Currently recognized properties are [{', '.join(CompositeContext._ctx().keys())}]."
+            ) from None
 
     @staticmethod
     def _ctx():
@@ -2308,6 +2305,7 @@ class Composite(Runner):
     """
     Executes a complex request structure which is measured by Rally as one composite operation.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.supported_op_types = [
@@ -2318,7 +2316,7 @@ class Composite(Runner):
             "sleep",
             "submit-async-search",
             "get-async-search",
-            "delete-async-search"
+            "delete-async-search",
         ]
 
     async def run_stream(self, es, stream, connection_limit):
@@ -2338,7 +2336,8 @@ class Composite(Runner):
                     op_type = item["operation-type"]
                     if op_type not in self.supported_op_types:
                         raise exceptions.RallyAssertionError(
-                            f"Unsupported operation-type [{op_type}]. Use one of [{', '.join(self.supported_op_types)}].")
+                            f"Unsupported operation-type [{op_type}]. Use one of [{', '.join(self.supported_op_types)}]."
+                        )
                     runner = RequestTiming(runner_for(op_type))
                     async with connection_limit:
                         async with runner:
@@ -2371,7 +2370,7 @@ class Composite(Runner):
         return {
             "weight": 1,
             "unit": "ops",
-            "dependent_timing": response
+            "dependent_timing": response,
         }
 
     def __repr__(self, *args, **kwargs):
@@ -2395,7 +2394,7 @@ class RequestTiming(Runner, Delegator):
                 result = {
                     "weight": total_ops,
                     "unit": total_ops_unit,
-                    "success": True
+                    "success": True,
                 }
             elif isinstance(return_value, dict):
                 result = return_value
@@ -2403,7 +2402,7 @@ class RequestTiming(Runner, Delegator):
                 result = {
                     "weight": 1,
                     "unit": "ops",
-                    "success": True
+                    "success": True,
                 }
 
             start = request_context.request_start
@@ -2414,7 +2413,7 @@ class RequestTiming(Runner, Delegator):
                 "absolute_time": absolute_time,
                 "request_start": start,
                 "request_end": end,
-                "service_time": end - start
+                "service_time": end - start,
             }
         return result
 
@@ -2449,8 +2448,9 @@ class Retry(Runner, Delegator):
 
     async def __call__(self, es, params):
         # pylint: disable=import-outside-toplevel
-        import elasticsearch
         import socket
+
+        import elasticsearch
 
         retry_until_success = params.get("retry-until-success", self.retry_until_success)
         if retry_until_success:
@@ -2474,8 +2474,12 @@ class Retry(Runner, Delegator):
                         self.logger.debug("%s has returned successfully", repr(self.delegate))
                         return return_value
                     else:
-                        self.logger.info("[%s] has returned with an error: %s. Retrying in [%.2f] seconds.",
-                                         repr(self.delegate), return_value, sleep_time)
+                        self.logger.info(
+                            "[%s] has returned with an error: %s. Retrying in [%.2f] seconds.",
+                            repr(self.delegate),
+                            return_value,
+                            sleep_time,
+                        )
                         await asyncio.sleep(sleep_time)
                 else:
                     return return_value

--- a/esrally/driver/scheduler.py
+++ b/esrally/driver/scheduler.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -187,6 +187,7 @@ class DelegatingScheduler(SimpleScheduler):
     """
     Delegates to a scheduler function and acts as an adapter to the rest of the system.
     """
+
     def __init__(self, delegate):
         super().__init__()
         self.delegate = delegate
@@ -200,6 +201,7 @@ class LegacyWrappingScheduler(Scheduler):
     """
     Wraps legacy implementations to stay backwards-compatible with older scheduler implementations.
     """
+
     def __init__(self, task, legacy_scheduler_class):
         super().__init__()
         # the legacy API was based on parameters so only provide these
@@ -213,6 +215,7 @@ class Unthrottled(Scheduler):
     """
     Rally-internal scheduler to handle unthrottled tasks.
     """
+
     def next(self, current):
         return 0
 
@@ -225,6 +228,7 @@ class DeterministicScheduler(SimpleScheduler):
     Schedules the next execution according to a
     `deterministic distribution <https://en.wikipedia.org/wiki/Degenerate_distribution>`_.
     """
+
     name = "deterministic"
 
     # pylint: disable=unused-variable
@@ -248,6 +252,7 @@ class PoissonScheduler(SimpleScheduler):
 
     See also http://preshing.com/20111007/how-to-generate-random-timings-for-a-poisson-process/
     """
+
     name = "poisson"
 
     # pylint: disable=unused-variable
@@ -268,6 +273,7 @@ class UnitAwareScheduler(Scheduler):
     scheduling to the scheduler provided by the user in the track.
 
     """
+
     def __init__(self, task, scheduler_class):
         super().__init__()
         self.task = task
@@ -288,18 +294,24 @@ class UnitAwareScheduler(Scheduler):
                 if expected_unit == "ops/s":
                     weight = 1
                     if self.first_request:
-                        logging.getLogger(__name__).warning("Task [%s] throttles based on [%s] but reports [%s]. "
-                                                            "Please specify the target throughput in [%s] instead.",
-                                                            self.task, expected_unit, actual_unit, actual_unit)
+                        logging.getLogger(__name__).warning(
+                            "Task [%s] throttles based on [%s] but reports [%s]. Please specify the target throughput in [%s] instead.",
+                            self.task,
+                            expected_unit,
+                            actual_unit,
+                            actual_unit,
+                        )
                 else:
-                    raise exceptions.RallyAssertionError(f"Target throughput for [{self.task}] is specified in "
-                                                         f"[{expected_unit}] but the task throughput is measured "
-                                                         f"in [{actual_unit}].")
+                    raise exceptions.RallyAssertionError(
+                        f"Target throughput for [{self.task}] is specified in "
+                        f"[{expected_unit}] but the task throughput is measured "
+                        f"in [{actual_unit}]."
+                    )
 
             self.first_request = False
             self.current_weight = weight
             # throughput in requests/s for this client
-            target_throughput = (self.task.target_throughput.value / self.task.clients / self.current_weight)
+            target_throughput = self.task.target_throughput.value / self.task.clients / self.current_weight
             self.scheduler = self.scheduler_class(self.task, target_throughput)
 
     def next(self, current):

--- a/esrally/exceptions.py
+++ b/esrally/exceptions.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/esrally/log.py
+++ b/esrally/log.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/esrally/mechanic/__init__.py
+++ b/esrally/mechanic/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -16,5 +16,16 @@
 # under the License.
 
 # expose only the minimum API
-from .mechanic import StartEngine, EngineStarted, StopEngine, EngineStopped, ResetRelativeTime, MechanicActor, \
-    cluster_distribution_version, download, install, start, stop
+from .mechanic import (
+    EngineStarted,
+    EngineStopped,
+    MechanicActor,
+    ResetRelativeTime,
+    StartEngine,
+    StopEngine,
+    cluster_distribution_version,
+    download,
+    install,
+    start,
+    stop,
+)

--- a/esrally/mechanic/cluster.py
+++ b/esrally/mechanic/cluster.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/esrally/mechanic/java_resolver.py
+++ b/esrally/mechanic/java_resolver.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -33,14 +33,14 @@ def java_home(car_runtime_jdks, specified_runtime_jdk=None, provides_bundled_jdk
     try:
         allowed_runtime_jdks = [int(v) for v in car_runtime_jdks.split(",")]
     except ValueError:
-        raise exceptions.SystemSetupError(
-            "Car config key \"runtime.jdk\" is invalid: \"{}\" (must be int)".format(car_runtime_jdks))
+        raise exceptions.SystemSetupError('Car config key "runtime.jdk" is invalid: "{}" (must be int)'.format(car_runtime_jdks))
 
     runtime_jdk_versions = determine_runtime_jdks()
     if runtime_jdk_versions[0] == "bundled":
         if not provides_bundled_jdk:
-            raise exceptions.SystemSetupError("This Elasticsearch version does not contain a bundled JDK. "
-                                              "Please specify a different runtime JDK.")
+            raise exceptions.SystemSetupError(
+                "This Elasticsearch version does not contain a bundled JDK. Please specify a different runtime JDK."
+            )
         logger.info("Using JDK bundled with Elasticsearch.")
         # assume that the bundled JDK is the highest available; the path is irrelevant
         return allowed_runtime_jdks[0], None

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -21,7 +21,7 @@ import subprocess
 
 import psutil
 
-from esrally import time, exceptions, telemetry
+from esrally import exceptions, telemetry, time
 from esrally.mechanic import cluster, java_resolver
 from esrally.utils import io, opts, process
 
@@ -119,6 +119,7 @@ class ProcessLauncher:
     """
     Launcher is responsible for starting and stopping the benchmark candidate.
     """
+
     PROCESS_WAIT_TIMEOUT_SECONDS = 90.0
 
     def __init__(self, cfg, clock=time.Clock):
@@ -138,9 +139,9 @@ class ProcessLauncher:
         data_paths = node_configuration.data_paths
         node_telemetry_dir = os.path.join(node_configuration.node_root_path, "telemetry")
 
-        java_major_version, java_home = java_resolver.java_home(node_configuration.car_runtime_jdks,
-                                                                self.cfg.opts("mechanic", "runtime.jdk"),
-                                                                node_configuration.car_provides_bundled_jdk)
+        java_major_version, java_home = java_resolver.java_home(
+            node_configuration.car_runtime_jdks, self.cfg.opts("mechanic", "runtime.jdk"), node_configuration.car_provides_bundled_jdk
+        )
 
         self.logger.info("Starting node [%s].", node_name)
 
@@ -186,7 +187,7 @@ class ProcessLauncher:
         self.logger.debug("env for [%s]: %s", node_name, str(env))
         return env
 
-    def _set_env(self, env, k, v, separator=' ', prepend=False):
+    def _set_env(self, env, k, v, separator=" ", prepend=False):
         if v is not None:
             if k not in env:
                 env[k] = v
@@ -199,11 +200,9 @@ class ProcessLauncher:
     def _run_subprocess(command_line, env):
         command_line_args = shlex.split(command_line)
 
-        with subprocess.Popen(command_line_args,
-                              stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL,
-                              env=env,
-                              start_new_session=True) as command_line_process:
+        with subprocess.Popen(
+            command_line_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env, start_new_session=True
+        ) as command_line_process:
             # wait for it to finish
             command_line_process.wait()
         return command_line_process.returncode

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -25,7 +25,7 @@ import uuid
 import jinja2
 
 from esrally import exceptions
-from esrally.mechanic import team, java_resolver
+from esrally.mechanic import java_resolver, team
 from esrally.utils import console, convert, io, process, versions
 
 
@@ -54,8 +54,7 @@ def docker(cfg, car, ip, http_port, target_root, node_name):
 
 
 class NodeConfiguration:
-    def __init__(self, build_type, car_runtime_jdks, car_provides_bundled_jdk, ip, node_name, node_root_path,
-                 binary_path, data_paths):
+    def __init__(self, build_type, car_runtime_jdks, car_provides_bundled_jdk, ip, node_name, node_root_path, binary_path, data_paths):
         self.build_type = build_type
         self.car_runtime_jdks = car_runtime_jdks
         self.car_provides_bundled_jdk = car_provides_bundled_jdk
@@ -74,13 +73,21 @@ class NodeConfiguration:
             "node-name": self.node_name,
             "node-root-path": self.node_root_path,
             "binary-path": self.binary_path,
-            "data-paths": self.data_paths
+            "data-paths": self.data_paths,
         }
 
     @staticmethod
     def from_dict(d):
-        return NodeConfiguration(d["build-type"], d["car-runtime-jdks"], d["car-provides-bundled-jdk"], d["ip"],
-                                 d["node-name"], d["node-root-path"], d["binary-path"], d["data-paths"])
+        return NodeConfiguration(
+            d["build-type"],
+            d["car-runtime-jdks"],
+            d["car-provides-bundled-jdk"],
+            d["ip"],
+            d["node-name"],
+            d["node-root-path"],
+            d["binary-path"],
+            d["data-paths"],
+        )
 
 
 def save_node_configuration(path, n):
@@ -142,7 +149,7 @@ def _apply_config(source_root_path, target_root_path, config_vars):
     for root, _, files in os.walk(source_root_path):
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(root))
 
-        relative_root = root[len(source_root_path) + 1:]
+        relative_root = root[len(source_root_path) + 1 :]
         absolute_target_root = os.path.join(target_root_path, relative_root)
         io.ensure_dir(absolute_target_root)
 
@@ -193,11 +200,16 @@ class BareProvisioner:
         for installer in self.plugin_installers:
             installer.invoke_install_hook(team.BootstrapPhase.post_install, provisioner_vars.copy())
 
-        return NodeConfiguration("tar", self.es_installer.car.mandatory_var("runtime.jdk"),
-                                 convert.to_bool(self.es_installer.car.mandatory_var("runtime.jdk.bundled")),
-                                 self.es_installer.node_ip, self.es_installer.node_name,
-                                 self.es_installer.node_root_dir, self.es_installer.es_home_path,
-                                 self.es_installer.data_paths)
+        return NodeConfiguration(
+            "tar",
+            self.es_installer.car.mandatory_var("runtime.jdk"),
+            convert.to_bool(self.es_installer.car.mandatory_var("runtime.jdk.bundled")),
+            self.es_installer.node_ip,
+            self.es_installer.node_name,
+            self.es_installer.node_root_dir,
+            self.es_installer.es_home_path,
+            self.es_installer.data_paths,
+        )
 
     def _provisioner_variables(self):
         plugin_variables = {}
@@ -233,8 +245,18 @@ class BareProvisioner:
 
 
 class ElasticsearchInstaller:
-    def __init__(self, car, java_home, node_name, node_root_dir, all_node_ips, all_node_names, ip, http_port,
-                 hook_handler_class=team.BootstrapHookHandler):
+    def __init__(
+        self,
+        car,
+        java_home,
+        node_name,
+        node_root_dir,
+        all_node_ips,
+        all_node_names,
+        ip,
+        http_port,
+        hook_handler_class=team.BootstrapHookHandler,
+    ):
         self.car = car
         self.java_home = java_home
         self.node_name = node_name
@@ -293,11 +315,11 @@ class ElasticsearchInstaller:
             "network_host": network_host,
             "http_port": str(self.http_port),
             "transport_port": str(self.http_port + 100),
-            "all_node_ips": "[\"%s\"]" % "\",\"".join(self.all_node_ips),
-            "all_node_names": "[\"%s\"]" % "\",\"".join(self.all_node_names),
+            "all_node_ips": '["%s"]' % '","'.join(self.all_node_ips),
+            "all_node_names": '["%s"]' % '","'.join(self.all_node_names),
             # at the moment we are strict and enforce that all nodes are master eligible nodes
             "minimum_master_nodes": len(self.all_node_ips),
-            "install_root_path": self.es_home_path
+            "install_root_path": self.es_home_path,
         }
         variables = {}
         variables.update(self.car.variables)
@@ -349,8 +371,10 @@ class PluginInstaller:
         elif return_code == 74:
             raise exceptions.SupplyError("I/O error while trying to install [%s]" % self.plugin_name)
         else:
-            raise exceptions.RallyError("Unknown error while trying to install [%s] (installer return code [%s]). Please check the logs." %
-                                        (self.plugin_name, str(return_code)))
+            raise exceptions.RallyError(
+                "Unknown error while trying to install [%s] (installer return code [%s]). Please check the logs."
+                % (self.plugin_name, str(return_code))
+            )
 
     def invoke_install_hook(self, phase, variables):
         self.hook_handler.invoke(phase.name, variables=variables, env=self.env())
@@ -408,7 +432,7 @@ class DockerProvisioner:
             "discovery_type": "single-node",
             "http_port": str(self.http_port),
             "transport_port": str(self.http_port + 100),
-            "cluster_settings": {}
+            "cluster_settings": {},
         }
 
         self.config_vars = {}
@@ -435,7 +459,7 @@ class DockerProvisioner:
             for root, _, files in os.walk(car_config_path):
                 env = jinja2.Environment(loader=jinja2.FileSystemLoader(root))
 
-                relative_root = root[len(car_config_path) + 1:]
+                relative_root = root[len(car_config_path) + 1 :]
                 absolute_target_root = os.path.join(self.binary_path, relative_root)
                 io.ensure_dir(absolute_target_root)
 
@@ -457,9 +481,16 @@ class DockerProvisioner:
         with open(os.path.join(self.binary_path, "docker-compose.yml"), mode="wt", encoding="utf-8") as f:
             f.write(docker_cfg)
 
-        return NodeConfiguration("docker", self.car.mandatory_var("runtime.jdk"),
-                                 convert.to_bool(self.car.mandatory_var("runtime.jdk.bundled")), self.node_ip,
-                                 self.node_name, self.node_root_dir, self.binary_path, self.data_paths)
+        return NodeConfiguration(
+            "docker",
+            self.car.mandatory_var("runtime.jdk"),
+            convert.to_bool(self.car.mandatory_var("runtime.jdk.bundled")),
+            self.node_ip,
+            self.node_name,
+            self.node_root_dir,
+            self.binary_path,
+            self.data_paths,
+        )
 
     def docker_vars(self, mounts):
         v = {
@@ -469,7 +500,7 @@ class DockerProvisioner:
             "es_data_dir": self.data_paths[0],
             "es_log_dir": self.node_log_dir,
             "es_heap_dump_dir": self.heap_dump_dir,
-            "mounts": mounts
+            "mounts": mounts,
         }
         self._add_if_defined_for_car(v, "docker_mem_limit")
         self._add_if_defined_for_car(v, "docker_cpu_count")
@@ -494,6 +525,6 @@ class DockerProvisioner:
 
     def _render_template_from_file(self, variables):
         compose_file = os.path.join(self.rally_root, "resources", "docker-compose.yml.j2")
-        return self._render_template(loader=jinja2.FileSystemLoader(io.dirname(compose_file)),
-                                     template_name=io.basename(compose_file),
-                                     variables=variables)
+        return self._render_template(
+            loader=jinja2.FileSystemLoader(io.dirname(compose_file)), template_name=io.basename(compose_file), variables=variables
+        )

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -22,8 +22,8 @@ from enum import Enum
 
 import tabulate
 
-from esrally import exceptions, PROGRAM_NAME, config
-from esrally.utils import console, repo, io, modules
+from esrally import PROGRAM_NAME, config, exceptions
+from esrally.utils import console, io, modules, repo
 
 TEAM_FORMAT_VERSION = 1
 
@@ -152,6 +152,7 @@ class CarLoader:
         def __is_car(path):
             _, extension = io.splitext(path)
             return extension == ".ini"
+
         return map(__car_name, filter(__is_car, os.listdir(self.cars_dir)))
 
     def _car_file(self, name):
@@ -256,7 +257,7 @@ class Car:
         try:
             return self.variables[name]
         except KeyError:
-            raise exceptions.SystemSetupError("Car \"{}\" requires config key \"{}\"".format(self.name, name))
+            raise exceptions.SystemSetupError('Car "{}" requires config key "{}"'.format(self.name, name))
 
     @property
     def name(self):
@@ -343,18 +344,19 @@ class PluginLoader:
         if not config_names:
             # maybe we only have a config folder but nothing else (e.g. if there is only an install hook)
             if io.exists(root_path):
-                return PluginDescriptor(name=name,
-                                        core_plugin=core_plugin is not None,
-                                        config=config_names,
-                                        root_path=root_path,
-                                        variables=plugin_params)
+                return PluginDescriptor(
+                    name=name, core_plugin=core_plugin is not None, config=config_names, root_path=root_path, variables=plugin_params
+                )
             else:
                 if core_plugin:
                     return core_plugin
                 # If we just have a plugin name then we assume that this is a community plugin and the user has specified a download URL
                 else:
-                    self.logger.info("The plugin [%s] is neither a configured nor an official plugin. Assuming that this is a community "
-                                     "plugin not requiring any configuration and you have set a proper download URL.", name)
+                    self.logger.info(
+                        "The plugin [%s] is neither a configured nor an official plugin. Assuming that this is a community "
+                        "plugin not requiring any configuration and you have set a proper download URL.",
+                        name,
+                    )
                     return PluginDescriptor(name, variables=plugin_params)
         else:
             variables = {}
@@ -367,12 +369,16 @@ class PluginLoader:
                 # Do we have an explicit configuration for this plugin?
                 if not io.exists(config_file):
                     if core_plugin:
-                        raise exceptions.SystemSetupError("Plugin [%s] does not provide configuration [%s]. List the available plugins "
-                                                          "and configurations with %s list elasticsearch-plugins "
-                                                          "--distribution-version=VERSION." % (name, config_name, PROGRAM_NAME))
+                        raise exceptions.SystemSetupError(
+                            "Plugin [%s] does not provide configuration [%s]. List the available plugins "
+                            "and configurations with %s list elasticsearch-plugins "
+                            "--distribution-version=VERSION." % (name, config_name, PROGRAM_NAME)
+                        )
                     else:
-                        raise exceptions.SystemSetupError("Unknown plugin [%s]. List the available plugins with %s list "
-                                                          "elasticsearch-plugins --distribution-version=VERSION." % (name, PROGRAM_NAME))
+                        raise exceptions.SystemSetupError(
+                            "Unknown plugin [%s]. List the available plugins with %s list "
+                            "elasticsearch-plugins --distribution-version=VERSION." % (name, PROGRAM_NAME)
+                        )
 
                 config = configparser.ConfigParser(interpolation=configparser.ExtendedInterpolation())
                 # Do not modify the case of option keys but read them as is
@@ -395,8 +401,14 @@ class PluginLoader:
             # maybe one of the configs is really just for providing variables. However, we still require one config base overall.
             if len(config_paths) == 0:
                 raise exceptions.SystemSetupError("At least one config base is required for plugin [%s]" % name)
-            return PluginDescriptor(name=name, core_plugin=core_plugin is not None, config=config_names, root_path=root_path,
-                                    config_paths=config_paths, variables=variables)
+            return PluginDescriptor(
+                name=name,
+                core_plugin=core_plugin is not None,
+                config=config_names,
+                root_path=root_path,
+                config_paths=config_paths,
+                variables=variables,
+            )
 
 
 class PluginDescriptor:
@@ -450,6 +462,7 @@ class BootstrapHookHandler:
     """
     Responsible for loading and executing component-specific intitialization code.
     """
+
     def __init__(self, component, loader_class=modules.ComponentLoader):
         """
         Creates a new BootstrapHookHandler.
@@ -496,5 +509,6 @@ class BootstrapHookHandler:
                 # hooks should only take keyword arguments to be forwards compatible with Rally!
                 hook(config_names=self.component.config, **kwargs)
         else:
-            self.logger.debug("Component [%s] in config [%s] has no hook registered for phase [%s].",
-                         self.component.name, self.component.config, phase)
+            self.logger.debug(
+                "Component [%s] in config [%s] has no hook registered for phase [%s].", self.component.name, self.component.config, phase
+            )

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -32,8 +32,8 @@ from http.client import responses
 
 import tabulate
 
-from esrally import client, time, exceptions, config, version, paths
-from esrally.utils import convert, console, io, versions
+from esrally import client, config, exceptions, paths, time, version
+from esrally.utils import console, convert, io, versions
 
 
 class EsClient:
@@ -59,21 +59,26 @@ class EsClient:
     def put_template(self, name, template):
         # TODO #653: Remove version-specific support for metrics stores before 7.0.0 (also adjust template)
         if self._cluster_version[0] > 6:
-            return self.guarded(self._client.indices.put_template, name=name, body=template, params={
-                # allows to include the type name although it is not allowed anymore by default
-                "include_type_name": "true"
-            })
+            return self.guarded(
+                self._client.indices.put_template,
+                name=name,
+                body=template,
+                params={
+                    # allows to include the type name although it is not allowed anymore by default
+                    "include_type_name": "true"
+                },
+            )
         else:
             return self.guarded(self._client.indices.put_template, name=name, body=template)
 
     def template_exists(self, name):
         return self.guarded(self._client.indices.exists_template, name)
 
-    def delete_template(self,  name):
+    def delete_template(self, name):
         self.guarded(self._client.indices.delete_template, name)
 
     def get_index(self, name):
-        return self.guarded(self._client.indices.get,  name)
+        return self.guarded(self._client.indices.get, name)
 
     def create_index(self, index):
         # ignore 400 cause by IndexAlreadyExistsException when creating an index
@@ -89,15 +94,14 @@ class EsClient:
         # TODO #653: Remove version-specific support for metrics stores before 7.0.0.
         # pylint: disable=import-outside-toplevel
         import elasticsearch.helpers
+
         if self._cluster_version[0] > 6:
             self.guarded(elasticsearch.helpers.bulk, self._client, items, index=index, chunk_size=5000)
         else:
             self.guarded(elasticsearch.helpers.bulk, self._client, items, index=index, doc_type=doc_type, chunk_size=5000)
 
     def index(self, index, doc_type, item, id=None):
-        doc = {
-            "_source": item
-        }
+        doc = {"_source": item}
         if id:
             doc["_id"] = id
         self.bulk_index(index, doc_type, [doc])
@@ -108,6 +112,7 @@ class EsClient:
     def guarded(self, target, *args, **kwargs):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
+
         max_execution_count = 11
         execution_count = 0
 
@@ -120,17 +125,20 @@ class EsClient:
             except elasticsearch.exceptions.AuthenticationException:
                 # we know that it is just one host (see EsClientFactory)
                 node = self._client.transport.hosts[0]
-                msg = "The configured user could not authenticate against your Elasticsearch metrics store running on host [%s] at " \
-                      "port [%s] (wrong password?). Please fix the configuration in [%s]." % \
-                      (node["host"], node["port"], config.ConfigFile().location)
+                msg = (
+                    "The configured user could not authenticate against your Elasticsearch metrics store running on host [%s] at "
+                    "port [%s] (wrong password?). Please fix the configuration in [%s]."
+                    % (node["host"], node["port"], config.ConfigFile().location)
+                )
                 self.logger.exception(msg)
                 raise exceptions.SystemSetupError(msg)
             except elasticsearch.exceptions.AuthorizationException:
                 node = self._client.transport.hosts[0]
-                msg = "The configured user does not have enough privileges to run the operation [%s] against your Elasticsearch metrics " \
-                      "store running on host [%s] at port [%s]. Please adjust your x-pack configuration or specify a user with enough " \
-                      "privileges in the configuration in [%s]." % \
-                      (target.__name__, node["host"], node["port"], config.ConfigFile().location)
+                msg = (
+                    "The configured user does not have enough privileges to run the operation [%s] against your Elasticsearch metrics "
+                    "store running on host [%s] at port [%s]. Please adjust your x-pack configuration or specify a user with enough "
+                    "privileges in the configuration in [%s]." % (target.__name__, node["host"], node["port"], config.ConfigFile().location)
+                )
                 self.logger.exception(msg)
                 raise exceptions.SystemSetupError(msg)
             except elasticsearch.exceptions.ConnectionTimeout:
@@ -141,31 +149,45 @@ class EsClient:
                     operation = target.__name__
                     self.logger.exception("Connection timeout while running [%s] (retried %d times).", operation, max_execution_count)
                     node = self._client.transport.hosts[0]
-                    msg = "A connection timeout occurred while running the operation [%s] against your Elasticsearch metrics store on " \
-                          "host [%s] at port [%s]." % (operation, node["host"], node["port"])
+                    msg = (
+                        "A connection timeout occurred while running the operation [%s] against your Elasticsearch metrics store on "
+                        "host [%s] at port [%s]." % (operation, node["host"], node["port"])
+                    )
                     raise exceptions.RallyError(msg)
             except elasticsearch.exceptions.ConnectionError:
                 node = self._client.transport.hosts[0]
-                msg = "Could not connect to your Elasticsearch metrics store. Please check that it is running on host [%s] at port [%s]" \
-                      " or fix the configuration in [%s]." % (node["host"], node["port"], config.ConfigFile().location)
+                msg = (
+                    "Could not connect to your Elasticsearch metrics store. Please check that it is running on host [%s] at port [%s]"
+                    " or fix the configuration in [%s]." % (node["host"], node["port"], config.ConfigFile().location)
+                )
                 self.logger.exception(msg)
                 raise exceptions.SystemSetupError(msg)
             except elasticsearch.TransportError as e:
                 if e.status_code in (502, 503, 504, 429) and execution_count < max_execution_count:
-                    self.logger.debug("%s (code: %d) in attempt [%d/%d]. Sleeping for [%f] seconds.",
-                                      responses[e.status_code], e.status_code, execution_count, max_execution_count, time_to_sleep)
+                    self.logger.debug(
+                        "%s (code: %d) in attempt [%d/%d]. Sleeping for [%f] seconds.",
+                        responses[e.status_code],
+                        e.status_code,
+                        execution_count,
+                        max_execution_count,
+                        time_to_sleep,
+                    )
                     time.sleep(time_to_sleep)
                 else:
                     node = self._client.transport.hosts[0]
-                    msg = "A transport error occurred while running the operation [%s] against your Elasticsearch metrics store on " \
-                          "host [%s] at port [%s]." % (target.__name__, node["host"], node["port"])
+                    msg = (
+                        "A transport error occurred while running the operation [%s] against your Elasticsearch metrics store on "
+                        "host [%s] at port [%s]." % (target.__name__, node["host"], node["port"])
+                    )
                     self.logger.exception(msg)
                     raise exceptions.RallyError(msg)
 
             except elasticsearch.exceptions.ElasticsearchException:
                 node = self._client.transport.hosts[0]
-                msg = "An unknown error occurred while running the operation [%s] against your Elasticsearch metrics store on host [%s] " \
-                      "at port [%s]." % (target.__name__, node["host"], node["port"])
+                msg = (
+                    "An unknown error occurred while running the operation [%s] against your Elasticsearch metrics store on host [%s] "
+                    "at port [%s]." % (target.__name__, node["host"], node["port"])
+                )
                 self.logger.exception(msg)
                 # this does not necessarily mean it's a system setup problem...
                 raise exceptions.RallyError(msg)
@@ -191,7 +213,7 @@ class EsClientFactory:
         client_options = {
             "use_ssl": secure,
             "verify_certs": verify,
-            "timeout": 120
+            "timeout": 120,
         }
         if ca_path:
             client_options["ca_certs"] = ca_path
@@ -236,6 +258,7 @@ class MetaInfoScope(Enum):
     Defines the scope of a meta-information. Meta-information provides more context for a metric, for example the concrete version
     of Elasticsearch that has been benchmarked or environment information like CPU model or OS.
     """
+
     cluster = 1
     """
     Cluster level meta-information is valid for all nodes in the cluster (e.g. the benchmarked Elasticsearch version)
@@ -385,8 +408,13 @@ class MetricsStore:
 
         self._car_name = "+".join(self._car) if isinstance(self._car, list) else self._car
 
-        self.logger.info("Opening metrics store for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s]",
-                         self._race_timestamp, self._track, self._challenge, self._car)
+        self.logger.info(
+            "Opening metrics store for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s]",
+            self._race_timestamp,
+            self._track,
+            self._challenge,
+            self._car,
+        )
 
         user_tags = extract_user_tags_from_config(self._config)
         for k, v in user_tags.items():
@@ -443,10 +471,7 @@ class MetricsStore:
         """
         Clears all internally stored meta-info. This is considered Rally internal API and not intended for normal client consumption.
         """
-        self._meta_info = {
-            MetaInfoScope.cluster: {},
-            MetaInfoScope.node: {}
-        }
+        self._meta_info = {MetaInfoScope.cluster: {}, MetaInfoScope.node: {}}
 
     @property
     def open_context(self):
@@ -455,11 +480,22 @@ class MetricsStore:
             "race-timestamp": self._race_timestamp,
             "track": self._track,
             "challenge": self._challenge,
-            "car": self._car
+            "car": self._car,
         }
 
-    def put_value_cluster_level(self, name, value, unit=None, task=None, operation=None, operation_type=None, sample_type=SampleType.Normal,
-                                absolute_time=None, relative_time=None, meta_data=None):
+    def put_value_cluster_level(
+        self,
+        name,
+        value,
+        unit=None,
+        task=None,
+        operation=None,
+        operation_type=None,
+        sample_type=SampleType.Normal,
+        absolute_time=None,
+        relative_time=None,
+        meta_data=None,
+    ):
         """
         Adds a new cluster level value metric.
 
@@ -476,11 +512,35 @@ class MetricsStore:
                Defaults to None. The metrics store will derive the timestamp automatically.
         :param meta_data: A dict, containing additional key-value pairs. Defaults to None.
         """
-        self._put_metric(MetaInfoScope.cluster, None, name, value, unit, task, operation, operation_type, sample_type, absolute_time,
-                         relative_time, meta_data)
+        self._put_metric(
+            MetaInfoScope.cluster,
+            None,
+            name,
+            value,
+            unit,
+            task,
+            operation,
+            operation_type,
+            sample_type,
+            absolute_time,
+            relative_time,
+            meta_data,
+        )
 
-    def put_value_node_level(self, node_name, name, value, unit=None, task=None, operation=None, operation_type=None,
-                             sample_type=SampleType.Normal, absolute_time=None, relative_time=None, meta_data=None):
+    def put_value_node_level(
+        self,
+        node_name,
+        name,
+        value,
+        unit=None,
+        task=None,
+        operation=None,
+        operation_type=None,
+        sample_type=SampleType.Normal,
+        absolute_time=None,
+        relative_time=None,
+        meta_data=None,
+    ):
         """
         Adds a new node level value metric.
 
@@ -498,11 +558,36 @@ class MetricsStore:
                Defaults to None. The metrics store will derive the timestamp automatically.
         :param meta_data: A dict, containing additional key-value pairs. Defaults to None.
         """
-        self._put_metric(MetaInfoScope.node, node_name, name, value, unit, task, operation, operation_type, sample_type, absolute_time,
-                         relative_time, meta_data)
+        self._put_metric(
+            MetaInfoScope.node,
+            node_name,
+            name,
+            value,
+            unit,
+            task,
+            operation,
+            operation_type,
+            sample_type,
+            absolute_time,
+            relative_time,
+            meta_data,
+        )
 
-    def _put_metric(self, level, level_key, name, value, unit, task, operation, operation_type, sample_type, absolute_time=None,
-                    relative_time=None, meta_data=None):
+    def _put_metric(
+        self,
+        level,
+        level_key,
+        name,
+        value,
+        unit,
+        task,
+        operation,
+        operation_type,
+        sample_type,
+        absolute_time=None,
+        relative_time=None,
+        meta_data=None,
+    ):
         if level == MetaInfoScope.cluster:
             meta = self._meta_info[MetaInfoScope.cluster].copy()
         elif level == MetaInfoScope.node:
@@ -534,7 +619,7 @@ class MetricsStore:
             "value": value,
             "unit": unit,
             "sample-type": sample_type.name.lower(),
-            "meta": meta
+            "meta": meta,
         }
         if task:
             doc["task"] = task
@@ -578,19 +663,20 @@ class MetricsStore:
         if relative_time is None:
             relative_time = self._stop_watch.split_time()
 
-        doc.update({
-            "@timestamp": time.to_epoch_millis(absolute_time),
-            # deprecated
-            "relative-time-ms": convert.seconds_to_ms(relative_time),
-            "relative-time": convert.seconds_to_ms(relative_time),
-            "race-id": self._race_id,
-            "race-timestamp": self._race_timestamp,
-            "environment": self._environment_name,
-            "track": self._track,
-            "challenge": self._challenge,
-            "car": self._car_name,
-
-        })
+        doc.update(
+            {
+                "@timestamp": time.to_epoch_millis(absolute_time),
+                # deprecated
+                "relative-time-ms": convert.seconds_to_ms(relative_time),
+                "relative-time": convert.seconds_to_ms(relative_time),
+                "race-id": self._race_id,
+                "race-timestamp": self._race_timestamp,
+                "environment": self._environment_name,
+                "track": self._track,
+                "challenge": self._challenge,
+                "car": self._car_name,
+            }
+        )
         if meta:
             doc["meta"] = meta
         if self._track_params:
@@ -620,8 +706,9 @@ class MetricsStore:
         """
         raise NotImplementedError("abstract method")
 
-    def get_one(self, name, sample_type=None, node_name=None, task=None, mapper=lambda doc: doc["value"],
-                sort_key=None, sort_reverse=False):
+    def get_one(
+        self, name, sample_type=None, node_name=None, task=None, mapper=lambda doc: doc["value"], sort_key=None, sort_reverse=False
+    ):
         """
         Gets one value for the given metric name (even if there should be more than one).
 
@@ -753,13 +840,17 @@ class EsMetricsStore(MetricsStore):
     """
     A metrics store backed by Elasticsearch.
     """
+
     METRICS_DOC_TYPE = "_doc"
 
-    def __init__(self,
-                 cfg,
-                 client_factory_class=EsClientFactory,
-                 index_template_provider_class=IndexTemplateProvider,
-                 clock=time.Clock, meta_info=None):
+    def __init__(
+        self,
+        cfg,
+        client_factory_class=EsClientFactory,
+        index_template_provider_class=IndexTemplateProvider,
+        clock=time.Clock,
+        meta_info=None,
+    ):
         """
         Creates a new metrics store.
 
@@ -812,9 +903,15 @@ class EsMetricsStore(MetricsStore):
             sw.start()
             self._client.bulk_index(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, items=self._docs)
             sw.stop()
-            self.logger.info("Successfully added %d metrics documents for race timestamp=[%s], track=[%s], "
-                             "challenge=[%s], car=[%s] in [%f] seconds.", len(self._docs), self._race_timestamp,
-                             self._track, self._challenge, self._car, sw.total_time())
+            self.logger.info(
+                "Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",
+                len(self._docs),
+                self._race_timestamp,
+                self._track,
+                self._challenge,
+                self._car,
+                sw.total_time(),
+            )
         self._docs = []
         # ensure we can search immediately after flushing
         if refresh:
@@ -824,20 +921,19 @@ class EsMetricsStore(MetricsStore):
         self._docs.append(doc)
 
     def _get(self, name, task, operation_type, sample_type, node_name, mapper):
-        query = {
-            "query": self._query_by_name(name, task, operation_type, sample_type, node_name)
-        }
+        query = {"query": self._query_by_name(name, task, operation_type, sample_type, node_name)}
         self.logger.debug("Issuing get against index=[%s], query=[%s].", self._index, query)
         result = self._client.search(index=self._index, body=query)
         self.logger.debug("Metrics query produced [%s] results.", result["hits"]["total"])
         return [mapper(v["_source"]) for v in result["hits"]["hits"]]
 
-    def get_one(self, name, sample_type=None, node_name=None, task=None, mapper=lambda doc: doc["value"],
-                sort_key=None, sort_reverse=False):
+    def get_one(
+        self, name, sample_type=None, node_name=None, task=None, mapper=lambda doc: doc["value"], sort_key=None, sort_reverse=False
+    ):
         order = "desc" if sort_reverse else "asc"
         query = {
             "query": self._query_by_name(name, task, None, sample_type, node_name),
-            "size": 1
+            "size": 1,
         }
         if sort_key:
             query["sort"] = [{sort_key: {"order": order}}]
@@ -860,10 +956,10 @@ class EsMetricsStore(MetricsStore):
             "aggs": {
                 "error_rate": {
                     "terms": {
-                        "field": "meta.success"
-                    }
-                }
-            }
+                        "field": "meta.success",
+                    },
+                },
+            },
         }
         self.logger.debug("Issuing get_error_rate against index=[%s], query=[%s]", self._index, query)
         result = self._client.search(index=self._index, body=query)
@@ -902,10 +998,10 @@ class EsMetricsStore(MetricsStore):
             "aggs": {
                 "metric_stats": {
                     "stats": {
-                        "field": "value"
-                    }
-                }
-            }
+                        "field": "value",
+                    },
+                },
+            },
         }
         self.logger.debug("Issuing get_stats against index=[%s], query=[%s]", self._index, query)
         result = self._client.search(index=self._index, body=query)
@@ -921,10 +1017,10 @@ class EsMetricsStore(MetricsStore):
                 "percentile_stats": {
                     "percentiles": {
                         "field": "value",
-                        "percents": percentiles
-                    }
-                }
-            }
+                        "percents": percentiles,
+                    },
+                },
+            },
         }
         self.logger.debug("Issuing get_percentiles against index=[%s], query=[%s]", self._index, query)
         result = self._client.search(index=self._index, body=query)
@@ -945,41 +1041,49 @@ class EsMetricsStore(MetricsStore):
                 "filter": [
                     {
                         "term": {
-                            "race-id": self._race_id
-                        }
+                            "race-id": self._race_id,
+                        },
                     },
                     {
                         "term": {
-                            "name": name
-                        }
-                    }
-                ]
-            }
+                            "name": name,
+                        },
+                    },
+                ],
+            },
         }
         if task:
-            q["bool"]["filter"].append({
-                "term": {
-                    "task": task
-                }
-            })
+            q["bool"]["filter"].append(
+                {
+                    "term": {
+                        "task": task,
+                    },
+                },
+            )
         if operation_type:
-            q["bool"]["filter"].append({
-                "term": {
-                    "operation-type": operation_type
-                }
-            })
+            q["bool"]["filter"].append(
+                {
+                    "term": {
+                        "operation-type": operation_type,
+                    },
+                },
+            )
         if sample_type:
-            q["bool"]["filter"].append({
-                "term": {
-                    "sample-type": sample_type.name.lower()
-                }
-            })
+            q["bool"]["filter"].append(
+                {
+                    "term": {
+                        "sample-type": sample_type.name.lower(),
+                    },
+                },
+            )
         if node_name:
-            q["bool"]["filter"].append({
-                "term": {
-                    "meta.node_name": node_name
-                }
-            })
+            q["bool"]["filter"].append(
+                {
+                    "term": {
+                        "meta.node_name": node_name,
+                    },
+                },
+            )
         return q
 
     def to_externalizable(self, clear=False):
@@ -1020,8 +1124,9 @@ class InMemoryMetricsStore(MetricsStore):
         if clear:
             self.docs = []
         compressed = zlib.compress(pickle.dumps(docs))
-        self.logger.debug("Compression changed size of metric store from [%d] bytes to [%d] bytes",
-                         sys.getsizeof(docs, -1), sys.getsizeof(compressed, -1))
+        self.logger.debug(
+            "Compression changed size of metric store from [%d] bytes to [%d] bytes", sys.getsizeof(docs, -1), sys.getsizeof(compressed, -1)
+        )
         return compressed
 
     def get_percentiles(self, name, task=None, operation_type=None, sample_type=None, percentiles=None):
@@ -1062,9 +1167,12 @@ class InMemoryMetricsStore(MetricsStore):
         total_count = 0
         for doc in self.docs:
             # we can use any request metrics record (i.e. service time or latency)
-            if doc["name"] == "service_time" and doc["task"] == task and \
-                    (operation_type is None or doc["operation-type"] == operation_type) and \
-                    (sample_type is None or doc["sample-type"] == sample_type.name.lower()):
+            if (
+                doc["name"] == "service_time"
+                and doc["task"] == task
+                and (operation_type is None or doc["operation-type"] == operation_type)
+                and (sample_type is None or doc["sample-type"] == sample_type.name.lower())
+            ):
                 total_count += 1
                 if doc["meta"]["success"] is False:
                     error += 1
@@ -1082,31 +1190,36 @@ class InMemoryMetricsStore(MetricsStore):
                 "min": sorted_values[0],
                 "max": sorted_values[-1],
                 "avg": statistics.mean(sorted_values),
-                "sum": sum(sorted_values)
+                "sum": sum(sorted_values),
             }
         else:
             return None
 
     def _get(self, name, task, operation_type, sample_type, node_name, mapper):
-        return [mapper(doc)
-                for doc in self.docs
-                if doc["name"] == name and
-                (task is None or doc["task"] == task) and
-                (operation_type is None or doc["operation-type"] == operation_type) and
-                (sample_type is None or doc["sample-type"] == sample_type.name.lower()) and
-                (node_name is None or doc.get("meta", {}).get("node_name") == node_name)
-                ]
+        return [
+            mapper(doc)
+            for doc in self.docs
+            if doc["name"] == name
+            and (task is None or doc["task"] == task)
+            and (operation_type is None or doc["operation-type"] == operation_type)
+            and (sample_type is None or doc["sample-type"] == sample_type.name.lower())
+            and (node_name is None or doc.get("meta", {}).get("node_name") == node_name)
+        ]
 
-    def get_one(self, name, sample_type=None, node_name=None, task=None, mapper=lambda doc: doc["value"],
-                sort_key=None, sort_reverse=False):
+    def get_one(
+        self, name, sample_type=None, node_name=None, task=None, mapper=lambda doc: doc["value"], sort_key=None, sort_reverse=False
+    ):
         if sort_key:
             docs = sorted(self.docs, key=lambda k: k[sort_key], reverse=sort_reverse)
         else:
             docs = self.docs
         for doc in docs:
-            if (doc["name"] == name and (task is None or doc["task"] == task) and
-                    (sample_type is None or doc["sample-type"] == sample_type.name.lower()) and
-                    (node_name is None or doc.get("meta", {}).get("node_name") == node_name)):
+            if (
+                doc["name"] == name
+                and (task is None or doc["task"] == task)
+                and (sample_type is None or doc["sample-type"] == sample_type.name.lower())
+                and (node_name is None or doc.get("meta", {}).get("node_name") == node_name)
+            ):
                 return mapper(doc)
         return None
 
@@ -1147,20 +1260,45 @@ def results_store(cfg):
 def list_races(cfg):
     def format_dict(d):
         if d:
-            items=sorted(d.items())
+            items = sorted(d.items())
             return ", ".join(["%s=%s" % (k, v) for k, v in items])
         else:
             return None
 
     races = []
     for race in race_store(cfg).list():
-        races.append([race.race_id, time.to_iso8601(race.race_timestamp), race.track, format_dict(race.track_params), race.challenge_name,
-                      race.car_name, format_dict(race.user_tags), race.track_revision, race.team_revision])
+        races.append(
+            [
+                race.race_id,
+                time.to_iso8601(race.race_timestamp),
+                race.track,
+                format_dict(race.track_params),
+                race.challenge_name,
+                race.car_name,
+                format_dict(race.user_tags),
+                race.track_revision,
+                race.team_revision,
+            ]
+        )
 
     if len(races) > 0:
         console.println("\nRecent races:\n")
-        console.println(tabulate.tabulate(races, headers=["Race ID", "Race Timestamp", "Track", "Track Parameters", "Challenge", "Car",
-                                                          "User Tags", "Track Revision", "Team Revision"]))
+        console.println(
+            tabulate.tabulate(
+                races,
+                headers=[
+                    "Race ID",
+                    "Race Timestamp",
+                    "Track",
+                    "Track Parameters",
+                    "Challenge",
+                    "Car",
+                    "User Tags",
+                    "Track Revision",
+                    "Team Revision",
+                ],
+            )
+        )
     else:
         console.println("")
         console.println("No recent races found.")
@@ -1179,14 +1317,48 @@ def create_race(cfg, track, challenge, track_revision=None):
     rally_version = version.version()
     rally_revision = version.revision()
 
-    return Race(rally_version, rally_revision, environment, race_id, race_timestamp, pipeline, user_tags, track,
-                track_params, challenge, car, car_params, plugin_params, track_revision)
+    return Race(
+        rally_version,
+        rally_revision,
+        environment,
+        race_id,
+        race_timestamp,
+        pipeline,
+        user_tags,
+        track,
+        track_params,
+        challenge,
+        car,
+        car_params,
+        plugin_params,
+        track_revision,
+    )
 
 
 class Race:
-    def __init__(self, rally_version, rally_revision, environment_name, race_id, race_timestamp, pipeline, user_tags,
-                 track, track_params, challenge, car, car_params, plugin_params, track_revision=None, team_revision=None,
-                 distribution_version=None, distribution_flavor=None, revision=None, results=None, meta_data=None):
+    def __init__(
+        self,
+        rally_version,
+        rally_revision,
+        environment_name,
+        race_id,
+        race_timestamp,
+        pipeline,
+        user_tags,
+        track,
+        track_params,
+        challenge,
+        car,
+        car_params,
+        plugin_params,
+        track_revision=None,
+        team_revision=None,
+        distribution_version=None,
+        distribution_flavor=None,
+        revision=None,
+        results=None,
+        meta_data=None,
+    ):
         if results is None:
             results = {}
         # this happens when the race is created initially
@@ -1251,7 +1423,7 @@ class Race:
                 "distribution-version": self.distribution_version,
                 "distribution-flavor": self.distribution_flavor,
                 "team-revision": self.team_revision,
-            }
+            },
         }
         if self.results:
             d["results"] = self.results.as_dict()
@@ -1284,7 +1456,7 @@ class Race:
             "challenge": self.challenge_name,
             "car": self.car_name,
             # allow to logically delete records, e.g. for UI purposes when we only want to show the latest result
-            "active": True
+            "active": True,
         }
         if self.distribution_version:
             result_template["distribution-major-version"] = versions.major_version(self.distribution_version)
@@ -1315,13 +1487,28 @@ class Race:
         user_tags = d.get("user-tags", {})
         # TODO: cluster is optional for BWC. This can be removed after some grace period.
         cluster = d.get("cluster", {})
-        return Race(d["rally-version"], d.get("rally-revision"), d["environment"], d["race-id"],
-                    time.from_is8601(d["race-timestamp"]), d["pipeline"], user_tags, d["track"], d.get("track-params"),
-                    d.get("challenge"), d["car"], d.get("car-params"), d.get("plugin-params"),
-                    track_revision=d.get("track-revision"), team_revision=cluster.get("team-revision"),
-                    distribution_version=cluster.get("distribution-version"),
-                    distribution_flavor=cluster.get("distribution-flavor"),
-                    revision=cluster.get("revision"), results=d.get("results"), meta_data=d.get("meta", {}))
+        return Race(
+            d["rally-version"],
+            d.get("rally-revision"),
+            d["environment"],
+            d["race-id"],
+            time.from_is8601(d["race-timestamp"]),
+            d["pipeline"],
+            user_tags,
+            d["track"],
+            d.get("track-params"),
+            d.get("challenge"),
+            d["car"],
+            d.get("car-params"),
+            d.get("plugin-params"),
+            track_revision=d.get("track-revision"),
+            team_revision=cluster.get("team-revision"),
+            distribution_version=cluster.get("distribution-version"),
+            distribution_flavor=cluster.get("distribution-flavor"),
+            revision=cluster.get("revision"),
+            results=d.get("results"),
+            meta_data=d.get("meta", {}),
+        )
 
 
 class RaceStore:
@@ -1349,6 +1536,7 @@ class CompositeRaceStore:
 
     It provides the same API as RaceStore. It delegates writes to all stores and all read operations only the Elasticsearch race store.
     """
+
     def __init__(self, es_store, file_store):
         self.es_store = es_store
         self.file_store = file_store
@@ -1378,7 +1566,7 @@ class FileRaceStore(RaceStore):
     def list(self):
         results = glob.glob(self._race_file(race_id="*"))
         all_races = self._to_races(results)
-        return all_races[:self._max_results()]
+        return all_races[: self._max_results()]
 
     def find_by_race_id(self, race_id):
         race_file = self._race_file(race_id=race_id)
@@ -1427,26 +1615,28 @@ class EsRaceStore(RaceStore):
         return f"{EsRaceStore.INDEX_PREFIX}{race_timestamp:%Y-%m}"
 
     def list(self):
-        filters = [{
-            "term": {
-                "environment": self.environment_name
+        filters = [
+            {
+                "term": {
+                    "environment": self.environment_name,
+                },
             }
-        }]
+        ]
 
         query = {
             "query": {
                 "bool": {
-                    "filter": filters
-                }
+                    "filter": filters,
+                },
             },
             "size": self._max_results(),
             "sort": [
                 {
                     "race-timestamp": {
-                        "order": "desc"
-                    }
-                }
-            ]
+                        "order": "desc",
+                    },
+                },
+            ],
         }
         result = self.client.search(index="%s*" % EsRaceStore.INDEX_PREFIX, body=query)
         hits = result["hits"]["total"]
@@ -1465,12 +1655,12 @@ class EsRaceStore(RaceStore):
                     "filter": [
                         {
                             "term": {
-                                "race-id": race_id
-                            }
-                        }
-                    ]
-                }
-            }
+                                "race-id": race_id,
+                            },
+                        },
+                    ],
+                },
+            },
         }
         result = self.client.search(index="%s*" % EsRaceStore.INDEX_PREFIX, body=query)
         hits = result["hits"]["total"]
@@ -1481,7 +1671,8 @@ class EsRaceStore(RaceStore):
             return Race.from_dict(result["hits"]["hits"][0]["_source"])
         elif hits > 1:
             raise exceptions.RallyAssertionError(
-                "Expected exactly one race to match race id [{}] but there were [{}] matches.".format(race_id, hits))
+                "Expected exactly one race to match race id [{}] but there were [{}] matches.".format(race_id, hits)
+            )
         else:
             raise exceptions.NotFound("No race with race id [{}]".format(race_id))
 
@@ -1490,6 +1681,7 @@ class EsResultsStore:
     """
     Stores the results of a race in a format that is better suited for reporting with Kibana.
     """
+
     INDEX_PREFIX = "rally-results-"
     RESULTS_DOC_TYPE = "_doc"
 
@@ -1508,9 +1700,7 @@ class EsResultsStore:
     def store_results(self, race):
         # always update the mapping to the latest version
         self.client.put_template("rally-results", self.index_template_provider.results_template())
-        self.client.bulk_index(index=self.index_name(race),
-                               doc_type=EsResultsStore.RESULTS_DOC_TYPE,
-                               items=race.to_result_dicts())
+        self.client.bulk_index(index=self.index_name(race), doc_type=EsResultsStore.RESULTS_DOC_TYPE, items=race.to_result_dicts())
 
     def index_name(self, race):
         race_timestamp = race.race_timestamp
@@ -1521,6 +1711,7 @@ class NoopResultsStore:
     """
     Does not store any results separately as these are stored as part of the race on the file system.
     """
+
     def store_results(self, race):
         pass
 
@@ -1576,11 +1767,7 @@ class GlobalStatsCalculator:
                         self.single_latency(t, op_type, metric_name="processing_time"),
                         error_rate,
                         duration,
-                        self.merge(
-                            self.track.meta_data,
-                            self.challenge.meta_data,
-                            task.operation.meta_data,
-                            task.meta_data)
+                        self.merge(self.track.meta_data, self.challenge.meta_data, task.operation.meta_data, task.meta_data),
                     )
         self.logger.debug("Gathering indexing metrics.")
         result.total_time = self.sum("indexing_total_time")
@@ -1659,7 +1846,7 @@ class GlobalStatsCalculator:
                 "mean": mean,
                 "median": median,
                 "max": stats["max"],
-                "unit": unit
+                "unit": unit,
             }
         else:
             return {
@@ -1667,7 +1854,7 @@ class GlobalStatsCalculator:
                 "mean": None,
                 "median": None,
                 "max": None,
-                "unit": unit
+                "unit": unit,
             }
 
     def shard_stats(self, metric_name):
@@ -1679,7 +1866,7 @@ class GlobalStatsCalculator:
                 "min": min(flat_values),
                 "median": statistics.median(flat_values),
                 "max": max(flat_values),
-                "unit": unit
+                "unit": unit,
             }
         else:
             return {}
@@ -1689,14 +1876,9 @@ class GlobalStatsCalculator:
         result = []
         if values:
             for v in values:
-                result.append({
-                    "job": v["job"],
-                    "min": v["min"],
-                    "mean": v["mean"],
-                    "median": v["median"],
-                    "max": v["max"],
-                    "unit": v["unit"]
-                })
+                result.append(
+                    {"job": v["job"], "min": v["min"], "mean": v["mean"], "median": v["median"], "max": v["max"], "unit": v["unit"]}
+                )
         return result
 
     def total_transform_metric(self, metric_name):
@@ -1706,19 +1888,16 @@ class GlobalStatsCalculator:
             for v in values:
                 transform_id = v.get("meta", {}).get("transform_id")
                 if transform_id is not None:
-                    result.append({
-                        "id": transform_id,
-                        "mean": v["value"],
-                        "unit": v["unit"]
-                    })
+                    result.append({"id": transform_id, "mean": v["value"], "unit": v["unit"]})
         return result
 
     def error_rate(self, task_name, operation_type):
         return self.store.get_error_rate(task=task_name, operation_type=operation_type, sample_type=SampleType.Normal)
 
     def duration(self, task_name):
-        return self.store.get_one("service_time", task=task_name, mapper=lambda doc: doc["relative-time"],
-                                  sort_key="relative-time", sort_reverse=True)
+        return self.store.get_one(
+            "service_time", task=task_name, mapper=lambda doc: doc["relative-time"], sort_key="relative-time", sort_reverse=True
+        )
 
     def median(self, metric_name, task_name=None, operation_type=None, sample_type=None):
         return self.store.get_median(metric_name, task=task_name, operation_type=operation_type, sample_type=sample_type)
@@ -1728,15 +1907,14 @@ class GlobalStatsCalculator:
         stats = self.store.get_stats(metric_name, task=task, operation_type=operation_type, sample_type=sample_type)
         sample_size = stats["count"] if stats else 0
         if sample_size > 0:
-            percentiles = self.store.get_percentiles(metric_name,
-                                                     task=task,
-                                                     operation_type=operation_type,
-                                                     sample_type=sample_type,
-                                                     percentiles=percentiles_for_sample_size(sample_size))
-            mean = self.store.get_mean(metric_name,
-                                       task=task,
-                                       operation_type=operation_type,
-                                       sample_type=sample_type)
+            percentiles = self.store.get_percentiles(
+                metric_name,
+                task=task,
+                operation_type=operation_type,
+                sample_type=sample_type,
+                percentiles=percentiles_for_sample_size(sample_size),
+            )
+            mean = self.store.get_mean(metric_name, task=task, operation_type=operation_type, sample_type=sample_type)
             unit = self.store.get_unit(metric_name, task=task, operation_type=operation_type)
             stats = collections.OrderedDict()
             for k, v in percentiles.items():
@@ -1794,13 +1972,9 @@ class GlobalStats:
 
     def as_flat_list(self):
         def op_metrics(op_item, key, single_value=False):
-            doc = {
-                "task": op_item["task"],
-                "operation": op_item["operation"],
-                "name": key
-            }
+            doc = {"task": op_item["task"], "operation": op_item["operation"], "name": key}
             if single_value:
-                doc["value"] = {"single":  op_item[key]}
+                doc["value"] = {"single": op_item[key]}
             else:
                 doc["value"] = op_item[key]
             if "meta" in op_item:
@@ -1825,35 +1999,21 @@ class GlobalStats:
                         all_results.append(op_metrics(item, "duration", single_value=True))
             elif metric == "ml_processing_time":
                 for item in value:
-                    all_results.append({
-                        "job": item["job"],
-                        "name": "ml_processing_time",
-                        "value": {
-                            "min": item["min"],
-                            "mean": item["mean"],
-                            "median": item["median"],
-                            "max": item["max"]
+                    all_results.append(
+                        {
+                            "job": item["job"],
+                            "name": "ml_processing_time",
+                            "value": {"min": item["min"], "mean": item["mean"], "median": item["median"], "max": item["max"]},
                         }
-                    })
+                    )
             elif metric.startswith("total_transform_") and value is not None:
                 for item in value:
-                    all_results.append({
-                        "id": item["id"],
-                        "name": metric,
-                        "value": {
-                            "single": item["mean"]
-                        }
-                    })
+                    all_results.append({"id": item["id"], "name": metric, "value": {"single": item["mean"]}})
             elif metric.endswith("_time_per_shard"):
                 if value:
                     all_results.append({"name": metric, "value": value})
             elif value is not None:
-                result = {
-                    "name": metric,
-                    "value": {
-                        "single": value
-                    }
-                }
+                result = {"name": metric, "value": {"single": value}}
                 all_results.append(result)
         # sorting is just necessary to have a stable order for tests. As we just have a small number of metrics, the overhead is neglible.
         return sorted(all_results, key=lambda m: m["name"])
@@ -1870,7 +2030,7 @@ class GlobalStats:
             "service_time": service_time,
             "processing_time": processing_time,
             "error_rate": error_rate,
-            "duration": duration
+            "duration": duration,
         }
         if meta:
             doc["meta"] = meta
@@ -1922,11 +2082,7 @@ class SystemStats:
         return d.get(k, default) if d else default
 
     def add_node_metrics(self, node, name, value, unit):
-        metric = {
-            "node": node,
-            "name": name,
-            "value": value
-        }
+        metric = {"node": node, "name": name, "value": value}
         if unit:
             metric["unit"] = unit
         self.node_metrics.append(metric)

--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -41,9 +41,6 @@ def install_root(cfg=None):
     return os.path.join(races_root(cfg), install_id)
 
 
-# There is a weird bug manifesting in jenkins that is somehow saying the following line has an invalid docstring
-# So to work around it, we are adding this disable, even though the docstring is perfectly fine.
-# pylint: disable=invalid-docstring-quote
 def logs():
     """
     :return: The absolute path to the directory that contains Rally's log file.

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -23,9 +23,20 @@ import sys
 import tabulate
 import thespian.actors
 
-from esrally import actor, config, doc_link, driver, exceptions, mechanic, metrics, reporter, track, version, PROGRAM_NAME
+from esrally import (
+    PROGRAM_NAME,
+    actor,
+    config,
+    doc_link,
+    driver,
+    exceptions,
+    mechanic,
+    metrics,
+    reporter,
+    track,
+    version,
+)
 from esrally.utils import console, opts, versions
-
 
 pipelines = collections.OrderedDict()
 
@@ -99,12 +110,12 @@ class BenchmarkActor(actor.RallyActor):
         self.coordinator.setup(sources=msg.sources)
         self.logger.info("Asking mechanic to start the engine.")
         self.mechanic = self.createActor(mechanic.MechanicActor, targetActorRequirements={"coordinator": True})
-        self.send(self.mechanic, mechanic.StartEngine(self.cfg,
-                                                      self.coordinator.metrics_store.open_context,
-                                                      msg.sources,
-                                                      msg.distribution,
-                                                      msg.external,
-                                                      msg.docker))
+        self.send(
+            self.mechanic,
+            mechanic.StartEngine(
+                self.cfg, self.coordinator.metrics_store.open_context, msg.sources, msg.distribution, msg.external, msg.docker
+            ),
+        )
 
     @actor.no_retry("race control")  # pylint: disable=no-value-for-parameter
     def receiveMsg_EngineStarted(self, msg, sender):
@@ -187,16 +198,15 @@ class BenchmarkCoordinator:
         if self.current_challenge is None:
             raise exceptions.SystemSetupError(
                 "Track [{}] does not provide challenge [{}]. List the available tracks with {} list tracks.".format(
-                    self.current_track.name, challenge_name, PROGRAM_NAME))
+                    self.current_track.name, challenge_name, PROGRAM_NAME
+                )
+            )
         if self.current_challenge.user_info:
             console.info(self.current_challenge.user_info)
         self.race = metrics.create_race(self.cfg, self.current_track, self.current_challenge, self.track_revision)
 
         self.metrics_store = metrics.metrics_store(
-            self.cfg,
-            track=self.race.track_name,
-            challenge=self.race.challenge_name,
-            read_only=False
+            self.cfg, track=self.race.track_name, challenge=self.race.challenge_name, read_only=False
         )
         self.race_store = metrics.race_store(self.cfg)
 
@@ -207,11 +217,17 @@ class BenchmarkCoordinator:
         # store race initially (without any results) so other components can retrieve full metadata
         self.race_store.store_race(self.race)
         if self.race.challenge.auto_generated:
-            console.info("Racing on track [{}] and car {} with version [{}].\n"
-                         .format(self.race.track_name, self.race.car, self.race.distribution_version))
+            console.info(
+                "Racing on track [{}] and car {} with version [{}].\n".format(
+                    self.race.track_name, self.race.car, self.race.distribution_version
+                )
+            )
         else:
-            console.info("Racing on track [{}], challenge [{}] and car {} with version [{}].\n"
-                         .format(self.race.track_name, self.race.challenge_name, self.race.car, self.race.distribution_version))
+            console.info(
+                "Racing on track [{}], challenge [{}] and car {} with version [{}].\n".format(
+                    self.race.track_name, self.race.challenge_name, self.race.car, self.race.distribution_version
+                )
+            )
 
     def on_task_finished(self, new_metrics):
         self.logger.info("Task has finished.")
@@ -268,7 +284,7 @@ def set_default_hosts(cfg, host="127.0.0.1", port=9200):
         logger.info("Using configured hosts %s", configured_hosts.default)
     else:
         logger.info("Setting default host to [%s:%d]", host, port)
-        default_host_object = opts.TargetHosts("{}:{}".format(host,port))
+        default_host_object = opts.TargetHosts("{}:{}".format(host, port))
         cfg.add(config.Scope.benchmark, "client", "hosts", default_host_object)
 
 
@@ -297,18 +313,16 @@ def docker(cfg):
     return race(cfg, docker=True)
 
 
-Pipeline("from-sources",
-         "Builds and provisions Elasticsearch, runs a benchmark and reports results.", from_sources)
+Pipeline("from-sources", "Builds and provisions Elasticsearch, runs a benchmark and reports results.", from_sources)
 
-Pipeline("from-distribution",
-         "Downloads an Elasticsearch distribution, provisions it, runs a benchmark and reports results.", from_distribution)
+Pipeline(
+    "from-distribution", "Downloads an Elasticsearch distribution, provisions it, runs a benchmark and reports results.", from_distribution
+)
 
-Pipeline("benchmark-only",
-         "Assumes an already running Elasticsearch instance, runs a benchmark and reports results", benchmark_only)
+Pipeline("benchmark-only", "Assumes an already running Elasticsearch instance, runs a benchmark and reports results", benchmark_only)
 
 # Very experimental Docker pipeline. Should only be used with great care and is also not supported on all platforms.
-Pipeline("docker",
-         "Runs a benchmark against the official Elasticsearch Docker container and reports results", docker, stable=False)
+Pipeline("docker", "Runs a benchmark against the official Elasticsearch Docker container and reports results", docker, stable=False)
 
 
 def available_pipelines():
@@ -342,14 +356,15 @@ def run(cfg):
             raise exceptions.SystemSetupError(
                 "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n"
                 "Add --pipeline=benchmark-only in your Rally arguments and try again.\n"
-                "For more details read the docs for the benchmark-only pipeline in {}\n".format(
-                    doc_link("pipelines.html#benchmark-only")))
+                "For more details read the docs for the benchmark-only pipeline in {}\n".format(doc_link("pipelines.html#benchmark-only"))
+            )
 
     try:
         pipeline = pipelines[name]
     except KeyError:
         raise exceptions.SystemSetupError(
-            "Unknown pipeline [%s]. List the available pipelines with %s list pipelines." % (name, PROGRAM_NAME))
+            "Unknown pipeline [%s]. List the available pipelines with %s list pipelines." % (name, PROGRAM_NAME)
+        )
     try:
         pipeline(cfg)
     except exceptions.RallyError as e:

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -26,12 +26,29 @@ import uuid
 
 import thespian.actors
 
-from esrally import PROGRAM_NAME, BANNER, FORUM_LINK, SKULL, check_python_version, doc_link, telemetry
-from esrally import version, actor, config, paths, racecontrol, reporter, metrics, track, chart_generator, exceptions, \
-    log
-from esrally.mechanic import team, mechanic
+from esrally import (
+    BANNER,
+    FORUM_LINK,
+    PROGRAM_NAME,
+    SKULL,
+    actor,
+    chart_generator,
+    check_python_version,
+    config,
+    doc_link,
+    exceptions,
+    log,
+    metrics,
+    paths,
+    racecontrol,
+    reporter,
+    telemetry,
+    track,
+    version,
+)
+from esrally.mechanic import mechanic, team
 from esrally.tracker import tracker
-from esrally.utils import io, convert, process, console, net, opts, versions
+from esrally.utils import console, convert, io, net, opts, process, versions
 
 
 def create_arg_parser():
@@ -70,15 +87,17 @@ def create_arg_parser():
             "--track-repository",
             help="Define the repository from where Rally will load tracks (default: default).",
             # argparse is smart enough to use this default only if the user did not use --track-path and also did not specify anything
-            default="default"
+            default="default",
         )
         track_source_group.add_argument(
             "--track-path",
-            help="Define the path to a track.")
+            help="Define the path to a track.",
+        )
         subparser.add_argument(
             "--track-revision",
             help="Define a specific revision in the track repository that Rally should use.",
-            default=None)
+            default=None,
+        )
 
     # try to preload configurable defaults, but this does not work together with `--configuration-name` (which is undocumented anyway)
     cfg = config.Config()
@@ -88,16 +107,19 @@ def create_arg_parser():
     else:
         preserve_install = False
 
-    parser = argparse.ArgumentParser(prog=PROGRAM_NAME,
-                                     description=BANNER + "\n\n You Know, for Benchmarking Elasticsearch.",
-                                     epilog="Find out more about Rally at {}".format(console.format.link(doc_link())),
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('--version', action='version', version="%(prog)s " + version.version())
+    parser = argparse.ArgumentParser(
+        prog=PROGRAM_NAME,
+        description=BANNER + "\n\n You Know, for Benchmarking Elasticsearch.",
+        epilog="Find out more about Rally at {}".format(console.format.link(doc_link())),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s " + version.version(),
+    )
 
-    subparsers = parser.add_subparsers(
-        title="subcommands",
-        dest="subcommand",
-        help="")
+    subparsers = parser.add_subparsers(title="subcommands", dest="subcommand", help="")
 
     race_parser = subparsers.add_parser("race", help="Run a benchmark")
     # change in favor of "list telemetry", "list tracks", "list pipelines"
@@ -106,8 +128,9 @@ def create_arg_parser():
         "configuration",
         metavar="configuration",
         help="The configuration for which Rally should show the available options. "
-             "Possible values are: telemetry, tracks, pipelines, races, cars, elasticsearch-plugins",
-        choices=["telemetry", "tracks", "pipelines", "races", "cars", "elasticsearch-plugins"])
+        "Possible values are: telemetry, tracks, pipelines, races, cars, elasticsearch-plugins",
+        choices=["telemetry", "tracks", "pipelines", "races", "cars", "elasticsearch-plugins"],
+    )
     list_parser.add_argument(
         "--limit",
         help="Limit the number of search results for recent races (default: 10).",
@@ -127,123 +150,146 @@ def create_arg_parser():
     info_parser.add_argument(
         "--track-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to the track as variables.",
-        default=""
+        default="",
     )
     info_parser.add_argument(
         "--challenge",
-        help=f"Define the challenge to use. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`."
+        help=f"Define the challenge to use. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`.",
     )
     info_task_filter_group = info_parser.add_mutually_exclusive_group()
     info_task_filter_group.add_argument(
         "--include-tasks",
-        help="Defines a comma-separated list of tasks to run. By default all tasks of a challenge are run.")
+        help="Defines a comma-separated list of tasks to run. By default all tasks of a challenge are run.",
+    )
     info_task_filter_group.add_argument(
         "--exclude-tasks",
-        help="Defines a comma-separated list of tasks not to run. By default all tasks of a challenge are run.")
+        help="Defines a comma-separated list of tasks not to run. By default all tasks of a challenge are run.",
+    )
 
     create_track_parser = subparsers.add_parser("create-track", help="Create a Rally track from existing data")
     create_track_parser.add_argument(
         "--track",
         required=True,
-        help="Name of the generated track")
+        help="Name of the generated track",
+    )
     create_track_parser.add_argument(
         "--indices",
         type=non_empty_list,
         required=True,
-        help="Comma-separated list of indices to include in the track")
+        help="Comma-separated list of indices to include in the track",
+    )
     create_track_parser.add_argument(
         "--target-hosts",
         default="",
         required=True,
-        help="Comma-separated list of host:port pairs which should be targeted")
+        help="Comma-separated list of host:port pairs which should be targeted",
+    )
     create_track_parser.add_argument(
         "--client-options",
         default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS,
-        help=f"Comma-separated list of client options to use. (default: {opts.ClientOptions.DEFAULT_CLIENT_OPTIONS})")
+        help=f"Comma-separated list of client options to use. (default: {opts.ClientOptions.DEFAULT_CLIENT_OPTIONS})",
+    )
     create_track_parser.add_argument(
         "--output-path",
         default=os.path.join(os.getcwd(), "tracks"),
-        help="Track output directory (default: tracks/)")
+        help="Track output directory (default: tracks/)",
+    )
 
     generate_parser = subparsers.add_parser("generate", help="Generate artifacts")
     generate_parser.add_argument(
         "artifact",
         metavar="artifact",
         help="The artifact to create. Possible values are: charts",
-        choices=["charts"])
+        choices=["charts"],
+    )
     generate_parser.add_argument(
         "--chart-spec-path",
         required=True,
         help="Path to a JSON file(s) containing all combinations of charts to generate. Wildcard patterns can be used to specify "
-             "multiple files.")
+        "multiple files.",
+    )
     generate_parser.add_argument(
         "--chart-type",
         help="Chart type to generate (default: time-series).",
         choices=["time-series", "bar"],
-        default="time-series")
+        default="time-series",
+    )
     generate_parser.add_argument(
         "--output-path",
         help="Output file name (default: stdout).",
-        default=None)
+        default=None,
+    )
 
     compare_parser = subparsers.add_parser("compare", help="Compare two races")
     compare_parser.add_argument(
         "--baseline",
         required=True,
-        help=f"Race ID of the baseline (see {PROGRAM_NAME} list races).")
+        help=f"Race ID of the baseline (see {PROGRAM_NAME} list races).",
+    )
     compare_parser.add_argument(
         "--contender",
         required=True,
-        help=f"Race ID of the contender (see {PROGRAM_NAME} list races).")
+        help=f"Race ID of the contender (see {PROGRAM_NAME} list races).",
+    )
     compare_parser.add_argument(
         "--report-format",
         help="Define the output format for the command line report (default: markdown).",
         choices=["markdown", "csv"],
-        default="markdown")
+        default="markdown",
+    )
     compare_parser.add_argument(
         "--report-numbers-align",
         help="Define the output column number alignment for the command line report (default: right).",
         choices=["right", "center", "left", "decimal"],
-        default="right")
+        default="right",
+    )
     compare_parser.add_argument(
         "--report-file",
         help="Write the command line report also to the provided file.",
-        default="")
+        default="",
+    )
     compare_parser.add_argument(
         "--show-in-report",
         help="Whether to include the comparison in the results file.",
-        default=True)
+        default=True,
+    )
 
     download_parser = subparsers.add_parser("download", help="Downloads an artifact")
     download_parser.add_argument(
         "--team-repository",
         help="Define the repository from where Rally will load teams and cars (default: default).",
-        default="default")
+        default="default",
+    )
     download_parser.add_argument(
         "--team-revision",
         help="Define a specific revision in the team repository that Rally should use.",
-        default=None)
+        default=None,
+    )
     download_parser.add_argument(
         "--team-path",
-        help="Define the path to the car and plugin configurations to use.")
+        help="Define the path to the car and plugin configurations to use.",
+    )
     download_parser.add_argument(
         "--distribution-version",
         type=supported_es_version,
         help="Define the version of the Elasticsearch distribution to download. "
-             "Check https://www.elastic.co/downloads/elasticsearch for released versions.",
-        default="")
+        "Check https://www.elastic.co/downloads/elasticsearch for released versions.",
+        default="",
+    )
     download_parser.add_argument(
         "--distribution-repository",
         help="Define the repository from where the Elasticsearch distribution should be downloaded (default: release).",
-        default="release")
+        default="release",
+    )
     download_parser.add_argument(
         "--car",
         help=f"Define the car to use. List possible cars with `{PROGRAM_NAME} list cars` (default: defaults).",
-        default="defaults")  # optimized for local usage
+        default="defaults",
+    )  # optimized for local usage
     download_parser.add_argument(
         "--car-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim as variables for the car.",
-        default=""
+        default="",
     )
     download_parser.add_argument(
         "--target-os",
@@ -258,84 +304,94 @@ def create_arg_parser():
     install_parser.add_argument(
         "--revision",
         help="Define the source code revision for building the benchmark candidate. 'current' uses the source tree as is,"
-             " 'latest' fetches the latest version on master. It is also possible to specify a commit id or a timestamp."
-             " The timestamp must be specified as: \"@ts\" where \"ts\" must be a valid ISO 8601 timestamp, "
-             "e.g. \"@2013-07-27T10:37:00Z\" (default: current).",
-        default="current")  # optimized for local usage, don't fetch sources
+        " 'latest' fetches the latest version on master. It is also possible to specify a commit id or a timestamp."
+        ' The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, '
+        'e.g. "@2013-07-27T10:37:00Z" (default: current).',
+        default="current",
+    )  # optimized for local usage, don't fetch sources
     # Intentionally undocumented as we do not consider Docker a fully supported option.
     install_parser.add_argument(
         "--build-type",
         help=argparse.SUPPRESS,
         choices=["tar", "docker"],
-        default="tar")
+        default="tar",
+    )
     install_parser.add_argument(
         "--team-repository",
         help="Define the repository from where Rally will load teams and cars (default: default).",
-        default="default")
+        default="default",
+    )
     install_parser.add_argument(
         "--team-revision",
         help="Define a specific revision in the team repository that Rally should use.",
-        default=None)
+        default=None,
+    )
     install_parser.add_argument(
         "--team-path",
-        help="Define the path to the car and plugin configurations to use.")
+        help="Define the path to the car and plugin configurations to use.",
+    )
     install_parser.add_argument(
         "--runtime-jdk",
         type=runtime_jdk,
         help="The major version of the runtime JDK to use during installation.",
-        default=None)
+        default=None,
+    )
     install_parser.add_argument(
         "--distribution-repository",
         help="Define the repository from where the Elasticsearch distribution should be downloaded (default: release).",
-        default="release")
+        default="release",
+    )
     install_parser.add_argument(
         "--distribution-version",
         type=supported_es_version,
         help="Define the version of the Elasticsearch distribution to download. "
-             "Check https://www.elastic.co/downloads/elasticsearch for released versions.",
-        default="")
+        "Check https://www.elastic.co/downloads/elasticsearch for released versions.",
+        default="",
+    )
     install_parser.add_argument(
         "--car",
         help=f"Define the car to use. List possible cars with `{PROGRAM_NAME} list cars` (default: defaults).",
-        default="defaults")  # optimized for local usage
+        default="defaults",
+    )  # optimized for local usage
     install_parser.add_argument(
         "--car-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim as variables for the car.",
-        default=""
+        default="",
     )
     install_parser.add_argument(
         "--elasticsearch-plugins",
         help="Define the Elasticsearch plugins to install. (default: install no plugins).",
-        default="")
+        default="",
+    )
     install_parser.add_argument(
         "--plugin-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to all plugins as variables.",
-        default=""
+        default="",
     )
     install_parser.add_argument(
         "--network-host",
         help="The IP address to bind to and publish",
-        default="127.0.0.1"
+        default="127.0.0.1",
     )
     install_parser.add_argument(
         "--http-port",
         help="The port to expose for HTTP traffic",
-        default="39200"
+        default="39200",
     )
     install_parser.add_argument(
         "--node-name",
         help="The name of this Elasticsearch node",
-        default="rally-node-0"
+        default="rally-node-0",
     )
     install_parser.add_argument(
         "--master-nodes",
         help="A comma-separated list of the initial master node names",
-        default=""
+        default="",
     )
     install_parser.add_argument(
         "--seed-hosts",
         help="A comma-separated list of the initial seed host IPs",
-        default=""
+        default="",
     )
 
     start_parser = subparsers.add_parser("start", help="Starts an Elasticsearch node locally")
@@ -344,26 +400,30 @@ def create_arg_parser():
         required=True,
         help="The id of the installation to start",
         # the default will be dynamically derived by racecontrol based on the presence / absence of other command line options
-        default="")
+        default="",
+    )
     start_parser.add_argument(
         "--race-id",
         required=True,
         help="Define a unique id for this race.",
-        default="")
+        default="",
+    )
     start_parser.add_argument(
         "--runtime-jdk",
         type=runtime_jdk,
         help="The major version of the runtime JDK to use.",
-        default=None)
+        default=None,
+    )
     start_parser.add_argument(
         "--telemetry",
         help=f"Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry "
-             f"devices with `{PROGRAM_NAME} list telemetry`.",
-        default="")
+        f"devices with `{PROGRAM_NAME} list telemetry`.",
+        default="",
+    )
     start_parser.add_argument(
         "--telemetry-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to the telemetry devices as parameters.",
-        default=""
+        default="",
     )
 
     stop_parser = subparsers.add_parser("stop", help="Stops an Elasticsearch node locally")
@@ -372,173 +432,204 @@ def create_arg_parser():
         required=True,
         help="The id of the installation to stop",
         # the default will be dynamically derived by racecontrol based on the presence / absence of other command line options
-        default="")
+        default="",
+    )
     stop_parser.add_argument(
         "--preserve-install",
         help=f"Keep the benchmark candidate and its index. (default: {str(preserve_install).lower()}).",
         default=preserve_install,
-        action="store_true")
+        action="store_true",
+    )
 
     for p in [list_parser, race_parser]:
         p.add_argument(
             "--distribution-version",
             type=supported_es_version,
             help="Define the version of the Elasticsearch distribution to download. "
-                 "Check https://www.elastic.co/downloads/elasticsearch for released versions.",
-            default="")
+            "Check https://www.elastic.co/downloads/elasticsearch for released versions.",
+            default="",
+        )
         p.add_argument(
             "--team-path",
-            help="Define the path to the car and plugin configurations to use.")
+            help="Define the path to the car and plugin configurations to use.",
+        )
         p.add_argument(
             "--team-repository",
             help="Define the repository from where Rally will load teams and cars (default: default).",
-            default="default")
+            default="default",
+        )
         p.add_argument(
             "--team-revision",
             help="Define a specific revision in the team repository that Rally should use.",
-            default=None)
+            default=None,
+        )
 
     race_parser.add_argument(
         "--race-id",
         help="Define a unique id for this race.",
-        default=str(uuid.uuid4()))
+        default=str(uuid.uuid4()),
+    )
     race_parser.add_argument(
         "--pipeline",
         help="Select the pipeline to run.",
         # the default will be dynamically derived by racecontrol based on the presence / absence of other command line options
-        default="")
+        default="",
+    )
     race_parser.add_argument(
         "--revision",
         help="Define the source code revision for building the benchmark candidate. 'current' uses the source tree as is,"
-             " 'latest' fetches the latest version on master. It is also possible to specify a commit id or a timestamp."
-             " The timestamp must be specified as: \"@ts\" where \"ts\" must be a valid ISO 8601 timestamp, "
-             "e.g. \"@2013-07-27T10:37:00Z\" (default: current).",
-        default="current")  # optimized for local usage, don't fetch sources
+        " 'latest' fetches the latest version on master. It is also possible to specify a commit id or a timestamp."
+        ' The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, '
+        'e.g. "@2013-07-27T10:37:00Z" (default: current).',
+        default="current",
+    )  # optimized for local usage, don't fetch sources
     add_track_source(race_parser)
     race_parser.add_argument(
         "--track",
-        help=f"Define the track to use. List possible tracks with `{PROGRAM_NAME} list tracks`."
+        help=f"Define the track to use. List possible tracks with `{PROGRAM_NAME} list tracks`.",
     )
     race_parser.add_argument(
         "--track-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to the track as variables.",
-        default=""
+        default="",
     )
     race_parser.add_argument(
         "--challenge",
-        help=f"Define the challenge to use. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`.")
+        help=f"Define the challenge to use. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`.",
+    )
     race_parser.add_argument(
         "--car",
         help=f"Define the car to use. List possible cars with `{PROGRAM_NAME} list cars` (default: defaults).",
-        default="defaults")  # optimized for local usage
+        default="defaults",
+    )  # optimized for local usage
     race_parser.add_argument(
         "--car-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim as variables for the car.",
-        default=""
+        default="",
     )
     race_parser.add_argument(
         "--runtime-jdk",
         type=runtime_jdk,
         help="The major version of the runtime JDK to use.",
-        default=None)
+        default=None,
+    )
     race_parser.add_argument(
         "--elasticsearch-plugins",
         help="Define the Elasticsearch plugins to install. (default: install no plugins).",
-        default="")
+        default="",
+    )
     race_parser.add_argument(
         "--plugin-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to all plugins as variables.",
-        default=""
+        default="",
     )
     race_parser.add_argument(
         "--target-hosts",
         help="Define a comma-separated list of host:port pairs which should be targeted if using the pipeline 'benchmark-only' "
-             "(default: localhost:9200).",
-        default="")  # actually the default is pipeline specific and it is set later
+        "(default: localhost:9200).",
+        default="",
+    )  # actually the default is pipeline specific and it is set later
     race_parser.add_argument(
         "--load-driver-hosts",
         help="Define a comma-separated list of hosts which should generate load (default: localhost).",
-        default="localhost")
+        default="localhost",
+    )
     race_parser.add_argument(
         "--client-options",
         help=f"Define a comma-separated list of client options to use. The options will be passed to the Elasticsearch "
-             f"Python client (default: {opts.ClientOptions.DEFAULT_CLIENT_OPTIONS}).",
-        default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS)
-    race_parser.add_argument("--on-error",
-                             choices=["continue", "abort"],
-                             help="Controls how Rally behaves on response errors (default: continue).",
-                             default="continue")
+        f"Python client (default: {opts.ClientOptions.DEFAULT_CLIENT_OPTIONS}).",
+        default=opts.ClientOptions.DEFAULT_CLIENT_OPTIONS,
+    )
+    race_parser.add_argument(
+        "--on-error",
+        choices=["continue", "abort"],
+        help="Controls how Rally behaves on response errors (default: continue).",
+        default="continue",
+    )
     race_parser.add_argument(
         "--telemetry",
         help=f"Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry "
-             f"devices with `{PROGRAM_NAME} list telemetry`.",
-        default="")
+        f"devices with `{PROGRAM_NAME} list telemetry`.",
+        default="",
+    )
     race_parser.add_argument(
         "--telemetry-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to the telemetry devices as parameters.",
-        default=""
+        default="",
     )
     race_parser.add_argument(
         "--distribution-repository",
         help="Define the repository from where the Elasticsearch distribution should be downloaded (default: release).",
-        default="release")
+        default="release",
+    )
 
     task_filter_group = race_parser.add_mutually_exclusive_group()
     task_filter_group.add_argument(
         "--include-tasks",
-        help="Defines a comma-separated list of tasks to run. By default all tasks of a challenge are run.")
+        help="Defines a comma-separated list of tasks to run. By default all tasks of a challenge are run.",
+    )
     task_filter_group.add_argument(
         "--exclude-tasks",
-        help="Defines a comma-separated list of tasks not to run. By default all tasks of a challenge are run.")
+        help="Defines a comma-separated list of tasks not to run. By default all tasks of a challenge are run.",
+    )
     race_parser.add_argument(
         "--user-tag",
         help="Define a user-specific key-value pair (separated by ':'). It is added to each metric record as meta info. "
-             "Example: intention:baseline-ticket-12345",
-        default="")
+        "Example: intention:baseline-ticket-12345",
+        default="",
+    )
     race_parser.add_argument(
         "--report-format",
         help="Define the output format for the command line report (default: markdown).",
         choices=["markdown", "csv"],
-        default="markdown")
+        default="markdown",
+    )
     race_parser.add_argument(
         "--report-numbers-align",
         help="Define the output column number alignment for the command line report (default: right).",
         choices=["right", "center", "left", "decimal"],
-        default="right")
+        default="right",
+    )
     race_parser.add_argument(
         "--show-in-report",
         help="Define which values are shown in the summary report (default: available).",
         choices=["available", "all-percentiles", "all"],
-        default="available")
+        default="available",
+    )
     race_parser.add_argument(
         "--report-file",
         help="Write the command line report also to the provided file.",
-        default="")
+        default="",
+    )
     race_parser.add_argument(
         "--preserve-install",
         help=f"Keep the benchmark candidate and its index. (default: {str(preserve_install).lower()}).",
         default=preserve_install,
-        action="store_true")
+        action="store_true",
+    )
     race_parser.add_argument(
         "--test-mode",
         help="Runs the given track in 'test mode'. Meant to check a track for errors but not for real benchmarks (default: false).",
         default=False,
-        action="store_true")
+        action="store_true",
+    )
     race_parser.add_argument(
         "--enable-driver-profiling",
         help="Enables a profiler for analyzing the performance of calls in Rally's driver (default: false).",
         default=False,
-        action="store_true")
+        action="store_true",
+    )
     race_parser.add_argument(
         "--enable-assertions",
         help="Enables assertion checks for tasks (default: false).",
         default=False,
-        action="store_true")
+        action="store_true",
+    )
     race_parser.add_argument(
         "--kill-running-processes",
         action="store_true",
         default=False,
-        help="If any processes is running, it is going to kill them and allow Rally to continue to run."
+        help="If any processes is running, it is going to kill them and allow Rally to continue to run.",
     )
 
     ###############################################################################
@@ -552,31 +643,46 @@ def create_arg_parser():
         "--effective-start-date",
         help=argparse.SUPPRESS,
         type=lambda s: datetime.datetime.strptime(s, "%Y-%m-%d %H:%M:%S"),
-        default=None)
+        default=None,
+    )
     # Skips checking that the REST API is available before proceeding with the benchmark
     race_parser.add_argument(
         "--skip-rest-api-check",
         help=argparse.SUPPRESS,
         action="store_true",
-        default=False)
+        default=False,
+    )
 
-    for p in [list_parser, race_parser, compare_parser, download_parser, install_parser,
-              start_parser, stop_parser, info_parser, generate_parser, create_track_parser]:
+    for p in [
+        list_parser,
+        race_parser,
+        compare_parser,
+        download_parser,
+        install_parser,
+        start_parser,
+        stop_parser,
+        info_parser,
+        generate_parser,
+        create_track_parser,
+    ]:
         # This option is needed to support a separate configuration for the integration tests on the same machine
         p.add_argument(
             "--configuration-name",
             help=argparse.SUPPRESS,
-            default=None)
+            default=None,
+        )
         p.add_argument(
             "--quiet",
             help="Suppress as much as output as possible (default: false).",
             default=False,
-            action="store_true")
+            action="store_true",
+        )
         p.add_argument(
             "--offline",
             help="Assume that Rally has no connection to the Internet (default: false).",
             default=False,
-            action="store_true")
+            action="store_true",
+        )
 
     return parser
 
@@ -606,8 +712,10 @@ def print_help_on_errors():
     console.println(f"* Check the log files in {paths.logs()} for errors.")
     console.println(f"* Read the documentation at {console.format.link(doc_link())}.")
     console.println(f"* Ask a question on the forum at {console.format.link(FORUM_LINK)}.")
-    console.println(f"* Raise an issue at {console.format.link('https://github.com/elastic/rally/issues')} "
-                    f"and include the log files in {paths.logs()}.")
+    console.println(
+        f"* Raise an issue at {console.format.link('https://github.com/elastic/rally/issues')} "
+        f"and include the log files in {paths.logs()}."
+    )
 
 
 def race(cfg, kill_running_processes=False):
@@ -621,17 +729,18 @@ def race(cfg, kill_running_processes=False):
         try:
             process.kill_running_rally_instances()
         except BaseException:
-            logger.exception(
-                "Could not terminate potentially running Rally instances correctly. Attempting to go on anyway.")
+            logger.exception("Could not terminate potentially running Rally instances correctly. Attempting to go on anyway.")
     else:
         other_rally_processes = process.find_all_other_rally_processes()
         if other_rally_processes:
             pids = [p.pid for p in other_rally_processes]
 
-            msg = f"There are other Rally processes running on this machine (PIDs: {pids}) but only one Rally " \
-                  f"benchmark is allowed to run at the same time.\n\nYou can use --kill-running-processes flag " \
-                  f"to kill running processes automatically and allow Rally to continue to run a new benchmark. " \
-                  f"Otherwise, you need to manually kill them."
+            msg = (
+                f"There are other Rally processes running on this machine (PIDs: {pids}) but only one Rally "
+                f"benchmark is allowed to run at the same time.\n\nYou can use --kill-running-processes flag "
+                f"to kill running processes automatically and allow Rally to continue to run a new benchmark. "
+                f"Otherwise, you need to manually kill them."
+            )
             raise exceptions.RallyError(msg)
 
     with_actor_system(racecontrol.run, cfg)
@@ -653,8 +762,9 @@ def with_actor_system(runnable, cfg):
     except Exception as e:
         logger.exception("Could not bootstrap actor system.")
         if str(e) == "Unable to determine valid external socket address.":
-            console.warn("Could not determine a socket address. Are you running without any network? Switching to degraded mode.",
-                         logger=logger)
+            console.warn(
+                "Could not determine a socket address. Are you running without any network? Switching to degraded mode.", logger=logger
+            )
             logger.info("Falling back to offline actor system.")
             actor.use_offline_actor_system()
             actors = actor.bootstrap_actor_system(try_join=True)
@@ -690,8 +800,7 @@ def with_actor_system(runnable, cfg):
                     logger.warning("User interrupted shutdown of internal actor system.")
                     console.info("Please wait a moment for Rally's internal components to shutdown.")
             if not shutdown_complete and times_interrupted > 0:
-                logger.warning("Terminating after user has interrupted actor system shutdown explicitly for [%d] times.",
-                               times_interrupted)
+                logger.warning("Terminating after user has interrupted actor system shutdown explicitly for [%d] times.", times_interrupted)
                 console.println("")
                 console.warn("Terminating now at the risk of leaving child processes behind.")
                 console.println("")
@@ -700,8 +809,9 @@ def with_actor_system(runnable, cfg):
                 console.println(SKULL)
                 console.println("")
             elif not shutdown_complete:
-                console.warn("Could not terminate all internal processes within timeout. Please check and force-terminate "
-                             "all Rally processes.")
+                console.warn(
+                    "Could not terminate all internal processes within timeout. Please check and force-terminate all Rally processes."
+                )
 
 
 def generate(cfg):
@@ -928,8 +1038,7 @@ def main():
     if not args.offline:
         probing_url = cfg.opts("system", "probing.url", default_value="https://github.com", mandatory=False)
         if not net.has_internet_connection(probing_url):
-            console.warn("No Internet connection detected. Automatic download of track data sets etc. is disabled.",
-                         logger=logger)
+            console.warn("No Internet connection detected. Automatic download of track data sets etc. is disabled.", logger=logger)
             cfg.add(config.Scope.applicationOverride, "system", "offline.mode", True)
         else:
             logger.info("Detected a working Internet connection.")

--- a/esrally/rallyd.py
+++ b/esrally/rallyd.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -20,7 +20,16 @@ import logging
 import sys
 import time
 
-from esrally import actor, version, exceptions, doc_link, BANNER, PROGRAM_NAME, check_python_version, log
+from esrally import (
+    BANNER,
+    PROGRAM_NAME,
+    actor,
+    check_python_version,
+    doc_link,
+    exceptions,
+    log,
+    version,
+)
 from esrally.utils import console
 
 
@@ -73,30 +82,22 @@ def main():
     log.configure_logging()
     console.init(assume_tty=False)
 
-    parser = argparse.ArgumentParser(prog=PROGRAM_NAME,
-                                     description=BANNER + "\n\n Rally daemon to support remote benchmarks",
-                                     epilog="Find out more about Rally at {}".format(console.format.link(doc_link())),
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('--version', action='version', version="%(prog)s " + version.version())
+    parser = argparse.ArgumentParser(
+        prog=PROGRAM_NAME,
+        description=BANNER + "\n\n Rally daemon to support remote benchmarks",
+        epilog="Find out more about Rally at {}".format(console.format.link(doc_link())),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--version", action="version", version="%(prog)s " + version.version())
 
-    subparsers = parser.add_subparsers(
-        title="subcommands",
-        dest="subcommand",
-        help="")
+    subparsers = parser.add_subparsers(title="subcommands", dest="subcommand", help="")
     subparsers.required = True
 
     start_command = subparsers.add_parser("start", help="Starts the Rally daemon")
     restart_command = subparsers.add_parser("restart", help="Restarts the Rally daemon")
     for p in [start_command, restart_command]:
-        p.add_argument(
-            "--node-ip",
-            required=True,
-            help="The IP of this node.")
-        p.add_argument(
-            "--coordinator-ip",
-            required=True,
-            help="The IP of the coordinator node."
-        )
+        p.add_argument("--node-ip", required=True, help="The IP of this node.")
+        p.add_argument("--coordinator-ip", required=True, help="The IP of the coordinator node.")
     subparsers.add_parser("stop", help="Stops the Rally daemon")
     subparsers.add_parser("status", help="Shows the current status of the local Rally daemon")
 
@@ -115,5 +116,5 @@ def main():
         raise exceptions.RallyError("Unknown subcommand [%s]" % args.subcommand)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/esrally/time.py
+++ b/esrally/time.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/esrally/track/__init__.py
+++ b/esrally/track/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -16,8 +16,14 @@
 # under the License.
 
 from .loader import (
-    list_tracks, track_info, load_track, load_track_plugins, track_repo, operation_parameters, set_absolute_data_path,
-    TrackProcessorRegistry
+    TrackProcessorRegistry,
+    list_tracks,
+    load_track,
+    load_track_plugins,
+    operation_parameters,
+    set_absolute_data_path,
+    track_info,
+    track_repo,
 )
 
 # expose the complete track API

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -22,9 +22,8 @@ import math
 import numbers
 import operator
 import random
-from abc import ABC
-
 import time
+from abc import ABC
 from enum import Enum
 
 from esrally import exceptions
@@ -145,7 +144,7 @@ class ParamSource:
         return {
             "request-timeout": self._params.get("request-timeout"),
             "headers": self._params.get("headers"),
-            "opaque-id": self._params.get("opaque-id")
+            "opaque-id": self._params.get("opaque-id"),
         }
 
 
@@ -195,9 +194,7 @@ class CreateIndexParamSource(ParamSource):
                         else:
                             body["settings"] = settings
                     elif not body and settings:
-                        body = {
-                            "settings": settings
-                        }
+                        body = {"settings": settings}
 
                     self.index_definitions.append((idx.name, body))
         else:
@@ -216,10 +213,12 @@ class CreateIndexParamSource(ParamSource):
         p = {}
         # ensure we pass all parameters...
         p.update(self._params)
-        p.update({
-            "indices": self.index_definitions,
-            "request-params": self.request_params
-        })
+        p.update(
+            {
+                "indices": self.index_definitions,
+                "request-params": self.request_params,
+            }
+        )
         return p
 
 
@@ -248,10 +247,12 @@ class CreateDataStreamParamSource(ParamSource):
         p = {}
         # ensure we pass all parameters...
         p.update(self._params)
-        p.update({
-            "data-streams": self.data_stream_definitions,
-            "request-params": self.request_params
-        })
+        p.update(
+            {
+                "data-streams": self.data_stream_definitions,
+                "request-params": self.request_params,
+            }
+        )
         return p
 
 
@@ -277,11 +278,9 @@ class DeleteDataStreamParamSource(ParamSource):
         p = {}
         # ensure we pass all parameters...
         p.update(self._params)
-        p.update({
-            "data-streams": self.data_stream_definitions,
-            "request-params": self.request_params,
-            "only-if-exists": self.only_if_exists
-        })
+        p.update(
+            {"data-streams": self.data_stream_definitions, "request-params": self.request_params, "only-if-exists": self.only_if_exists}
+        )
         return p
 
 
@@ -308,11 +307,13 @@ class DeleteIndexParamSource(ParamSource):
         p = {}
         # ensure we pass all parameters...
         p.update(self._params)
-        p.update({
-            "indices": self.index_definitions,
-            "request-params": self.request_params,
-            "only-if-exists": self.only_if_exists
-        })
+        p.update(
+            {
+                "indices": self.index_definitions,
+                "request-params": self.request_params,
+                "only-if-exists": self.only_if_exists,
+            }
+        )
         return p
 
 
@@ -345,10 +346,12 @@ class CreateIndexTemplateParamSource(ParamSource):
         p = {}
         # ensure we pass all parameters...
         p.update(self._params)
-        p.update({
-            "templates": self.template_definitions,
-            "request-params": self.request_params
-        })
+        p.update(
+            {
+                "templates": self.template_definitions,
+                "request-params": self.request_params,
+            }
+        )
         return p
 
 
@@ -373,19 +376,22 @@ class DeleteIndexTemplateParamSource(ParamSource):
             try:
                 index_pattern = params["index-pattern"] if delete_matching else None
             except KeyError:
-                raise exceptions.InvalidSyntax("The property 'index-pattern' is required for delete-index-template if "
-                                               "'delete-matching-indices' is true.")
+                raise exceptions.InvalidSyntax(
+                    "The property 'index-pattern' is required for delete-index-template if 'delete-matching-indices' is true."
+                )
             self.template_definitions.append((template, delete_matching, index_pattern))
 
     def params(self):
         p = {}
         # ensure we pass all parameters...
         p.update(self._params)
-        p.update({
-            "templates": self.template_definitions,
-            "only-if-exists": self.only_if_exists,
-            "request-params": self.request_params
-        })
+        p.update(
+            {
+                "templates": self.template_definitions,
+                "only-if-exists": self.only_if_exists,
+                "request-params": self.request_params,
+            }
+        )
         return p
 
 
@@ -411,7 +417,7 @@ class DeleteComponentTemplateParamSource(ParamSource):
         return {
             "templates": self.template_definitions,
             "only-if-exists": self.only_if_exists,
-            "request-params": self.request_params
+            "request-params": self.request_params,
         }
 
 
@@ -429,13 +435,14 @@ class CreateTemplateParamSource(ABC, ParamSource):
                 if not filter_template or template.name == filter_template:
                     body = template.content
                     if body and "template" in body:
-                        body = CreateComposableTemplateParamSource._create_or_merge(template.content,
-                                                                                    ["template", "settings"], settings)
+                        body = CreateComposableTemplateParamSource._create_or_merge(template.content, ["template", "settings"], settings)
                         self.template_definitions.append((template.name, body))
         else:
-            raise exceptions.InvalidSyntax("Please set the properties 'template' and 'body' for the "
-                                           f"{params.get('operation-type')} operation or declare composable and/or component "
-                                           "templates in the track")
+            raise exceptions.InvalidSyntax(
+                "Please set the properties 'template' and 'body' for the "
+                f"{params.get('operation-type')} operation or declare composable and/or component "
+                "templates in the track"
+            )
 
     @staticmethod
     def _create_or_merge(content, path, new_content):
@@ -451,8 +458,7 @@ class CreateTemplateParamSource(ABC, ParamSource):
     @staticmethod
     def __merge(dct, merge_dct):
         for k in merge_dct.keys():
-            if (k in dct and isinstance(dct[k], dict)
-                    and isinstance(merge_dct[k], collections.abc.Mapping)):
+            if k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], collections.abc.Mapping):
                 CreateTemplateParamSource.__merge(dct[k], merge_dct[k])
             else:
                 dct[k] = merge_dct[k]
@@ -460,7 +466,7 @@ class CreateTemplateParamSource(ABC, ParamSource):
     def params(self):
         return {
             "templates": self.template_definitions,
-            "request-params": self.request_params
+            "request-params": self.request_params,
         }
 
 
@@ -480,8 +486,7 @@ class SearchParamSource(ParamSource):
         target_name = get_target(track, params)
         type_name = params.get("type")
         if params.get("data-stream") and type_name:
-            raise exceptions.InvalidSyntax(
-                f"'type' not supported with 'data-stream' for operation '{kwargs.get('operation_name')}'")
+            raise exceptions.InvalidSyntax(f"'type' not supported with 'data-stream' for operation '{kwargs.get('operation_name')}'")
         request_cache = params.get("cache", None)
         detailed_results = params.get("detailed-results", False)
         query_body = params.get("body", None)
@@ -498,12 +503,13 @@ class SearchParamSource(ParamSource):
             "detailed-results": detailed_results,
             "request-params": request_params,
             "response-compression-enabled": response_compression_enabled,
-            "body": query_body
+            "body": query_body,
         }
 
         if not target_name:
             raise exceptions.InvalidSyntax(
-                f"'index' or 'data-stream' is mandatory and is missing for operation '{kwargs.get('operation_name')}'")
+                f"'index' or 'data-stream' is mandatory and is missing for operation '{kwargs.get('operation_name')}'"
+            )
 
         if pages:
             self.query_params["pages"] = pages
@@ -536,6 +542,7 @@ class IndexIdConflict(Enum):
 
     Note that this assumes that each document in the benchmark corpus has an id between [1, size_of(corpus)]
     """
+
     NoConflicts = 0
     SequentialConflicts = 1
     RandomConflicts = 2
@@ -558,8 +565,9 @@ class BulkIndexParamSource(ParamSource):
             raise exceptions.InvalidSyntax("'conflicts' cannot be used with 'data-streams'")
 
         if self.id_conflicts != IndexIdConflict.NoConflicts:
-            self.conflict_probability = self.float_param(params, name="conflict-probability", default_value=25, min_value=0, max_value=100,
-                                                         min_operator=operator.lt)
+            self.conflict_probability = self.float_param(
+                params, name="conflict-probability", default_value=25, min_value=0, max_value=100, min_operator=operator.lt
+            )
             self.on_conflict = params.get("on-conflict", "index")
             if self.on_conflict not in ["index", "update"]:
                 raise exceptions.InvalidSyntax("Unknown 'on-conflict' setting [{}]".format(self.on_conflict))
@@ -573,16 +581,20 @@ class BulkIndexParamSource(ParamSource):
         self.corpora = self.used_corpora(track, params)
 
         if len(self.corpora) == 0:
-            raise exceptions.InvalidSyntax(f"There is no document corpus definition for track {track}. You must add at "
-                                           f"least one before making bulk requests to Elasticsearch.")
+            raise exceptions.InvalidSyntax(
+                f"There is no document corpus definition for track {track}. You must add at "
+                f"least one before making bulk requests to Elasticsearch."
+            )
 
         for corpus in self.corpora:
             for document_set in corpus.documents:
                 if document_set.includes_action_and_meta_data and self.id_conflicts != IndexIdConflict.NoConflicts:
                     file_name = document_set.document_archive if document_set.has_compressed_corpus() else document_set.document_file
 
-                    raise exceptions.InvalidSyntax("Cannot generate id conflicts [%s] as [%s] in document corpus [%s] already contains an "
-                                                   "action and meta-data line." % (id_conflicts, file_name, corpus))
+                    raise exceptions.InvalidSyntax(
+                        "Cannot generate id conflicts [%s] as [%s] in document corpus [%s] already contains an "
+                        "action and meta-data line." % (id_conflicts, file_name, corpus)
+                    )
 
         self.pipeline = params.get("pipeline", None)
         try:
@@ -606,10 +618,18 @@ class BulkIndexParamSource(ParamSource):
             raise exceptions.InvalidSyntax("'batch-size' must be numeric")
 
         self.ingest_percentage = self.float_param(params, name="ingest-percentage", default_value=100, min_value=0, max_value=100)
-        self.param_source = PartitionBulkIndexParamSource(self.corpora, self.batch_size, self.bulk_size,
-                                                          self.ingest_percentage, self.id_conflicts,
-                                                          self.conflict_probability, self.on_conflict,
-                                                          self.recency, self.pipeline, self._params)
+        self.param_source = PartitionBulkIndexParamSource(
+            self.corpora,
+            self.batch_size,
+            self.bulk_size,
+            self.ingest_percentage,
+            self.id_conflicts,
+            self.conflict_probability,
+            self.on_conflict,
+            self.recency,
+            self.pipeline,
+            self._params,
+        )
 
     def float_param(self, params, name, default_value, min_value, max_value, min_operator=operator.le):
         try:
@@ -617,7 +637,8 @@ class BulkIndexParamSource(ParamSource):
             if min_operator(value, min_value) or value > max_value:
                 interval_min = "(" if min_operator is operator.le else "["
                 raise exceptions.InvalidSyntax(
-                    "'{}' must be in the range {}{:.1f}, {:.1f}] but was {:.1f}".format(name, interval_min, min_value, max_value, value))
+                    "'{}' must be in the range {}{:.1f}, {:.1f}] but was {:.1f}".format(name, interval_min, min_value, max_value, value)
+                )
             return value
         except ValueError:
             raise exceptions.InvalidSyntax("'{}' must be numeric".format(name))
@@ -631,16 +652,19 @@ class BulkIndexParamSource(ParamSource):
 
         for corpus in t.corpora:
             if corpus.name in corpora_names:
-                filtered_corpus = corpus.filter(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                target_indices=params.get("indices"),
-                                                target_data_streams=params.get("data-streams"))
+                filtered_corpus = corpus.filter(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    target_indices=params.get("indices"),
+                    target_data_streams=params.get("data-streams"),
+                )
                 if filtered_corpus.number_of_documents(source_format=track.Documents.SOURCE_FORMAT_BULK) > 0:
                     corpora.append(filtered_corpus)
 
         # the track has corpora but none of them match
         if t.corpora and not corpora:
-            raise exceptions.RallyAssertionError("The provided corpus %s does not match any of the corpora %s." %
-                                                 (corpora_names, track_corpora_names))
+            raise exceptions.RallyAssertionError(
+                "The provided corpus %s does not match any of the corpora %s." % (corpora_names, track_corpora_names)
+            )
 
         return corpora
 
@@ -654,8 +678,19 @@ class BulkIndexParamSource(ParamSource):
 
 
 class PartitionBulkIndexParamSource:
-    def __init__(self, corpora, batch_size, bulk_size, ingest_percentage, id_conflicts, conflict_probability,
-                 on_conflict, recency, pipeline=None, original_params=None):
+    def __init__(
+        self,
+        corpora,
+        batch_size,
+        bulk_size,
+        ingest_percentage,
+        id_conflicts,
+        conflict_probability,
+        on_conflict,
+        recency,
+        pipeline=None,
+        original_params=None,
+    ):
         """
 
         :param corpora: Specification of affected document corpora.
@@ -694,7 +729,8 @@ class PartitionBulkIndexParamSource:
             self.total_partitions = total_partitions
         elif self.total_partitions != total_partitions:
             raise exceptions.RallyAssertionError(
-                f"Total partitions is expected to be [{self.total_partitions}] but was [{total_partitions}]")
+                f"Total partitions is expected to be [{self.total_partitions}] but was [{total_partitions}]"
+            )
         self.partitions.append(partition_index)
 
     def params(self):
@@ -713,10 +749,21 @@ class PartitionBulkIndexParamSource:
         start_index = self.partitions[0]
         end_index = self.partitions[-1]
 
-        self.internal_params = bulk_data_based(self.total_partitions, start_index, end_index, self.corpora,
-                                               self.batch_size, self.bulk_size, self.id_conflicts,
-                                               self.conflict_probability, self.on_conflict, self.recency,
-                                               self.pipeline, self.original_params, self.create_reader)
+        self.internal_params = bulk_data_based(
+            self.total_partitions,
+            start_index,
+            end_index,
+            self.corpora,
+            self.batch_size,
+            self.bulk_size,
+            self.id_conflicts,
+            self.conflict_probability,
+            self.on_conflict,
+            self.recency,
+            self.pipeline,
+            self.original_params,
+            self.create_reader,
+        )
 
         all_bulks = number_of_bulks(self.corpora, start_index, end_index, self.total_partitions, self.bulk_size)
         self.total_bulks = math.ceil((all_bulks * self.ingest_percentage) / 100)
@@ -734,10 +781,7 @@ class OpenPointInTimeParamSource(ParamSource):
         self._keep_alive = params.get("keep-alive")
 
     def params(self):
-        parsed_params = {
-            "index": self._index_name,
-            "keep-alive": self._keep_alive
-        }
+        parsed_params = {"index": self._index_name, "keep-alive": self._keep_alive}
         parsed_params.update(self._client_params())
         return parsed_params
 
@@ -748,9 +792,7 @@ class ClosePointInTimeParamSource(ParamSource):
         self._pit_task_name = params.get("with-point-in-time-from")
 
     def params(self):
-        parsed_params = {
-            "with-point-in-time-from": self._pit_task_name
-        }
+        parsed_params = {"with-point-in-time-from": self._pit_task_name}
         parsed_params.update(self._client_params())
         return parsed_params
 
@@ -760,7 +802,7 @@ class ForceMergeParamSource(ParamSource):
         super().__init__(track, params, **kwargs)
         if len(track.indices) > 0 or len(track.data_streams) > 0:
             # force merge data streams and indices - API call is the same so treat as indices
-            default_target = ','.join(map(str, track.indices + track.data_streams))
+            default_target = ",".join(map(str, track.indices + track.data_streams))
         else:
             default_target = "_all"
 
@@ -777,10 +819,11 @@ class ForceMergeParamSource(ParamSource):
             "index": self._target_name,
             "max-num-segments": self._max_num_segments,
             "mode": self._mode,
-            "poll-period": self._poll_period
+            "poll-period": self._poll_period,
         }
         parsed_params.update(self._client_params())
         return parsed_params
+
 
 def get_target(track, params):
     if len(track.indices) == 1:
@@ -795,6 +838,7 @@ def get_target(track, params):
         target_name = params.get("data-stream", default_target)
     return target_name
 
+
 def number_of_bulks(corpora, start_partition_index, end_partition_index, total_partitions, bulk_size):
     """
     :return: The number of bulk operations that the given client will issue.
@@ -802,8 +846,9 @@ def number_of_bulks(corpora, start_partition_index, end_partition_index, total_p
     bulks = 0
     for corpus in corpora:
         for docs in corpus.documents:
-            _, num_docs, _ = bounds(docs.number_of_documents, start_partition_index, end_partition_index,
-                                    total_partitions, docs.includes_action_and_meta_data)
+            _, num_docs, _ = bounds(
+                docs.number_of_documents, start_partition_index, end_partition_index, total_partitions, docs.includes_action_and_meta_data
+            )
             complete_bulks, rest = (num_docs // bulk_size, num_docs % bulk_size)
             bulks += complete_bulks
             if rest > 0:
@@ -837,8 +882,9 @@ def chain(*iterables):
                 yield element
 
 
-def create_default_reader(docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability,
-                          on_conflict, recency):
+def create_default_reader(
+    docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict, recency
+):
     source = Slice(io.MmapSource, offset, num_lines)
     target = None
     use_create = False
@@ -854,32 +900,64 @@ def create_default_reader(docs, offset, num_lines, num_docs, batch_size, bulk_si
     if docs.includes_action_and_meta_data:
         return SourceOnlyIndexDataReader(docs.document_file, batch_size, bulk_size, source, target, docs.target_type)
     else:
-        am_handler = GenerateActionMetaData(target, docs.target_type,
-                                            build_conflicting_ids(id_conflicts, num_docs, offset), conflict_probability,
-                                            on_conflict, recency, use_create=use_create)
+        am_handler = GenerateActionMetaData(
+            target,
+            docs.target_type,
+            build_conflicting_ids(id_conflicts, num_docs, offset),
+            conflict_probability,
+            on_conflict,
+            recency,
+            use_create=use_create,
+        )
         return MetadataIndexDataReader(docs.document_file, batch_size, bulk_size, source, am_handler, target, docs.target_type)
 
 
-def create_readers(num_clients, start_client_index, end_client_index, corpora, batch_size, bulk_size, id_conflicts,
-                   conflict_probability, on_conflict, recency, create_reader):
+def create_readers(
+    num_clients,
+    start_client_index,
+    end_client_index,
+    corpora,
+    batch_size,
+    bulk_size,
+    id_conflicts,
+    conflict_probability,
+    on_conflict,
+    recency,
+    create_reader,
+):
     logger = logging.getLogger(__name__)
     readers = []
     for corpus in corpora:
         for docs in corpus.documents:
-            offset, num_docs, num_lines = bounds(docs.number_of_documents, start_client_index, end_client_index,
-                                                 num_clients, docs.includes_action_and_meta_data)
+            offset, num_docs, num_lines = bounds(
+                docs.number_of_documents, start_client_index, end_client_index, num_clients, docs.includes_action_and_meta_data
+            )
             if num_docs > 0:
                 target = f"{docs.target_index}/{docs.target_type}" if docs.target_index else "/"
                 if docs.target_data_stream:
                     target = docs.target_data_stream
-                logger.info("Task-relative clients at index [%d-%d] will bulk index [%d] docs starting from line offset [%d] for [%s] "
-                            "from corpus [%s].", start_client_index, end_client_index, num_docs, offset,
-                            target, corpus.name)
-                readers.append(create_reader(docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts,
-                                             conflict_probability, on_conflict, recency))
+                logger.info(
+                    "Task-relative clients at index [%d-%d] will bulk index [%d] docs starting from line offset [%d] for [%s] "
+                    "from corpus [%s].",
+                    start_client_index,
+                    end_client_index,
+                    num_docs,
+                    offset,
+                    target,
+                    corpus.name,
+                )
+                readers.append(
+                    create_reader(
+                        docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict, recency
+                    )
+                )
             else:
-                logger.info("Task-relative clients at index [%d-%d] skip [%s] (no documents to read).",
-                            start_client_index, end_client_index, corpus.name)
+                logger.info(
+                    "Task-relative clients at index [%d-%d] skip [%s] (no documents to read).",
+                    start_client_index,
+                    end_client_index,
+                    corpus.name,
+                )
     return readers
 
 
@@ -925,7 +1003,7 @@ def bulk_generator(readers, pipeline, original_params):
                 "body": bulk,
                 # This is not always equal to the bulk_size we get as parameter. The last bulk may be less than the bulk size.
                 "bulk-size": docs_in_bulk,
-                "unit": "docs"
+                "unit": "docs",
             }
             if pipeline:
                 bulk_params["pipeline"] = pipeline
@@ -935,8 +1013,21 @@ def bulk_generator(readers, pipeline, original_params):
             yield params
 
 
-def bulk_data_based(num_clients, start_client_index, end_client_index, corpora, batch_size, bulk_size, id_conflicts,
-                    conflict_probability, on_conflict, recency, pipeline, original_params, create_reader=create_default_reader):
+def bulk_data_based(
+    num_clients,
+    start_client_index,
+    end_client_index,
+    corpora,
+    batch_size,
+    bulk_size,
+    id_conflicts,
+    conflict_probability,
+    on_conflict,
+    recency,
+    pipeline,
+    original_params,
+    create_reader=create_default_reader,
+):
     """
     Calculates the necessary schedule for bulk operations.
 
@@ -957,21 +1048,41 @@ def bulk_data_based(num_clients, start_client_index, end_client_index, corpora, 
                       intended for testing only.
     :return: A generator for the bulk operations of the given client.
     """
-    readers = create_readers(num_clients, start_client_index, end_client_index, corpora, batch_size, bulk_size,
-                             id_conflicts, conflict_probability, on_conflict, recency, create_reader)
+    readers = create_readers(
+        num_clients,
+        start_client_index,
+        end_client_index,
+        corpora,
+        batch_size,
+        bulk_size,
+        id_conflicts,
+        conflict_probability,
+        on_conflict,
+        recency,
+        create_reader,
+    )
     return bulk_generator(chain(*readers), pipeline, original_params)
 
 
 class GenerateActionMetaData:
     RECENCY_SLOPE = 30
 
-    def __init__(self, index_name, type_name, conflicting_ids=None, conflict_probability=None, on_conflict=None, recency=None,
-                 rand=random.random, randint=random.randint, randexp=random.expovariate, use_create=False):
+    def __init__(
+        self,
+        index_name,
+        type_name,
+        conflicting_ids=None,
+        conflict_probability=None,
+        on_conflict=None,
+        recency=None,
+        rand=random.random,
+        randint=random.randint,
+        randexp=random.expovariate,
+        use_create=False,
+    ):
         if type_name:
-            self.meta_data_index_with_id = '{"index": {"_index": "%s", "_type": "%s", "_id": "%s"}}\n' % \
-                                           (index_name, type_name, "%s")
-            self.meta_data_update_with_id = '{"update": {"_index": "%s", "_type": "%s", "_id": "%s"}}\n' % \
-                                            (index_name, type_name, "%s")
+            self.meta_data_index_with_id = '{"index": {"_index": "%s", "_type": "%s", "_id": "%s"}}\n' % (index_name, type_name, "%s")
+            self.meta_data_update_with_id = '{"update": {"_index": "%s", "_type": "%s", "_id": "%s"}}\n' % (index_name, type_name, "%s")
             self.meta_data_index_no_id = '{"index": {"_index": "%s", "_type": "%s"}}\n' % (index_name, type_name)
         else:
             self.meta_data_index_with_id = '{"index": {"_index": "%s", "_id": "%s"}}\n' % (index_name, "%s")
@@ -1053,8 +1164,13 @@ class Slice:
     def open(self, file_name, mode, bulk_size):
         self.bulk_size = bulk_size
         self.source = self.source_class(file_name, mode).open()
-        self.logger.info("Will read [%d] lines from [%s] starting from line [%d] with bulk size [%d].",
-                         self.number_of_lines, file_name, self.offset, self.bulk_size)
+        self.logger.info(
+            "Will read [%d] lines from [%s] starting from line [%d] with bulk size [%d].",
+            self.number_of_lines,
+            file_name,
+            self.offset,
+            self.bulk_size,
+        )
         start = time.perf_counter()
         io.skip_lines(file_name, self.source, self.offset)
         end = time.perf_counter()
@@ -1177,7 +1293,7 @@ class MetadataIndexDataReader(IndexDataReader):
                 if action_type == "update":
                     # remove the trailing "\n" as the doc needs to fit on one line
                     doc = doc.strip()
-                    current_bulk.append(b"{\"doc\":%s}\n" % doc)
+                    current_bulk.append(b'{"doc":%s}\n' % doc)
                 else:
                     current_bulk.append(doc)
             else:

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -180,10 +180,21 @@ class ComponentTemplate:
 class Documents:
     SOURCE_FORMAT_BULK = "bulk"
 
-    def __init__(self, source_format, document_file=None, document_archive=None, base_url=None,
-                 includes_action_and_meta_data=False,
-                 number_of_documents=0, compressed_size_in_bytes=0, uncompressed_size_in_bytes=0, target_index=None,
-                 target_data_stream=None, target_type=None, meta_data=None):
+    def __init__(
+        self,
+        source_format,
+        document_file=None,
+        document_archive=None,
+        base_url=None,
+        includes_action_and_meta_data=False,
+        number_of_documents=0,
+        compressed_size_in_bytes=0,
+        uncompressed_size_in_bytes=0,
+        target_index=None,
+        target_data_stream=None,
+        target_type=None,
+        meta_data=None,
+    ):
         """
 
         :param source_format: The format of these documents. Mandatory.
@@ -272,19 +283,49 @@ class Documents:
         return ", ".join(r)
 
     def __hash__(self):
-        return hash(self.source_format) ^ hash(self.document_file) ^ hash(self.document_archive) ^ hash(self.base_url) ^ \
-               hash(self.includes_action_and_meta_data) ^ hash(self.number_of_documents) ^ hash(self.compressed_size_in_bytes) ^ \
-               hash(self.uncompressed_size_in_bytes) ^ hash(self.target_index) ^ hash(self.target_data_stream) ^ hash(self.target_type) ^ \
-               hash(frozenset(self.meta_data.items()))
+        return (
+            hash(self.source_format)
+            ^ hash(self.document_file)
+            ^ hash(self.document_archive)
+            ^ hash(self.base_url)
+            ^ hash(self.includes_action_and_meta_data)
+            ^ hash(self.number_of_documents)
+            ^ hash(self.compressed_size_in_bytes)
+            ^ hash(self.uncompressed_size_in_bytes)
+            ^ hash(self.target_index)
+            ^ hash(self.target_data_stream)
+            ^ hash(self.target_type)
+            ^ hash(frozenset(self.meta_data.items()))
+        )
 
     def __eq__(self, othr):
-        return (isinstance(othr, type(self)) and
-                (self.source_format, self.document_file, self.document_archive, self.base_url, self.includes_action_and_meta_data,
-                 self.number_of_documents, self.compressed_size_in_bytes, self.uncompressed_size_in_bytes,
-                 self.target_type, self.target_data_stream, self.target_type, self.meta_data) ==
-                (othr.source_format, othr.document_file, othr.document_archive, othr.base_url, othr.includes_action_and_meta_data,
-                 othr.number_of_documents, othr.compressed_size_in_bytes, othr.uncompressed_size_in_bytes,
-                 othr.target_type, othr.target_data_stream, othr.target_type, othr.meta_data))
+        return isinstance(othr, type(self)) and (
+            self.source_format,
+            self.document_file,
+            self.document_archive,
+            self.base_url,
+            self.includes_action_and_meta_data,
+            self.number_of_documents,
+            self.compressed_size_in_bytes,
+            self.uncompressed_size_in_bytes,
+            self.target_type,
+            self.target_data_stream,
+            self.target_type,
+            self.meta_data,
+        ) == (
+            othr.source_format,
+            othr.document_file,
+            othr.document_archive,
+            othr.base_url,
+            othr.includes_action_and_meta_data,
+            othr.number_of_documents,
+            othr.compressed_size_in_bytes,
+            othr.uncompressed_size_in_bytes,
+            othr.target_type,
+            othr.target_data_stream,
+            othr.target_type,
+            othr.meta_data,
+        )
 
 
 class DocumentCorpus:
@@ -355,9 +396,9 @@ class DocumentCorpus:
         if self is other:
             return self
         else:
-            return DocumentCorpus(name=self.name,
-                                  documents=list(set(self.documents).union(other.documents)),
-                                  meta_data=dict(self.meta_data))
+            return DocumentCorpus(
+                name=self.name, documents=list(set(self.documents).union(other.documents)), meta_data=dict(self.meta_data)
+            )
 
     def __str__(self):
         return self.name
@@ -372,9 +413,7 @@ class DocumentCorpus:
         return hash(self.name) ^ hash(self.documents) ^ hash(frozenset(self.meta_data.items()))
 
     def __eq__(self, othr):
-        return (isinstance(othr, type(self)) and
-                (self.name, self.documents, self.meta_data) ==
-                (othr.name, othr.documents, othr.meta_data))
+        return isinstance(othr, type(self)) and (self.name, self.documents, self.meta_data) == (othr.name, othr.documents, othr.meta_data)
 
 
 class Track:
@@ -382,8 +421,20 @@ class Track:
     A track defines the data set that is used. It corresponds loosely to a use case (e.g. logging, event processing, analytics, ...)
     """
 
-    def __init__(self, name, description=None, meta_data=None, challenges=None, indices=None, data_streams=None,
-                 templates=None, composable_templates=None, component_templates=None, corpora=None, has_plugins=False):
+    def __init__(
+        self,
+        name,
+        description=None,
+        meta_data=None,
+        challenges=None,
+        indices=None,
+        data_streams=None,
+        templates=None,
+        composable_templates=None,
+        component_templates=None,
+        corpora=None,
+        has_plugins=False,
+    ):
         """
 
         Creates a new track.
@@ -489,16 +540,42 @@ class Track:
         return ", ".join(r)
 
     def __hash__(self):
-        return hash(self.name) ^ hash(self.meta_data) ^ hash(self.description) ^ hash(self.challenges) ^ \
-               hash(self.indices) ^ hash(self.templates) ^ hash(self.composable_templates) ^ hash(self.component_templates) \
-               ^ hash(self.corpora)
+        return (
+            hash(self.name)
+            ^ hash(self.meta_data)
+            ^ hash(self.description)
+            ^ hash(self.challenges)
+            ^ hash(self.indices)
+            ^ hash(self.templates)
+            ^ hash(self.composable_templates)
+            ^ hash(self.component_templates)
+            ^ hash(self.corpora)
+        )
 
     def __eq__(self, othr):
-        return (isinstance(othr, type(self)) and
-                (self.name, self.meta_data, self.description, self.challenges, self.indices, self.data_streams,
-                 self.templates, self.composable_templates, self.component_templates, self.corpora) ==
-                (othr.name, othr.meta_data, othr.description, othr.challenges, othr.indices, othr.data_streams,
-                 othr.templates, othr.composable_templates, othr.component_templates, othr.corpora))
+        return isinstance(othr, type(self)) and (
+            self.name,
+            self.meta_data,
+            self.description,
+            self.challenges,
+            self.indices,
+            self.data_streams,
+            self.templates,
+            self.composable_templates,
+            self.component_templates,
+            self.corpora,
+        ) == (
+            othr.name,
+            othr.meta_data,
+            othr.description,
+            othr.challenges,
+            othr.indices,
+            othr.data_streams,
+            othr.templates,
+            othr.composable_templates,
+            othr.component_templates,
+            othr.corpora,
+        )
 
 
 class Challenge:
@@ -506,16 +583,18 @@ class Challenge:
     A challenge defines the concrete operations that will be done.
     """
 
-    def __init__(self,
-                 name,
-                 description=None,
-                 user_info=None,
-                 default=False,
-                 selected=False,
-                 auto_generated=False,
-                 parameters=None,
-                 meta_data=None,
-                 schedule=None):
+    def __init__(
+        self,
+        name,
+        description=None,
+        user_info=None,
+        default=False,
+        selected=False,
+        auto_generated=False,
+        parameters=None,
+        meta_data=None,
+        schedule=None,
+    ):
         self.name = name
         self.parameters = parameters if parameters else {}
         self.meta_data = meta_data if meta_data else {}
@@ -542,16 +621,37 @@ class Challenge:
         return ", ".join(r)
 
     def __hash__(self):
-        return hash(self.name) ^ hash(self.description) ^ hash(self.default) ^ \
-               hash(self.selected) ^ hash(self.auto_generated) ^ hash(self.parameters) ^ hash(self.meta_data) ^ \
-               hash(self.schedule)
+        return (
+            hash(self.name)
+            ^ hash(self.description)
+            ^ hash(self.default)
+            ^ hash(self.selected)
+            ^ hash(self.auto_generated)
+            ^ hash(self.parameters)
+            ^ hash(self.meta_data)
+            ^ hash(self.schedule)
+        )
 
     def __eq__(self, othr):
-        return (isinstance(othr, type(self)) and
-                (self.name, self.description, self.default, self.selected, self.auto_generated,
-                 self.parameters, self.meta_data, self.schedule) ==
-                (othr.name, othr.description, othr.default, othr.selected, othr.auto_generated,
-                 othr.parameters, othr.meta_data, othr.schedule))
+        return isinstance(othr, type(self)) and (
+            self.name,
+            self.description,
+            self.default,
+            self.selected,
+            self.auto_generated,
+            self.parameters,
+            self.meta_data,
+            self.schedule,
+        ) == (
+            othr.name,
+            othr.description,
+            othr.default,
+            othr.selected,
+            othr.auto_generated,
+            othr.parameters,
+            othr.meta_data,
+            othr.schedule,
+        )
 
 
 @unique
@@ -840,9 +940,22 @@ class Task:
     THROUGHPUT_PATTERN = re.compile(r"(?P<value>(\d*\.)?\d+)\s(?P<unit>\w+/s)")
     IGNORE_RESPONSE_ERROR_LEVEL_WHITELIST = ["non-fatal"]
 
-    def __init__(self, name, operation, tags=None, meta_data=None, warmup_iterations=None, iterations=None,
-                 warmup_time_period=None, time_period=None, ramp_up_time_period=None, clients=1, completes_parent=False,
-                 schedule=None, params=None):
+    def __init__(
+        self,
+        name,
+        operation,
+        tags=None,
+        meta_data=None,
+        warmup_iterations=None,
+        iterations=None,
+        warmup_time_period=None,
+        time_period=None,
+        ramp_up_time_period=None,
+        clients=1,
+        completes_parent=False,
+        schedule=None,
+        params=None,
+    ):
         self.name = name
         self.operation = operation
         if isinstance(tags, str):
@@ -876,8 +989,10 @@ class Task:
         target_interval = self.params.get("target-interval")
 
         if target_interval is not None and target_throughput is not None:
-            raise exceptions.InvalidSyntax(f"Task [{self}] specifies target-interval [{target_interval}] and "
-                                           f"target-throughput [{target_throughput}] but only one of them is allowed.")
+            raise exceptions.InvalidSyntax(
+                f"Task [{self}] specifies target-interval [{target_interval}] and "
+                f"target-throughput [{target_throughput}] but only one of them is allowed."
+            )
 
         value = None
         unit = "ops/s"
@@ -897,8 +1012,7 @@ class Task:
             elif numeric(target_throughput):
                 value = float(target_throughput)
             else:
-                raise exceptions.InvalidSyntax(f"Target throughput [{target_throughput}] for task [{self}] "
-                                               f"must be string or numeric.")
+                raise exceptions.InvalidSyntax(f"Target throughput [{target_throughput}] for task [{self}] must be string or numeric.")
 
         if value:
             return Throughput(value, unit)
@@ -909,11 +1023,11 @@ class Task:
     def ignore_response_error_level(self):
         ignore_response_error_level = self.params.get("ignore-response-error-level")
 
-        if ignore_response_error_level and \
-                ignore_response_error_level not in Task.IGNORE_RESPONSE_ERROR_LEVEL_WHITELIST:
+        if ignore_response_error_level and ignore_response_error_level not in Task.IGNORE_RESPONSE_ERROR_LEVEL_WHITELIST:
             raise exceptions.InvalidSyntax(
                 f"Task [{self}] specifies ignore-response-error-level to [{ignore_response_error_level}] but "
-                f"the only allowed values are [{','.join(Task.IGNORE_RESPONSE_ERROR_LEVEL_WHITELIST)}].")
+                f"the only allowed values are [{','.join(Task.IGNORE_RESPONSE_ERROR_LEVEL_WHITELIST)}]."
+            )
 
         return ignore_response_error_level
 
@@ -936,18 +1050,44 @@ class Task:
 
     def __hash__(self):
         # Note that we do not include `params` in __hash__ and __eq__ (the other attributes suffice to uniquely define a task)
-        return hash(self.name) ^ hash(self.operation) ^ hash(self.warmup_iterations) ^ hash(self.iterations) ^ \
-               hash(self.warmup_time_period) ^ hash(self.time_period) ^ hash(self.ramp_up_time_period) ^ \
-               hash(self.clients) ^ hash(self.schedule) ^ hash(self.completes_parent)
+        return (
+            hash(self.name)
+            ^ hash(self.operation)
+            ^ hash(self.warmup_iterations)
+            ^ hash(self.iterations)
+            ^ hash(self.warmup_time_period)
+            ^ hash(self.time_period)
+            ^ hash(self.ramp_up_time_period)
+            ^ hash(self.clients)
+            ^ hash(self.schedule)
+            ^ hash(self.completes_parent)
+        )
 
     def __eq__(self, other):
         # Note that we do not include `params` in __hash__ and __eq__ (the other attributes suffice to uniquely define a task)
-        return isinstance(other, type(self)) and \
-               (self.name, self.operation, self.warmup_iterations, self.iterations, self.warmup_time_period,
-                self.time_period, self.ramp_up_time_period, self.clients, self.schedule,
-                self.completes_parent) == (other.name, other.operation, other.warmup_iterations, other.iterations,
-                                           other.warmup_time_period, other.time_period, other.ramp_up_time_period,
-                                           other.clients, other.schedule, other.completes_parent)
+        return isinstance(other, type(self)) and (
+            self.name,
+            self.operation,
+            self.warmup_iterations,
+            self.iterations,
+            self.warmup_time_period,
+            self.time_period,
+            self.ramp_up_time_period,
+            self.clients,
+            self.schedule,
+            self.completes_parent,
+        ) == (
+            other.name,
+            other.operation,
+            other.warmup_iterations,
+            other.iterations,
+            other.warmup_time_period,
+            other.time_period,
+            other.ramp_up_time_period,
+            other.clients,
+            other.schedule,
+            other.completes_parent,
+        )
 
     def __iter__(self):
         return iter([self])

--- a/esrally/tracker/__init__.py
+++ b/esrally/tracker/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/esrally/tracker/corpus.py
+++ b/esrally/tracker/corpus.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -22,7 +22,6 @@ import os
 
 from esrally.utils import console
 
-
 DOCS_COMPRESSOR = bz2.BZ2Compressor
 COMP_EXT = ".bz2"
 
@@ -35,7 +34,7 @@ def template_vars(index_name, out_path, doc_count):
         "path": comp_outpath,
         "doc_count": doc_count,
         "uncompressed_bytes": os.path.getsize(out_path),
-        "compressed_bytes": os.path.getsize(comp_outpath)
+        "compressed_bytes": os.path.getsize(comp_outpath),
     }
 
 

--- a/esrally/tracker/index.py
+++ b/esrally/tracker/index.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -19,14 +19,10 @@ import json
 import logging
 import os
 
-INDEX_SETTINGS_EPHEMERAL_KEYS = ["uuid",
-                                 "creation_date",
-                                 "version",
-                                 "provided_name",
-                                 "store"]
+INDEX_SETTINGS_EPHEMERAL_KEYS = ["uuid", "creation_date", "version", "provided_name", "store"]
 INDEX_SETTINGS_PARAMETERS = {
     "number_of_replicas": "{{{{number_of_replicas | default({orig})}}}}",
-    "number_of_shards": "{{{{number_of_shards | default({orig})}}}}"
+    "number_of_shards": "{{{{number_of_shards | default({orig})}}}}",
 }
 
 
@@ -76,12 +72,7 @@ def extract_index_mapping_and_settings(client, index_pattern):
             mappings = details["mappings"]
             index_settings = filter_ephemeral_index_settings(details["settings"]["index"])
             update_index_setting_parameters(index_settings)
-            results[index] = {
-                "mappings": mappings,
-                "settings": {
-                    "index": index_settings
-                }
-            }
+            results[index] = {"mappings": mappings, "settings": {"index": index_settings}}
         else:
             logger.info("Skipping index [%s] (reason: %s).", index, reason)
 
@@ -105,9 +96,11 @@ def extract(client, outdir, index_pattern):
         with open(outpath, "w") as outfile:
             json.dump(details, outfile, indent=4, sort_keys=True)
             outfile.write("\n")
-        results.append({
-            "name": index,
-            "path": outpath,
-            "filename": filename,
-        })
+        results.append(
+            {
+                "name": index,
+                "path": outpath,
+                "filename": filename,
+            }
+        )
     return results

--- a/esrally/tracker/tracker.py
+++ b/esrally/tracker/tracker.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -24,7 +24,7 @@ from jinja2 import Environment, FileSystemLoader
 from esrally import PROGRAM_NAME
 from esrally.client import EsClientFactory
 from esrally.tracker import corpus, index
-from esrally.utils import io, opts, console
+from esrally.utils import console, io, opts
 
 
 def process_template(templates_path, template_filename, template_vars, output_path):
@@ -66,8 +66,9 @@ def create_track(cfg):
 
     logger.info("Creating track [%s] matching indices [%s]", track_name, indices)
 
-    client = EsClientFactory(hosts=target_hosts.all_hosts[opts.TargetHosts.DEFAULT],
-                             client_options=client_options.all_client_options[opts.TargetHosts.DEFAULT]).create()
+    client = EsClientFactory(
+        hosts=target_hosts.all_hosts[opts.TargetHosts.DEFAULT], client_options=client_options.all_client_options[opts.TargetHosts.DEFAULT]
+    ).create()
 
     info = client.info()
     console.info(f"Connected to Elasticsearch cluster [{info['name']}] version [{info['version']['number']}].\n", logger=logger)
@@ -79,11 +80,7 @@ def create_track(cfg):
     if len(indices) == 0:
         raise RuntimeError("Failed to extract any indices for track!")
 
-    template_vars = {
-        "track_name": track_name,
-        "indices": indices,
-        "corpora": corpora
-    }
+    template_vars = {"track_name": track_name, "indices": indices, "corpora": corpora}
 
     track_path = os.path.join(output_path, "track.json")
     templates_path = os.path.join(cfg.opts("node", "rally.root"), "resources")

--- a/esrally/utils/__init__.py
+++ b/esrally/utils/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/esrally/utils/collections.py
+++ b/esrally/utils/collections.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/esrally/utils/console.py
+++ b/esrally/utils/console.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -114,7 +114,7 @@ def init(quiet=False, assume_tty=True):
     except (KeyError, ValueError):
         # noinspection PyBroadException
         try:
-            os.environ['COLUMNS'] = str(shutil.get_terminal_size().columns)
+            os.environ["COLUMNS"] = str(shutil.get_terminal_size().columns)
         except BaseException:
             # don't fail if anything goes wrong here
             pass
@@ -132,18 +132,42 @@ def set_assume_tty(assume_tty):
 
 
 def info(msg, end="\n", flush=False, force=False, logger=None, overline=None, underline=None):
-    println(msg, console_prefix="[INFO]", end=end, flush=flush, force=force, overline=overline, underline=underline,
-            logger=logger.info if logger else None)
+    println(
+        msg,
+        console_prefix="[INFO]",
+        end=end,
+        flush=flush,
+        force=force,
+        overline=overline,
+        underline=underline,
+        logger=logger.info if logger else None,
+    )
 
 
 def warn(msg, end="\n", flush=False, force=False, logger=None, overline=None, underline=None):
-    println(msg, console_prefix="[WARNING]", end=end, flush=flush, force=force, overline=overline, underline=underline
-            , logger=logger.warning if logger else None)
+    println(
+        msg,
+        console_prefix="[WARNING]",
+        end=end,
+        flush=flush,
+        force=force,
+        overline=overline,
+        underline=underline,
+        logger=logger.warning if logger else None,
+    )
 
 
 def error(msg, end="\n", flush=False, force=False, logger=None, overline=None, underline=None):
-    println(msg, console_prefix="[ERROR]", end=end, flush=flush, force=force, overline=overline, underline=underline
-            , logger=logger.error if logger else None)
+    println(
+        msg,
+        console_prefix="[ERROR]",
+        end=end,
+        flush=flush,
+        force=force,
+        overline=overline,
+        underline=underline,
+        logger=logger.error if logger else None,
+    )
 
 
 def println(msg, console_prefix=None, end="\n", flush=False, force=False, logger=None, overline=None, underline=None):
@@ -207,7 +231,7 @@ class CmdLineProgressReporter:
         if len(text) <= max_length:
             return text
         else:
-            return "%s%s" % (text[0:max_length - len(omission) - 5], omission)
+            return "%s%s" % (text[0 : max_length - len(omission) - 5], omission)
 
     def finish(self):
         if QUIET or (not RALLY_RUNNING_IN_DOCKER and not ASSUME_TTY and not sys.stdout.isatty()):

--- a/esrally/utils/convert.py
+++ b/esrally/utils/convert.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 
 def bytes_to_kb(b):
     return b / 1024.0 if b else b

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -25,8 +25,9 @@ from esrally.utils import io, process
 def probed(f):
     def probe(src, *args, **kwargs):
         # Probe for -C
-        if not process.exit_status_as_bool(lambda: process.run_subprocess_with_logging(
-                "git -C {} --version".format(io.escape_path(src)), level=logging.DEBUG), quiet=True):
+        if not process.exit_status_as_bool(
+            lambda: process.run_subprocess_with_logging("git -C {} --version".format(io.escape_path(src)), level=logging.DEBUG), quiet=True
+        ):
             version = process.run_subprocess_with_output("git --version")
             if version:
                 version = str(version).strip()
@@ -34,6 +35,7 @@ def probed(f):
                 version = "Unknown"
             raise exceptions.SystemSetupError("Your git version is [%s] but Rally requires at least git 1.9. Please update git." % version)
         return f(src, *args, **kwargs)
+
     return probe
 
 
@@ -83,7 +85,8 @@ def pull_ts(src_dir, ts):
     fetch(src_dir)
     clean_src = io.escape_path(src_dir)
     revision = process.run_subprocess_with_output(
-        "git -C {0} rev-list -n 1 --before=\"{1}\" --date=iso8601 origin/master".format(clean_src, ts))[0].strip()
+        'git -C {0} rev-list -n 1 --before="{1}" --date=iso8601 origin/master'.format(clean_src, ts)
+    )[0].strip()
     if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(clean_src, revision)):
         raise exceptions.SupplyError("Could not checkout source tree for timestamped revision [%s]" % ts)
 
@@ -97,14 +100,12 @@ def pull_revision(src_dir, revision):
 
 @probed
 def head_revision(src_dir):
-    return process.run_subprocess_with_output("git -C {0} rev-parse --short HEAD".format(
-        io.escape_path(src_dir)))[0].strip()
+    return process.run_subprocess_with_output("git -C {0} rev-parse --short HEAD".format(io.escape_path(src_dir)))[0].strip()
 
 
 @probed
 def current_branch(src_dir):
-    return process.run_subprocess_with_output("git -C {0} rev-parse --abbrev-ref HEAD".format(
-        io.escape_path(src_dir)))[0].strip()
+    return process.run_subprocess_with_output("git -C {0} rev-parse --abbrev-ref HEAD".format(io.escape_path(src_dir)))[0].strip()
 
 
 @probed
@@ -112,12 +113,13 @@ def branches(src_dir, remote=True):
     clean_src = io.escape_path(src_dir)
     if remote:
         # alternatively: git for-each-ref refs/remotes/ --format='%(refname:short)'
-        return _cleanup_remote_branch_names(process.run_subprocess_with_output(
-                "git -C {src} for-each-ref refs/remotes/ --format='%(refname:short)'".format(src=clean_src)))
+        return _cleanup_remote_branch_names(
+            process.run_subprocess_with_output("git -C {src} for-each-ref refs/remotes/ --format='%(refname:short)'".format(src=clean_src))
+        )
     else:
         return _cleanup_local_branch_names(
-                process.run_subprocess_with_output(
-                        "git -C {src} for-each-ref refs/heads/ --format='%(refname:short)'".format(src=clean_src)))
+            process.run_subprocess_with_output("git -C {src} for-each-ref refs/heads/ --format='%(refname:short)'".format(src=clean_src))
+        )
 
 
 @probed
@@ -126,7 +128,7 @@ def tags(src_dir):
 
 
 def _cleanup_remote_branch_names(branch_names):
-    return [(b[b.index("/") + 1:]).strip() for b in branch_names if not b.endswith("/HEAD")]
+    return [(b[b.index("/") + 1 :]).strip() for b in branch_names if not b.endswith("/HEAD")]
 
 
 def _cleanup_local_branch_names(branch_names):

--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -18,14 +18,13 @@
 import bz2
 import gzip
 import logging
+import mmap
 import os
 import shutil
 import subprocess
 import tarfile
 import zipfile
 from contextlib import suppress
-
-import mmap
 
 from esrally.utils import console
 
@@ -34,6 +33,7 @@ class FileSource:
     """
     FileSource is a wrapper around a plain file which simplifies testing of file I/O calls.
     """
+
     def __init__(self, file_name, mode, encoding="utf-8"):
         self.file_name = file_name
         self.mode = mode
@@ -84,6 +84,7 @@ class MmapSource:
     """
     MmapSource is a wrapper around a memory-mapped file which simplifies testing of file I/O calls.
     """
+
     def __init__(self, file_name, mode, encoding="utf-8"):
         self.file_name = file_name
         self.mode = mode
@@ -144,6 +145,7 @@ class DictStringFileSourceFactory:
 
     It is intended for scenarios where multiple files may be read by client code.
     """
+
     def __init__(self, name_to_contents):
         self.name_to_contents = name_to_contents
 
@@ -156,6 +158,7 @@ class StringAsFileSource:
     Implementation of ``FileSource`` intended for tests. It's kept close to ``FileSource`` to simplify maintenance but it is not meant to
      be used in production code.
     """
+
     def __init__(self, contents, mode, encoding="utf-8"):
         """
         :param contents: The file contents as an array of strings. Each item in the array should correspond to one line.
@@ -233,7 +236,8 @@ def _zipdir(source_directory, archive):
         for file in files:
             archive.write(
                 filename=os.path.join(root, file),
-                arcname=os.path.relpath(os.path.join(root, file), os.path.join(source_directory, "..")))
+                arcname=os.path.relpath(os.path.join(root, file), os.path.join(source_directory, "..")),
+            )
 
 
 def is_archive(name):
@@ -308,8 +312,9 @@ def _do_decompress_manually(target_directory, filename, decompressor_args, decom
         if _do_decompress_manually_external(target_directory, filename, base_path_without_extension, decompressor_args):
             return
     else:
-        logging.getLogger(__name__).warning("%s not found in PATH. Using standard library, decompression will take longer.",
-                                            decompressor_bin)
+        logging.getLogger(__name__).warning(
+            "%s not found in PATH. Using standard library, decompression will take longer.", decompressor_bin
+        )
 
     _do_decompress_manually_with_lib(target_directory, filename, decompressor_lib(filename))
 
@@ -319,8 +324,9 @@ def _do_decompress_manually_external(target_directory, filename, base_path_witho
         try:
             subprocess.run(decompressor_args + [filename], stdout=new_file, stderr=subprocess.PIPE, check=True)
         except subprocess.CalledProcessError as err:
-            logging.getLogger(__name__).warning("Failed to decompress [%s] with [%s]. Error [%s]. Falling back to standard library.",
-                                                filename, err.cmd, err.stderr)
+            logging.getLogger(__name__).warning(
+                "Failed to decompress [%s] with [%s]. Error [%s]. Falling back to standard library.", filename, err.cmd, err.stderr
+            )
             return False
     return True
 
@@ -410,6 +416,7 @@ class FileOffsetTable:
     The FileOffsetTable represents a persistent mapping from lines in a data file to their offset in bytes in the
     data file. This helps bulk-indexing clients to advance quickly to a certain position in a large data file.
     """
+
     def __init__(self, data_file_path, offset_table_path, mode):
         """
         Creates a new FileOffsetTable instance. The constructor should not be called directly but instead the

--- a/esrally/utils/jvm.py
+++ b/esrally/utils/jvm.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -34,8 +34,7 @@ def supports_option(java_home, option):
     :param option: The JVM option or combination of JVM options (separated by spaces) to check.
     :return: True iff the provided ``option`` is supported on this JVM.
     """
-    return process.exit_status_as_bool(
-        lambda: process.run_subprocess_with_logging("{} {} -version".format(_java(java_home), option)))
+    return process.exit_status_as_bool(lambda: process.run_subprocess_with_logging("{} {} -version".format(_java(java_home), option)))
 
 
 def system_property(java_home, system_property_name):
@@ -119,8 +118,9 @@ def resolve_path(majors, sysprop_reader=system_property):
             java_home = _resolve_single_path(major, mandatory=False, sysprop_reader=sysprop_reader)
             if java_home:
                 return major, java_home
-        raise exceptions.SystemSetupError("Install a JDK with one of the versions {} and point to it with one of {}."
-                                          .format(majors, _checked_env_vars(majors)))
+        raise exceptions.SystemSetupError(
+            "Install a JDK with one of the versions {} and point to it with one of {}.".format(majors, _checked_env_vars(majors))
+        )
 
 
 def _resolve_single_path(major, mandatory=True, sysprop_reader=system_property):
@@ -133,6 +133,7 @@ def _resolve_single_path(major, mandatory=True, sysprop_reader=system_property):
     :param sysprop_reader: (Optional) only relevant for testing.
     :return: The resolved path to the JDK or ``None`` if ``mandatory`` is ``False`` and no appropriate JDK has been found.
     """
+
     def do_resolve(env_var, major):
         java_v_home = os.getenv(env_var)
         if java_v_home:
@@ -157,8 +158,9 @@ def _resolve_single_path(major, mandatory=True, sysprop_reader=system_property):
         if java_home:
             return java_home
         elif mandatory:
-            raise exceptions.SystemSetupError("Neither {} nor {} point to a JDK {} installation.".
-                                              format(specific_env_var, generic_env_var, major))
+            raise exceptions.SystemSetupError(
+                "Neither {} nor {} point to a JDK {} installation.".format(specific_env_var, generic_env_var, major)
+            )
         else:
             return None
 

--- a/esrally/utils/modules.py
+++ b/esrally/utils/modules.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -33,6 +33,7 @@ class ComponentLoader:
     install hooks. A component may also consist of multiple Python modules.
 
     """
+
     def __init__(self, root_path, component_entry_point, recurse=True):
         """
         Creates a new component loader.
@@ -52,7 +53,7 @@ class ComponentLoader:
             for filename in os.listdir(path):
                 name, ext = os.path.splitext(filename)
                 if ext.endswith(".py"):
-                    root_relative_path = os.path.join(path, name)[len(self.root_path) + len(os.path.sep):]
+                    root_relative_path = os.path.join(path, name)[len(self.root_path) + len(os.path.sep) :]
                     module_name = "%s.%s" % (component_name, root_relative_path.replace(os.path.sep, "."))
                     yield module_name
 

--- a/esrally/utils/opts.py
+++ b/esrally/utils/opts.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -90,7 +90,7 @@ def bulleted_list_of(src_list):
 
 
 def double_quoted_list_of(src_list):
-    return ["\"{}\"".format(param) for param in src_list]
+    return ['"{}"'.format(param) for param in src_list]
 
 
 def make_list_of_close_matches(word_list, all_possibilities):
@@ -153,6 +153,7 @@ class TargetHosts(ConnectOptions):
             """
             # pylint: disable=import-outside-toplevel
             from elasticsearch.client import _normalize_hosts
+
             return {TargetHosts.DEFAULT: _normalize_hosts(arg)}
 
         self.parsed_options = to_dict(self.argvalue, default_parser=normalize_to_dict)
@@ -193,8 +194,9 @@ class ClientOptions(ConnectOptions):
 
         if self.argvalue == ClientOptions.DEFAULT_CLIENT_OPTIONS and self.target_hosts is not None:
             # --client-options unset but multi-clusters used in --target-hosts? apply options defaults for all cluster names.
-            self.parsed_options = {cluster_name: kv_to_map([ClientOptions.DEFAULT_CLIENT_OPTIONS])
-                                   for cluster_name in self.target_hosts.all_hosts.keys()}
+            self.parsed_options = {
+                cluster_name: kv_to_map([ClientOptions.DEFAULT_CLIENT_OPTIONS]) for cluster_name in self.target_hosts.all_hosts.keys()
+            }
         else:
             self.parsed_options = to_dict(self.argvalue, default_parser=normalize_to_dict)
 

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -81,13 +81,15 @@ def run_subprocess_with_logging(command_line, header=None, level=logging.INFO, s
         logger.info(header)
 
     # pylint: disable=subprocess-popen-preexec-fn
-    with subprocess.Popen(command_line_args,
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT,
-                          universal_newlines=True,
-                          env=env,
-                          stdin=stdin if stdin else None,
-                          preexec_fn=pre_exec) as command_line_process:
+    with subprocess.Popen(
+        command_line_args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        env=env,
+        stdin=stdin if stdin else None,
+        preexec_fn=pre_exec,
+    ) as command_line_process:
         stdout, _ = command_line_process.communicate()
         if stdout:
             logger.log(level=level, msg=stdout)
@@ -97,11 +99,15 @@ def run_subprocess_with_logging(command_line, header=None, level=logging.INFO, s
 
 
 def is_rally_process(p):
-    return p.name() == "esrally" or \
-           p.name() == "rally" or \
-           (p.name().lower().startswith("python")
+    return (
+        p.name() == "esrally"
+        or p.name() == "rally"
+        or (
+            p.name().lower().startswith("python")
             and any("esrally" in e for e in p.cmdline())
-            and not any("esrallyd" in e for e in p.cmdline()))
+            and not any("esrallyd" in e for e in p.cmdline())
+        )
+    )
 
 
 def find_all_other_rally_processes():
@@ -139,10 +145,14 @@ def for_all_other_processes(predicate, action):
 
 def kill_running_rally_instances():
     def rally_process(p):
-        return p.name() == "esrally" or \
-               p.name() == "rally" or \
-               (p.name().lower().startswith("python")
+        return (
+            p.name() == "esrally"
+            or p.name() == "rally"
+            or (
+                p.name().lower().startswith("python")
                 and any("esrally" in e for e in p.cmdline())
-                and not any("esrallyd" in e for e in p.cmdline()))
+                and not any("esrallyd" in e for e in p.cmdline())
+            )
+        )
 
     kill_all(rally_process)

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -20,7 +20,7 @@ import os
 import sys
 
 from esrally import exceptions
-from esrally.utils import io, git, console, versions
+from esrally.utils import console, git, io, versions
 
 
 class RallyRepository:
@@ -49,11 +49,13 @@ class RallyRepository:
         else:
             if not git.is_working_copy(self.repo_dir):
                 if io.exists(self.repo_dir):
-                    raise exceptions.SystemSetupError("[{src}] must be a git repository.\n\nPlease run:\ngit -C {src} init"
-                                                      .format(src=self.repo_dir))
+                    raise exceptions.SystemSetupError(
+                        "[{src}] must be a git repository.\n\nPlease run:\ngit -C {src} init".format(src=self.repo_dir)
+                    )
                 else:
-                    raise exceptions.SystemSetupError("Expected a git repository at [{src}] but the directory does not exist."
-                                                      .format(src=self.repo_dir))
+                    raise exceptions.SystemSetupError(
+                        "Expected a git repository at [{src}] but the directory does not exist.".format(src=self.repo_dir)
+                    )
 
     def update(self, distribution_version):
         try:
@@ -62,7 +64,8 @@ class RallyRepository:
                 if branch:
                     # Allow uncommitted changes iff we do not have to change the branch
                     self.logger.info(
-                        "Checking out [%s] in [%s] for distribution version [%s].", branch, self.repo_dir, distribution_version)
+                        "Checking out [%s] in [%s] for distribution version [%s].", branch, self.repo_dir, distribution_version
+                    )
                     git.checkout(self.repo_dir, branch=branch)
                     self.logger.info("Rebasing on [%s] in [%s] for distribution version [%s].", branch, self.repo_dir, distribution_version)
                     try:
@@ -71,32 +74,40 @@ class RallyRepository:
                     except exceptions.SupplyError:
                         self.logger.exception("Cannot rebase due to local changes in [%s]", self.repo_dir)
                         console.warn(
-                            "Local changes in [%s] prevent %s update from remote. Please commit your changes." %
-                            (self.repo_dir, self.resource_name))
+                            "Local changes in [%s] prevent %s update from remote. Please commit your changes."
+                            % (self.repo_dir, self.resource_name)
+                        )
                     return
                 else:
-                    msg = "Could not find %s remotely for distribution version [%s]. Trying to find %s locally." % \
-                          (self.resource_name, distribution_version, self.resource_name)
+                    msg = "Could not find %s remotely for distribution version [%s]. Trying to find %s locally." % (
+                        self.resource_name,
+                        distribution_version,
+                        self.resource_name,
+                    )
                     self.logger.warning(msg)
             branch = versions.best_match(git.branches(self.repo_dir, remote=False), distribution_version)
             if branch:
                 if git.current_branch(self.repo_dir) != branch:
-                    self.logger.info("Checking out [%s] in [%s] for distribution version [%s].",
-                                     branch, self.repo_dir, distribution_version)
+                    self.logger.info(
+                        "Checking out [%s] in [%s] for distribution version [%s].", branch, self.repo_dir, distribution_version
+                    )
                     git.checkout(self.repo_dir, branch=branch)
                     self.revision = git.head_revision(self.repo_dir)
             else:
-                self.logger.info("No local branch found for distribution version [%s] in [%s]. Checking tags.",
-                                 distribution_version, self.repo_dir)
+                self.logger.info(
+                    "No local branch found for distribution version [%s] in [%s]. Checking tags.", distribution_version, self.repo_dir
+                )
                 tag = self._find_matching_tag(distribution_version)
                 if tag:
-                    self.logger.info("Checking out tag [%s] in [%s] for distribution version [%s].",
-                                     tag, self.repo_dir, distribution_version)
+                    self.logger.info(
+                        "Checking out tag [%s] in [%s] for distribution version [%s].", tag, self.repo_dir, distribution_version
+                    )
                     git.checkout(self.repo_dir, branch=tag)
                     self.revision = git.head_revision(self.repo_dir)
                 else:
-                    raise exceptions.SystemSetupError("Cannot find %s for distribution version %s"
-                                                      % (self.resource_name, distribution_version))
+                    raise exceptions.SystemSetupError(
+                        "Cannot find %s for distribution version %s" % (self.resource_name, distribution_version)
+                    )
         except exceptions.SupplyError as e:
             tb = sys.exc_info()[2]
             raise exceptions.DataError("Cannot update %s in [%s] (%s)." % (self.resource_name, self.repo_dir, e.message)).with_traceback(tb)

--- a/esrally/utils/sysstats.py
+++ b/esrally/utils/sysstats.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -23,6 +23,7 @@ import psutil
 # noinspection PyBroadException
 try:
     import cpuinfo
+
     cpuinfo_available = True
 except Exception:
     cpuinfo_available = False

--- a/esrally/utils/versions.py
+++ b/esrally/utils/versions.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import re
 import functools
+import re
 
 from esrally import exceptions
 
@@ -74,6 +74,7 @@ class Version:
     Represents a version with components major, minor, patch and suffix (suffix is optional). Suffixes are not
     considered for version comparisons as its contents are opaque and a semantically correct order cannot be defined.
     """
+
     def __init__(self, major, minor, patch, suffix=None):
         self.major = major
         self.minor = minor
@@ -123,8 +124,7 @@ class VersionVariants:
         self.with_major = f"{int(self.major)}"
         self.with_minor = f"{int(self.major)}.{int(self.minor)}"
         self.with_patch = f"{int(self.major)}.{int(self.minor)}.{int(self.patch)}"
-        self.with_suffix = f"{int(self.major)}.{int(self.minor)}.{int(self.patch)}-{self.suffix}" if self.suffix \
-            else None
+        self.with_suffix = f"{int(self.major)}.{int(self.minor)}.{int(self.patch)}-{self.suffix}" if self.suffix else None
 
     @property
     def all_versions(self):
@@ -137,9 +137,13 @@ class VersionVariants:
         """
 
         versions = [(self.with_suffix, "with_suffix")] if self.suffix else []
-        versions.extend([(self.with_patch, "with_patch"),
-                         (self.with_minor, "with_minor"),
-                         (self.with_major, "with_major")])
+        versions.extend(
+            [
+                (self.with_patch, "with_patch"),
+                (self.with_minor, "with_minor"),
+                (self.with_major, "with_major"),
+            ]
+        )
 
         return versions
 

--- a/esrally/version.py
+++ b/esrally/version.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -31,7 +31,7 @@ from esrally.utils import process
 CONFIG_NAMES = ["in-memory-it", "es-it"]
 DISTRIBUTIONS = ["6.8.0", "7.6.0"]
 TRACKS = ["geonames", "nyc_taxis", "http_logs", "nested"]
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 
 def all_rally_configs(t):
@@ -159,18 +159,21 @@ class TestCluster:
             output = process.run_subprocess_with_output(
                 "esrally install --configuration-name={cfg} --quiet --distribution-version={dist} --build-type=tar "
                 "--http-port={http_port} --node={node_name} --master-nodes={node_name} --car={car} "
-                "--seed-hosts=\"127.0.0.1:{transport_port}\"".format(cfg=self.cfg,
-                                                                     dist=distribution_version,
-                                                                     http_port=http_port,
-                                                                     node_name=node_name,
-                                                                     car=car,
-                                                                     transport_port=transport_port))
+                '--seed-hosts="127.0.0.1:{transport_port}"'.format(
+                    cfg=self.cfg,
+                    dist=distribution_version,
+                    http_port=http_port,
+                    node_name=node_name,
+                    car=car,
+                    transport_port=transport_port,
+                )
+            )
             self.installation_id = json.loads("".join(output))["installation-id"]
         except BaseException as e:
             raise AssertionError("Failed to install Elasticsearch {}.".format(distribution_version), e)
 
     def start(self, race_id):
-        cmd = "start --runtime-jdk=\"bundled\" --installation-id={} --race-id={}".format(self.installation_id, race_id)
+        cmd = 'start --runtime-jdk="bundled" --installation-id={} --race-id={}'.format(self.installation_id, race_id)
         if esrally(self.cfg, cmd) != 0:
             raise AssertionError("Failed to start Elasticsearch test cluster.")
         es = client.EsClientFactory(hosts=[{"host": "127.0.0.1", "port": self.http_port}], client_options={}).create()
@@ -192,10 +195,12 @@ class EsMetricsStore:
         self.cluster = TestCluster("in-memory-it")
 
     def start(self):
-        self.cluster.install(distribution_version=EsMetricsStore.VERSION,
-                             node_name="metrics-store",
-                             car="defaults",
-                             http_port=10200)
+        self.cluster.install(
+            distribution_version=EsMetricsStore.VERSION,
+            node_name="metrics-store",
+            car="defaults",
+            http_port=10200,
+        )
         self.cluster.start(race_id="metrics-store")
 
     def stop(self):
@@ -221,7 +226,7 @@ ES_METRICS_STORE = EsMetricsStore()
 
 
 def get_license():
-    with open(os.path.join(ROOT_DIR, 'LICENSE')) as license_file:
+    with open(os.path.join(ROOT_DIR, "LICENSE")) as license_file:
         return license_file.readlines()[1].strip()
 
 
@@ -229,11 +234,13 @@ def build_docker_image():
     rally_version = version.__version__
 
     env_variables = os.environ.copy()
-    env_variables['RALLY_VERSION'] = rally_version
-    env_variables['RALLY_LICENSE'] = get_license()
+    env_variables["RALLY_VERSION"] = rally_version
+    env_variables["RALLY_LICENSE"] = get_license()
 
-    command = f"docker build -t elastic/rally:{rally_version} --build-arg RALLY_VERSION --build-arg RALLY_LICENSE " \
-              f"-f {ROOT_DIR}/docker/Dockerfiles/Dockerfile-dev {ROOT_DIR}"
+    command = (
+        f"docker build -t elastic/rally:{rally_version} --build-arg RALLY_VERSION --build-arg RALLY_LICENSE "
+        f"-f {ROOT_DIR}/docker/Dockerfiles/Dockerfile-dev {ROOT_DIR}"
+    )
 
     if process.run_subprocess_with_logging(command, env=env_variables) != 0:
         raise AssertionError("It was not possible to build the docker image from Dockerfile-dev")

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -28,8 +28,12 @@ def test_tar_distributions(cfg):
     for dist in it.DISTRIBUTIONS:
         for track in it.TRACKS:
             it.wait_until_port_is_free(port_number=port)
-            assert it.race(cfg, f"--distribution-version=\"{dist}\" --track=\"{track}\" "
-                                f"--test-mode --car=4gheap --target-hosts=127.0.0.1:{port}") == 0
+            assert (
+                it.race(
+                    cfg, f'--distribution-version="{dist}" --track="{track}" ' f"--test-mode --car=4gheap --target-hosts=127.0.0.1:{port}"
+                )
+                == 0
+            )
 
 
 @it.random_rally_config
@@ -38,17 +42,27 @@ def test_docker_distribution(cfg):
     # only test the most recent Docker distribution
     dist = it.DISTRIBUTIONS[-1]
     it.wait_until_port_is_free(port_number=port)
-    assert it.race(cfg, f"--pipeline=\"docker\" --distribution-version=\"{dist}\" "
-                        f"--track=\"geonames\" --challenge=\"append-no-conflicts-index-only\" --test-mode "
-                        f"--car=4gheap --target-hosts=127.0.0.1:{port}") == 0
+    assert (
+        it.race(
+            cfg,
+            f'--pipeline="docker" --distribution-version="{dist}" '
+            f'--track="geonames" --challenge="append-no-conflicts-index-only" --test-mode '
+            f"--car=4gheap --target-hosts=127.0.0.1:{port}",
+        )
+        == 0
+    )
 
 
 @it.random_rally_config
 def test_does_not_benchmark_unsupported_distribution(cfg):
     port = 19200
     it.wait_until_port_is_free(port_number=port)
-    assert it.race(cfg, f"--distribution-version=\"1.7.6\" --track=\"{it.TRACKS[0]}\" "
-                        f"--target-hosts=127.0.0.1:{port} --test-mode --car=4gheap") != 0
+    assert (
+        it.race(
+            cfg, f'--distribution-version="1.7.6" --track="{it.TRACKS[0]}" ' f"--target-hosts=127.0.0.1:{port} --test-mode --car=4gheap"
+        )
+        != 0
+    )
 
 
 @pytest.fixture(scope="module")
@@ -75,12 +89,16 @@ def test_eventdata_frozen(cfg, test_cluster):
 
 @it.random_rally_config
 def test_eventdata_indexing_and_querying(cfg, test_cluster):
-    challenges = ["elasticlogs-1bn-load",
-                  "elasticlogs-continuous-index-and-query",
-                  "combined-indexing-and-querying",
-                  "elasticlogs-querying"]
-    track_params = "bulk_indexing_clients:1,number_of_replicas:0,rate_limit_max:2,rate_limit_duration_secs:5," \
-                   "p1_bulk_indexing_clients:1,p2_bulk_indexing_clients:1,p1_duration_secs:5,p2_duration_secs:5"
+    challenges = [
+        "elasticlogs-1bn-load",
+        "elasticlogs-continuous-index-and-query",
+        "combined-indexing-and-querying",
+        "elasticlogs-querying",
+    ]
+    track_params = (
+        "bulk_indexing_clients:1,number_of_replicas:0,rate_limit_max:2,rate_limit_duration_secs:5,"
+        "p1_bulk_indexing_clients:1,p2_bulk_indexing_clients:1,p1_duration_secs:5,p2_duration_secs:5"
+    )
     execute_eventdata(cfg, test_cluster, challenges, track_params)
 
 
@@ -100,7 +118,9 @@ def test_eventdata_daily_volume(cfg, test_cluster):
 
 def execute_eventdata(cfg, test_cluster, challenges, track_params):
     for challenge in challenges:
-        cmd = f"--test-mode --pipeline=benchmark-only --target-host=127.0.0.1:{test_cluster.http_port} " \
-              f"--track-repository=eventdata --track=eventdata --track-params=\"{track_params}\" " \
-              f"--challenge={challenge}"
+        cmd = (
+            f"--test-mode --pipeline=benchmark-only --target-host=127.0.0.1:{test_cluster.http_port} "
+            f'--track-repository=eventdata --track=eventdata --track-params="{track_params}" '
+            f"--challenge={challenge}"
+        )
         assert it.race(cfg, cmd) == 0

--- a/it/docker_dev_image_test.py
+++ b/it/docker_dev_image_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -16,15 +16,16 @@
 # under the License.
 
 import os
-import it
 
-from esrally.utils import process
+import it
 from esrally import version
+from esrally.utils import process
 
 
 def test_docker_geonames():
-    test_command = "race --pipeline=benchmark-only --test-mode --track=geonames " \
-                   "--challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
+    test_command = (
+        "race --pipeline=benchmark-only --test-mode --track=geonames --challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
+    )
     run_docker_compose_test(test_command)
 
 
@@ -39,8 +40,10 @@ def test_docker_help():
 
 
 def test_docker_override_cmd():
-    test_command = "esrally race --pipeline=benchmark-only --test-mode --track=geonames " \
-                   "--challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
+    test_command = (
+        "esrally race --pipeline=benchmark-only --test-mode --track=geonames "
+        "--challenge=append-no-conflicts-index-only --target-hosts=es01:9200"
+    )
     run_docker_compose_test(test_command)
 
 
@@ -56,10 +59,11 @@ def run_docker_compose_test(test_command):
 def run_docker_compose_up(test_command):
     env_variables = os.environ.copy()
     env_variables["TEST_COMMAND"] = test_command
-    env_variables['RALLY_VERSION'] = version.__version__
+    env_variables["RALLY_VERSION"] = version.__version__
 
-    return process.run_subprocess_with_logging(f"docker-compose -f {it.ROOT_DIR}/docker/docker-compose-tests.yml up "
-                                               f"--abort-on-container-exit", env=env_variables)
+    return process.run_subprocess_with_logging(
+        f"docker-compose -f {it.ROOT_DIR}/docker/docker-compose-tests.yml up --abort-on-container-exit", env=env_variables
+    )
 
 
 def run_docker_compose_down():

--- a/it/download_test.py
+++ b/it/download_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -21,9 +21,9 @@ import it
 @it.random_rally_config
 def test_download_distribution(cfg):
     for d in it.DISTRIBUTIONS:
-        assert it.esrally(cfg, f"download --distribution-version=\"{d}\" --quiet") == 0
+        assert it.esrally(cfg, f'download --distribution-version="{d}" --quiet') == 0
 
 
 @it.random_rally_config
 def test_does_not_download_unsupported_distribution(cfg):
-    assert it.esrally(cfg, "download --distribution-version=\"1.7.6\" --quiet") != 0
+    assert it.esrally(cfg, 'download --distribution-version="1.7.6" --quiet') != 0

--- a/it/generate_test.py
+++ b/it/generate_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -25,16 +25,11 @@ def test_track_info_with_challenge(cfg, tmp_path):
     cwd = os.path.dirname(__file__)
     chart_spec_path = os.path.join(cwd, "resources", "sample-race-config.json")
     output_path = os.path.join(tmp_path, "nightly-charts.ndjson")
-    assert it.esrally(cfg, f"generate charts "
-                           f"--chart-spec-path={chart_spec_path} "
-                           f"--chart-type=time-series "
-                           f"--output-path={output_path}") == 0
+    assert it.esrally(cfg, f"generate charts --chart-spec-path={chart_spec_path} --chart-type=time-series --output-path={output_path}") == 0
+
 
 @it.rally_in_mem
 def test_fails_when_spec_not_found(cfg, tmp_path):
     chart_spec_path = "/non/existent/path"
     output_path = os.path.join(tmp_path, "nightly-charts.ndjson")
-    assert it.esrally(cfg, f"generate charts "
-                           f"--chart-spec-path={chart_spec_path} "
-                           f"--chart-type=time-series "
-                           f"--output-path={output_path}") !=0
+    assert it.esrally(cfg, f"generate charts --chart-spec-path={chart_spec_path} --chart-type=time-series --output-path={output_path}") != 0

--- a/it/info_test.py
+++ b/it/info_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -31,7 +31,7 @@ def test_track_info_with_track_repo(cfg):
 
 @it.rally_in_mem
 def test_track_info_with_task_filter(cfg):
-    assert it.esrally(cfg, "info --track=geonames --challenge=append-no-conflicts --include-tasks=\"type:search\"") == 0
+    assert it.esrally(cfg, 'info --track=geonames --challenge=append-no-conflicts --include-tasks="type:search"') == 0
 
 
 @it.rally_in_mem
@@ -39,8 +39,10 @@ def test_track_info_fails_with_wrong_track_params(cfg):
     # simulate a typo in track parameter
     cmd = it.esrally_command_line_for(cfg, "info --track=geonames --track-params='conflict_probability:5,number-of-replicas:1'")
     output = process.run_subprocess_with_output(cmd)
-    expected = "Some of your track parameter(s) \"number-of-replicas\" are not used by this track; " \
-               "perhaps you intend to use \"number_of_replicas\" instead.\n\nAll track parameters you " \
-               "provided are:\n- conflict_probability\n- number-of-replicas\n\nAll parameters exposed by this track"
+    expected = (
+        'Some of your track parameter(s) "number-of-replicas" are not used by this track; '
+        'perhaps you intend to use "number_of_replicas" instead.\n\nAll track parameters you '
+        "provided are:\n- conflict_probability\n- number-of-replicas\n\nAll parameters exposed by this track"
+    )
 
     assert expected in "\n".join(output)

--- a/it/installation_test.py
+++ b/it/installation_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -24,7 +24,7 @@ import os
 
 import it
 
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 _CI_VARS = ".ci/variables.json"
 
 with open(os.path.join(ROOT_DIR, _CI_VARS), "rt") as fp:

--- a/it/list_test.py
+++ b/it/list_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -37,8 +37,7 @@ def test_list_elasticsearch_plugins(cfg):
 def test_list_tracks(cfg):
     assert it.esrally(cfg, "list tracks") == 0
     assert it.esrally(cfg, "list tracks --track-repository=eventdata") == 0
-    assert it.esrally(cfg, "list tracks --track-repository=default "
-                           "--track-revision=4080dc9850d07e23b6fc7cfcdc7cf57b14e5168d") == 0
+    assert it.esrally(cfg, "list tracks --track-repository=default --track-revision=4080dc9850d07e23b6fc7cfcdc7cf57b14e5168d") == 0
 
 
 @it.rally_in_mem

--- a/it/proxy_test.py
+++ b/it/proxy_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -32,13 +32,14 @@ HttpProxy = collections.namedtuple("HttpProxy", ["authenticated_url", "anonymous
 def http_proxy():
     config_dir = os.path.join(os.path.dirname(__file__), "resources", "squid")
 
-    lines = process.run_subprocess_with_output(f"docker run --rm --name squid -d "
-                                               f"-v {config_dir}/squidpasswords:/etc/squid/squidpasswords "
-                                               f"-v {config_dir}/squid.conf:/etc/squid/squid.conf "
-                                               f"-p 3128:3128 datadog/squid")
+    lines = process.run_subprocess_with_output(
+        f"docker run --rm --name squid -d "
+        f"-v {config_dir}/squidpasswords:/etc/squid/squidpasswords "
+        f"-v {config_dir}/squid.conf:/etc/squid/squid.conf "
+        f"-p 3128:3128 datadog/squid"
+    )
     proxy_container_id = lines[0].strip()
-    proxy = HttpProxy(authenticated_url="http://testuser:testuser@127.0.0.1:3128",
-                      anonymous_url="http://127.0.0.1:3128")
+    proxy = HttpProxy(authenticated_url="http://testuser:testuser@127.0.0.1:3128", anonymous_url="http://127.0.0.1:3128")
     yield proxy
     process.run_subprocess(f"docker stop {proxy_container_id}")
 
@@ -88,7 +89,6 @@ def test_authenticated_proxy_user_can_connect(cfg, http_proxy, fresh_log_file):
     env = dict(os.environ)
     env["http_proxy"] = http_proxy.authenticated_url
     assert process.run_subprocess_with_logging(it.esrally_command_line_for(cfg, "list tracks"), env=env) == 0
-    assert_log_line_present(fresh_log_file,
-                            f"Connecting via proxy URL [{http_proxy.authenticated_url}] to the Internet")
+    assert_log_line_present(fresh_log_file, f"Connecting via proxy URL [{http_proxy.authenticated_url}] to the Internet")
     # authenticated proxy access is allowed
     assert_log_line_present(fresh_log_file, "Detected a working Internet connection")

--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -22,9 +22,21 @@ import it
 def test_sources(cfg):
     port = 19200
     it.wait_until_port_is_free(port_number=port)
-    assert it.race(cfg, f"--revision=latest --track=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
-                        f"--challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu") == 0
+    assert (
+        it.race(
+            cfg,
+            f"--revision=latest --track=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
+            f"--challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu",
+        )
+        == 0
+    )
 
     it.wait_until_port_is_free(port_number=port)
-    assert it.race(cfg, f"--pipeline=from-sources --track=geonames --test-mode --target-hosts=127.0.0.1:{port} "
-                        f"--challenge=append-no-conflicts-index-only --car=\"4gheap,ea\"") == 0
+    assert (
+        it.race(
+            cfg,
+            f"--pipeline=from-sources --track=geonames --test-mode --target-hosts=127.0.0.1:{port} "
+            f'--challenge=append-no-conflicts-index-only --car="4gheap,ea"',
+        )
+        == 0
+    )

--- a/it/tracker_test.py
+++ b/it/tracker_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -40,23 +40,33 @@ def test_cluster():
 @it.rally_in_mem
 def test_create_track(cfg, tmp_path, test_cluster):
     # prepare some data
-    cmd = f"--test-mode --pipeline=benchmark-only --target-hosts=127.0.0.1:{test_cluster.http_port} " \
-          f" --track=geonames --challenge=append-no-conflicts-index-only --quiet"
+    cmd = (
+        f"--test-mode --pipeline=benchmark-only --target-hosts=127.0.0.1:{test_cluster.http_port} "
+        f" --track=geonames --challenge=append-no-conflicts-index-only --quiet"
+    )
     assert it.race(cfg, cmd) == 0
 
     # create the track
     track_name = f"test-track-{uuid.uuid4()}"
     track_path = tmp_path / track_name
 
-    assert it.esrally(cfg, f"create-track --target-hosts=127.0.0.1:{test_cluster.http_port} --indices=geonames "
-                           f"--track={track_name} --output-path={tmp_path}") == 0
+    assert (
+        it.esrally(
+            cfg,
+            f"create-track --target-hosts=127.0.0.1:{test_cluster.http_port} --indices=geonames "
+            f"--track={track_name} --output-path={tmp_path}",
+        )
+        == 0
+    )
 
-    expected_files = ["track.json",
-                      "geonames.json",
-                      "geonames-documents-1k.json",
-                      "geonames-documents.json",
-                      "geonames-documents-1k.json.bz2",
-                      "geonames-documents.json.bz2"]
+    expected_files = [
+        "track.json",
+        "geonames.json",
+        "geonames-documents-1k.json",
+        "geonames-documents.json",
+        "geonames-documents-1k.json.bz2",
+        "geonames-documents.json.bz2",
+    ]
 
     for f in expected_files:
         full_path = track_path / f

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 140
+target-version = ['py38']
+
+[tool.isort]
+profile = 'black'

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -48,7 +48,7 @@ def create_plot():
 
 
 def present(a_plot, name):
-    a_plot.savefig("%s.png" % name, bbox_inches='tight')
+    a_plot.savefig("%s.png" % name, bbox_inches="tight")
     # plt.show()  # alternatively only show it
     # explicitly close to free resources
     a_plot.close()
@@ -83,11 +83,13 @@ def plot_service_time(raw_data, label_key):
             service_time_metrics = op_metrics["service_time"]
             if operation not in service_time_per_op:
                 service_time_per_op[operation] = []
-            service_time_per_op[operation].append({
-                "data_series": data_series,
-                "percentiles": [decode_percentile_key(p) for p in service_time_metrics.keys()],
-                "percentile_values": list(service_time_metrics.values()),
-            })
+            service_time_per_op[operation].append(
+                {
+                    "data_series": data_series,
+                    "percentiles": [decode_percentile_key(p) for p in service_time_metrics.keys()],
+                    "percentile_values": list(service_time_metrics.values()),
+                }
+            )
 
     for op, results in service_time_per_op.items():
         _, ax = create_plot()
@@ -96,7 +98,7 @@ def plot_service_time(raw_data, label_key):
 
         for candidate in results:
             label = candidate["data_series"]
-            series = ax.plot(candidate["percentiles"], candidate["percentile_values"], marker='.', label=label)
+            series = ax.plot(candidate["percentiles"], candidate["percentile_values"], marker=".", label=label)
             legend_handles.append(series[0])
             legend_labels.append(label)
 
@@ -107,7 +109,7 @@ def plot_service_time(raw_data, label_key):
 
         box = ax.get_position()
         ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
-        ax.legend(legend_handles, legend_labels, loc='center left', bbox_to_anchor=(1, 0.5))
+        ax.legend(legend_handles, legend_labels, loc="center left", bbox_to_anchor=(1, 0.5))
 
         present(plt, "service_time_%s" % op)
 
@@ -123,13 +125,15 @@ def plot_throughput(raw_data, label_key):
             throughput_metrics = op_metrics["throughput"]
             if operation not in throughput_per_op:
                 throughput_per_op[operation] = []
-            throughput_per_op[operation].append({
-                "data_series": data_series,
-                "max": throughput_metrics["max"],
-                "median": throughput_metrics["median"],
-                "min": throughput_metrics["min"],
-                "unit": throughput_metrics["unit"]
-            })
+            throughput_per_op[operation].append(
+                {
+                    "data_series": data_series,
+                    "max": throughput_metrics["max"],
+                    "median": throughput_metrics["median"],
+                    "min": throughput_metrics["min"],
+                    "unit": throughput_metrics["unit"],
+                }
+            )
 
     for op, results in throughput_per_op.items():
         _, ax = create_plot()
@@ -198,7 +202,7 @@ def plot_gc_times(raw_data, label_key):
     box = ax.get_position()
     ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
 
-    ax.legend([old_bar[0], young_bar[0]], ["Old GC", "Young GC"], loc='center left', bbox_to_anchor=(1, 0.5))
+    ax.legend([old_bar[0], young_bar[0]], ["Old GC", "Young GC"], loc="center left", bbox_to_anchor=(1, 0.5))
     ax.set_ylim(ymin=0)
 
     present(plt, "gc_times")
@@ -217,11 +221,14 @@ def parse_args():
         "--label",
         help="defines which attribute to use for labelling data series (default: race-timestamp).",
         # choices=["environment", "race-timestamp", "user-tags", "challenge", "car"],
-        default="race-timestamp")
+        default="race-timestamp",
+    )
 
-    parser.add_argument("path",
-                        nargs="+",
-                        help="Full path to one or more race.json files")
+    parser.add_argument(
+        "path",
+        nargs="+",
+        help="Full path to one or more race.json files",
+    )
 
     return parser.parse_args()
 
@@ -237,5 +244,5 @@ def main():
     plot(series, args.label)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,8 @@ develop_require = [
     "wheel==0.33.6",
     "github3.py==1.3.0",
     "pylint==2.6.0",
-    "pylint-quotes==0.2.1"
+    "black==21.5b2",
+    "isort==5.8.0",
 ]
 
 python_version_classifiers = ["Programming Language :: Python :: {}.{}".format(major, minor)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -24,8 +24,10 @@ def run_async(t):
 
     :param t: The test case to wrap.
     """
+
     def async_wrapper(*args, **kwargs):
         asyncio.run(t(*args, **kwargs), debug=True)
+
     return async_wrapper
 
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -26,7 +26,7 @@ from unittest import TestCase, mock
 import elasticsearch
 import urllib3.exceptions
 
-from esrally import client, exceptions, doc_link
+from esrally import client, doc_link, exceptions
 from esrally.utils import console
 from tests import run_async
 
@@ -55,7 +55,7 @@ class EsClientFactoryTests(TestCase):
         client_options = {
             "use_ssl": True,
             "verify_certs": True,
-            "http_auth": ("user", "password")
+            "http_auth": ("user", "password"),
         }
         # make a copy so we can verify later that the factory did not modify it
         original_client_options = deepcopy(client_options)
@@ -63,14 +63,17 @@ class EsClientFactoryTests(TestCase):
         logger = logging.getLogger("esrally.client")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.EsClientFactory(hosts, client_options)
-        mocked_info_logger.assert_has_calls([
-            mock.call("SSL support: on"),
-            mock.call("SSL certificate verification: on"),
-            mock.call("SSL client authentication: off")
-        ])
+        mocked_info_logger.assert_has_calls(
+            [
+                mock.call("SSL support: on"),
+                mock.call("SSL certificate verification: on"),
+                mock.call("SSL client authentication: off"),
+            ]
+        )
 
-        assert not mocked_load_cert_chain.called, "ssl_context.load_cert_chain should not have been called as we have not supplied " \
-                                                  "client certs"
+        assert (
+            not mocked_load_cert_chain.called
+        ), "ssl_context.load_cert_chain should not have been called as we have not supplied client certs"
 
         self.assertEqual(hosts, f.hosts)
         self.assertTrue(f.ssl_context.check_hostname)
@@ -93,7 +96,7 @@ class EsClientFactoryTests(TestCase):
             "http_auth": ("user", "password"),
             "ca_certs": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/ca.crt"),
             "client_cert": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/client.crt"),
-            "client_key": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/client.key")
+            "client_key": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/client.key"),
         }
         # make a copy so we can verify later that the factory did not modify it
         original_client_options = deepcopy(client_options)
@@ -101,15 +104,17 @@ class EsClientFactoryTests(TestCase):
         logger = logging.getLogger("esrally.client")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.EsClientFactory(hosts, client_options)
-        mocked_info_logger.assert_has_calls([
-            mock.call("SSL support: on"),
-            mock.call("SSL certificate verification: on"),
-            mock.call("SSL client authentication: on")
-        ])
+        mocked_info_logger.assert_has_calls(
+            [
+                mock.call("SSL support: on"),
+                mock.call("SSL certificate verification: on"),
+                mock.call("SSL client authentication: on"),
+            ]
+        )
 
         mocked_load_cert_chain.assert_called_with(
             certfile=client_options["client_cert"],
-            keyfile=client_options["client_key"]
+            keyfile=client_options["client_key"],
         )
 
         self.assertEqual(hosts, f.hosts)
@@ -133,7 +138,7 @@ class EsClientFactoryTests(TestCase):
             "use_ssl": True,
             "verify_certs": True,
             "http_auth": ("user", "password"),
-            "ca_certs": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/ca.crt")
+            "ca_certs": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/ca.crt"),
         }
         # make a copy so we can verify later that the factory did not modify it
         original_client_options = deepcopy(client_options)
@@ -141,14 +146,17 @@ class EsClientFactoryTests(TestCase):
         logger = logging.getLogger("esrally.client")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.EsClientFactory(hosts, client_options)
-        mocked_info_logger.assert_has_calls([
-            mock.call("SSL support: on"),
-            mock.call("SSL certificate verification: on"),
-            mock.call("SSL client authentication: off")
-        ])
+        mocked_info_logger.assert_has_calls(
+            [
+                mock.call("SSL support: on"),
+                mock.call("SSL certificate verification: on"),
+                mock.call("SSL client authentication: off"),
+            ]
+        )
 
-        assert not mocked_load_cert_chain.called, "ssl_context.load_cert_chain should not have been called as we have not supplied " \
-            "client certs"
+        assert (
+            not mocked_load_cert_chain.called
+        ), "ssl_context.load_cert_chain should not have been called as we have not supplied client certs"
         self.assertEqual(hosts, f.hosts)
         self.assertTrue(f.ssl_context.check_hostname)
         self.assertEqual(ssl.CERT_REQUIRED, f.ssl_context.verify_mode)
@@ -167,19 +175,14 @@ class EsClientFactoryTests(TestCase):
             "use_ssl": True,
             "verify_certs": True,
             "http_auth": ("user", "password"),
-            "ca_certs": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/ca.crt")
+            "ca_certs": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/ca.crt"),
         }
 
-        client_ssl_options = {
-            "client_cert": "utils/resources/certs/client.crt",
-            "client_key": "utils/resources/certs/client.key"
-        }
+        client_ssl_options = {"client_cert": "utils/resources/certs/client.crt", "client_key": "utils/resources/certs/client.key"}
 
         random_client_ssl_option = random.choice(list(client_ssl_options.keys()))
-        missing_client_ssl_option = list(set(client_ssl_options)-set([random_client_ssl_option]))[0]
-        client_options.update(
-            {random_client_ssl_option: client_ssl_options[random_client_ssl_option]}
-        )
+        missing_client_ssl_option = list(set(client_ssl_options) - set([random_client_ssl_option]))[0]
+        client_options.update({random_client_ssl_option: client_ssl_options[random_client_ssl_option]})
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             with mock.patch.object(console, "println") as mocked_console_println:
@@ -190,15 +193,14 @@ class EsClientFactoryTests(TestCase):
             "Read the documentation at {}\n".format(
                 missing_client_ssl_option,
                 random_client_ssl_option,
-                console.format.link(doc_link("command_line_reference.html#client-options"))
+                console.format.link(doc_link("command_line_reference.html#client-options")),
             )
         )
         self.assertEqual(
             "Cannot specify '{}' without also specifying '{}' in client-options.".format(
-                random_client_ssl_option,
-                missing_client_ssl_option
+                random_client_ssl_option, missing_client_ssl_option
             ),
-            ctx.exception.args[0]
+            ctx.exception.args[0],
         )
 
     @mock.patch.object(ssl.SSLContext, "load_cert_chain")
@@ -208,7 +210,7 @@ class EsClientFactoryTests(TestCase):
             "use_ssl": True,
             "verify_certs": False,
             "basic_auth_user": "user",
-            "basic_auth_password": "password"
+            "basic_auth_password": "password",
         }
         # make a copy so we can verify later that the factory did not modify it
         original_client_options = dict(client_options)
@@ -216,14 +218,17 @@ class EsClientFactoryTests(TestCase):
         logger = logging.getLogger("esrally.client")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.EsClientFactory(hosts, client_options)
-        mocked_info_logger.assert_has_calls([
-            mock.call("SSL support: on"),
-            mock.call("SSL certificate verification: off"),
-            mock.call("SSL client authentication: off")
-        ])
+        mocked_info_logger.assert_has_calls(
+            [
+                mock.call("SSL support: on"),
+                mock.call("SSL certificate verification: off"),
+                mock.call("SSL client authentication: off"),
+            ]
+        )
 
-        assert not mocked_load_cert_chain.called, "ssl_context.load_cert_chain should not have been called as we have not supplied " \
-                                                  "client certs"
+        assert (
+            not mocked_load_cert_chain.called
+        ), "ssl_context.load_cert_chain should not have been called as we have not supplied client certs"
 
         self.assertEqual(hosts, f.hosts)
         self.assertFalse(f.ssl_context.check_hostname)
@@ -246,7 +251,7 @@ class EsClientFactoryTests(TestCase):
             "verify_certs": False,
             "http_auth": ("user", "password"),
             "client_cert": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/client.crt"),
-            "client_key": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/client.key")
+            "client_key": os.path.join(EsClientFactoryTests.cwd, "utils/resources/certs/client.key"),
         }
         # make a copy so we can verify later that the factory did not modify it
         original_client_options = deepcopy(client_options)
@@ -254,14 +259,16 @@ class EsClientFactoryTests(TestCase):
         logger = logging.getLogger("esrally.client")
         with mock.patch.object(logger, "info") as mocked_info_logger:
             f = client.EsClientFactory(hosts, client_options)
-        mocked_info_logger.assert_has_calls([
-            mock.call("SSL certificate verification: off"),
-            mock.call("SSL client authentication: on")
-        ])
+        mocked_info_logger.assert_has_calls(
+            [
+                mock.call("SSL certificate verification: off"),
+                mock.call("SSL client authentication: on"),
+            ],
+        )
 
         mocked_load_cert_chain.assert_called_with(
             certfile=client_options["client_cert"],
-            keyfile=client_options["client_key"]
+            keyfile=client_options["client_key"],
         )
 
         self.assertEqual(hosts, f.hosts)
@@ -307,14 +314,14 @@ class RestLayerTests(TestCase):
     def test_successfully_waits_for_rest_layer(self, es):
         es.transport.hosts = [
             {"host": "node-a.example.org", "port": 9200},
-            {"host": "node-b.example.org", "port": 9200}
+            {"host": "node-b.example.org", "port": 9200},
         ]
-
         self.assertTrue(client.wait_for_rest_layer(es, max_attempts=3))
-
-        es.cluster.health.assert_has_calls([
-            mock.call(wait_for_nodes=">=2"),
-        ])
+        es.cluster.health.assert_has_calls(
+            [
+                mock.call(wait_for_nodes=">=2"),
+            ]
+        )
 
     # don't sleep in realtime
     @mock.patch("time.sleep")
@@ -325,12 +332,7 @@ class RestLayerTests(TestCase):
             elasticsearch.TransportError(401, "Unauthorized"),
             elasticsearch.TransportError(408, "Timed Out"),
             elasticsearch.TransportError(408, "Timed Out"),
-            {
-                "version": {
-                    "number": "5.0.0",
-                    "build_hash": "abc123"
-                }
-            }
+            {"version": {"number": "5.0.0", "build_hash": "abc123"}},
         ]
         self.assertTrue(client.wait_for_rest_layer(es, max_attempts=5))
 
@@ -343,10 +345,13 @@ class RestLayerTests(TestCase):
 
     @mock.patch("elasticsearch.Elasticsearch")
     def test_ssl_error(self, es):
-        es.cluster.health.side_effect = elasticsearch.ConnectionError("N/A",
-                                                            "[SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:719)",
-                                                            urllib3.exceptions.SSLError(
-                                                                "[SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:719)"))
-        with self.assertRaisesRegex(expected_exception=exceptions.SystemSetupError,
-                                    expected_regex="Could not connect to cluster via https. Is this an https endpoint?"):
+        es.cluster.health.side_effect = elasticsearch.ConnectionError(
+            "N/A",
+            "[SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:719)",
+            urllib3.exceptions.SSLError("[SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:719)"),
+        )
+        with self.assertRaisesRegex(
+            expected_exception=exceptions.SystemSetupError,
+            expected_regex="Could not connect to cluster via https. Is this an https endpoint?",
+        ):
             client.wait_for_rest_layer(es, max_attempts=3)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -55,21 +55,17 @@ class InMemoryConfigStore:
         self.backup_created = True
 
     def store_default_config(self):
-        self.store({
-            "distributions": {
-                "release.url": "https://acme.com/releases",
-                "release.cache": "true",
-            },
-            "system": {
-                "env.name": "existing-unit-test-config"
-            },
-            "meta": {
-                "config.version": config.Config.CURRENT_CONFIG_VERSION
-            },
-            "benchmarks": {
-                "local.dataset.cache": "/tmp/rally/data"
+        self.store(
+            {
+                "distributions": {
+                    "release.url": "https://acme.com/releases",
+                    "release.cache": "true",
+                },
+                "system": {"env.name": "existing-unit-test-config"},
+                "meta": {"config.version": config.Config.CURRENT_CONFIG_VERSION},
+                "benchmarks": {"local.dataset.cache": "/tmp/rally/data"},
             }
-        })
+        )
 
     def store(self, c):
         self.present = True
@@ -93,12 +89,8 @@ class ConfigTests(TestCase):
         self.assertFalse(cfg.config_present())
 
         sample_config = {
-            "tests": {
-                "sample.key": "value"
-            },
-            "meta": {
-                "config.version": config.Config.CURRENT_CONFIG_VERSION
-            }
+            "tests": {"sample.key": "value"},
+            "meta": {"config.version": config.Config.CURRENT_CONFIG_VERSION},
         }
         cfg.config_file.store(sample_config)
 
@@ -120,14 +112,10 @@ class ConfigTests(TestCase):
                 "release.url": "https://acme.com/releases",
                 "release.cache": "true",
                 "snapshot.url": "https://acme.com/snapshots",
-                "snapshot.cache": "false"
+                "snapshot.cache": "false",
             },
-            "system": {
-                "env.name": "local"
-            },
-            "meta": {
-                "config.version": config.Config.CURRENT_CONFIG_VERSION
-            }
+            "system": {"env.name": "local"},
+            "meta": {"config.version": config.Config.CURRENT_CONFIG_VERSION},
         }
         cfg.config_file.store(sample_config)
 
@@ -136,27 +124,23 @@ class ConfigTests(TestCase):
         # override a value so we can see that the scoping logic still works. Default is scope "application"
         cfg.add(config.Scope.applicationOverride, "distributions", "snapshot.cache", "true")
 
-        self.assertEqual({
-            "release.url": "https://acme.com/releases",
-            "release.cache": "true",
-            "snapshot.url": "https://acme.com/snapshots",
-            # overridden!
-            "snapshot.cache": "true"
-        }, cfg.all_opts("distributions"))
+        self.assertEqual(
+            {
+                "release.url": "https://acme.com/releases",
+                "release.cache": "true",
+                "snapshot.url": "https://acme.com/snapshots",
+                # overridden!
+                "snapshot.cache": "true",
+            },
+            cfg.all_opts("distributions"),
+        )
 
     def test_add_all_in_section(self):
         source_cfg = config.Config(config_file_class=InMemoryConfigStore)
         sample_config = {
-            "tests": {
-                "sample.key": "value",
-                "sample.key2": "value"
-            },
-            "no_copy": {
-                "other.key": "value"
-            },
-            "meta": {
-                "config.version": config.Config.CURRENT_CONFIG_VERSION
-            }
+            "tests": {"sample.key": "value", "sample.key2": "value"},
+            "no_copy": {"other.key": "value"},
+            "meta": {"config.version": config.Config.CURRENT_CONFIG_VERSION},
         }
         source_cfg.config_file.store(sample_config)
         source_cfg.load_config()
@@ -201,22 +185,21 @@ class AutoLoadConfigTests(TestCase):
         base_cfg.add(config.Scope.application, "benchmarks", "local.dataset.cache", "/base-config/data-set-cache")
         base_cfg.add(config.Scope.application, "unit-test", "sample.property", "let me copy you")
 
-        cfg = config.auto_load_local_config(base_cfg, additional_sections=["unit-test"],
-                                            config_file_class=InMemoryConfigStore, present=True, config={
-            "distributions": {
-                "release.url": "https://acme.com/releases",
-                "release.cache": "true",
+        cfg = config.auto_load_local_config(
+            base_cfg,
+            additional_sections=["unit-test"],
+            config_file_class=InMemoryConfigStore,
+            present=True,
+            config={
+                "distributions": {
+                    "release.url": "https://acme.com/releases",
+                    "release.cache": "true",
+                },
+                "system": {"env.name": "existing-unit-test-config"},
+                "meta": {"config.version": config.Config.CURRENT_CONFIG_VERSION},
+                "benchmarks": {"local.dataset.cache": "/tmp/rally/data"},
             },
-            "system": {
-                "env.name": "existing-unit-test-config"
-            },
-            "meta": {
-                "config.version": config.Config.CURRENT_CONFIG_VERSION
-            },
-            "benchmarks": {
-                "local.dataset.cache": "/tmp/rally/data"
-            }
-        })
+        )
         self.assertTrue(cfg.config_file.present)
         # did not just copy base config
         self.assertNotEqual(base_cfg.opts("benchmarks", "local.dataset.cache"), cfg.opts("benchmarks", "local.dataset.cache"))
@@ -231,27 +214,26 @@ class AutoLoadConfigTests(TestCase):
         base_cfg.add(config.Scope.application, "benchmarks", "local.dataset.cache", "/base-config/data-set-cache")
         base_cfg.add(config.Scope.application, "unit-test", "sample.property", "let me copy you")
 
-        cfg = config.auto_load_local_config(base_cfg, additional_sections=["unit-test"],
-                                            config_file_class=InMemoryConfigStore, present=True, config={
+        cfg = config.auto_load_local_config(
+            base_cfg,
+            additional_sections=["unit-test"],
+            config_file_class=InMemoryConfigStore,
+            present=True,
+            config={
                 "distributions": {
                     "release.url": "https://acme.com/releases",
                     "release.cache": "true",
                 },
-                "system": {
-                    "env.name": "existing-unit-test-config"
-                },
+                "system": {"env.name": "existing-unit-test-config"},
                 # outdated
                 "meta": {
                     # ensure we don't attempt to migrate if that version is unsupported
                     "config.version": max(config.Config.CURRENT_CONFIG_VERSION - 1, config.Config.EARLIEST_SUPPORTED_VERSION)
                 },
-                "benchmarks": {
-                    "local.dataset.cache": "/tmp/rally/data"
-                },
-                "runtime": {
-                    "java8.home": "/opt/jdk8"
-                }
-            })
+                "benchmarks": {"local.dataset.cache": "/tmp/rally/data"},
+                "runtime": {"java8.home": "/opt/jdk8"},
+            },
+        )
         self.assertTrue(cfg.config_file.present)
         # did not just copy base config
         self.assertNotEqual(base_cfg.opts("benchmarks", "local.dataset.cache"), cfg.opts("benchmarks", "local.dataset.cache"))
@@ -267,29 +249,28 @@ class ConfigMigrationTests(TestCase):
         config_file = InMemoryConfigStore("test")
         sample_config = {
             "system": {
-                "root.dir": "in-memory"
+                "root.dir": "in-memory",
             },
-            "provisioning": {
-
-            },
+            "provisioning": {},
             "build": {
-                "maven.bin": "/usr/local/mvn"
+                "maven.bin": "/usr/local/mvn",
             },
             "benchmarks": {
-                "metrics.stats.disk.device": "/dev/hdd1"
+                "metrics.stats.disk.device": "/dev/hdd1",
             },
             "reporting": {
                 "report.base.dir": "/tests/rally/reporting",
-                "output.html.report.filename": "index.html"
+                "output.html.report.filename": "index.html",
             },
             "runtime": {
                 "java8.home": "/opt/jdk/8",
-            }
+            },
         }
 
         config_file.store(sample_config)
-        with self.assertRaisesRegex(exceptions.ConfigError,
-                                    "The config file.*is too old. Please delete it and reconfigure Rally from scratch"):
+        with self.assertRaisesRegex(
+            exceptions.ConfigError, "The config file.*is too old. Please delete it and reconfigure Rally from scratch"
+        ):
             config.migrate(config_file, config.Config.EARLIEST_SUPPORTED_VERSION - 1, config.Config.CURRENT_CONFIG_VERSION, out=null_output)
 
     # catch all test, migrations are checked in more detail in the other tests
@@ -297,30 +278,28 @@ class ConfigMigrationTests(TestCase):
         config_file = InMemoryConfigStore("test")
         sample_config = {
             "meta": {
-                "config.version": config.Config.EARLIEST_SUPPORTED_VERSION
+                "config.version": config.Config.EARLIEST_SUPPORTED_VERSION,
             },
             "system": {
-                "root.dir": "in-memory"
+                "root.dir": "in-memory",
             },
-            "provisioning": {
-
-            },
+            "provisioning": {},
             "build": {
-                "maven.bin": "/usr/local/mvn"
+                "maven.bin": "/usr/local/mvn",
             },
             "benchmarks": {
-                "metrics.stats.disk.device": "/dev/hdd1"
+                "metrics.stats.disk.device": "/dev/hdd1",
             },
             "reporting": {
                 "report.base.dir": "/tests/rally/reporting",
-                "output.html.report.filename": "index.html"
+                "output.html.report.filename": "index.html",
             },
             "runtime": {
                 "java8.home": "/opt/jdk/8",
             },
             "distributions": {
-                "release.url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz"
-            }
+                "release.url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
+            },
         }
 
         config_file.store(sample_config)

--- a/tests/driver/__init__.py
+++ b/tests/driver/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -26,10 +26,10 @@ from unittest import TestCase
 
 import elasticsearch
 
-from esrally import metrics, track, exceptions, config
+from esrally import config, exceptions, metrics, track
 from esrally.driver import driver, runner, scheduler
 from esrally.track import params
-from tests import run_async, as_future
+from tests import as_future, run_async
 
 
 class DriverTestParamSource:
@@ -65,7 +65,7 @@ class DriverTests(TestCase):
             self.all_client_options = all_client_options
             self.uses_static_responses = False
 
-    def __init__(self, methodName='runTest'):
+    def __init__(self, methodName="runTest"):
         super().__init__(methodName)
         self.cfg = None
         self.track = None
@@ -99,15 +99,16 @@ class DriverTests(TestCase):
         self.cfg.add(config.Scope.application, "telemetry", "params", {})
         self.cfg.add(config.Scope.application, "mechanic", "car.names", ["default"])
         self.cfg.add(config.Scope.application, "mechanic", "skip.rest.api.check", True)
-        self.cfg.add(config.Scope.application, "client", "hosts",
-                     DriverTests.Holder(all_hosts={"default": ["localhost:9200"]}))
+        self.cfg.add(config.Scope.application, "client", "hosts", DriverTests.Holder(all_hosts={"default": ["localhost:9200"]}))
         self.cfg.add(config.Scope.application, "client", "options", DriverTests.Holder(all_client_options={"default": {}}))
         self.cfg.add(config.Scope.application, "driver", "load_driver_hosts", ["localhost"])
         self.cfg.add(config.Scope.application, "reporting", "datastore.type", "in-memory")
 
-        default_challenge = track.Challenge("default", default=True, schedule=[
-            track.Task(name="index", operation=track.Operation("index", operation_type=track.OperationType.Bulk), clients=4)
-        ])
+        default_challenge = track.Challenge(
+            "default",
+            default=True,
+            schedule=[track.Task(name="index", operation=track.Operation("index", operation_type=track.OperationType.Bulk), clients=4)],
+        )
         another_challenge = track.Challenge("other", default=False)
         self.track = track.Track(name="unittest", description="unittest track", challenges=[another_challenge, default_challenge])
 
@@ -116,9 +117,7 @@ class DriverTests(TestCase):
 
     def create_test_driver_target(self):
         client = "client_marker"
-        attrs = {
-            "create_client.return_value": client
-        }
+        attrs = {"create_client.return_value": client}
         return mock.Mock(**attrs)
 
     @mock.patch("esrally.utils.net.resolve")
@@ -134,12 +133,14 @@ class DriverTests(TestCase):
         target.prepare_track.assert_called_once_with(["10.5.5.1", "10.5.5.2"], self.cfg, self.track)
         d.start_benchmark()
 
-        target.create_client.assert_has_calls(calls=[
-            mock.call("10.5.5.1"),
-            mock.call("10.5.5.1"),
-            mock.call("10.5.5.2"),
-            mock.call("10.5.5.2"),
-        ])
+        target.create_client.assert_has_calls(
+            calls=[
+                mock.call("10.5.5.1"),
+                mock.call("10.5.5.1"),
+                mock.call("10.5.5.2"),
+                mock.call("10.5.5.2"),
+            ]
+        )
 
         # Did we start all load generators? There is no specific mock assert for this...
         self.assertEqual(4, target.start_worker.call_count)
@@ -154,12 +155,14 @@ class DriverTests(TestCase):
 
         d.start_benchmark()
 
-        target.create_client.assert_has_calls(calls=[
-            mock.call("localhost"),
-            mock.call("localhost"),
-            mock.call("localhost"),
-            mock.call("localhost"),
-        ])
+        target.create_client.assert_has_calls(
+            calls=[
+                mock.call("localhost"),
+                mock.call("localhost"),
+                mock.call("localhost"),
+                mock.call("localhost"),
+            ]
+        )
 
         # Did we start all load generators? There is no specific mock assert for this...
         self.assertEqual(4, target.start_worker.call_count)
@@ -173,9 +176,9 @@ class DriverTests(TestCase):
 
         self.assertEqual(0, len(d.workers_completed_current_step))
 
-        d.joinpoint_reached(worker_id=0,
-                            worker_local_timestamp=10,
-                            task_allocations=[driver.ClientAllocation(client_id=0, task=driver.JoinPoint(id=0))])
+        d.joinpoint_reached(
+            worker_id=0, worker_local_timestamp=10, task_allocations=[driver.ClientAllocation(client_id=0, task=driver.JoinPoint(id=0))]
+        )
 
         self.assertEqual(1, len(d.workers_completed_current_step))
 
@@ -191,12 +194,11 @@ class DriverTests(TestCase):
 
         self.assertEqual(0, len(d.workers_completed_current_step))
 
-        d.joinpoint_reached(worker_id=0,
-                            worker_local_timestamp=10,
-                            task_allocations=[
-                                driver.ClientAllocation(client_id=0,
-                                                        task=driver.JoinPoint(id=0,
-                                                                              clients_executing_completing_task=[0]))])
+        d.joinpoint_reached(
+            worker_id=0,
+            worker_local_timestamp=10,
+            task_allocations=[driver.ClientAllocation(client_id=0, task=driver.JoinPoint(id=0, clients_executing_completing_task=[0]))],
+        )
 
         self.assertEqual(-1, d.current_step)
         self.assertEqual(1, len(d.workers_completed_current_step))
@@ -204,31 +206,28 @@ class DriverTests(TestCase):
         self.assertEqual(4, target.complete_current_task.call_count)
 
         # awaiting responses of other clients
-        d.joinpoint_reached(worker_id=1,
-                            worker_local_timestamp=11,
-                            task_allocations=[
-                                driver.ClientAllocation(client_id=1,
-                                                        task=driver.JoinPoint(id=0,
-                                                                              clients_executing_completing_task=[0]))])
+        d.joinpoint_reached(
+            worker_id=1,
+            worker_local_timestamp=11,
+            task_allocations=[driver.ClientAllocation(client_id=1, task=driver.JoinPoint(id=0, clients_executing_completing_task=[0]))],
+        )
 
         self.assertEqual(-1, d.current_step)
         self.assertEqual(2, len(d.workers_completed_current_step))
 
-        d.joinpoint_reached(worker_id=2,
-                            worker_local_timestamp=12,
-                            task_allocations=[
-                                driver.ClientAllocation(client_id=2,
-                                                        task=driver.JoinPoint(id=0,
-                                                                              clients_executing_completing_task=[0]))])
+        d.joinpoint_reached(
+            worker_id=2,
+            worker_local_timestamp=12,
+            task_allocations=[driver.ClientAllocation(client_id=2, task=driver.JoinPoint(id=0, clients_executing_completing_task=[0]))],
+        )
         self.assertEqual(-1, d.current_step)
         self.assertEqual(3, len(d.workers_completed_current_step))
 
-        d.joinpoint_reached(worker_id=3,
-                            worker_local_timestamp=13,
-                            task_allocations=[
-                                driver.ClientAllocation(client_id=3,
-                                                        task=driver.JoinPoint(id=0,
-                                                                              clients_executing_completing_task=[0]))])
+        d.joinpoint_reached(
+            worker_id=3,
+            worker_local_timestamp=13,
+            task_allocations=[driver.ClientAllocation(client_id=3, task=driver.JoinPoint(id=0, clients_executing_completing_task=[0]))],
+        )
 
         # by now the previous step should be considered completed and we are at the next one
         self.assertEqual(0, d.current_step)
@@ -246,16 +245,18 @@ def op(name, operation_type):
 
 class SamplePostprocessorTests(TestCase):
     def throughput(self, absolute_time, relative_time, value):
-        return mock.call(name="throughput",
-                         value=value,
-                         unit="docs/s",
-                         task="index",
-                         operation="index-op",
-                         operation_type="bulk",
-                         sample_type=metrics.SampleType.Normal,
-                         absolute_time=absolute_time,
-                         relative_time=relative_time,
-                         meta_data={})
+        return mock.call(
+            name="throughput",
+            value=value,
+            unit="docs/s",
+            task="index",
+            operation="index-op",
+            operation_type="bulk",
+            sample_type=metrics.SampleType.Normal,
+            absolute_time=absolute_time,
+            relative_time=relative_time,
+            meta_data={},
+        )
 
     def service_time(self, absolute_time, relative_time, value):
         return self.request_metric(absolute_time, relative_time, "service_time", value)
@@ -267,23 +268,22 @@ class SamplePostprocessorTests(TestCase):
         return self.request_metric(absolute_time, relative_time, "latency", value)
 
     def request_metric(self, absolute_time, relative_time, name, value):
-        return mock.call(name=name,
-                         value=value,
-                         unit="ms",
-                         task="index",
-                         operation="index-op",
-                         operation_type="bulk",
-                         sample_type=metrics.SampleType.Normal,
-                         absolute_time=absolute_time,
-                         relative_time=relative_time,
-                         meta_data={})
+        return mock.call(
+            name=name,
+            value=value,
+            unit="ms",
+            task="index",
+            operation="index-op",
+            operation_type="bulk",
+            sample_type=metrics.SampleType.Normal,
+            absolute_time=absolute_time,
+            relative_time=relative_time,
+            meta_data={},
+        )
 
     @mock.patch("esrally.metrics.MetricsStore")
     def test_all_samples(self, metrics_store):
-        post_process = driver.SamplePostprocessor(metrics_store,
-                                                  downsample_factor=1,
-                                                  track_meta_data={},
-                                                  challenge_meta_data={})
+        post_process = driver.SamplePostprocessor(metrics_store, downsample_factor=1, track_meta_data={}, challenge_meta_data={})
 
         task = track.Task("index", track.Operation("index-op", "bulk", param_source="driver-test-param-source"))
         samples = [
@@ -294,8 +294,12 @@ class SamplePostprocessorTests(TestCase):
         post_process(samples)
 
         calls = [
-            self.latency(38598, 24, 10.0), self.service_time(38598, 24, 7.0), self.processing_time(38598, 24, 9.0),
-            self.latency(38599, 25, 10.0), self.service_time(38599, 25, 7.0), self.processing_time(38599, 25, 9.0),
+            self.latency(38598, 24, 10.0),
+            self.service_time(38598, 24, 7.0),
+            self.processing_time(38598, 24, 9.0),
+            self.latency(38599, 25, 10.0),
+            self.service_time(38599, 25, 7.0),
+            self.processing_time(38599, 25, 9.0),
             self.throughput(38598, 24, 5000),
             self.throughput(38599, 25, 5000),
         ]
@@ -303,10 +307,7 @@ class SamplePostprocessorTests(TestCase):
 
     @mock.patch("esrally.metrics.MetricsStore")
     def test_downsamples(self, metrics_store):
-        post_process = driver.SamplePostprocessor(metrics_store,
-                                                  downsample_factor=2,
-                                                  track_meta_data={},
-                                                  challenge_meta_data={})
+        post_process = driver.SamplePostprocessor(metrics_store, downsample_factor=2, track_meta_data={}, challenge_meta_data={})
 
         task = track.Task("index", track.Operation("index-op", "bulk", param_source="driver-test-param-source"))
 
@@ -319,7 +320,9 @@ class SamplePostprocessorTests(TestCase):
 
         calls = [
             # only the first out of two request samples is included, throughput metrics are still complete
-            self.latency(38598, 24, 10.0), self.service_time(38598, 24, 7.0), self.processing_time(38598, 24, 9.0),
+            self.latency(38598, 24, 10.0),
+            self.service_time(38598, 24, 7.0),
+            self.processing_time(38598, 24, 9.0),
             self.throughput(38598, 24, 5000),
             self.throughput(38599, 25, 5000),
         ]
@@ -327,36 +330,39 @@ class SamplePostprocessorTests(TestCase):
 
     @mock.patch("esrally.metrics.MetricsStore")
     def test_dependent_samples(self, metrics_store):
-        post_process = driver.SamplePostprocessor(metrics_store,
-                                                  downsample_factor=1,
-                                                  track_meta_data={},
-                                                  challenge_meta_data={})
+        post_process = driver.SamplePostprocessor(metrics_store, downsample_factor=1, track_meta_data={}, challenge_meta_data={})
 
         task = track.Task("index", track.Operation("index-op", "bulk", param_source="driver-test-param-source"))
         samples = [
-            driver.Sample(0, 38598, 24, 0, task, metrics.SampleType.Normal, None, 0.01, 0.007, 0.009, None, 5000, "docs", 1, 1 / 2,
-                          dependent_timing=[
-                              {
-                                  "absolute_time": 38601,
-                                  "request_start": 25,
-                                  "service_time": 0.05,
-                                  "operation": "index-op",
-                                  "operation-type": "bulk"
-                              },
-                              {
-                                  "absolute_time": 38602,
-                                  "request_start": 26,
-                                  "service_time": 0.08,
-                                  "operation": "index-op",
-                                  "operation-type": "bulk"
-                              }
-                          ]),
+            driver.Sample(
+                0,
+                38598,
+                24,
+                0,
+                task,
+                metrics.SampleType.Normal,
+                None,
+                0.01,
+                0.007,
+                0.009,
+                None,
+                5000,
+                "docs",
+                1,
+                1 / 2,
+                dependent_timing=[
+                    {"absolute_time": 38601, "request_start": 25, "service_time": 0.05, "operation": "index-op", "operation-type": "bulk"},
+                    {"absolute_time": 38602, "request_start": 26, "service_time": 0.08, "operation": "index-op", "operation-type": "bulk"},
+                ],
+            ),
         ]
 
         post_process(samples)
 
         calls = [
-            self.latency(38598, 24, 10.0), self.service_time(38598, 24, 7.0), self.processing_time(38598, 24, 9.0),
+            self.latency(38598, 24, 10.0),
+            self.service_time(38598, 24, 7.0),
+            self.processing_time(38598, 24, 9.0),
             # dependent timings
             self.service_time(38601, 25, 50.0),
             self.service_time(38602, 26, 80.0),
@@ -367,182 +373,206 @@ class SamplePostprocessorTests(TestCase):
 
 class WorkerAssignmentTests(TestCase):
     def test_single_host_assignment_clients_matches_cores(self):
-        host_configs = [{
-            "host": "localhost",
-            "cores": 4
-        }]
+        host_configs = [
+            {
+                "host": "localhost",
+                "cores": 4,
+            }
+        ]
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=4)
 
-        self.assertEqual([
-            {
-                "host": "localhost",
-                "workers": [
-                    [0],
-                    [1],
-                    [2],
-                    [3]
-                ]
-            }
-        ], assignments)
+        self.assertEqual(
+            [
+                {
+                    "host": "localhost",
+                    "workers": [
+                        [0],
+                        [1],
+                        [2],
+                        [3],
+                    ],
+                }
+            ],
+            assignments,
+        )
 
     def test_single_host_assignment_more_clients_than_cores(self):
-        host_configs = [{
-            "host": "localhost",
-            "cores": 4
-        }]
+        host_configs = [
+            {
+                "host": "localhost",
+                "cores": 4,
+            }
+        ]
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=6)
 
-        self.assertEqual([
-            {
-                "host": "localhost",
-                "workers": [
-                    [0, 1],
-                    [2, 3],
-                    [4],
-                    [5]
-                ]
-            }
-        ], assignments)
+        self.assertEqual(
+            [
+                {
+                    "host": "localhost",
+                    "workers": [
+                        [0, 1],
+                        [2, 3],
+                        [4],
+                        [5],
+                    ],
+                }
+            ],
+            assignments,
+        )
 
     def test_single_host_assignment_less_clients_than_cores(self):
-        host_configs = [{
-            "host": "localhost",
-            "cores": 4
-        }]
+        host_configs = [
+            {
+                "host": "localhost",
+                "cores": 4,
+            }
+        ]
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=2)
 
-        self.assertEqual([
-            {
-                "host": "localhost",
-                "workers": [
-                    [0],
-                    [1],
-                    [],
-                    []
-                ]
-            }
-        ], assignments)
+        self.assertEqual(
+            [
+                {
+                    "host": "localhost",
+                    "workers": [
+                        [0],
+                        [1],
+                        [],
+                        [],
+                    ],
+                }
+            ],
+            assignments,
+        )
 
     def test_multiple_host_assignment_more_clients_than_cores(self):
         host_configs = [
             {
                 "host": "host-a",
-                "cores": 4
+                "cores": 4,
             },
             {
                 "host": "host-b",
-                "cores": 4
-            }
+                "cores": 4,
+            },
         ]
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=16)
 
-        self.assertEqual([
-            {
-                "host": "host-a",
-                "workers": [
-                    [0, 1],
-                    [2, 3],
-                    [4, 5],
-                    [6, 7]
-                ]
-            },
-            {
-                "host": "host-b",
-                "workers": [
-                    [8, 9],
-                    [10, 11],
-                    [12, 13],
-                    [14, 15]
-                ]
-            }
-        ], assignments)
+        self.assertEqual(
+            [
+                {
+                    "host": "host-a",
+                    "workers": [
+                        [0, 1],
+                        [2, 3],
+                        [4, 5],
+                        [6, 7],
+                    ],
+                },
+                {
+                    "host": "host-b",
+                    "workers": [
+                        [8, 9],
+                        [10, 11],
+                        [12, 13],
+                        [14, 15],
+                    ],
+                },
+            ],
+            assignments,
+        )
 
     def test_multiple_host_assignment_less_clients_than_cores(self):
         host_configs = [
             {
                 "host": "host-a",
-                "cores": 4
+                "cores": 4,
             },
             {
                 "host": "host-b",
-                "cores": 4
-            }
+                "cores": 4,
+            },
         ]
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=4)
 
-        self.assertEqual([
-            {
-                "host": "host-a",
-                "workers": [
-                    [0],
-                    [1],
-                    [],
-                    []
-                ]
-            },
-            {
-                "host": "host-b",
-                "workers": [
-                    [2],
-                    [3],
-                    [],
-                    []
-                ]
-            }
-        ], assignments)
+        self.assertEqual(
+            [
+                {
+                    "host": "host-a",
+                    "workers": [
+                        [0],
+                        [1],
+                        [],
+                        [],
+                    ],
+                },
+                {
+                    "host": "host-b",
+                    "workers": [
+                        [2],
+                        [3],
+                        [],
+                        [],
+                    ],
+                },
+            ],
+            assignments,
+        )
 
     def test_uneven_assignment_across_hosts(self):
         host_configs = [
             {
                 "host": "host-a",
-                "cores": 4
+                "cores": 4,
             },
             {
                 "host": "host-b",
-                "cores": 4
+                "cores": 4,
             },
             {
                 "host": "host-c",
-                "cores": 4
-            }
+                "cores": 4,
+            },
         ]
 
         assignments = driver.calculate_worker_assignments(host_configs, client_count=17)
 
-        self.assertEqual([
-            {
-                "host": "host-a",
-                "workers": [
-                    [0, 1],
-                    [2, 3],
-                    [4],
-                    [5]
-                ]
-            },
-            {
-                "host": "host-b",
-                "workers": [
-                    [6, 7],
-                    [8, 9],
-                    [10],
-                    [11]
-                ]
-            },
-            {
-                "host": "host-c",
-                "workers": [
-                    [12, 13],
-                    [14],
-                    [15],
-                    [16]
-                ]
-            }
-        ], assignments)
+        self.assertEqual(
+            [
+                {
+                    "host": "host-a",
+                    "workers": [
+                        [0, 1],
+                        [2, 3],
+                        [4],
+                        [5],
+                    ],
+                },
+                {
+                    "host": "host-b",
+                    "workers": [
+                        [6, 7],
+                        [8, 9],
+                        [10],
+                        [11],
+                    ],
+                },
+                {
+                    "host": "host-c",
+                    "workers": [
+                        [12, 13],
+                        [14],
+                        [15],
+                        [16],
+                    ],
+                },
+            ],
+            assignments,
+        )
 
 
 class AllocatorTests(TestCase):
@@ -550,10 +580,12 @@ class AllocatorTests(TestCase):
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
 
     def ta(self, task, client_index_in_task, global_client_index=None, total_clients=None):
-        return driver.TaskAllocation(task,
-                                     client_index_in_task,
-                                     client_index_in_task if global_client_index is None else global_client_index,
-                                     task.clients if total_clients is None else total_clients)
+        return driver.TaskAllocation(
+            task,
+            client_index_in_task,
+            client_index_in_task if global_client_index is None else global_client_index,
+            task.clients if total_clients is None else total_clients,
+        )
 
     def test_allocates_one_task(self):
         task = track.Task("index", op("index", track.OperationType.Bulk))
@@ -611,11 +643,7 @@ class AllocatorTests(TestCase):
         stats = track.Task("stats", op("stats", track.OperationType.IndexStats))
         search = track.Task("search", op("search", track.OperationType.Search))
 
-        allocator = driver.Allocator([index,
-                                      track.Parallel([index, stats, stats]),
-                                      index,
-                                      index,
-                                      track.Parallel([search, search, search])])
+        allocator = driver.Allocator([index, track.Parallel([index, stats, stats]), index, index, track.Parallel([search, search, search])])
 
         self.assertEqual(3, allocator.clients)
 
@@ -648,22 +676,28 @@ class AllocatorTests(TestCase):
         # join_point, index_a, index_c, index_e, join_point
         self.assertEqual(5, len(allocations[0]))
         # we really have no chance to extract the join point so we just take what is there...
-        self.assertEqual([
-            allocations[0][0],
-            self.ta(index_a, client_index_in_task=0, global_client_index=0, total_clients=2),
-            self.ta(index_c, client_index_in_task=0, global_client_index=2, total_clients=2),
-            self.ta(index_e, client_index_in_task=0, global_client_index=4, total_clients=2),
-            allocations[0][4]
-        ], allocations[0])
+        self.assertEqual(
+            [
+                allocations[0][0],
+                self.ta(index_a, client_index_in_task=0, global_client_index=0, total_clients=2),
+                self.ta(index_c, client_index_in_task=0, global_client_index=2, total_clients=2),
+                self.ta(index_e, client_index_in_task=0, global_client_index=4, total_clients=2),
+                allocations[0][4],
+            ],
+            allocations[0],
+        )
         # join_point, index_a, index_c, None, join_point
         self.assertEqual(5, len(allocator.allocations[1]))
-        self.assertEqual([
-            allocations[1][0],
-            self.ta(index_b, client_index_in_task=0, global_client_index=1, total_clients=2),
-            self.ta(index_d, client_index_in_task=0, global_client_index=3, total_clients=2),
-            None,
-            allocations[1][4]
-        ], allocations[1])
+        self.assertEqual(
+            [
+                allocations[1][0],
+                self.ta(index_b, client_index_in_task=0, global_client_index=1, total_clients=2),
+                self.ta(index_d, client_index_in_task=0, global_client_index=3, total_clients=2),
+                None,
+                allocations[1][4],
+            ],
+            allocations[1],
+        )
 
         self.assertEqual([{index_a, index_b, index_c, index_d, index_e}], allocator.tasks_per_joinpoint)
         self.assertEqual(2, len(allocator.join_points))
@@ -691,31 +725,40 @@ class AllocatorTests(TestCase):
         # join_point, index_a, index_c, join_point
         self.assertEqual(4, len(allocations[0]))
         # we really have no chance to extract the join point so we just take what is there...
-        self.assertEqual([
-            allocations[0][0],
-            self.ta(index_a, client_index_in_task=0, global_client_index=0, total_clients=3),
-            self.ta(index_c, client_index_in_task=1, global_client_index=3, total_clients=3),
-            allocations[0][3]
-        ], allocations[0])
+        self.assertEqual(
+            [
+                allocations[0][0],
+                self.ta(index_a, client_index_in_task=0, global_client_index=0, total_clients=3),
+                self.ta(index_c, client_index_in_task=1, global_client_index=3, total_clients=3),
+                allocations[0][3],
+            ],
+            allocations[0],
+        )
 
         # task that client 1 will execute:
         # join_point, index_b, None, join_point
         self.assertEqual(4, len(allocator.allocations[1]))
-        self.assertEqual([
-            allocations[1][0],
-            self.ta(index_b, client_index_in_task=0, global_client_index=1, total_clients=3),
-            None,
-            allocations[1][3]
-        ], allocations[1])
+        self.assertEqual(
+            [
+                allocations[1][0],
+                self.ta(index_b, client_index_in_task=0, global_client_index=1, total_clients=3),
+                None,
+                allocations[1][3],
+            ],
+            allocations[1],
+        )
 
         # tasks that client 2 will execute:
         self.assertEqual(4, len(allocator.allocations[2]))
-        self.assertEqual([
-            allocations[2][0],
-            self.ta(index_c, client_index_in_task=0, global_client_index=2, total_clients=3),
-            None,
-            allocations[2][3]
-        ], allocations[2])
+        self.assertEqual(
+            [
+                allocations[2][0],
+                self.ta(index_c, client_index_in_task=0, global_client_index=2, total_clients=3),
+                None,
+                allocations[2][3],
+            ],
+            allocations[2],
+        )
 
         self.assertEqual([{index_a, index_b, index_c}], allocator.tasks_per_joinpoint)
 
@@ -761,7 +804,7 @@ class MetricsAggregationTests(TestCase):
             driver.Sample(0, 38600, 26, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, None, 5000, "docs", 6, 6 / 9),
             driver.Sample(1, 38598.5, 24.5, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, None, 5000, "docs", 4.5, 7 / 9),
             driver.Sample(1, 38599.5, 25.5, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, None, 5000, "docs", 5.5, 8 / 9),
-            driver.Sample(1, 38600.5, 26.5, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, None, 5000, "docs", 6.5, 9 / 9)
+            driver.Sample(1, 38600.5, 26.5, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, None, 5000, "docs", 6.5, 9 / 9),
         ]
 
         aggregated = self.calculate_global_throughput(samples)
@@ -780,8 +823,7 @@ class MetricsAggregationTests(TestCase):
         # self.assertEqual((1470838600.5, 26.5, metrics.SampleType.Normal, 10000), throughput[6])
 
     def test_use_provided_throughput(self):
-        op = track.Operation("index-recovery", track.OperationType.WaitForRecovery,
-                             param_source="driver-test-param-source")
+        op = track.Operation("index-recovery", track.OperationType.WaitForRecovery, param_source="driver-test-param-source")
 
         samples = [
             driver.Sample(0, 38595, 21, 0, op, metrics.SampleType.Normal, None, -1, -1, -1, 8000, 5000, "byte", 1, 1 / 3),
@@ -868,22 +910,17 @@ class SchedulerTests(TestCase):
         scheduler.remove_scheduler("custom-complex-scheduler")
 
     def test_injects_parameter_source_into_scheduler(self):
-        task = track.Task(name="search",
-                          schedule="custom-complex-scheduler",
-                          operation=track.Operation(
-                              name="search",
-                              operation_type=track.OperationType.Search.to_hyphenated_string(),
-                              param_source="driver-test-param-source"
-                          ),
-                          clients=4,
-                          params={
-                              "target-throughput": "5000 ops/s"
-                          })
+        task = track.Task(
+            name="search",
+            schedule="custom-complex-scheduler",
+            operation=track.Operation(
+                name="search", operation_type=track.OperationType.Search.to_hyphenated_string(), param_source="driver-test-param-source"
+            ),
+            clients=4,
+            params={"target-throughput": "5000 ops/s"},
+        )
 
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         param_source = track.operation_parameters(self.test_track, task)
         schedule = driver.schedule_for(task_allocation, param_source)
 
@@ -892,14 +929,16 @@ class SchedulerTests(TestCase):
 
     @run_async
     async def test_search_task_one_client(self):
-        task = track.Task("search", track.Operation("search", track.OperationType.Search.to_hyphenated_string(),
-                                                    param_source="driver-test-param-source"),
-                          warmup_iterations=3, iterations=5, clients=1, params={"target-throughput": 10, "clients": 1})
+        task = track.Task(
+            "search",
+            track.Operation("search", track.OperationType.Search.to_hyphenated_string(), param_source="driver-test-param-source"),
+            warmup_iterations=3,
+            iterations=5,
+            clients=1,
+            params={"target-throughput": 10, "clients": 1},
+        )
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
         expected_schedule = [
@@ -916,14 +955,16 @@ class SchedulerTests(TestCase):
 
     @run_async
     async def test_search_task_two_clients(self):
-        task = track.Task("search", track.Operation("search", track.OperationType.Search.to_hyphenated_string(),
-                                                    param_source="driver-test-param-source"),
-                          warmup_iterations=1, iterations=5, clients=2, params={"target-throughput": 10, "clients": 2})
+        task = track.Task(
+            "search",
+            track.Operation("search", track.OperationType.Search.to_hyphenated_string(), param_source="driver-test-param-source"),
+            warmup_iterations=1,
+            iterations=5,
+            clients=2,
+            params={"target-throughput": 10, "clients": 2},
+        )
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
         expected_schedule = [
@@ -939,175 +980,230 @@ class SchedulerTests(TestCase):
     @run_async
     async def test_schedule_param_source_determines_iterations_no_warmup(self):
         # we neither define any time-period nor any iteration count on the task.
-        task = track.Task("bulk-index", track.Operation("bulk-index", track.OperationType.Bulk.to_hyphenated_string(),
-                                                        params={"body": ["a"], "size": 3},
-                                                        param_source="driver-test-param-source"),
-                          clients=4, params={"target-throughput": 4})
+        task = track.Task(
+            "bulk-index",
+            track.Operation(
+                "bulk-index",
+                track.OperationType.Bulk.to_hyphenated_string(),
+                params={"body": ["a"], "size": 3},
+                param_source="driver-test-param-source",
+            ),
+            clients=4,
+            params={"target-throughput": 4},
+        )
 
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
-        await self.assert_schedule([
-            (0.0, metrics.SampleType.Normal, 1 / 3, {"body": ["a"], "size": 3}),
-            (1.0, metrics.SampleType.Normal, 2 / 3, {"body": ["a"], "size": 3}),
-            (2.0, metrics.SampleType.Normal, 3 / 3, {"body": ["a"], "size": 3}),
-        ], schedule)
+        await self.assert_schedule(
+            [
+                (0.0, metrics.SampleType.Normal, 1 / 3, {"body": ["a"], "size": 3}),
+                (1.0, metrics.SampleType.Normal, 2 / 3, {"body": ["a"], "size": 3}),
+                (2.0, metrics.SampleType.Normal, 3 / 3, {"body": ["a"], "size": 3}),
+            ],
+            schedule,
+        )
 
     @run_async
     async def test_schedule_param_source_determines_iterations_including_warmup(self):
-        task = track.Task("bulk-index", track.Operation("bulk-index", track.OperationType.Bulk.to_hyphenated_string(),
-                                                        params={"body": ["a"], "size": 5},
-                                                        param_source="driver-test-param-source"),
-                          warmup_iterations=2, clients=4, params={"target-throughput": 4})
+        task = track.Task(
+            "bulk-index",
+            track.Operation(
+                "bulk-index",
+                track.OperationType.Bulk.to_hyphenated_string(),
+                params={"body": ["a"], "size": 5},
+                param_source="driver-test-param-source",
+            ),
+            warmup_iterations=2,
+            clients=4,
+            params={"target-throughput": 4},
+        )
 
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
-        await self.assert_schedule([
-            (0.0, metrics.SampleType.Warmup, 1 / 5, {"body": ["a"], "size": 5}),
-            (1.0, metrics.SampleType.Warmup, 2 / 5, {"body": ["a"], "size": 5}),
-            (2.0, metrics.SampleType.Normal, 3 / 5, {"body": ["a"], "size": 5}),
-            (3.0, metrics.SampleType.Normal, 4 / 5, {"body": ["a"], "size": 5}),
-            (4.0, metrics.SampleType.Normal, 5 / 5, {"body": ["a"], "size": 5}),
-        ], schedule)
+        await self.assert_schedule(
+            [
+                (0.0, metrics.SampleType.Warmup, 1 / 5, {"body": ["a"], "size": 5}),
+                (1.0, metrics.SampleType.Warmup, 2 / 5, {"body": ["a"], "size": 5}),
+                (2.0, metrics.SampleType.Normal, 3 / 5, {"body": ["a"], "size": 5}),
+                (3.0, metrics.SampleType.Normal, 4 / 5, {"body": ["a"], "size": 5}),
+                (4.0, metrics.SampleType.Normal, 5 / 5, {"body": ["a"], "size": 5}),
+            ],
+            schedule,
+        )
 
     @run_async
     async def test_schedule_defaults_to_iteration_based(self):
         # no time-period and no iterations specified on the task. Also, the parameter source does not define a size.
-        task = track.Task("bulk-index", track.Operation("bulk-index", track.OperationType.Bulk.to_hyphenated_string(),
-                                                        params={"body": ["a"]},
-                                                        param_source="driver-test-param-source"),
-                          clients=1, params={"target-throughput": 4, "clients": 4})
+        task = track.Task(
+            "bulk-index",
+            track.Operation(
+                "bulk-index",
+                track.OperationType.Bulk.to_hyphenated_string(),
+                params={"body": ["a"]},
+                param_source="driver-test-param-source",
+            ),
+            clients=1,
+            params={"target-throughput": 4, "clients": 4},
+        )
 
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
-        await self.assert_schedule([
-            (0.0, metrics.SampleType.Normal, 1 / 1, {"body": ["a"]}),
-        ], schedule)
+        await self.assert_schedule(
+            [
+                (0.0, metrics.SampleType.Normal, 1 / 1, {"body": ["a"]}),
+            ],
+            schedule,
+        )
 
     @run_async
     async def test_schedule_for_warmup_time_based(self):
-        task = track.Task("time-based", track.Operation("time-based", track.OperationType.Bulk.to_hyphenated_string(),
-                                                        params={"body": ["a"], "size": 11},
-                                                        param_source="driver-test-param-source"),
-                          warmup_time_period=0, clients=4, params={"target-throughput": 4, "clients": 4})
+        task = track.Task(
+            "time-based",
+            track.Operation(
+                "time-based",
+                track.OperationType.Bulk.to_hyphenated_string(),
+                params={"body": ["a"], "size": 11},
+                param_source="driver-test-param-source",
+            ),
+            warmup_time_period=0,
+            clients=4,
+            params={"target-throughput": 4, "clients": 4},
+        )
 
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
-        await self.assert_schedule([
-            (0.0, metrics.SampleType.Normal, 1 / 11, {"body": ["a"], "size": 11}),
-            (1.0, metrics.SampleType.Normal, 2 / 11, {"body": ["a"], "size": 11}),
-            (2.0, metrics.SampleType.Normal, 3 / 11, {"body": ["a"], "size": 11}),
-            (3.0, metrics.SampleType.Normal, 4 / 11, {"body": ["a"], "size": 11}),
-            (4.0, metrics.SampleType.Normal, 5 / 11, {"body": ["a"], "size": 11}),
-            (5.0, metrics.SampleType.Normal, 6 / 11, {"body": ["a"], "size": 11}),
-            (6.0, metrics.SampleType.Normal, 7 / 11, {"body": ["a"], "size": 11}),
-            (7.0, metrics.SampleType.Normal, 8 / 11, {"body": ["a"], "size": 11}),
-            (8.0, metrics.SampleType.Normal, 9 / 11, {"body": ["a"], "size": 11}),
-            (9.0, metrics.SampleType.Normal, 10 / 11, {"body": ["a"], "size": 11}),
-            (10.0, metrics.SampleType.Normal, 11 / 11, {"body": ["a"], "size": 11}),
-        ], schedule)
+        await self.assert_schedule(
+            [
+                (0.0, metrics.SampleType.Normal, 1 / 11, {"body": ["a"], "size": 11}),
+                (1.0, metrics.SampleType.Normal, 2 / 11, {"body": ["a"], "size": 11}),
+                (2.0, metrics.SampleType.Normal, 3 / 11, {"body": ["a"], "size": 11}),
+                (3.0, metrics.SampleType.Normal, 4 / 11, {"body": ["a"], "size": 11}),
+                (4.0, metrics.SampleType.Normal, 5 / 11, {"body": ["a"], "size": 11}),
+                (5.0, metrics.SampleType.Normal, 6 / 11, {"body": ["a"], "size": 11}),
+                (6.0, metrics.SampleType.Normal, 7 / 11, {"body": ["a"], "size": 11}),
+                (7.0, metrics.SampleType.Normal, 8 / 11, {"body": ["a"], "size": 11}),
+                (8.0, metrics.SampleType.Normal, 9 / 11, {"body": ["a"], "size": 11}),
+                (9.0, metrics.SampleType.Normal, 10 / 11, {"body": ["a"], "size": 11}),
+                (10.0, metrics.SampleType.Normal, 11 / 11, {"body": ["a"], "size": 11}),
+            ],
+            schedule,
+        )
 
     @run_async
     async def test_infinite_schedule_without_progress_indication(self):
-        task = track.Task("time-based", track.Operation("time-based", track.OperationType.Bulk.to_hyphenated_string(),
-                                                        params={"body": ["a"]},
-                                                        param_source="driver-test-param-source"),
-                          warmup_time_period=0, clients=4, params={"target-throughput": 4, "clients": 4})
+        task = track.Task(
+            "time-based",
+            track.Operation(
+                "time-based",
+                track.OperationType.Bulk.to_hyphenated_string(),
+                params={"body": ["a"]},
+                param_source="driver-test-param-source",
+            ),
+            warmup_time_period=0,
+            clients=4,
+            params={"target-throughput": 4, "clients": 4},
+        )
 
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
-        await self.assert_schedule([
-            (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-            (1.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-            (2.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-            (3.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-            (4.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-        ], schedule, infinite_schedule=True)
+        await self.assert_schedule(
+            [
+                (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+                (1.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+                (2.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+                (3.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+                (4.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+            ],
+            schedule,
+            infinite_schedule=True,
+        )
 
     @run_async
     async def test_finite_schedule_with_progress_indication(self):
-        task = track.Task("time-based", track.Operation("time-based", track.OperationType.Bulk.to_hyphenated_string(),
-                                                        params={"body": ["a"], "size": 5},
-                                                        param_source="driver-test-param-source"),
-                          warmup_time_period=0, clients=4, params={"target-throughput": 4, "clients": 4})
+        task = track.Task(
+            "time-based",
+            track.Operation(
+                "time-based",
+                track.OperationType.Bulk.to_hyphenated_string(),
+                params={"body": ["a"], "size": 5},
+                param_source="driver-test-param-source",
+            ),
+            warmup_time_period=0,
+            clients=4,
+            params={"target-throughput": 4, "clients": 4},
+        )
 
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
-        await self.assert_schedule([
-            (0.0, metrics.SampleType.Normal, 1 / 5, {"body": ["a"], "size": 5}),
-            (1.0, metrics.SampleType.Normal, 2 / 5, {"body": ["a"], "size": 5}),
-            (2.0, metrics.SampleType.Normal, 3 / 5, {"body": ["a"], "size": 5}),
-            (3.0, metrics.SampleType.Normal, 4 / 5, {"body": ["a"], "size": 5}),
-            (4.0, metrics.SampleType.Normal, 5 / 5, {"body": ["a"], "size": 5}),
-        ], schedule, infinite_schedule=False)
+        await self.assert_schedule(
+            [
+                (0.0, metrics.SampleType.Normal, 1 / 5, {"body": ["a"], "size": 5}),
+                (1.0, metrics.SampleType.Normal, 2 / 5, {"body": ["a"], "size": 5}),
+                (2.0, metrics.SampleType.Normal, 3 / 5, {"body": ["a"], "size": 5}),
+                (3.0, metrics.SampleType.Normal, 4 / 5, {"body": ["a"], "size": 5}),
+                (4.0, metrics.SampleType.Normal, 5 / 5, {"body": ["a"], "size": 5}),
+            ],
+            schedule,
+            infinite_schedule=False,
+        )
 
     @run_async
     async def test_schedule_with_progress_determined_by_runner(self):
-        task = track.Task("time-based", track.Operation("time-based", "driver-test-runner-with-completion",
-                                                        params={"body": ["a"]},
-                                                        param_source="driver-test-param-source"),
-                          clients=1,
-                          params={"target-throughput": 1, "clients": 1})
+        task = track.Task(
+            "time-based",
+            track.Operation(
+                "time-based", "driver-test-runner-with-completion", params={"body": ["a"]}, param_source="driver-test-param-source"
+            ),
+            clients=1,
+            params={"target-throughput": 1, "clients": 1},
+        )
 
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
-        await self.assert_schedule([
-            (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-            (1.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-            (2.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-            (3.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-            (4.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-        ], schedule, infinite_schedule=True)
+        await self.assert_schedule(
+            [
+                (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+                (1.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+                (2.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+                (3.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+                (4.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+            ],
+            schedule,
+            infinite_schedule=True,
+        )
 
     @run_async
     async def test_schedule_for_time_based(self):
-        task = track.Task("time-based", track.Operation("time-based", track.OperationType.Bulk.to_hyphenated_string(),
-                                                        params={"body": ["a"], "size": 11},
-                                                        param_source="driver-test-param-source"),
-                          ramp_up_time_period=0.1,
-                          warmup_time_period=0.1,
-                          time_period=0.1,
-                          clients=1)
+        task = track.Task(
+            "time-based",
+            track.Operation(
+                "time-based",
+                track.OperationType.Bulk.to_hyphenated_string(),
+                params={"body": ["a"], "size": 11},
+                param_source="driver-test-param-source",
+            ),
+            ramp_up_time_period=0.1,
+            warmup_time_period=0.1,
+            time_period=0.1,
+            clients=1,
+        )
 
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule_handle = driver.schedule_for(task_allocation, param_source)
         schedule_handle.start()
         # first client does not wait
@@ -1132,21 +1228,29 @@ class SchedulerTests(TestCase):
 
     @run_async
     async def test_schedule_for_time_based_with_multiple_clients(self):
-        task = track.Task("time-based", track.Operation("time-based", track.OperationType.Bulk.to_hyphenated_string(),
-                                                        params={"body": ["a"], "size": 11},
-                                                        param_source="driver-test-param-source"),
-                          ramp_up_time_period=0.1,
-                          warmup_time_period=0.1,
-                          time_period=0.1,
-                          clients=4)
+        task = track.Task(
+            "time-based",
+            track.Operation(
+                "time-based",
+                track.OperationType.Bulk.to_hyphenated_string(),
+                params={"body": ["a"], "size": 11},
+                param_source="driver-test-param-source",
+            ),
+            ramp_up_time_period=0.1,
+            warmup_time_period=0.1,
+            time_period=0.1,
+            clients=4,
+        )
 
         param_source = track.operation_parameters(self.test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                # assume this task is embedded in a parallel structure
-                                                # with 8 clients in total
-                                                client_index_in_task=0,
-                                                global_client_index=4,
-                                                total_clients=8)
+        task_allocation = driver.TaskAllocation(
+            task=task,
+            # assume this task is embedded in a parallel structure
+            # with 8 clients in total
+            client_index_in_task=0,
+            global_client_index=4,
+            total_clients=8,
+        )
         schedule_handle = driver.schedule_for(task_allocation, param_source)
         schedule_handle.start()
         # client number 4 out of 8 -> 0.1 * (4 / 8) = 0.05
@@ -1168,7 +1272,6 @@ class SchedulerTests(TestCase):
             self.assertTrue(round(progress_percent, 2) <= 1.0, "progress should be <= 1.0 but was [%f]" % progress_percent)
             self.assertIsNotNone(runner, "runner must be defined")
             self.assertEqual({"body": ["a"], "size": 11}, params)
-
 
 
 class AsyncExecutorTests(TestCase):
@@ -1227,11 +1330,7 @@ class AsyncExecutorTests(TestCase):
 
     class RunnerOverridingThroughput:
         async def __call__(self, es, params):
-            return {
-                "weight": 1,
-                "unit": "ops",
-                "throughput": 1.23
-            }
+            return {"weight": 1, "unit": "ops", "throughput": 1.23}
 
     def __init__(self, methodName):
         super().__init__(methodName)
@@ -1257,44 +1356,46 @@ class AsyncExecutorTests(TestCase):
         es.bulk.return_value = as_future(io.StringIO('{"errors": false, "took": 8}'))
 
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
-        test_track = track.Track(name="unittest", description="unittest track",
-                                 indices=None,
-                                 challenges=None)
+        test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)
 
-        task = track.Task("time-based", track.Operation("time-based", track.OperationType.Bulk.to_hyphenated_string(),
-                                                        params={
-                                                            "body": ["action_metadata_line", "index_line"],
-                                                            "action-metadata-present": True,
-                                                            "bulk-size": 1,
-                                                            "unit": "docs",
-                                                            # we need this because DriverTestParamSource does not know
-                                                            # that we only have one bulk and hence size() returns
-                                                            # incorrect results
-                                                            "size": 1
-                                                        },
-                                                        param_source="driver-test-param-source"),
-                          warmup_time_period=0, clients=4)
+        task = track.Task(
+            "time-based",
+            track.Operation(
+                "time-based",
+                track.OperationType.Bulk.to_hyphenated_string(),
+                params={
+                    "body": ["action_metadata_line", "index_line"],
+                    "action-metadata-present": True,
+                    "bulk-size": 1,
+                    "unit": "docs",
+                    # we need this because DriverTestParamSource does not know
+                    # that we only have one bulk and hence size() returns
+                    # incorrect results
+                    "size": 1,
+                },
+                param_source="driver-test-param-source",
+            ),
+            warmup_time_period=0,
+            clients=4,
+        )
         param_source = track.operation_parameters(test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
         sampler = driver.Sampler(start_timestamp=task_start)
         cancel = threading.Event()
         complete = threading.Event()
 
-        execute_schedule = driver.AsyncExecutor(client_id=2,
-                                                task=task,
-                                                schedule=schedule,
-                                                es={
-                                                    "default": es
-                                                },
-                                                sampler=sampler,
-                                                cancel=cancel,
-                                                complete=complete,
-                                                on_error="continue")
+        execute_schedule = driver.AsyncExecutor(
+            client_id=2,
+            task=task,
+            schedule=schedule,
+            es={"default": es},
+            sampler=sampler,
+            cancel=cancel,
+            complete=complete,
+            on_error="continue",
+        )
         await execute_schedule()
 
         samples = sampler.samples
@@ -1324,36 +1425,41 @@ class AsyncExecutorTests(TestCase):
         es.new_request_context.return_value = AsyncExecutorTests.StaticRequestTiming(task_start=task_start)
 
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
-        test_track = track.Track(name="unittest", description="unittest track",
-                                 indices=None,
-                                 challenges=None)
+        test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)
 
-        task = track.Task("time-based", track.Operation("time-based", operation_type="unit-test-recovery", params={
-            "indices-to-restore": "*",
-            # The runner will determine progress
-            "size": None
-        }, param_source="driver-test-param-source"), warmup_time_period=0, clients=4)
+        task = track.Task(
+            "time-based",
+            track.Operation(
+                "time-based",
+                operation_type="unit-test-recovery",
+                params={
+                    "indices-to-restore": "*",
+                    # The runner will determine progress
+                    "size": None,
+                },
+                param_source="driver-test-param-source",
+            ),
+            warmup_time_period=0,
+            clients=4,
+        )
         param_source = track.operation_parameters(test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
         sampler = driver.Sampler(start_timestamp=task_start)
         cancel = threading.Event()
         complete = threading.Event()
 
-        execute_schedule = driver.AsyncExecutor(client_id=2,
-                                                task=task,
-                                                schedule=schedule,
-                                                es={
-                                                    "default": es
-                                                },
-                                                sampler=sampler,
-                                                cancel=cancel,
-                                                complete=complete,
-                                                on_error="continue")
+        execute_schedule = driver.AsyncExecutor(
+            client_id=2,
+            task=task,
+            schedule=schedule,
+            es={"default": es},
+            sampler=sampler,
+            cancel=cancel,
+            complete=complete,
+            on_error="continue",
+        )
         await execute_schedule()
 
         samples = sampler.samples
@@ -1387,39 +1493,42 @@ class AsyncExecutorTests(TestCase):
         es.new_request_context.return_value = AsyncExecutorTests.StaticRequestTiming(task_start=task_start)
 
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
-        test_track = track.Track(name="unittest", description="unittest track",
-                                 indices=None,
-                                 challenges=None)
+        test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)
 
-        task = track.Task("override-throughput", track.Operation("override-throughput",
-                                                                 operation_type="override-throughput", params={
-                # we need this because DriverTestParamSource does not know that we only have one iteration and hence
-                # size() returns incorrect results
-                "size": 1
-            },
-                                                                 param_source="driver-test-param-source"),
-                          warmup_iterations=0, iterations=1, clients=1)
+        task = track.Task(
+            "override-throughput",
+            track.Operation(
+                "override-throughput",
+                operation_type="override-throughput",
+                params={
+                    # we need this because DriverTestParamSource does not know that we only have one iteration and hence
+                    # size() returns incorrect results
+                    "size": 1
+                },
+                param_source="driver-test-param-source",
+            ),
+            warmup_iterations=0,
+            iterations=1,
+            clients=1,
+        )
         param_source = track.operation_parameters(test_track, task)
-        task_allocation = driver.TaskAllocation(task=task,
-                                                client_index_in_task=0,
-                                                global_client_index=0,
-                                                total_clients=task.clients)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
         schedule = driver.schedule_for(task_allocation, param_source)
 
         sampler = driver.Sampler(start_timestamp=task_start)
         cancel = threading.Event()
         complete = threading.Event()
 
-        execute_schedule = driver.AsyncExecutor(client_id=0,
-                                                task=task,
-                                                schedule=schedule,
-                                                es={
-                                                    "default": es
-                                                },
-                                                sampler=sampler,
-                                                cancel=cancel,
-                                                complete=complete,
-                                                on_error="continue")
+        execute_schedule = driver.AsyncExecutor(
+            client_id=0,
+            task=task,
+            schedule=schedule,
+            es={"default": es},
+            sampler=sampler,
+            cancel=cancel,
+            complete=complete,
+            on_error="continue",
+        )
         await execute_schedule()
 
         samples = sampler.samples
@@ -1444,56 +1553,55 @@ class AsyncExecutorTests(TestCase):
         def perform_request(*args, **kwargs):
             return as_future()
 
-        es.init_request_context.return_value = {
-            "request_start": 0,
-            "request_end": 10
-        }
+        es.init_request_context.return_value = {"request_start": 0, "request_end": 10}
         # as this method is called several times we need to return a fresh instance every time as the previous
         # one has been "consumed".
         es.transport.perform_request.side_effect = perform_request
 
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
-        test_track = track.Track(name="unittest", description="unittest track",
-                                 indices=None,
-                                 challenges=None)
+        test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)
 
         # in one second (0.5 warmup + 0.5 measurement) we should get 1000 [ops/s] / 4 [clients] = 250 samples
         for target_throughput, bounds in {10: [2, 4], 100: [24, 26], 1000: [235, 255]}.items():
-            task = track.Task("time-based", track.Operation("time-based",
-                                                            track.OperationType.Search.to_hyphenated_string(),
-                                                            params={
-                                                                "index": "_all",
-                                                                "type": None,
-                                                                "body": {"query": {"match_all": {}}},
-                                                                "request-params": {},
-                                                                "cache": False,
-                                                                "response-compression-enabled": True
-                                                            },
-                                                            param_source="driver-test-param-source"),
-                              warmup_time_period=0.5, time_period=0.5, clients=4,
-                              params={"target-throughput": target_throughput, "clients": 4},
-                              completes_parent=True)
+            task = track.Task(
+                "time-based",
+                track.Operation(
+                    "time-based",
+                    track.OperationType.Search.to_hyphenated_string(),
+                    params={
+                        "index": "_all",
+                        "type": None,
+                        "body": {"query": {"match_all": {}}},
+                        "request-params": {},
+                        "cache": False,
+                        "response-compression-enabled": True,
+                    },
+                    param_source="driver-test-param-source",
+                ),
+                warmup_time_period=0.5,
+                time_period=0.5,
+                clients=4,
+                params={"target-throughput": target_throughput, "clients": 4},
+                completes_parent=True,
+            )
             sampler = driver.Sampler(start_timestamp=0)
 
             cancel = threading.Event()
             complete = threading.Event()
 
             param_source = track.operation_parameters(test_track, task)
-            task_allocation = driver.TaskAllocation(task=task,
-                                                    client_index_in_task=0,
-                                                    global_client_index=0,
-                                                    total_clients=task.clients)
+            task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
             schedule = driver.schedule_for(task_allocation, param_source)
-            execute_schedule = driver.AsyncExecutor(client_id=0,
-                                                    task=task,
-                                                    schedule=schedule,
-                                                    es={
-                                                        "default": es
-                                                    },
-                                                    sampler=sampler,
-                                                    cancel=cancel,
-                                                    complete=complete,
-                                                    on_error="continue")
+            execute_schedule = driver.AsyncExecutor(
+                client_id=0,
+                task=task,
+                schedule=schedule,
+                es={"default": es},
+                sampler=sampler,
+                cancel=cancel,
+                complete=complete,
+                on_error="continue",
+            )
             await execute_schedule()
 
             samples = sampler.samples
@@ -1501,57 +1609,54 @@ class AsyncExecutorTests(TestCase):
             sample_size = len(samples)
             lower_bound = bounds[0]
             upper_bound = bounds[1]
-            self.assertTrue(lower_bound <= sample_size <= upper_bound,
-                            msg="Expected sample size to be between %d and %d but was %d" % (lower_bound, upper_bound, sample_size))
+            self.assertTrue(
+                lower_bound <= sample_size <= upper_bound,
+                msg="Expected sample size to be between %d and %d but was %d" % (lower_bound, upper_bound, sample_size),
+            )
             self.assertTrue(complete.is_set(), "Executor should auto-complete a task that terminates its parent")
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_cancel_execute_schedule(self, es):
-        es.init_request_context.return_value = {
-            "request_start": 0,
-            "request_end": 10
-        }
+        es.init_request_context.return_value = {"request_start": 0, "request_end": 10}
         es.bulk.return_value = as_future(io.StringIO('{"errors": false, "took": 8}'))
 
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
-        test_track = track.Track(name="unittest", description="unittest track",
-                                 indices=None,
-                                 challenges=None)
+        test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)
 
         # in one second (0.5 warmup + 0.5 measurement) we should get 1000 [ops/s] / 4 [clients] = 250 samples
         for target_throughput in [10, 100, 1000]:
-            task = track.Task("time-based", track.Operation("time-based",
-                                                            track.OperationType.Bulk.to_hyphenated_string(),
-                                                            params={
-                                                                "body": ["action_metadata_line", "index_line"],
-                                                                "action-metadata-present": True,
-                                                                "bulk-size": 1
-                                                            },
-                                                            param_source="driver-test-param-source"),
-                              warmup_time_period=0.5, time_period=0.5, clients=4,
-                              params={"target-throughput": target_throughput, "clients": 4})
+            task = track.Task(
+                "time-based",
+                track.Operation(
+                    "time-based",
+                    track.OperationType.Bulk.to_hyphenated_string(),
+                    params={"body": ["action_metadata_line", "index_line"], "action-metadata-present": True, "bulk-size": 1},
+                    param_source="driver-test-param-source",
+                ),
+                warmup_time_period=0.5,
+                time_period=0.5,
+                clients=4,
+                params={"target-throughput": target_throughput, "clients": 4},
+            )
 
             param_source = track.operation_parameters(test_track, task)
-            task_allocation = driver.TaskAllocation(task=task,
-                                                    client_index_in_task=0,
-                                                    global_client_index=0,
-                                                    total_clients=task.clients)
+            task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
             schedule = driver.schedule_for(task_allocation, param_source)
             sampler = driver.Sampler(start_timestamp=0)
 
             cancel = threading.Event()
             complete = threading.Event()
-            execute_schedule = driver.AsyncExecutor(client_id=0,
-                                                    task=task,
-                                                    schedule=schedule,
-                                                    es={
-                                                        "default": es
-                                                    },
-                                                    sampler=sampler,
-                                                    cancel=cancel,
-                                                    complete=complete,
-                                                    on_error="continue")
+            execute_schedule = driver.AsyncExecutor(
+                client_id=0,
+                task=task,
+                schedule=schedule,
+                es={"default": es},
+                sampler=sampler,
+                cancel=cancel,
+                complete=complete,
+                on_error="continue",
+            )
 
             cancel.set()
             await execute_schedule()
@@ -1565,7 +1670,6 @@ class AsyncExecutorTests(TestCase):
     @run_async
     async def test_execute_schedule_aborts_on_error(self, es):
         class ExpectedUnitTestException(Exception):
-
             def __str__(self):
                 return "expected unit test exception"
 
@@ -1590,25 +1694,28 @@ class AsyncExecutorTests(TestCase):
                 for invocation in invocations:
                     yield invocation
 
-        task = track.Task("no-op", track.Operation("no-op", track.OperationType.Bulk.to_hyphenated_string(),
-                                                   params={},
-                                                   param_source="driver-test-param-source"),
-                          warmup_time_period=0.5, time_period=0.5, clients=4,
-                          params={"clients": 4})
+        task = track.Task(
+            "no-op",
+            track.Operation("no-op", track.OperationType.Bulk.to_hyphenated_string(), params={}, param_source="driver-test-param-source"),
+            warmup_time_period=0.5,
+            time_period=0.5,
+            clients=4,
+            params={"clients": 4},
+        )
 
         sampler = driver.Sampler(start_timestamp=0)
         cancel = threading.Event()
         complete = threading.Event()
-        execute_schedule = driver.AsyncExecutor(client_id=2,
-                                                task=task,
-                                                schedule=ScheduleHandle(),
-                                                es={
-                                                    "default": es
-                                                },
-                                                sampler=sampler,
-                                                cancel=cancel,
-                                                complete=complete,
-                                                on_error="continue")
+        execute_schedule = driver.AsyncExecutor(
+            client_id=2,
+            task=task,
+            schedule=ScheduleHandle(),
+            es={"default": es},
+            sampler=sampler,
+            cancel=cancel,
+            complete=complete,
+            on_error="continue",
+        )
 
         with self.assertRaisesRegex(exceptions.RallyError, r"Cannot run task \[no-op\]: expected unit test exception"):
             await execute_schedule()
@@ -1646,22 +1753,27 @@ class AsyncExecutorTests(TestCase):
         es = None
         params = None
         runner = mock.Mock()
-        runner.return_value = as_future({
-            "weight": 50,
-            "unit": "docs",
-            "some-custom-meta-data": "valid",
-            "http-status": 200
-        })
+        runner.return_value = as_future(
+            {
+                "weight": 50,
+                "unit": "docs",
+                "some-custom-meta-data": "valid",
+                "http-status": 200,
+            }
+        )
 
         ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
 
         self.assertEqual(50, ops)
         self.assertEqual("docs", unit)
-        self.assertEqual({
-            "some-custom-meta-data": "valid",
-            "http-status": 200,
-            "success": True
-        }, request_meta_data)
+        self.assertEqual(
+            {
+                "some-custom-meta-data": "valid",
+                "http-status": 200,
+                "success": True,
+            },
+            request_meta_data,
+        )
 
     @run_async
     async def test_execute_single_with_connection_error_always_aborts(self):
@@ -1674,61 +1786,64 @@ class AsyncExecutorTests(TestCase):
 
                 with self.assertRaises(exceptions.RallyAssertionError) as ctx:
                     await driver.execute_single(self.context_managed(runner), es, params, on_error=on_error)
-                self.assertEqual(
-                    "Request returned an error. Error type: transport, Description: no route to host",
-                    ctx.exception.args[0])
+                self.assertEqual("Request returned an error. Error type: transport, Description: no route to host", ctx.exception.args[0])
 
     @run_async
     async def test_execute_single_with_http_400_aborts_when_specified(self):
         es = None
         params = None
-        runner = mock.Mock(side_effect=
-                           as_future(exception=elasticsearch.NotFoundError(404, "not found", "the requested document could not be found")))
+        runner = mock.Mock(
+            side_effect=as_future(exception=elasticsearch.NotFoundError(404, "not found", "the requested document could not be found"))
+        )
 
         with self.assertRaises(exceptions.RallyAssertionError) as ctx:
             await driver.execute_single(self.context_managed(runner), es, params, on_error="abort")
         self.assertEqual(
             "Request returned an error. Error type: transport, Description: not found (the requested document could not be found)",
-            ctx.exception.args[0])
-
+            ctx.exception.args[0],
+        )
 
     @run_async
     async def test_execute_single_with_http_400(self):
         es = None
         params = None
-        runner = mock.Mock(side_effect=
-                           as_future(exception=elasticsearch.NotFoundError(404, "not found", "the requested document could not be found")))
+        runner = mock.Mock(
+            side_effect=as_future(exception=elasticsearch.NotFoundError(404, "not found", "the requested document could not be found"))
+        )
 
-        ops, unit, request_meta_data = await driver.execute_single(
-            self.context_managed(runner), es, params, on_error="continue")
+        ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
 
         self.assertEqual(0, ops)
         self.assertEqual("ops", unit)
-        self.assertEqual({
-            "http-status": 404,
-            "error-type": "transport",
-            "error-description": "not found (the requested document could not be found)",
-            "success": False
-        }, request_meta_data)
+        self.assertEqual(
+            {
+                "http-status": 404,
+                "error-type": "transport",
+                "error-description": "not found (the requested document could not be found)",
+                "success": False,
+            },
+            request_meta_data,
+        )
 
     @run_async
     async def test_execute_single_with_http_413(self):
         es = None
         params = None
-        runner = mock.Mock(side_effect=
-                           as_future(exception=elasticsearch.NotFoundError(413, b"", b"")))
+        runner = mock.Mock(side_effect=as_future(exception=elasticsearch.NotFoundError(413, b"", b"")))
 
-        ops, unit, request_meta_data = await driver.execute_single(
-            self.context_managed(runner), es, params, on_error="continue")
+        ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
 
         self.assertEqual(0, ops)
         self.assertEqual("ops", unit)
-        self.assertEqual({
-            "http-status": 413,
-            "error-type": "transport",
-            "error-description": "",
-            "success": False
-        }, request_meta_data)
+        self.assertEqual(
+            {
+                "http-status": 413,
+                "error-type": "transport",
+                "error-description": "",
+                "success": False,
+            },
+            request_meta_data,
+        )
 
     @run_async
     async def test_execute_single_with_key_error(self):
@@ -1750,7 +1865,8 @@ class AsyncExecutorTests(TestCase):
             await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
         self.assertEqual(
             "Cannot execute [failing_mock_runner]. Provided parameters are: ['bulk', 'mode']. Error: ['bulk-size missing'].",
-            ctx.exception.args[0])
+            ctx.exception.args[0],
+        )
 
 
 class AsyncProfilerTests(TestCase):

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -4645,7 +4645,7 @@ class QueryWithSearchAfterScrollTests(TestCase):
                     {"timestamp": "asc", "tie_breaker_id": "asc"},
                 ],
                 "query": {
-                    "match-all": {},
+                    "match_all": {},
                 },
             },
         }
@@ -4696,7 +4696,7 @@ class QueryWithSearchAfterScrollTests(TestCase):
                     params={},
                     body={
                         "query": {
-                            "match-all": {},
+                            "match_all": {},
                         },
                         "sort": [
                             {
@@ -4718,7 +4718,7 @@ class QueryWithSearchAfterScrollTests(TestCase):
                     params={},
                     body={
                         "query": {
-                            "match-all": {},
+                            "match_all": {},
                         },
                         "sort": [
                             {
@@ -4750,7 +4750,7 @@ class QueryWithSearchAfterScrollTests(TestCase):
             "body": {
                 "sort": [{"timestamp": "asc", "tie_breaker_id": "asc"}],
                 "query": {
-                    "match-all": {},
+                    "match_all": {},
                 },
             },
         }
@@ -4798,7 +4798,7 @@ class QueryWithSearchAfterScrollTests(TestCase):
                     params={},
                     body={
                         "query": {
-                            "match-all": {},
+                            "match_all": {},
                         },
                         "sort": [
                             {"timestamp": "asc", "tie_breaker_id": "asc"},
@@ -4813,7 +4813,7 @@ class QueryWithSearchAfterScrollTests(TestCase):
                     params={},
                     body={
                         "query": {
-                            "match-all": {},
+                            "match_all": {},
                         },
                         "sort": [
                             {"timestamp": "asc", "tie_breaker_id": "asc"},

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -26,7 +26,7 @@ import elasticsearch
 
 from esrally import client, exceptions
 from esrally.driver import runner
-from tests import run_async, as_future
+from tests import as_future, run_async
 
 
 class BaseUnitTestContextManagerRunner:
@@ -52,8 +52,9 @@ class RegisterRunnerTests(TestCase):
         returned_runner = runner.runner_for("unit_test")
         self.assertIsInstance(returned_runner, runner.NoCompletion)
         self.assertEqual("user-defined runner for [runner_function]", repr(returned_runner))
-        self.assertEqual(("default_client", "param"),
-                         await returned_runner({"default": "default_client", "other": "other_client"}, "param"))
+        self.assertEqual(
+            ("default_client", "param"), await returned_runner({"default": "default_client", "other": "other_client"}, "param")
+        )
 
     @run_async
     async def test_single_cluster_runner_class_with_context_manager_should_be_wrapped_with_context_manager_enabled(self):
@@ -68,12 +69,14 @@ class RegisterRunnerTests(TestCase):
         runner.register_runner(operation_type="unit_test", runner=test_runner, async_runner=True)
         returned_runner = runner.runner_for("unit_test")
         self.assertIsInstance(returned_runner, runner.NoCompletion)
-        self.assertEqual("user-defined context-manager enabled runner for [UnitTestSingleClusterContextManagerRunner]",
-                         repr(returned_runner))
+        self.assertEqual(
+            "user-defined context-manager enabled runner for [UnitTestSingleClusterContextManagerRunner]", repr(returned_runner)
+        )
         # test that context_manager functionality gets preserved after wrapping
         async with returned_runner:
-            self.assertEqual(("default_client", "param"),
-                             await returned_runner({"default": "default_client", "other": "other_client"}, "param"))
+            self.assertEqual(
+                ("default_client", "param"), await returned_runner({"default": "default_client", "other": "other_client"}, "param")
+            )
         # check that the context manager interface of our inner runner has been respected.
         self.assertTrue(test_runner.fp.closed)
 
@@ -92,8 +95,9 @@ class RegisterRunnerTests(TestCase):
         runner.register_runner(operation_type="unit_test", runner=test_runner, async_runner=True)
         returned_runner = runner.runner_for("unit_test")
         self.assertIsInstance(returned_runner, runner.NoCompletion)
-        self.assertEqual("user-defined context-manager enabled runner for [UnitTestMultiClusterContextManagerRunner]",
-                         repr(returned_runner))
+        self.assertEqual(
+            "user-defined context-manager enabled runner for [UnitTestMultiClusterContextManagerRunner]", repr(returned_runner)
+        )
 
         # test that context_manager functionality gets preserved after wrapping
         all_clients = {"default": "default_client", "other": "other_client"}
@@ -116,8 +120,9 @@ class RegisterRunnerTests(TestCase):
         returned_runner = runner.runner_for("unit_test")
         self.assertIsInstance(returned_runner, runner.NoCompletion)
         self.assertEqual("user-defined runner for [UnitTestSingleClusterRunner]", repr(returned_runner))
-        self.assertEqual(("default_client", "param"),
-                         await returned_runner({"default": "default_client", "other": "other_client"}, "param"))
+        self.assertEqual(
+            ("default_client", "param"), await returned_runner({"default": "default_client", "other": "other_client"}, "param")
+        )
 
     @run_async
     async def test_multi_cluster_runner_class_should_be_wrapped(self):
@@ -153,29 +158,24 @@ class AssertingRunnerTests(TestCase):
             "hits": {
                 "hits": {
                     "value": 5,
-                    "relation": "eq"
-                }
-            }
+                    "relation": "eq",
+                },
+            },
         }
         delegate = mock.MagicMock()
         delegate.return_value = as_future(response)
         r = runner.AssertingRunner(delegate)
         async with r:
-            final_response = await r(es, {
-                "name": "test-task",
-                "assertions": [
-                    {
-                        "property": "hits.hits.value",
-                        "condition": "==",
-                        "value": 5
-                    },
-                    {
-                        "property": "hits.hits.relation",
-                        "condition": "==",
-                        "value": "eq"
-                    }
-                ]
-            })
+            final_response = await r(
+                es,
+                {
+                    "name": "test-task",
+                    "assertions": [
+                        {"property": "hits.hits.value", "condition": "==", "value": 5},
+                        {"property": "hits.hits.relation", "condition": "==", "value": "eq"},
+                    ],
+                },
+            )
 
         self.assertEqual(response, final_response)
 
@@ -186,31 +186,27 @@ class AssertingRunnerTests(TestCase):
             "hits": {
                 "hits": {
                     "value": 10000,
-                    "relation": "gte"
-                }
-            }
+                    "relation": "gte",
+                },
+            },
         }
         delegate = mock.MagicMock()
         delegate.return_value = as_future(response)
         r = runner.AssertingRunner(delegate)
-        with self.assertRaisesRegex(exceptions.RallyTaskAssertionError,
-                                    r"Expected \[hits.hits.relation\] in \[test-task\] to be == \[eq\] but was \[gte\]."):
+        with self.assertRaisesRegex(
+            exceptions.RallyTaskAssertionError, r"Expected \[hits.hits.relation\] in \[test-task\] to be == \[eq\] but was \[gte\]."
+        ):
             async with r:
-                await r(es, {
-                    "name": "test-task",
-                    "assertions": [
-                        {
-                            "property": "hits.hits.value",
-                            "condition": "==",
-                            "value": 10000
-                        },
-                        {
-                            "property": "hits.hits.relation",
-                            "condition": "==",
-                            "value": "eq"
-                        }
-                    ]
-                })
+                await r(
+                    es,
+                    {
+                        "name": "test-task",
+                        "assertions": [
+                            {"property": "hits.hits.value", "condition": "==", "value": 10000},
+                            {"property": "hits.hits.relation", "condition": "==", "value": "eq"},
+                        ],
+                    },
+                )
 
     @run_async
     async def test_skips_asserts_for_non_dicts(self):
@@ -220,16 +216,19 @@ class AssertingRunnerTests(TestCase):
         delegate.return_value = as_future(response)
         r = runner.AssertingRunner(delegate)
         async with r:
-            final_response = await r(es, {
-                "name": "test-task",
-                "assertions": [
-                    {
-                        "property": "hits.hits.value",
-                        "condition": "==",
-                        "value": 5
-                    }
-                ]
-            })
+            final_response = await r(
+                es,
+                {
+                    "name": "test-task",
+                    "assertions": [
+                        {
+                            "property": "hits.hits.value",
+                            "condition": "==",
+                            "value": 5,
+                        },
+                    ],
+                },
+            )
         # still passes response as is
         self.assertEqual(response, final_response)
 
@@ -248,8 +247,7 @@ class AssertingRunnerTests(TestCase):
 
         for predicate, vals in predicate_success.items():
             expected, actual = vals
-            self.assertTrue(r.predicates[predicate](expected, actual),
-                            f"Expected [{expected} {predicate} {actual}] to succeed.")
+            self.assertTrue(r.predicates[predicate](expected, actual), f"Expected [{expected} {predicate} {actual}] to succeed.")
 
         predicate_fail = {
             # predicate: (expected, actual)
@@ -262,8 +260,7 @@ class AssertingRunnerTests(TestCase):
 
         for predicate, vals in predicate_fail.items():
             expected, actual = vals
-            self.assertFalse(r.predicates[predicate](expected, actual),
-                             f"Expected [{expected} {predicate} {actual}] to fail.")
+            self.assertFalse(r.predicates[predicate](expected, actual), f"Expected [{expected} {predicate} {actual}] to fail.")
 
 
 class SelectiveJsonParserTests(TestCase):
@@ -271,64 +268,75 @@ class SelectiveJsonParserTests(TestCase):
         return io.StringIO(json.dumps(doc))
 
     def test_parse_all_expected(self):
-        doc = self.doc_as_text({
-            "title": "Hello",
-            "meta": {
-                "length": 100,
-                "date": {
-                    "year": 2000
-                }
-            }
-        })
+        doc = self.doc_as_text(
+            {
+                "title": "Hello",
+                "meta": {
+                    "length": 100,
+                    "date": {
+                        "year": 2000,
+                    },
+                },
+            },
+        )
 
-        parsed = runner.parse(doc, [
-            # simple property
-            "title",
-            # a nested property
-            "meta.date.year",
-            # ignores unknown properties
-            "meta.date.month"
-        ])
+        parsed = runner.parse(
+            doc,
+            [
+                # simple property
+                "title",
+                # a nested property
+                "meta.date.year",
+                # ignores unknown properties
+                "meta.date.month",
+            ],
+        )
 
         self.assertEqual("Hello", parsed.get("title"))
         self.assertEqual(2000, parsed.get("meta.date.year"))
         self.assertNotIn("meta.date.month", parsed)
 
     def test_list_length(self):
-        doc = self.doc_as_text({
-            "title": "Hello",
-            "meta": {
-                "length": 100,
-                "date": {
-                    "year": 2000
-                }
-            },
-            "authors": ["George", "Harry"],
-            "readers": [
-                {
-                    "name": "Tom",
-                    "age": 14
+        doc = self.doc_as_text(
+            {
+                "title": "Hello",
+                "meta": {
+                    "length": 100,
+                    "date": {
+                        "year": 2000,
+                    },
                 },
-                {
-                    "name": "Bob",
-                    "age": 17
-                },
-                {
-                    "name": "Alice",
-                    "age": 22
-                }
-            ],
-            "supporters": []
-        })
+                "authors": ["George", "Harry"],
+                "readers": [
+                    {
+                        "name": "Tom",
+                        "age": 14,
+                    },
+                    {
+                        "name": "Bob",
+                        "age": 17,
+                    },
+                    {
+                        "name": "Alice",
+                        "age": 22,
+                    },
+                ],
+                "supporters": [],
+            }
+        )
 
-        parsed = runner.parse(doc, [
-            # simple property
-            "title",
-            # a nested property
-            "meta.date.year",
-            # ignores unknown properties
-            "meta.date.month"
-        ], ["authors", "readers", "supporters"])
+        parsed = runner.parse(
+            doc,
+            [
+                # simple property
+                "title",
+                # a nested property
+                "meta.date.year",
+                # ignores unknown properties
+                "meta.date.month",
+            ],
+            ["authors", "readers", "supporters"],
+        )
 
         self.assertEqual("Hello", parsed.get("title"))
         self.assertEqual(2000, parsed.get("meta.date.year"))
@@ -340,54 +348,64 @@ class SelectiveJsonParserTests(TestCase):
         self.assertTrue(parsed.get("supporters"))
 
 
+def _build_bulk_body(*lines):
+    return "".join(line + "\n" for line in lines)
+
+
 class BulkIndexRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_bulk_index_missing_params(self, es):
         bulk_response = {
             "errors": False,
-            "took": 8
+            "took": 8,
         }
         es.bulk.return_value = as_future(io.StringIO(json.dumps(bulk_response)))
 
         bulk = runner.BulkIndex()
 
         bulk_params = {
-            "body": "action_meta_data\n" +
-                    "index_line\n" +
-                    "action_meta_data\n" +
-                    "index_line\n" +
-                    "action_meta_data\n" +
-                    "index_line\n"
+            "body": _build_bulk_body(
+                "action_meta_data",
+                "index_line",
+                "action_meta_data",
+                "index_line",
+                "action_meta_data",
+                "index_line",
+            )
         }
 
         with self.assertRaises(exceptions.DataError) as ctx:
             await bulk(es, bulk_params)
         self.assertEqual(
             "Parameter source for operation 'bulk-index' did not provide the mandatory parameter 'action-metadata-present'. "
-            "Add it to your parameter source and try again.", ctx.exception.args[0])
+            "Add it to your parameter source and try again.",
+            ctx.exception.args[0],
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_bulk_index_success_with_metadata(self, es):
         bulk_response = {
             "errors": False,
-            "took": 8
+            "took": 8,
         }
         es.bulk.return_value = as_future(io.StringIO(json.dumps(bulk_response)))
 
         bulk = runner.BulkIndex()
 
         bulk_params = {
-            "body": "action_meta_data\n" +
-                    "index_line\n" +
-                    "action_meta_data\n" +
-                    "index_line\n" +
-                    "action_meta_data\n" +
-                    "index_line\n",
+            "body": _build_bulk_body(
+                "action_meta_data",
+                "index_line",
+                "action_meta_data",
+                "index_line",
+                "action_meta_data",
+                "index_line",
+            ),
             "action-metadata-present": True,
             "bulk-size": 3,
-            "unit": "docs"
+            "unit": "docs",
         }
 
         result = await bulk(es, bulk_params)
@@ -407,24 +425,26 @@ class BulkIndexRunnerTests(TestCase):
     async def test_simple_bulk_with_timeout_and_headers(self, es):
         bulk_response = {
             "errors": False,
-            "took": 8
+            "took": 8,
         }
         es.bulk.return_value = as_future(io.StringIO(json.dumps(bulk_response)))
 
         bulk = runner.BulkIndex()
 
         bulk_params = {
-            "body": "index_line\n" +
-                    "index_line\n" +
-                    "index_line\n",
+            "body": _build_bulk_body(
+                "index_line",
+                "index_line",
+                "index_line",
+            ),
             "action-metadata-present": False,
             "type": "_doc",
             "index": "test1",
             "request-timeout": 3.0,
-            "headers": { "x-test-id": "1234"},
+            "headers": {"x-test-id": "1234"},
             "opaque-id": "DESIRED-OPAQUE-ID",
             "bulk-size": 3,
-            "unit": "docs"
+            "unit": "docs",
         }
 
         result = await bulk(es, bulk_params)
@@ -436,33 +456,37 @@ class BulkIndexRunnerTests(TestCase):
         self.assertEqual(0, result["error-count"])
         self.assertFalse("error-type" in result)
 
-        es.bulk.assert_called_with(doc_type="_doc",
-                                   params={},
-                                   body="index_line\nindex_line\nindex_line\n",
-                                   headers={"x-test-id": "1234"},
-                                   index="test1",
-                                   opaque_id="DESIRED-OPAQUE-ID",
-                                   request_timeout=3.0)
+        es.bulk.assert_called_with(
+            doc_type="_doc",
+            params={},
+            body="index_line\nindex_line\nindex_line\n",
+            headers={"x-test-id": "1234"},
+            index="test1",
+            opaque_id="DESIRED-OPAQUE-ID",
+            request_timeout=3.0,
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_bulk_index_success_without_metadata_with_doc_type(self, es):
         bulk_response = {
             "errors": False,
-            "took": 8
+            "took": 8,
         }
         es.bulk.return_value = as_future(io.StringIO(json.dumps(bulk_response)))
         bulk = runner.BulkIndex()
 
         bulk_params = {
-            "body": "index_line\n" +
-                    "index_line\n" +
-                    "index_line\n",
+            "body": _build_bulk_body(
+                "index_line",
+                "index_line",
+                "index_line",
+            ),
             "action-metadata-present": False,
             "bulk-size": 3,
             "unit": "docs",
             "index": "test-index",
-            "type": "_doc"
+            "type": "_doc",
         }
 
         result = await bulk(es, bulk_params)
@@ -482,19 +506,21 @@ class BulkIndexRunnerTests(TestCase):
     async def test_bulk_index_success_without_metadata_and_without_doc_type(self, es):
         bulk_response = {
             "errors": False,
-            "took": 8
+            "took": 8,
         }
         es.bulk.return_value = as_future(io.StringIO(json.dumps(bulk_response)))
         bulk = runner.BulkIndex()
 
         bulk_params = {
-            "body": "index_line\n" +
-                    "index_line\n" +
-                    "index_line\n",
+            "body": _build_bulk_body(
+                "index_line",
+                "index_line",
+                "index_line",
+            ),
             "action-metadata-present": False,
             "bulk-size": 3,
             "unit": "docs",
-            "index": "test-index"
+            "index": "test-index",
         }
 
         result = await bulk(es, bulk_params)
@@ -516,37 +542,10 @@ class BulkIndexRunnerTests(TestCase):
             "took": 5,
             "errors": True,
             "items": [
-                {
-                    "index": {
-                        "status": 201,
-                        "_shards": {
-                            "total": 2,
-                            "successful": 1,
-                            "failed": 0
-                        }
-                    }
-                },
-                {
-                    "index": {
-                        "status": 500,
-                        "_shards": {
-                            "total": 2,
-                            "successful": 0,
-                            "failed": 2
-                        }
-                    }
-                },
-                {
-                    "index": {
-                        "status": 404,
-                        "_shards": {
-                            "total": 2,
-                            "successful": 0,
-                            "failed": 2
-                        }
-                    }
-                },
-            ]
+                {"index": {"status": 201, "_shards": {"total": 2, "successful": 1, "failed": 0}}},
+                {"index": {"status": 500, "_shards": {"total": 2, "successful": 0, "failed": 2}}},
+                {"index": {"status": 404, "_shards": {"total": 2, "successful": 0, "failed": 2}}},
+            ],
         }
 
         es.bulk.return_value = as_future(io.StringIO(json.dumps(bulk_response)))
@@ -554,16 +553,18 @@ class BulkIndexRunnerTests(TestCase):
         bulk = runner.BulkIndex()
 
         bulk_params = {
-            "body": "action_meta_data\n" +
-                    "index_line\n" +
-                    "action_meta_data\n" +
-                    "index_line\n" +
-                    "action_meta_data\n" +
-                    "index_line\n",
+            "body": _build_bulk_body(
+                "action_meta_data",
+                "index_line",
+                "action_meta_data",
+                "index_line",
+                "action_meta_data",
+                "index_line",
+            ),
             "action-metadata-present": True,
             "bulk-size": 3,
             "unit": "docs",
-            "index": "test"
+            "index": "test",
         }
 
         result = await bulk(es, bulk_params)
@@ -591,7 +592,7 @@ class BulkIndexRunnerTests(TestCase):
                         "_type": "doc",
                         "_id": "1",
                         "status": 429,
-                        "error": "EsRejectedExecutionException[rejected execution (queue capacity 50) on org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$PrimaryPhase$1@1]" # pylint: disable=line-too-long
+                        "error": "EsRejectedExecutionException[rejected execution (queue capacity 50) on org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$PrimaryPhase$1@1]",  # pylint: disable=line-too-long
                     }
                 },
                 {
@@ -600,7 +601,7 @@ class BulkIndexRunnerTests(TestCase):
                         "_type": "doc",
                         "_id": "2",
                         "status": 429,
-                        "error": "EsRejectedExecutionException[rejected execution (queue capacity 50) on org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$PrimaryPhase$1@2]" # pylint: disable=line-too-long
+                        "error": "EsRejectedExecutionException[rejected execution (queue capacity 50) on org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$PrimaryPhase$1@2]",  # pylint: disable=line-too-long
                     }
                 },
                 {
@@ -609,10 +610,10 @@ class BulkIndexRunnerTests(TestCase):
                         "_type": "doc",
                         "_id": "3",
                         "status": 429,
-                        "error": "EsRejectedExecutionException[rejected execution (queue capacity 50) on org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$PrimaryPhase$1@3]" # pylint: disable=line-too-long
+                        "error": "EsRejectedExecutionException[rejected execution (queue capacity 50) on org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$PrimaryPhase$1@3]",  # pylint: disable=line-too-long
                     }
-                }
-            ]
+                },
+            ],
         }
 
         es.bulk.return_value = as_future(io.StringIO(json.dumps(bulk_response)))
@@ -620,17 +621,19 @@ class BulkIndexRunnerTests(TestCase):
         bulk = runner.BulkIndex()
 
         bulk_params = {
-            "body": "action_meta_data\n" +
-                    "index_line\n" +
-                    "action_meta_data\n" +
-                    "index_line\n" +
-                    "action_meta_data\n" +
-                    "index_line\n",
+            "body": _build_bulk_body(
+                "action_meta_data",
+                "index_line",
+                "action_meta_data",
+                "index_line",
+                "action_meta_data",
+                "index_line",
+            ),
             "action-metadata-present": True,
             "detailed-results": False,
             "bulk-size": 3,
             "unit": "docs",
-            "index": "test"
+            "index": "test",
         }
 
         result = await bulk(es, bulk_params)
@@ -660,14 +663,10 @@ class BulkIndexRunnerTests(TestCase):
                         "_id": "1",
                         "_version": 1,
                         "result": "created",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 1,
-                            "failed": 0
-                        },
+                        "_shards": {"total": 2, "successful": 1, "failed": 0},
                         "created": True,
                         "status": 201,
-                        "_seq_no": 0
+                        "_seq_no": 0,
                     }
                 },
                 {
@@ -677,13 +676,9 @@ class BulkIndexRunnerTests(TestCase):
                         "_id": "2",
                         "_version": 2,
                         "result": "updated",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 1,
-                            "failed": 0
-                        },
+                        "_shards": {"total": 2, "successful": 1, "failed": 0},
                         "status": 200,
-                        "_seq_no": 1
+                        "_seq_no": 1,
                     }
                 },
                 {
@@ -693,14 +688,10 @@ class BulkIndexRunnerTests(TestCase):
                         "_id": "3",
                         "_version": 1,
                         "result": "noop",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 0,
-                            "failed": 2
-                        },
+                        "_shards": {"total": 2, "successful": 0, "failed": 2},
                         "created": False,
                         "status": 500,
-                        "_seq_no": -2
+                        "_seq_no": -2,
                     }
                 },
                 {
@@ -710,34 +701,32 @@ class BulkIndexRunnerTests(TestCase):
                         "_id": "6",
                         "_version": 2,
                         "result": "noop",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 0,
-                            "failed": 2
-                        },
+                        "_shards": {"total": 2, "successful": 0, "failed": 2},
                         "status": 404,
-                        "_seq_no": 5
+                        "_seq_no": 5,
                     }
-                }
-            ]
+                },
+            ],
         }
         es.bulk.return_value = as_future(io.StringIO(json.dumps(bulk_response)))
         bulk = runner.BulkIndex()
 
         bulk_params = {
-            "body": "action_meta_data\n" +
-                    "index_line\n" +
-                    "action_meta_data\n" +
-                    "update_line\n" +
-                    "action_meta_data\n" +
-                    "index_line\n" +
-                    "action_meta_data\n" +
-                    "update_line\n",
+            "body": _build_bulk_body(
+                "action_meta_data",
+                "index_line",
+                "action_meta_data",
+                "update_line",
+                "action_meta_data",
+                "index_line",
+                "action_meta_data",
+                "update_line",
+            ),
             "action-metadata-present": True,
             "detailed-results": False,
             "bulk-size": 4,
             "unit": "docs",
-            "index": "test"
+            "index": "test",
         }
 
         result = await bulk(es, bulk_params)
@@ -756,133 +745,113 @@ class BulkIndexRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_mixed_bulk_with_detailed_stats_body_as_string(self, es):
-        es.bulk.return_value = as_future({
-            "took": 30,
-            "ingest_took": 20,
-            "errors": True,
-            "items": [
-                {
-                    "index": {
-                        "_index": "test",
-                        "_type": "type1",
-                        "_id": "1",
-                        "_version": 1,
-                        "result": "created",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 1,
-                            "failed": 0
-                        },
-                        "created": True,
-                        "status": 201,
-                        "_seq_no": 0
-                    }
-                },
-                {
-                    "update": {
-                        "_index": "test",
-                        "_type": "type1",
-                        "_id": "2",
-                        "_version": 2,
-                        "result": "updated",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 1,
-                            "failed": 0
-                        },
-                        "status": 200,
-                        "_seq_no": 1
-                    }
-                },
-                {
-                    "index": {
-                        "_index": "test",
-                        "_type": "type1",
-                        "_id": "3",
-                        "_version": 1,
-                        "result": "noop",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 0,
-                            "failed": 2
-                        },
-                        "created": False,
-                        "status": 500,
-                        "_seq_no": -2
-                    }
-                },
-                {
-                    "index": {
-                        "_index": "test",
-                        "_type": "type1",
-                        "_id": "4",
-                        "_version": 1,
-                        "result": "noop",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 1,
-                            "failed": 1
-                        },
-                        "created": False,
-                        "status": 500,
-                        "_seq_no": -2
-                    }
-                },
-                {
-                    "index": {
-                        "_index": "test",
-                        "_type": "type1",
-                        "_id": "5",
-                        "_version": 1,
-                        "result": "created",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 1,
-                            "failed": 0
-                        },
-                        "created": True,
-                        "status": 201,
-                        "_seq_no": 4
-                    }
-                },
-                {
-                    "update": {
-                        "_index": "test",
-                        "_type": "type1",
-                        "_id": "6",
-                        "_version": 2,
-                        "result": "noop",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 0,
-                            "failed": 2
-                        },
-                        "status": 404,
-                        "_seq_no": 5
-                    }
-                }
-            ]
-        })
+        es.bulk.return_value = as_future(
+            {
+                "took": 30,
+                "ingest_took": 20,
+                "errors": True,
+                "items": [
+                    {
+                        "index": {
+                            "_index": "test",
+                            "_type": "type1",
+                            "_id": "1",
+                            "_version": 1,
+                            "result": "created",
+                            "_shards": {"total": 2, "successful": 1, "failed": 0},
+                            "created": True,
+                            "status": 201,
+                            "_seq_no": 0,
+                        }
+                    },
+                    {
+                        "update": {
+                            "_index": "test",
+                            "_type": "type1",
+                            "_id": "2",
+                            "_version": 2,
+                            "result": "updated",
+                            "_shards": {"total": 2, "successful": 1, "failed": 0},
+                            "status": 200,
+                            "_seq_no": 1,
+                        }
+                    },
+                    {
+                        "index": {
+                            "_index": "test",
+                            "_type": "type1",
+                            "_id": "3",
+                            "_version": 1,
+                            "result": "noop",
+                            "_shards": {"total": 2, "successful": 0, "failed": 2},
+                            "created": False,
+                            "status": 500,
+                            "_seq_no": -2,
+                        }
+                    },
+                    {
+                        "index": {
+                            "_index": "test",
+                            "_type": "type1",
+                            "_id": "4",
+                            "_version": 1,
+                            "result": "noop",
+                            "_shards": {"total": 2, "successful": 1, "failed": 1},
+                            "created": False,
+                            "status": 500,
+                            "_seq_no": -2,
+                        }
+                    },
+                    {
+                        "index": {
+                            "_index": "test",
+                            "_type": "type1",
+                            "_id": "5",
+                            "_version": 1,
+                            "result": "created",
+                            "_shards": {"total": 2, "successful": 1, "failed": 0},
+                            "created": True,
+                            "status": 201,
+                            "_seq_no": 4,
+                        }
+                    },
+                    {
+                        "update": {
+                            "_index": "test",
+                            "_type": "type1",
+                            "_id": "6",
+                            "_version": 2,
+                            "result": "noop",
+                            "_shards": {"total": 2, "successful": 0, "failed": 2},
+                            "status": 404,
+                            "_seq_no": 5,
+                        }
+                    },
+                ],
+            }
+        )
         bulk = runner.BulkIndex()
 
         bulk_params = {
-            "body": '{ "index" : { "_index" : "test", "_type" : "type1" } }\n' +
-                    '{"location" : [-0.1485188, 51.5250666]}\n' +
-                    '{ "update" : { "_index" : "test", "_type" : "type1", "_id: "2" } }\n' +
-                    '{"location" : [-0.1479949, 51.5252071]}\n' +
-                    '{ "index" : { "_index" : "test", "_type" : "type1" } }\n' +
-                    '{"location" : [-0.1458559, 51.5289059]}\n' +
-                    '{ "index" : { "_index" : "test", "_type" : "type1" } }\n' +
-                    '{"location" : [-0.1498551, 51.5282564]}\n' +
-                    '{ "index" : { "_index" : "test", "_type" : "type1" } }\n' +
-                    '{"location" : [-0.1487043, 51.5254843]}\n' +
-                    '{ "update" : { "_index" : "test", "_type" : "type1", "_id: "3" } }\n' +
-                    '{"location" : [-0.1533367, 51.5261779]}\n',
+            "body": _build_bulk_body(
+                '{ "index" : { "_index" : "test", "_type" : "type1" } }',
+                '{"location" : [-0.1485188, 51.5250666]}',
+                '{ "update" : { "_index" : "test", "_type" : "type1", "_id: "2" } }',
+                '{"location" : [-0.1479949, 51.5252071]}',
+                '{ "index" : { "_index" : "test", "_type" : "type1" } }',
+                '{"location" : [-0.1458559, 51.5289059]}',
+                '{ "index" : { "_index" : "test", "_type" : "type1" } }',
+                '{"location" : [-0.1498551, 51.5282564]}',
+                '{ "index" : { "_index" : "test", "_type" : "type1" } }',
+                '{"location" : [-0.1487043, 51.5254843]}',
+                '{ "update" : { "_index" : "test", "_type" : "type1", "_id: "3" } }',
+                '{"location" : [-0.1533367, 51.5261779]}',
+            ),
             "action-metadata-present": True,
             "bulk-size": 6,
             "unit": "docs",
             "detailed-results": True,
-            "index": "test"
+            "index": "test",
         }
 
         result = await bulk(es, bulk_params)
@@ -897,45 +866,19 @@ class BulkIndexRunnerTests(TestCase):
         self.assertEqual("bulk", result["error-type"])
         self.assertEqual(
             {
-                "index": {
-                    "item-count": 4,
-                    "created": 2,
-                    "noop": 2
-                },
-
-                "update": {
-                    "item-count": 2,
-                    "updated": 1,
-                    "noop": 1
-                }
-            }, result["ops"])
+                "index": {"item-count": 4, "created": 2, "noop": 2},
+                "update": {"item-count": 2, "updated": 1, "noop": 1},
+            },
+            result["ops"],
+        )
         self.assertEqual(
             [
-                {
-                    "item-count": 3,
-                    "shards": {
-                        "total": 2,
-                        "successful": 1,
-                        "failed": 0
-                    }
-                },
-                {
-                    "item-count": 2,
-                    "shards": {
-                        "total": 2,
-                        "successful": 0,
-                        "failed": 2
-                    }
-                },
-                {
-                    "item-count": 1,
-                    "shards": {
-                        "total": 2,
-                        "successful": 1,
-                        "failed": 1
-                    }
-                }
-            ], result["shards_histogram"])
+                {"item-count": 3, "shards": {"total": 2, "successful": 1, "failed": 0}},
+                {"item-count": 2, "shards": {"total": 2, "successful": 0, "failed": 2}},
+                {"item-count": 1, "shards": {"total": 2, "successful": 1, "failed": 1}},
+            ],
+            result["shards_histogram"],
+        )
         self.assertEqual(582, result["bulk-request-size-bytes"])
         self.assertEqual(234, result["total-document-size-bytes"])
 
@@ -948,40 +891,40 @@ class BulkIndexRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_simple_bulk_with_detailed_stats_body_as_list(self, es):
-        es.bulk.return_value = as_future({
-            "took": 30,
-            "ingest_took": 20,
-            "errors": False,
-            "items": [
-                {
-                    "index": {
-                        "_index": "test",
-                        "_type": "type1",
-                        "_id": "1",
-                        "_version": 1,
-                        "result": "created",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 1,
-                            "failed": 0
-                        },
-                        "created": True,
-                        "status": 201,
-                        "_seq_no": 0
+        es.bulk.return_value = as_future(
+            {
+                "took": 30,
+                "ingest_took": 20,
+                "errors": False,
+                "items": [
+                    {
+                        "index": {
+                            "_index": "test",
+                            "_type": "type1",
+                            "_id": "1",
+                            "_version": 1,
+                            "result": "created",
+                            "_shards": {"total": 2, "successful": 1, "failed": 0},
+                            "created": True,
+                            "status": 201,
+                            "_seq_no": 0,
+                        }
                     }
-                }
-            ]
-        })
+                ],
+            }
+        )
         bulk = runner.BulkIndex()
 
         bulk_params = {
-            "body": '{ "index" : { "_index" : "test", "_type" : "type1" } }\n' +
-                    '{"location" : [-0.1485188, 51.5250666]}\n',
+            "body": _build_bulk_body(
+                '{ "index" : { "_index" : "test", "_type" : "type1" } }',
+                '{"location" : [-0.1485188, 51.5250666]}',
+            ),
             "action-metadata-present": True,
             "bulk-size": 1,
             "unit": "docs",
             "detailed-results": True,
-            "index": "test"
+            "index": "test",
         }
 
         result = await bulk(es, bulk_params)
@@ -995,22 +938,19 @@ class BulkIndexRunnerTests(TestCase):
         self.assertEqual(0, result["error-count"])
         self.assertEqual(
             {
-                "index": {
-                    "item-count": 1,
-                    "created": 1
-                },
-            }, result["ops"])
+                "index": {"item-count": 1, "created": 1},
+            },
+            result["ops"],
+        )
         self.assertEqual(
             [
                 {
                     "item-count": 1,
-                    "shards": {
-                        "total": 2,
-                        "successful": 1,
-                        "failed": 0
-                    }
+                    "shards": {"total": 2, "successful": 1, "failed": 0},
                 }
-            ], result["shards_histogram"])
+            ],
+            result["shards_histogram"],
+        )
         self.assertEqual(93, result["bulk-request-size-bytes"])
         self.assertEqual(39, result["total-document-size-bytes"])
 
@@ -1023,42 +963,42 @@ class BulkIndexRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_simple_bulk_with_detailed_stats_body_as_unrecognized_type(self, es):
-        es.bulk.return_value = as_future({
-            "took": 30,
-            "ingest_took": 20,
-            "errors": False,
-            "items": [
-                {
-                    "index": {
-                        "_index": "test",
-                        "_type": "type1",
-                        "_id": "1",
-                        "_version": 1,
-                        "result": "created",
-                        "_shards": {
-                            "total": 2,
-                            "successful": 1,
-                            "failed": 0
-                        },
-                        "created": True,
-                        "status": 201,
-                        "_seq_no": 0
+        es.bulk.return_value = as_future(
+            {
+                "took": 30,
+                "ingest_took": 20,
+                "errors": False,
+                "items": [
+                    {
+                        "index": {
+                            "_index": "test",
+                            "_type": "type1",
+                            "_id": "1",
+                            "_version": 1,
+                            "result": "created",
+                            "_shards": {"total": 2, "successful": 1, "failed": 0},
+                            "created": True,
+                            "status": 201,
+                            "_seq_no": 0,
+                        }
                     }
-                }
-            ]
-        })
+                ],
+            }
+        )
         bulk = runner.BulkIndex()
 
         bulk_params = {
             "body": {
-                "items": '{ "index" : { "_index" : "test", "_type" : "type1" } }\n' +
-                         '{"location" : [-0.1485188, 51.5250666]}\n',
+                "items": _build_bulk_body(
+                    '{ "index" : { "_index" : "test", "_type" : "type1" } }',
+                    '{"location" : [-0.1485188, 51.5250666]}',
+                ),
             },
             "action-metadata-present": True,
             "bulk-size": 1,
             "unit": "docs",
             "detailed-results": True,
-            "index": "test"
+            "index": "test",
         }
 
         with self.assertRaisesRegex(exceptions.DataError, "bulk body is neither string nor list"):
@@ -1082,15 +1022,9 @@ class ForceMergeRunnerTests(TestCase):
     async def test_force_merge_with_timeout_and_headers(self, es):
         es.indices.forcemerge.return_value = as_future()
         force_merge = runner.ForceMerge()
-        await force_merge(es, params={"index": "_all",
-                                      "opaque-id": "test-id",
-                                      "request-timeout": 3.0,
-                                      "headers": {"header1": "value1"}})
+        await force_merge(es, params={"index": "_all", "opaque-id": "test-id", "request-timeout": 3.0, "headers": {"header1": "value1"}})
 
-        es.indices.forcemerge.assert_called_once_with(headers={"header1": "value1"},
-                                                      index="_all",
-                                                      opaque_id="test-id",
-                                                      request_timeout=3.0)
+        es.indices.forcemerge.assert_called_once_with(headers={"header1": "value1"}, index="_all", opaque_id="test-id", request_timeout=3.0)
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -1118,7 +1052,7 @@ class ForceMergeRunnerTests(TestCase):
         es.indices.forcemerge.return_value = as_future()
 
         force_merge = runner.ForceMerge()
-        await force_merge(es, params={"index" : "_all", "mode": "polling", 'poll-period': 0})
+        await force_merge(es, params={"index": "_all", "mode": "polling", "poll-period": 0})
         es.indices.forcemerge.assert_called_once_with(index="_all")
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -1126,47 +1060,41 @@ class ForceMergeRunnerTests(TestCase):
     async def test_force_merge_with_polling(self, es):
         es.indices.forcemerge.return_value = as_future(exception=elasticsearch.ConnectionTimeout())
         es.tasks.list.side_effect = [
-            as_future({
-                "nodes": {
-                    "Ap3OfntPT7qL4CBeKvamxg": {
-                        "name": "instance-0000000001",
-                        "transport_address": "10.46.79.231:19693",
-                        "host": "10.46.79.231",
-                        "ip": "10.46.79.231:19693",
-                        "roles": [
-                            "data",
-                            "ingest",
-                            "master",
-                            "remote_cluster_client",
-                            "transform"
-                        ],
-                        "attributes": {
-                            "logical_availability_zone": "zone-1",
-                            "server_name": "instance-0000000001.64cb4c66f4f24d85b41f120ef2df5526",
-                            "availability_zone": "us-east4-a",
-                            "xpack.installed": "true",
-                            "instance_configuration": "gcp.data.highio.1",
-                            "transform.node": "true",
-                            "region": "unknown-region"
-                        },
-                        "tasks": {
-                            "Ap3OfntPT7qL4CBeKvamxg:417009036": {
-                                "node": "Ap3OfntPT7qL4CBeKvamxg",
-                                "id": 417009036,
-                                "type": "transport",
-                                "action": "indices:admin/forcemerge",
-                                "start_time_in_millis": 1598018980850,
-                                "running_time_in_nanos": 3659821411,
-                                "cancellable": False,
-                                "headers": {}
-                            }
+            as_future(
+                {
+                    "nodes": {
+                        "Ap3OfntPT7qL4CBeKvamxg": {
+                            "name": "instance-0000000001",
+                            "transport_address": "10.46.79.231:19693",
+                            "host": "10.46.79.231",
+                            "ip": "10.46.79.231:19693",
+                            "roles": ["data", "ingest", "master", "remote_cluster_client", "transform"],
+                            "attributes": {
+                                "logical_availability_zone": "zone-1",
+                                "server_name": "instance-0000000001.64cb4c66f4f24d85b41f120ef2df5526",
+                                "availability_zone": "us-east4-a",
+                                "xpack.installed": "true",
+                                "instance_configuration": "gcp.data.highio.1",
+                                "transform.node": "true",
+                                "region": "unknown-region",
+                            },
+                            "tasks": {
+                                "Ap3OfntPT7qL4CBeKvamxg:417009036": {
+                                    "node": "Ap3OfntPT7qL4CBeKvamxg",
+                                    "id": 417009036,
+                                    "type": "transport",
+                                    "action": "indices:admin/forcemerge",
+                                    "start_time_in_millis": 1598018980850,
+                                    "running_time_in_nanos": 3659821411,
+                                    "cancellable": False,
+                                    "headers": {},
+                                }
+                            },
                         }
                     }
                 }
-            }),
-            as_future({
-                "nodes": {}
-            })
+            ),
+            as_future({"nodes": {}}),
         ]
         force_merge = runner.ForceMerge()
         await force_merge(es, params={"index": "_all", "mode": "polling", "poll-period": 0})
@@ -1177,52 +1105,54 @@ class ForceMergeRunnerTests(TestCase):
     async def test_force_merge_with_polling_and_params(self, es):
         es.indices.forcemerge.return_value = as_future(exception=elasticsearch.ConnectionTimeout())
         es.tasks.list.side_effect = [
-            as_future({
-                "nodes": {
-                    "Ap3OfntPT7qL4CBeKvamxg": {
-                        "name": "instance-0000000001",
-                        "transport_address": "10.46.79.231:19693",
-                        "host": "10.46.79.231",
-                        "ip": "10.46.79.231:19693",
-                        "roles": [
-                            "data",
-                            "ingest",
-                            "master",
-                            "remote_cluster_client",
-                            "transform"
-                        ],
-                        "attributes": {
-                            "logical_availability_zone": "zone-1",
-                            "server_name": "instance-0000000001.64cb4c66f4f24d85b41f120ef2df5526",
-                            "availability_zone": "us-east4-a",
-                            "xpack.installed": "true",
-                            "instance_configuration": "gcp.data.highio.1",
-                            "transform.node": "true",
-                            "region": "unknown-region"
-                        },
-                        "tasks": {
-                            "Ap3OfntPT7qL4CBeKvamxg:417009036": {
-                                "node": "Ap3OfntPT7qL4CBeKvamxg",
-                                "id": 417009036,
-                                "type": "transport",
-                                "action": "indices:admin/forcemerge",
-                                "start_time_in_millis": 1598018980850,
-                                "running_time_in_nanos": 3659821411,
-                                "cancellable": False,
-                                "headers": {}
-                            }
+            as_future(
+                {
+                    "nodes": {
+                        "Ap3OfntPT7qL4CBeKvamxg": {
+                            "name": "instance-0000000001",
+                            "transport_address": "10.46.79.231:19693",
+                            "host": "10.46.79.231",
+                            "ip": "10.46.79.231:19693",
+                            "roles": ["data", "ingest", "master", "remote_cluster_client", "transform"],
+                            "attributes": {
+                                "logical_availability_zone": "zone-1",
+                                "server_name": "instance-0000000001.64cb4c66f4f24d85b41f120ef2df5526",
+                                "availability_zone": "us-east4-a",
+                                "xpack.installed": "true",
+                                "instance_configuration": "gcp.data.highio.1",
+                                "transform.node": "true",
+                                "region": "unknown-region",
+                            },
+                            "tasks": {
+                                "Ap3OfntPT7qL4CBeKvamxg:417009036": {
+                                    "node": "Ap3OfntPT7qL4CBeKvamxg",
+                                    "id": 417009036,
+                                    "type": "transport",
+                                    "action": "indices:admin/forcemerge",
+                                    "start_time_in_millis": 1598018980850,
+                                    "running_time_in_nanos": 3659821411,
+                                    "cancellable": False,
+                                    "headers": {},
+                                }
+                            },
                         }
                     }
                 }
-            }),
-            as_future({
-                "nodes": {}
-            })
+            ),
+            as_future({"nodes": {}}),
         ]
         force_merge = runner.ForceMerge()
         # request-timeout should be ignored as mode:polling
-        await force_merge(es, params={"index" : "_all", "mode": "polling", "max-num-segments": 1,
-                                      "request-timeout": 50000, "poll-period": 0})
+        await force_merge(
+            es,
+            params={
+                "index": "_all",
+                "mode": "polling",
+                "max-num-segments": 1,
+                "request-timeout": 50000,
+                "poll-period": 0,
+            },
+        )
         es.indices.forcemerge.assert_called_once_with(index="_all", max_num_segments=1, request_timeout=50000)
 
 
@@ -1244,118 +1174,128 @@ class IndicesStatsRunnerTests(TestCase):
     async def test_indices_stats_with_timeout_and_headers(self, es):
         es.indices.stats.return_value = as_future({})
         indices_stats = runner.IndicesStats()
-        result = await indices_stats(es, params={"request-timeout": 3.0,
-                                                 "headers": {"header1": "value1"},
-                                                 "opaque-id": "test-id1"})
+        result = await indices_stats(
+            es,
+            params={
+                "request-timeout": 3.0,
+                "headers": {"header1": "value1"},
+                "opaque-id": "test-id1",
+            },
+        )
         self.assertEqual(1, result["weight"])
         self.assertEqual("ops", result["unit"])
         self.assertTrue(result["success"])
 
-        es.indices.stats.assert_called_once_with(index="_all",
-                                                 metric="_all",
-                                                 headers={"header1": "value1"},
-                                                 opaque_id="test-id1",
-                                                 request_timeout=3.0)
+        es.indices.stats.assert_called_once_with(
+            index="_all", metric="_all", headers={"header1": "value1"}, opaque_id="test-id1", request_timeout=3.0
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_indices_stats_with_failed_condition(self, es):
-        es.indices.stats.return_value = as_future({
-            "_all": {
-                "total": {
-                    "merges": {
-                        "current": 2,
-                        "current_docs": 292698,
+        es.indices.stats.return_value = as_future(
+            {
+                "_all": {
+                    "total": {
+                        "merges": {
+                            "current": 2,
+                            "current_docs": 292698,
+                        }
                     }
                 }
             }
-        })
+        )
 
         indices_stats = runner.IndicesStats()
 
-        result = await indices_stats(es, params={
-            "index": "logs-*",
-            "condition": {
-                "path": "_all.total.merges.current",
-                "expected-value": 0
-            }
-        })
+        result = await indices_stats(
+            es, params={"index": "logs-*", "condition": {"path": "_all.total.merges.current", "expected-value": 0}}
+        )
         self.assertEqual(1, result["weight"])
         self.assertEqual("ops", result["unit"])
         self.assertFalse(result["success"])
-        self.assertDictEqual({
-            "path": "_all.total.merges.current",
-            "actual-value": "2",
-            "expected-value": "0"
-        }, result["condition"])
+        self.assertDictEqual(
+            {
+                "path": "_all.total.merges.current",
+                "actual-value": "2",
+                "expected-value": "0",
+            },
+            result["condition"],
+        )
 
         es.indices.stats.assert_called_once_with(index="logs-*", metric="_all")
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_indices_stats_with_successful_condition(self, es):
-        es.indices.stats.return_value = as_future({
-            "_all": {
-                "total": {
-                    "merges": {
-                        "current": 0,
-                        "current_docs": 292698,
+        es.indices.stats.return_value = as_future(
+            {
+                "_all": {
+                    "total": {
+                        "merges": {
+                            "current": 0,
+                            "current_docs": 292698,
+                        }
                     }
                 }
             }
-        })
+        )
 
         indices_stats = runner.IndicesStats()
 
-        result = await indices_stats(es, params={
-            "index": "logs-*",
-            "condition": {
-                "path": "_all.total.merges.current",
-                "expected-value": 0
-            }
-        })
+        result = await indices_stats(
+            es,
+            params={
+                "index": "logs-*",
+                "condition": {
+                    "path": "_all.total.merges.current",
+                    "expected-value": 0,
+                },
+            },
+        )
         self.assertEqual(1, result["weight"])
         self.assertEqual("ops", result["unit"])
         self.assertTrue(result["success"])
-        self.assertDictEqual({
-            "path": "_all.total.merges.current",
-            "actual-value": "0",
-            "expected-value": "0"
-        }, result["condition"])
+        self.assertDictEqual(
+            {
+                "path": "_all.total.merges.current",
+                "actual-value": "0",
+                "expected-value": "0",
+            },
+            result["condition"],
+        )
 
         es.indices.stats.assert_called_once_with(index="logs-*", metric="_all")
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_indices_stats_with_non_existing_path(self, es):
-        es.indices.stats.return_value = as_future({
-            "indices": {
-                "total": {
-                    "docs": {
-                        "current": 0
-                    }
-                }
-            }
-        })
+        es.indices.stats.return_value = as_future({"indices": {"total": {"docs": {"current": 0}}}})
 
         indices_stats = runner.IndicesStats()
 
-        result = await indices_stats(es, params={
-            "index": "logs-*",
-            "condition": {
-                # non-existing path
-                "path": "indices.my_index.total.docs.count",
-                "expected-value": 0
-            }
-        })
+        result = await indices_stats(
+            es,
+            params={
+                "index": "logs-*",
+                "condition": {
+                    # non-existing path
+                    "path": "indices.my_index.total.docs.count",
+                    "expected-value": 0,
+                },
+            },
+        )
         self.assertEqual(1, result["weight"])
         self.assertEqual("ops", result["unit"])
         self.assertFalse(result["success"])
-        self.assertDictEqual({
-            "path": "indices.my_index.total.docs.count",
-            "actual-value": None,
-            "expected-value": "0"
-        }, result["condition"])
+        self.assertDictEqual(
+            {
+                "path": "indices.my_index.total.docs.count",
+                "actual-value": None,
+                "expected-value": "0",
+            },
+            result["condition"],
+        )
 
         es.indices.stats.assert_called_once_with(index="logs-*", metric="_all")
 
@@ -1370,17 +1310,13 @@ class QueryRunnerTests(TestCase):
             "hits": {
                 "total": {
                     "value": 1,
-                    "relation": "gte"
+                    "relation": "gte",
                 },
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
 
@@ -1392,9 +1328,9 @@ class QueryRunnerTests(TestCase):
             "cache": True,
             "body": {
                 "query": {
-                    "match_all": {}
-                }
-            }
+                    "match_all": {},
+                },
+            },
         }
 
         async with query_runner:
@@ -1409,11 +1345,7 @@ class QueryRunnerTests(TestCase):
         self.assertFalse("error-type" in result)
 
         es.transport.perform_request.assert_called_once_with(
-            "GET",
-            "/_all/_search",
-            params={"request_cache": "true"},
-            body=params["body"],
-            headers=None
+            "GET", "/_all/_search", params={"request_cache": "true"}, body=params["body"], headers=None
         )
         es.clear_scroll.assert_not_called()
 
@@ -1424,19 +1356,12 @@ class QueryRunnerTests(TestCase):
             "timed_out": False,
             "took": 5,
             "hits": {
-                "total": {
-                    "value": 1,
-                    "relation": "gte"
-                },
+                "total": {"value": 1, "relation": "gte"},
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
 
@@ -1449,11 +1374,7 @@ class QueryRunnerTests(TestCase):
             "request-timeout": 3.0,
             "headers": {"header1": "value1"},
             "opaque-id": "test-id1",
-            "body": {
-                "query": {
-                    "match_all": {}
-                }
-            }
+            "body": {"query": {"match_all": {}}},
         }
 
         async with query_runner:
@@ -1472,7 +1393,7 @@ class QueryRunnerTests(TestCase):
             "/_all/_search",
             params={"request_timeout": 3.0, "request_cache": "true"},
             body=params["body"],
-            headers={"header1": "value1", "x-opaque-id": "test-id1"}
+            headers={"header1": "value1", "x-opaque-id": "test-id1"},
         )
         es.clear_scroll.assert_not_called()
 
@@ -1485,18 +1406,13 @@ class QueryRunnerTests(TestCase):
             "hits": {
                 "total": {
                     "value": 2,
-                    "relation": "eq"
+                    "relation": "eq",
                 },
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(response)))
 
@@ -1507,8 +1423,8 @@ class QueryRunnerTests(TestCase):
             "detailed-results": True,
             "body": None,
             "request-params": {
-                "q": "user:kimchy"
-            }
+                "q": "user:kimchy",
+            },
         }
 
         async with query_runner:
@@ -1527,10 +1443,10 @@ class QueryRunnerTests(TestCase):
             "/_all/_search",
             params={
                 "request_cache": "false",
-                "q": "user:kimchy"
+                "q": "user:kimchy",
             },
             body=params["body"],
-            headers=None
+            headers=None,
         )
         es.clear_scroll.assert_not_called()
 
@@ -1543,18 +1459,13 @@ class QueryRunnerTests(TestCase):
             "hits": {
                 "total": {
                     "value": 2,
-                    "relation": "eq"
+                    "relation": "eq",
                 },
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(response)))
 
@@ -1562,10 +1473,8 @@ class QueryRunnerTests(TestCase):
         params = {
             "index": "_all",
             "body": None,
-            "request-params": {
-                "q": "user:kimchy"
-            },
-            "detailed-results": False
+            "request-params": {"q": "user:kimchy"},
+            "detailed-results": False,
         }
 
         async with query_runner:
@@ -1582,9 +1491,11 @@ class QueryRunnerTests(TestCase):
         es.transport.perform_request.assert_called_once_with(
             "GET",
             "/_all/_search",
-            params={"q": "user:kimchy"},
+            params={
+                "q": "user:kimchy",
+            },
             body=params["body"],
-            headers=None
+            headers=None,
         )
         es.clear_scroll.assert_not_called()
 
@@ -1597,14 +1508,10 @@ class QueryRunnerTests(TestCase):
             "hits": {
                 "total": 2,
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
 
@@ -1616,9 +1523,9 @@ class QueryRunnerTests(TestCase):
             "detailed-results": True,
             "body": {
                 "query": {
-                    "match_all": {}
-                }
-            }
+                    "match_all": {},
+                },
+            },
         }
 
         async with query_runner:
@@ -1636,10 +1543,10 @@ class QueryRunnerTests(TestCase):
             "GET",
             "/_all/_search",
             params={
-                "request_cache": "true"
+                "request_cache": "true",
             },
             body=params["body"],
-            headers=None
+            headers=None,
         )
         es.clear_scroll.assert_not_called()
 
@@ -1652,17 +1559,13 @@ class QueryRunnerTests(TestCase):
             "hits": {
                 "total": {
                     "value": 2,
-                    "relation": "eq"
+                    "relation": "eq",
                 },
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
 
@@ -1674,9 +1577,9 @@ class QueryRunnerTests(TestCase):
             "response-compression-enabled": False,
             "body": {
                 "query": {
-                    "match_all": {}
-                }
-            }
+                    "match_all": {},
+                },
+            },
         }
 
         async with query_runner:
@@ -1695,7 +1598,9 @@ class QueryRunnerTests(TestCase):
             "/unittest/_search",
             params={},
             body=params["body"],
-            headers={"Accept-Encoding": "identity"}
+            headers={
+                "Accept-Encoding": "identity",
+            },
         )
         es.clear_scroll.assert_not_called()
 
@@ -1706,19 +1611,12 @@ class QueryRunnerTests(TestCase):
             "timed_out": False,
             "took": 5,
             "hits": {
-                "total": {
-                    "value": 2,
-                    "relation": "eq"
-                },
+                "total": {"value": 2, "relation": "eq"},
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
 
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
@@ -1732,9 +1630,9 @@ class QueryRunnerTests(TestCase):
             "cache": None,
             "body": {
                 "query": {
-                    "match_all": {}
-                }
-            }
+                    "match_all": {},
+                },
+            },
         }
 
         async with query_runner:
@@ -1749,10 +1647,11 @@ class QueryRunnerTests(TestCase):
         self.assertFalse("error-type" in result)
 
         es.transport.perform_request.assert_called_once_with(
-            "GET", "/unittest/type/_search",
+            "GET",
+            "/unittest/type/_search",
             body=params["body"],
             params={},
-            headers=None
+            headers=None,
         )
         es.clear_scroll.assert_not_called()
 
@@ -1765,19 +1664,12 @@ class QueryRunnerTests(TestCase):
             "took": 4,
             "timed_out": False,
             "hits": {
-                "total": {
-                    "value": 2,
-                    "relation": "eq"
-                },
+                "total": {"value": 2, "relation": "eq"},
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
 
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
@@ -1792,9 +1684,9 @@ class QueryRunnerTests(TestCase):
             "cache": True,
             "body": {
                 "query": {
-                    "match_all": {}
-                }
-            }
+                    "match_all": {},
+                },
+            },
         }
 
         async with query_runner:
@@ -1812,9 +1704,14 @@ class QueryRunnerTests(TestCase):
         es.transport.perform_request.assert_called_once_with(
             "GET",
             "/unittest/_search",
-            params={"request_cache": "true", "sort": "_doc", "scroll": "10s", "size": 100},
+            params={
+                "request_cache": "true",
+                "sort": "_doc",
+                "scroll": "10s",
+                "size": 100,
+            },
             body=params["body"],
-            headers=None
+            headers=None,
         )
         es.clear_scroll.assert_called_once_with(body={"scroll_id": ["some-scroll-id"]})
 
@@ -1827,19 +1724,12 @@ class QueryRunnerTests(TestCase):
             "took": 4,
             "timed_out": False,
             "hits": {
-                "total": {
-                    "value": 2,
-                    "relation": "eq"
-                },
+                "total": {"value": 2, "relation": "eq"},
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
 
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
@@ -1854,9 +1744,9 @@ class QueryRunnerTests(TestCase):
             "response-compression-enabled": False,
             "body": {
                 "query": {
-                    "match_all": {}
-                }
-            }
+                    "match_all": {},
+                },
+            },
         }
 
         async with query_runner:
@@ -1876,7 +1766,7 @@ class QueryRunnerTests(TestCase):
             "/unittest/_search",
             params={"sort": "_doc", "scroll": "10s", "size": 100},
             body=params["body"],
-            headers={"Accept-Encoding": "identity"}
+            headers={"Accept-Encoding": "identity"},
         )
         es.clear_scroll.assert_called_once_with(body={"scroll_id": ["some-scroll-id"]})
 
@@ -1889,19 +1779,12 @@ class QueryRunnerTests(TestCase):
             "took": 4,
             "timed_out": False,
             "hits": {
-                "total": {
-                    "value": 2,
-                    "relation": "eq"
-                },
+                "total": {"value": 2, "relation": "eq"},
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
 
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
@@ -1915,9 +1798,9 @@ class QueryRunnerTests(TestCase):
             "results-per-page": 100,
             "body": {
                 "query": {
-                    "match_all": {}
-                }
-            }
+                    "match_all": {},
+                },
+            },
         }
 
         async with query_runner:
@@ -1935,9 +1818,13 @@ class QueryRunnerTests(TestCase):
         es.transport.perform_request.assert_called_once_with(
             "GET",
             "/_all/_search",
-            params={"sort": "_doc", "scroll": "10s", "size": 100},
+            params={
+                "sort": "_doc",
+                "scroll": "10s",
+                "size": 100,
+            },
             body=params["body"],
-            headers=None
+            headers=None,
         )
 
         es.clear_scroll.assert_called_once_with(body={"scroll_id": ["some-scroll-id"]})
@@ -1954,17 +1841,13 @@ class QueryRunnerTests(TestCase):
                 "total": {
                     # includes all hits across all pages
                     "value": 3,
-                    "relation": "eq"
+                    "relation": "eq",
                 },
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                ],
+            },
         }
 
         # page 2
@@ -1974,16 +1857,14 @@ class QueryRunnerTests(TestCase):
             "took": 25,
             "hits": {
                 "hits": [
-                    {
-                        "title": "some-doc-3"
-                    }
-                ]
-            }
+                    {"title": "some-doc-3"},
+                ],
+            },
         }
 
         es.transport.perform_request.side_effect = [
             as_future(io.StringIO(json.dumps(search_response))),
-            as_future(io.StringIO(json.dumps(scroll_response)))
+            as_future(io.StringIO(json.dumps(scroll_response))),
         ]
 
         es.clear_scroll.return_value = as_future(io.StringIO('{"acknowledged": true}'))
@@ -1997,9 +1878,9 @@ class QueryRunnerTests(TestCase):
             "cache": False,
             "body": {
                 "query": {
-                    "match_all": {}
-                }
-            }
+                    "match_all": {},
+                },
+            },
         }
 
         async with query_runner:
@@ -2025,16 +1906,11 @@ class QueryRunnerTests(TestCase):
             "timed_out": False,
             "took": 53,
             "hits": {
-                "total": {
-                    "value": 1,
-                    "relation": "eq"
-                },
+                "total": {"value": 1, "relation": "eq"},
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                ],
+            },
         }
 
         es.transport.perform_request.return_value = as_future(io.StringIO(json.dumps(search_response)))
@@ -2049,9 +1925,9 @@ class QueryRunnerTests(TestCase):
             "cache": False,
             "body": {
                 "query": {
-                    "match_all": {}
-                }
-            }
+                    "match_all": {},
+                },
+            },
         }
 
         async with query_runner:
@@ -2076,25 +1952,14 @@ class QueryRunnerTests(TestCase):
             "timed_out": False,
             "took": 876,
             "hits": {
-                "total": {
-                    "value": 4,
-                    "relation": "gte"
-                },
+                "total": {"value": 4, "relation": "gte"},
                 "hits": [
-                    {
-                        "title": "some-doc-1"
-                    },
-                    {
-                        "title": "some-doc-2"
-                    },
-                    {
-                        "title": "some-doc-3"
-                    },
-                    {
-                        "title": "some-doc-4"
-                    }
-                ]
-            }
+                    {"title": "some-doc-1"},
+                    {"title": "some-doc-2"},
+                    {"title": "some-doc-3"},
+                    {"title": "some-doc-4"},
+                ],
+            },
         }
 
         # page 2 has no results
@@ -2103,13 +1968,13 @@ class QueryRunnerTests(TestCase):
             "timed_out": False,
             "took": 2,
             "hits": {
-                "hits": []
-            }
+                "hits": [],
+            },
         }
 
         es.transport.perform_request.side_effect = [
             as_future(io.StringIO(json.dumps(search_response))),
-            as_future(io.StringIO(json.dumps(scroll_response)))
+            as_future(io.StringIO(json.dumps(scroll_response))),
         ]
         es.clear_scroll.return_value = as_future(io.StringIO('{"acknowledged": true}'))
 
@@ -2122,9 +1987,9 @@ class QueryRunnerTests(TestCase):
             "cache": False,
             "body": {
                 "query": {
-                    "match_all": {}
-                }
-            }
+                    "match_all": {},
+                },
+            },
         }
 
         async with query_runner:
@@ -2156,13 +2021,10 @@ class PutPipelineRunnerTests(TestCase):
                 "description": "describe pipeline",
                 "processors": [
                     {
-                        "set": {
-                            "field": "foo",
-                            "value": "bar"
-                        }
-                    }
-                ]
-            }
+                        "set": {"field": "foo", "value": "bar"},
+                    },
+                ],
+            },
         }
 
         await r(es, params)
@@ -2176,12 +2038,12 @@ class PutPipelineRunnerTests(TestCase):
 
         r = runner.PutPipeline()
 
-        params = {
-            "id": "rename"
-        }
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'put-pipeline' did not provide the mandatory parameter 'body'. "
-                                    "Add it to your parameter source and try again."):
+        params = {"id": "rename"}
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'put-pipeline' did not provide the mandatory parameter 'body'. "
+            "Add it to your parameter source and try again.",
+        ):
             await r(es, params)
 
         self.assertEqual(0, es.ingest.put_pipeline.call_count)
@@ -2193,12 +2055,12 @@ class PutPipelineRunnerTests(TestCase):
 
         r = runner.PutPipeline()
 
-        params = {
-            "body": {}
-        }
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'put-pipeline' did not provide the mandatory parameter 'id'. "
-                                    "Add it to your parameter source and try again."):
+        params = {"body": {}}
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'put-pipeline' did not provide the mandatory parameter 'id'. "
+            "Add it to your parameter source and try again.",
+        ):
             await r(es, params)
 
         self.assertEqual(0, es.ingest.put_pipeline.call_count)
@@ -2208,144 +2070,128 @@ class ClusterHealthRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_waits_for_expected_cluster_status(self, es):
-        es.cluster.health.return_value = as_future({
-            "status": "green",
-            "relocating_shards": 0
-        })
+        es.cluster.health.return_value = as_future({"status": "green", "relocating_shards": 0})
         r = runner.ClusterHealth()
 
-        params = {
-            "request-params": {
-                "wait_for_status": "green"
-            }
-        }
+        params = {"request-params": {"wait_for_status": "green"}}
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": True,
-            "cluster-status": "green",
-            "relocating-shards": 0
-        }, result)
+        self.assertDictEqual(
+            {
+                "weight": 1,
+                "unit": "ops",
+                "success": True,
+                "cluster-status": "green",
+                "relocating-shards": 0,
+            },
+            result,
+        )
 
         es.cluster.health.assert_called_once_with(params={"wait_for_status": "green"})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_accepts_better_cluster_status(self, es):
-        es.cluster.health.return_value = as_future({
-            "status": "green",
-            "relocating_shards": 0
-        })
+        es.cluster.health.return_value = as_future({"status": "green", "relocating_shards": 0})
         r = runner.ClusterHealth()
 
-        params = {
-            "request-params": {
-                "wait_for_status": "yellow"
-            }
-        }
+        params = {"request-params": {"wait_for_status": "yellow"}}
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": True,
-            "cluster-status": "green",
-            "relocating-shards": 0
-        }, result)
+        self.assertDictEqual(
+            {
+                "weight": 1,
+                "unit": "ops",
+                "success": True,
+                "cluster-status": "green",
+                "relocating-shards": 0,
+            },
+            result,
+        )
 
         es.cluster.health.assert_called_once_with(params={"wait_for_status": "yellow"})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_cluster_health_with_timeout_and_headers(self, es):
-        es.cluster.health.return_value = as_future({
-            "status": "green",
-            "relocating_shards": 0
-        })
+        es.cluster.health.return_value = as_future({"status": "green", "relocating_shards": 0})
         cluster_health_runner = runner.ClusterHealth()
 
         params = {
-            "request-params": {
-                "wait_for_status": "yellow"
-            },
+            "request-params": {"wait_for_status": "yellow"},
             "request-timeout": 3.0,
             "headers": {"header1": "value1"},
-            "opaque-id": "testid-1"
+            "opaque-id": "testid-1",
         }
 
         result = await cluster_health_runner(es, params)
 
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": True,
-            "cluster-status": "green",
-            "relocating-shards": 0
-        }, result)
+        self.assertDictEqual(
+            {
+                "weight": 1,
+                "unit": "ops",
+                "success": True,
+                "cluster-status": "green",
+                "relocating-shards": 0,
+            },
+            result,
+        )
 
-        es.cluster.health.assert_called_once_with(headers={"header1": "value1"},
-                                                  opaque_id="testid-1",
-                                                  params={"wait_for_status": "yellow"},
-                                                  request_timeout=3.0)
+        es.cluster.health.assert_called_once_with(
+            headers={"header1": "value1"}, opaque_id="testid-1", params={"wait_for_status": "yellow"}, request_timeout=3.0
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_rejects_relocating_shards(self, es):
-        es.cluster.health.return_value = as_future({
-            "status": "yellow",
-            "relocating_shards": 3
-        })
+        es.cluster.health.return_value = as_future({"status": "yellow", "relocating_shards": 3})
         r = runner.ClusterHealth()
 
         params = {
             "index": "logs-*",
             "request-params": {
                 "wait_for_status": "red",
-                "wait_for_no_relocating_shards": True
-            }
+                "wait_for_no_relocating_shards": True,
+            },
         }
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": False,
-            "cluster-status": "yellow",
-            "relocating-shards": 3
-        }, result)
+        self.assertDictEqual(
+            {
+                "weight": 1,
+                "unit": "ops",
+                "success": False,
+                "cluster-status": "yellow",
+                "relocating-shards": 3,
+            },
+            result,
+        )
 
-        es.cluster.health.assert_called_once_with(index="logs-*",
-                                                  params={"wait_for_status": "red", "wait_for_no_relocating_shards": True})
+        es.cluster.health.assert_called_once_with(index="logs-*", params={"wait_for_status": "red", "wait_for_no_relocating_shards": True})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_rejects_unknown_cluster_status(self, es):
-        es.cluster.health.return_value = as_future({
-            "status": None,
-            "relocating_shards": 0
-        })
+        es.cluster.health.return_value = as_future({"status": None, "relocating_shards": 0})
         r = runner.ClusterHealth()
 
-        params = {
-            "request-params": {
-                "wait_for_status": "green"
-            }
-        }
+        params = {"request-params": {"wait_for_status": "green"}}
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": False,
-            "cluster-status": None,
-            "relocating-shards": 0
-        }, result)
+        self.assertDictEqual(
+            {
+                "weight": 1,
+                "unit": "ops",
+                "success": False,
+                "cluster-status": None,
+                "relocating-shards": 0,
+            },
+            result,
+        )
 
         es.cluster.health.assert_called_once_with(params={"wait_for_status": "green"})
 
@@ -2358,30 +2204,26 @@ class CreateIndexRunnerTests(TestCase):
 
         r = runner.CreateIndex()
 
-        request_params = {
-            "wait_for_active_shards": "true"
-        }
+        request_params = {"wait_for_active_shards": "true"}
 
         params = {
             "indices": [
                 ("indexA", {"settings": {}}),
                 ("indexB", {"settings": {}}),
             ],
-            "request-params": request_params
+            "request-params": request_params,
         }
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 2,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 2, "unit": "ops", "success": True}, result)
 
-        es.indices.create.assert_has_calls([
-            mock.call(index="indexA", body={"settings": {}}, params=request_params),
-            mock.call(index="indexB", body={"settings": {}}, params=request_params)
-        ])
+        es.indices.create.assert_has_calls(
+            [
+                mock.call(index="indexA", body={"settings": {}}, params=request_params),
+                mock.call(index="indexB", body={"settings": {}}, params=request_params),
+            ]
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -2390,9 +2232,7 @@ class CreateIndexRunnerTests(TestCase):
 
         create_index_runner = runner.CreateIndex()
 
-        request_params = {
-            "wait_for_active_shards": "true"
-        }
+        request_params = {"wait_for_active_shards": "true"}
 
         params = {
             "indices": [
@@ -2401,24 +2241,21 @@ class CreateIndexRunnerTests(TestCase):
             "request-timeout": 3.0,
             "headers": {"header1": "value1"},
             "opaque-id": "test-id1",
-            "request-params": request_params
+            "request-params": request_params,
         }
 
         result = await create_index_runner(es, params)
 
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 1, "unit": "ops", "success": True}, result)
 
-
-        es.indices.create.assert_called_once_with(index="indexA",
-                                                  body={"settings": {}},
-                                                  headers={"header1": "value1"},
-                                                  opaque_id="test-id1",
-                                                  params={"wait_for_active_shards": "true"},
-                                                  request_timeout=3.0)
+        es.indices.create.assert_called_once_with(
+            index="indexA",
+            body={"settings": {}},
+            headers={"header1": "value1"},
+            opaque_id="test-id1",
+            params={"wait_for_active_shards": "true"},
+            request_timeout=3.0,
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -2427,9 +2264,7 @@ class CreateIndexRunnerTests(TestCase):
 
         r = runner.CreateIndex()
 
-        request_params = {
-            "wait_for_active_shards": "true"
-        }
+        request_params = {"wait_for_active_shards": "true"}
 
         params = {
             "indices": [
@@ -2437,20 +2272,14 @@ class CreateIndexRunnerTests(TestCase):
             ],
             "index": "SHOULD-NOT-BE-PASSED",
             "body": "SHOULD-NOT-BE-PASSED",
-            "request-params": request_params
+            "request-params": request_params,
         }
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 1, "unit": "ops", "success": True}, result)
 
-        es.indices.create.assert_called_once_with(index="indexA",
-                                                  body={"settings": {}},
-                                                  params={"wait_for_active_shards": "true"})
+        es.indices.create.assert_called_once_with(index="indexA", body={"settings": {}}, params={"wait_for_active_shards": "true"})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -2460,9 +2289,11 @@ class CreateIndexRunnerTests(TestCase):
         r = runner.CreateIndex()
 
         params = {}
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'create-index' did not provide the mandatory parameter 'indices'. "
-                                    "Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'create-index' did not provide the mandatory parameter 'indices'. "
+            "Add it to your parameter source and try again.",
+        ):
             await r(es, params)
 
         self.assertEqual(0, es.indices.create.call_count)
@@ -2476,30 +2307,26 @@ class CreateDataStreamRunnerTests(TestCase):
 
         r = runner.CreateDataStream()
 
-        request_params = {
-            "wait_for_active_shards": "true"
-        }
+        request_params = {"wait_for_active_shards": "true"}
 
         params = {
             "data-streams": [
                 "data-stream-A",
-                "data-stream-B"
+                "data-stream-B",
             ],
-            "request-params": request_params
+            "request-params": request_params,
         }
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 2,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 2, "unit": "ops", "success": True}, result)
 
-        es.indices.create_data_stream.assert_has_calls([
-            mock.call("data-stream-A", params=request_params),
-            mock.call("data-stream-B", params=request_params)
-        ])
+        es.indices.create_data_stream.assert_has_calls(
+            [
+                mock.call("data-stream-A", params=request_params),
+                mock.call("data-stream-B", params=request_params),
+            ]
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -2509,9 +2336,11 @@ class CreateDataStreamRunnerTests(TestCase):
         r = runner.CreateDataStream()
 
         params = {}
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'create-data-stream' did not provide the "
-                                    "mandatory parameter 'data-streams'. Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'create-data-stream' did not provide the "
+            "mandatory parameter 'data-streams'. Add it to your parameter source and try again.",
+        ):
             await r(es, params)
 
         self.assertEqual(0, es.indices.create_data_stream.call_count)
@@ -2523,28 +2352,22 @@ class DeleteIndexRunnerTests(TestCase):
     async def test_deletes_existing_indices(self, es):
         es.indices.exists.side_effect = [as_future(False), as_future(True)]
         es.indices.delete.return_value = as_future()
-        es.cluster.get_settings.return_value = as_future({"persistent": {},
-                                                          "transient": {"action.destructive_requires_name": True}})
+        es.cluster.get_settings.return_value = as_future({"persistent": {}, "transient": {"action.destructive_requires_name": True}})
         es.cluster.put_settings.return_value = as_future()
         r = runner.DeleteIndex()
 
-        params = {
-            "indices": ["indexA", "indexB"],
-            "only-if-exists": True
-        }
+        params = {"indices": ["indexA", "indexB"], "only-if-exists": True}
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 1, "unit": "ops", "success": True}, result)
 
-        es.cluster.put_settings.assert_has_calls([
-            mock.call(body={"transient": {"action.destructive_requires_name": False}}),
-            mock.call(body={"transient": {"action.destructive_requires_name": True}})
-        ])
+        es.cluster.put_settings.assert_has_calls(
+            [
+                mock.call(body={"transient": {"action.destructive_requires_name": False}}),
+                mock.call(body={"transient": {"action.destructive_requires_name": True}}),
+            ]
+        )
         es.indices.delete.assert_called_once_with(index="indexB", params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -2558,28 +2381,22 @@ class DeleteIndexRunnerTests(TestCase):
         params = {
             "indices": ["indexA", "indexB"],
             "only-if-exists": False,
-            "request-params": {
-                "ignore_unavailable": "true",
-                "expand_wildcards": "none"
-            }
+            "request-params": {"ignore_unavailable": "true", "expand_wildcards": "none"},
         }
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 2,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 2, "unit": "ops", "success": True}, result)
 
-        es.cluster.put_settings.assert_has_calls([
-            mock.call(body={"transient": {"action.destructive_requires_name": False}}),
-            mock.call(body={"transient": {"action.destructive_requires_name": None}})
-        ])
-        es.indices.delete.assert_has_calls([
-            mock.call(index="indexA", params=params["request-params"]),
-            mock.call(index="indexB", params=params["request-params"])
-        ])
+        es.cluster.put_settings.assert_has_calls(
+            [
+                mock.call(body={"transient": {"action.destructive_requires_name": False}}),
+                mock.call(body={"transient": {"action.destructive_requires_name": None}}),
+            ]
+        )
+        es.indices.delete.assert_has_calls(
+            [mock.call(index="indexA", params=params["request-params"]), mock.call(index="indexB", params=params["request-params"])]
+        )
         self.assertEqual(0, es.indices.exists.call_count)
 
 
@@ -2592,19 +2409,11 @@ class DeleteDataStreamRunnerTests(TestCase):
 
         r = runner.DeleteDataStream()
 
-        params = {
-            "data-streams": ["data-stream-A", "data-stream-B"],
-            "only-if-exists": True,
-            "request-params": {}
-        }
+        params = {"data-streams": ["data-stream-A", "data-stream-B"], "only-if-exists": True, "request-params": {}}
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 1, "unit": "ops", "success": True}, result)
 
         es.indices.delete_data_stream.assert_called_once_with("data-stream-B", params={})
 
@@ -2618,24 +2427,19 @@ class DeleteDataStreamRunnerTests(TestCase):
         params = {
             "data-streams": ["data-stream-A", "data-stream-B"],
             "only-if-exists": False,
-            "request-params": {
-                "ignore_unavailable": "true",
-                "expand_wildcards": "none"
-            }
+            "request-params": {"ignore_unavailable": "true", "expand_wildcards": "none"},
         }
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 2,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 2, "unit": "ops", "success": True}, result)
 
-        es.indices.delete_data_stream.assert_has_calls([
-            mock.call("data-stream-A", ignore=[404], params=params["request-params"]),
-            mock.call("data-stream-B", ignore=[404], params=params["request-params"])
-        ])
+        es.indices.delete_data_stream.assert_has_calls(
+            [
+                mock.call("data-stream-A", ignore=[404], params=params["request-params"]),
+                mock.call("data-stream-B", ignore=[404], params=params["request-params"]),
+            ]
+        )
         self.assertEqual(0, es.indices.exists.call_count)
 
 
@@ -2652,24 +2456,19 @@ class CreateIndexTemplateRunnerTests(TestCase):
                 ("templateA", {"settings": {}}),
                 ("templateB", {"settings": {}}),
             ],
-            "request-params": {
-                "timeout": 50,
-                "create": "true"
-            }
+            "request-params": {"timeout": 50, "create": "true"},
         }
 
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 2,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 2, "unit": "ops", "success": True}, result)
 
-        es.indices.put_template.assert_has_calls([
-            mock.call(name="templateA", body={"settings": {}}, params=params["request-params"]),
-            mock.call(name="templateB", body={"settings": {}}, params=params["request-params"])
-        ])
+        es.indices.put_template.assert_has_calls(
+            [
+                mock.call(name="templateA", body={"settings": {}}, params=params["request-params"]),
+                mock.call(name="templateB", body={"settings": {}}, params=params["request-params"]),
+            ]
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -2679,9 +2478,11 @@ class CreateIndexTemplateRunnerTests(TestCase):
         r = runner.CreateIndexTemplate()
 
         params = {}
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'create-index-template' did not provide the mandatory parameter "
-                                    "'templates'. Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'create-index-template' did not provide the mandatory parameter "
+            "'templates'. Add it to your parameter source and try again.",
+        ):
             await r(es, params)
 
         self.assertEqual(0, es.indices.put_template.call_count)
@@ -2701,23 +2502,16 @@ class DeleteIndexTemplateRunnerTests(TestCase):
                 ("templateA", False, None),
                 ("templateB", True, "logs-*"),
             ],
-            "request-params": {
-                "timeout": 60
-            }
+            "request-params": {"timeout": 60},
         }
         result = await r(es, params)
 
         # 2 times delete index template, one time delete matching indices
-        self.assertDictEqual({
-            "weight": 3,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 3, "unit": "ops", "success": True}, result)
 
-        es.indices.delete_template.assert_has_calls([
-            mock.call(name="templateA", params=params["request-params"]),
-            mock.call(name="templateB", params=params["request-params"])
-        ])
+        es.indices.delete_template.assert_has_calls(
+            [mock.call(name="templateA", params=params["request-params"]), mock.call(name="templateB", params=params["request-params"])]
+        )
         es.indices.delete.assert_called_once_with(index="logs-*")
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -2734,19 +2528,13 @@ class DeleteIndexTemplateRunnerTests(TestCase):
                 # will not accidentally delete all indices
                 ("templateB", True, ""),
             ],
-            "request-params": {
-                "timeout": 60
-            },
-            "only-if-exists": True
+            "request-params": {"timeout": 60},
+            "only-if-exists": True,
         }
         result = await r(es, params)
 
         # 2 times delete index template, one time delete matching indices
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 1, "unit": "ops", "success": True}, result)
 
         es.indices.delete_template.assert_called_once_with(name="templateB", params=params["request-params"])
         # not called because the matching index is empty.
@@ -2758,9 +2546,11 @@ class DeleteIndexTemplateRunnerTests(TestCase):
         r = runner.DeleteIndexTemplate()
 
         params = {}
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'delete-index-template' did not provide the mandatory parameter "
-                                    "'templates'. Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'delete-index-template' did not provide the mandatory parameter "
+            "'templates'. Add it to your parameter source and try again.",
+        ):
             await r(es, params)
 
         self.assertEqual(0, es.indices.delete_template.call_count)
@@ -2774,27 +2564,28 @@ class CreateComponentTemplateRunnerTests(TestCase):
         r = runner.CreateComponentTemplate()
         params = {
             "templates": [
-                ("templateA", {"template":{"mappings":{"properties":{"@timestamp":{"type": "date"}}}}}),
-                ("templateB", {"template":{"settings": {"index.number_of_shards": 1,"index.number_of_replicas": 1}}}),
+                ("templateA", {"template": {"mappings": {"properties": {"@timestamp": {"type": "date"}}}}}),
+                ("templateB", {"template": {"settings": {"index.number_of_shards": 1, "index.number_of_replicas": 1}}}),
             ],
-            "request-params": {
-                "timeout": 50,
-                "create": "true"
-            }
+            "request-params": {"timeout": 50, "create": "true"},
         }
 
         result = await r(es, params)
-        self.assertDictEqual({
-            "weight": 2,
-            "unit": "ops",
-            "success": True
-        }, result)
-        es.cluster.put_component_template.assert_has_calls([
-            mock.call(name="templateA", body={"template":{"mappings":{"properties":{"@timestamp":{"type": "date"}}}}},
-                      params=params["request-params"]),
-            mock.call(name="templateB", body={"template":{"settings": {"index.number_of_shards": 1,"index.number_of_replicas": 1}}},
-                      params=params["request-params"])
-        ])
+        self.assertDictEqual({"weight": 2, "unit": "ops", "success": True}, result)
+        es.cluster.put_component_template.assert_has_calls(
+            [
+                mock.call(
+                    name="templateA",
+                    body={"template": {"mappings": {"properties": {"@timestamp": {"type": "date"}}}}},
+                    params=params["request-params"],
+                ),
+                mock.call(
+                    name="templateB",
+                    body={"template": {"settings": {"index.number_of_shards": 1, "index.number_of_replicas": 1}}},
+                    params=params["request-params"],
+                ),
+            ]
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -2804,9 +2595,11 @@ class CreateComponentTemplateRunnerTests(TestCase):
         r = runner.CreateComponentTemplate()
 
         params = {}
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'create-component-template' did not provide the mandatory parameter "
-                                    "'templates'. Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'create-component-template' did not provide the mandatory parameter "
+            "'templates'. Add it to your parameter source and try again.",
+        ):
             await r(es, params)
 
         self.assertEqual(0, es.cluster.put_component_template.call_count)
@@ -2826,27 +2619,22 @@ class DeleteComponentTemplateRunnerTests(TestCase):
                 "templateA",
                 "templateB",
             ],
-            "request-params": {
-                "timeout": 60
-            },
-            "only-if-exists": False
+            "request-params": {"timeout": 60},
+            "only-if-exists": False,
         }
         result = await r(es, params)
-        self.assertDictEqual({
-            "weight": 2,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 2, "unit": "ops", "success": True}, result)
 
-        es.cluster.delete_component_template.assert_has_calls([
-            mock.call(name="templateA", params=params["request-params"], ignore=[404]),
-            mock.call(name="templateB", params=params["request-params"], ignore=[404])
-        ])
+        es.cluster.delete_component_template.assert_has_calls(
+            [
+                mock.call(name="templateA", params=params["request-params"], ignore=[404]),
+                mock.call(name="templateB", params=params["request-params"], ignore=[404]),
+            ]
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_deletes_only_existing_index_templates(self, es):
-
         def _side_effect(http_method, path):
             if http_method == "HEAD":
                 return as_future(path == "/_component_template/templateB")
@@ -2862,18 +2650,12 @@ class DeleteComponentTemplateRunnerTests(TestCase):
                 "templateA",
                 "templateB",
             ],
-            "request-params": {
-                "timeout": 60
-            },
-            "only-if-exists": True
+            "request-params": {"timeout": 60},
+            "only-if-exists": True,
         }
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 1, "unit": "ops", "success": True}, result)
 
         es.cluster.delete_component_template.assert_called_once_with(name="templateB", params=params["request-params"])
 
@@ -2883,9 +2665,11 @@ class DeleteComponentTemplateRunnerTests(TestCase):
         r = runner.DeleteComponentTemplate()
 
         params = {}
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'delete-component-template' did not provide the mandatory parameter "
-                                    "'templates'. Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'delete-component-template' did not provide the mandatory parameter "
+            "'templates'. Add it to your parameter source and try again.",
+        ):
             await r(es, params)
 
         self.assertEqual(0, es.indices.delete_template.call_count)
@@ -2899,28 +2683,65 @@ class CreateComposableTemplateRunnerTests(TestCase):
         r = runner.CreateComposableTemplate()
         params = {
             "templates": [
-                ("templateA", {"index_patterns":["logs-*"],"template":{"settings":{"index.number_of_shards":3}},
-                               "composed_of":["ct1","ct2"]}),
-                ("templateB", {"index_patterns":["metrics-*"],"template":{"settings":{"index.number_of_shards":2}},
-                               "composed_of":["ct3","ct4"]}),
+                (
+                    "templateA",
+                    {
+                        "index_patterns": ["logs-*"],
+                        "template": {"settings": {"index.number_of_shards": 3}},
+                        "composed_of": ["ct1", "ct2"],
+                    },
+                ),
+                (
+                    "templateB",
+                    {
+                        "index_patterns": ["metrics-*"],
+                        "template": {"settings": {"index.number_of_shards": 2}},
+                        "composed_of": ["ct3", "ct4"],
+                    },
+                ),
             ],
-            "request-params": {
-                "timeout": 50
-            }
+            "request-params": {"timeout": 50},
         }
 
         result = await r(es, params)
-        self.assertDictEqual({
-            "weight": 2,
-            "unit": "ops",
-            "success": True
-        }, result)
-        es.indices.put_index_template.assert_has_calls([
-            mock.call(name="templateA", body={"index_patterns":["logs-*"],"template":{"settings":{"index.number_of_shards":3}},
-                                              "composed_of":["ct1","ct2"]}, params=params["request-params"]),
-            mock.call(name="templateB", body={"index_patterns":["metrics-*"],"template":{"settings":{"index.number_of_shards":2}},
-                                              "composed_of":["ct3","ct4"]}, params=params["request-params"])
-        ])
+        self.assertDictEqual(
+            {
+                "weight": 2,
+                "unit": "ops",
+                "success": True,
+            },
+            result,
+        )
+        es.indices.put_index_template.assert_has_calls(
+            [
+                mock.call(
+                    name="templateA",
+                    body={
+                        "index_patterns": ["logs-*"],
+                        "template": {
+                            "settings": {
+                                "index.number_of_shards": 3,
+                            },
+                        },
+                        "composed_of": ["ct1", "ct2"],
+                    },
+                    params=params["request-params"],
+                ),
+                mock.call(
+                    name="templateB",
+                    body={
+                        "index_patterns": ["metrics-*"],
+                        "template": {
+                            "settings": {
+                                "index.number_of_shards": 2,
+                            },
+                        },
+                        "composed_of": ["ct3", "ct4"],
+                    },
+                    params=params["request-params"],
+                ),
+            ]
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -2930,9 +2751,11 @@ class CreateComposableTemplateRunnerTests(TestCase):
         r = runner.CreateComposableTemplate()
 
         params = {}
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'create-composable-template' did not provide the mandatory parameter "
-                                    "'templates'. Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'create-composable-template' did not provide the mandatory parameter "
+            "'templates'. Add it to your parameter source and try again.",
+        ):
             await r(es, params)
 
         self.assertEqual(0, es.indices.put_index_template.call_count)
@@ -2952,24 +2775,20 @@ class DeleteComposableTemplateRunnerTests(TestCase):
                 ("templateA", False, None),
                 ("templateB", True, "logs-*"),
             ],
-            "request-params": {
-                "timeout": 60
-            },
-            "only-if-exists": False
+            "request-params": {"timeout": 60},
+            "only-if-exists": False,
         }
         result = await r(es, params)
 
         # 2 times delete index template, one time delete matching indices
-        self.assertDictEqual({
-            "weight": 3,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 3, "unit": "ops", "success": True}, result)
 
-        es.indices.delete_index_template.assert_has_calls([
-            mock.call(name="templateA", params=params["request-params"], ignore=[404]),
-            mock.call(name="templateB", params=params["request-params"], ignore=[404])
-        ])
+        es.indices.delete_index_template.assert_has_calls(
+            [
+                mock.call(name="templateA", params=params["request-params"], ignore=[404]),
+                mock.call(name="templateB", params=params["request-params"], ignore=[404]),
+            ]
+        )
         es.indices.delete.assert_called_once_with(index="logs-*")
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -2986,19 +2805,13 @@ class DeleteComposableTemplateRunnerTests(TestCase):
                 # will not accidentally delete all indices
                 ("templateB", True, ""),
             ],
-            "request-params": {
-                "timeout": 60
-            },
-            "only-if-exists": True
+            "request-params": {"timeout": 60},
+            "only-if-exists": True,
         }
         result = await r(es, params)
 
         # 2 times delete index template, one time delete matching indices
-        self.assertDictEqual({
-            "weight": 1,
-            "unit": "ops",
-            "success": True
-        }, result)
+        self.assertDictEqual({"weight": 1, "unit": "ops", "success": True}, result)
 
         es.indices.delete_index_template.assert_called_once_with(name="templateB", params=params["request-params"])
         # not called because the matching index is empty.
@@ -3010,9 +2823,11 @@ class DeleteComposableTemplateRunnerTests(TestCase):
         r = runner.DeleteComposableTemplate()
 
         params = {}
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'delete-composable-template' did not provide the mandatory parameter "
-                                    "'templates'. Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'delete-composable-template' did not provide the mandatory parameter "
+            "'templates'. Add it to your parameter source and try again.",
+        ):
             await r(es, params)
 
         self.assertEqual(0, es.indices.delete_index_template.call_count)
@@ -3024,13 +2839,7 @@ class CreateMlDatafeedTests(TestCase):
     async def test_create_ml_datafeed(self, es):
         es.xpack.ml.put_datafeed.return_value = as_future()
 
-        params = {
-            "datafeed-id": "some-data-feed",
-            "body": {
-                "job_id": "total-requests",
-                "indices": ["server-metrics"]
-            }
-        }
+        params = {"datafeed-id": "some-data-feed", "body": {"job_id": "total-requests", "indices": ["server-metrics"]}}
 
         r = runner.CreateMlDatafeed()
         await r(es, params)
@@ -3043,14 +2852,8 @@ class CreateMlDatafeedTests(TestCase):
         es.xpack.ml.put_datafeed.side_effect = as_future(exception=elasticsearch.TransportError(400, "Bad Request"))
         es.transport.perform_request.return_value = as_future()
         datafeed_id = "some-data-feed"
-        body = {
-                "job_id": "total-requests",
-                "indices": ["server-metrics"]
-            }
-        params = {
-            "datafeed-id": datafeed_id,
-            "body": body
-        }
+        body = {"job_id": "total-requests", "indices": ["server-metrics"]}
+        params = {"datafeed-id": datafeed_id, "body": body}
 
         r = runner.CreateMlDatafeed()
         await r(es, params)
@@ -3065,9 +2868,7 @@ class DeleteMlDatafeedTests(TestCase):
         es.xpack.ml.delete_datafeed.return_value = as_future()
 
         datafeed_id = "some-data-feed"
-        params = {
-            "datafeed-id": datafeed_id
-        }
+        params = {"datafeed-id": datafeed_id}
 
         r = runner.DeleteMlDatafeed()
         await r(es, params)
@@ -3087,12 +2888,9 @@ class DeleteMlDatafeedTests(TestCase):
         r = runner.DeleteMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with("DELETE",
-                                                             f"/_xpack/ml/datafeeds/{datafeed_id}",
-                                                             params={
-                                                                 "force": "false",
-                                                                 "ignore": 404
-                                                             })
+        es.transport.perform_request.assert_called_once_with(
+            "DELETE", f"/_xpack/ml/datafeeds/{datafeed_id}", params={"force": "false", "ignore": 404}
+        )
 
 
 class StartMlDatafeedTests(TestCase):
@@ -3100,41 +2898,27 @@ class StartMlDatafeedTests(TestCase):
     @run_async
     async def test_start_ml_datafeed_with_body(self, es):
         es.xpack.ml.start_datafeed.return_value = as_future()
-        params = {
-            "datafeed-id": "some-data-feed",
-            "body": {
-                "end": "now"
-            }
-        }
+        params = {"datafeed-id": "some-data-feed", "body": {"end": "now"}}
 
         r = runner.StartMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.start_datafeed.assert_called_once_with(datafeed_id=params["datafeed-id"],
-                                                           body=params["body"],
-                                                           start=None,
-                                                           end=None,
-                                                           timeout=None)
+        es.xpack.ml.start_datafeed.assert_called_once_with(
+            datafeed_id=params["datafeed-id"], body=params["body"], start=None, end=None, timeout=None
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_start_ml_datafeed_with_body_fallback(self, es):
         es.xpack.ml.start_datafeed.side_effect = as_future(exception=elasticsearch.TransportError(400, "Bad Request"))
         es.transport.perform_request.return_value = as_future()
-        body = {
-                "end": "now"
-            }
-        params = {
-            "datafeed-id": "some-data-feed",
-            "body": body
-        }
+        body = {"end": "now"}
+        params = {"datafeed-id": "some-data-feed", "body": body}
 
         r = runner.StartMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with("POST",
-                                                             f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_start",
-                                                             body=body)
+        es.transport.perform_request.assert_called_once_with("POST", f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_start", body=body)
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -3144,17 +2928,15 @@ class StartMlDatafeedTests(TestCase):
             "datafeed-id": "some-data-feed",
             "start": "2017-01-01T01:00:00Z",
             "end": "now",
-            "timeout": "10s"
+            "timeout": "10s",
         }
 
         r = runner.StartMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.start_datafeed.assert_called_once_with(datafeed_id=params["datafeed-id"],
-                                                           body=None,
-                                                           start=params["start"],
-                                                           end=params["end"],
-                                                           timeout=params["timeout"])
+        es.xpack.ml.start_datafeed.assert_called_once_with(
+            datafeed_id=params["datafeed-id"], body=None, start=params["start"], end=params["end"], timeout=params["timeout"]
+        )
 
 
 class StopMlDatafeedTests(TestCase):
@@ -3165,15 +2947,15 @@ class StopMlDatafeedTests(TestCase):
         params = {
             "datafeed-id": "some-data-feed",
             "force": random.choice([False, True]),
-            "timeout": "5s"
+            "timeout": "5s",
         }
 
         r = runner.StopMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.stop_datafeed.assert_called_once_with(datafeed_id=params["datafeed-id"],
-                                                          force=params["force"],
-                                                          timeout=params["timeout"])
+        es.xpack.ml.stop_datafeed.assert_called_once_with(
+            datafeed_id=params["datafeed-id"], force=params["force"], timeout=params["timeout"]
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -3184,18 +2966,17 @@ class StopMlDatafeedTests(TestCase):
         params = {
             "datafeed-id": "some-data-feed",
             "force": random.choice([False, True]),
-            "timeout": "5s"
+            "timeout": "5s",
         }
 
         r = runner.StopMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with("POST",
-                                                             f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_stop",
-                                                             params={
-                                                                 "force": str(params["force"]).lower(),
-                                                                 "timeout": params["timeout"]
-                                                             })
+        es.transport.perform_request.assert_called_once_with(
+            "POST",
+            f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_stop",
+            params={"force": str(params["force"]).lower(), "timeout": params["timeout"]},
+        )
 
 
 class CreateMlJobTests(TestCase):
@@ -3214,15 +2995,12 @@ class CreateMlJobTests(TestCase):
                         {
                             "detector_description": "Sum of total",
                             "function": "sum",
-                            "field_name": "total"
-                        }
-                    ]
+                            "field_name": "total",
+                        },
+                    ],
                 },
-                "data_description": {
-                    "time_field": "timestamp",
-                    "time_format": "epoch_ms"
-                }
-            }
+                "data_description": {"time_field": "timestamp", "time_format": "epoch_ms"},
+            },
         }
 
         r = runner.CreateMlJob()
@@ -3237,33 +3015,25 @@ class CreateMlJobTests(TestCase):
         es.transport.perform_request.return_value = as_future()
 
         body = {
-                "description": "Total sum of requests",
-                "analysis_config": {
-                    "bucket_span": "10m",
-                    "detectors": [
-                        {
-                            "detector_description": "Sum of total",
-                            "function": "sum",
-                            "field_name": "total"
-                        }
-                    ]
-                },
-                "data_description": {
-                    "time_field": "timestamp",
-                    "time_format": "epoch_ms"
-                }
-            }
-        params = {
-            "job-id": "an-ml-job",
-            "body": body
+            "description": "Total sum of requests",
+            "analysis_config": {
+                "bucket_span": "10m",
+                "detectors": [
+                    {
+                        "detector_description": "Sum of total",
+                        "function": "sum",
+                        "field_name": "total",
+                    },
+                ],
+            },
+            "data_description": {"time_field": "timestamp", "time_format": "epoch_ms"},
         }
+        params = {"job-id": "an-ml-job", "body": body}
 
         r = runner.CreateMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with("PUT",
-                                                             f"/_xpack/ml/anomaly_detectors/{params['job-id']}",
-                                                             body=body)
+        es.transport.perform_request.assert_called_once_with("PUT", f"/_xpack/ml/anomaly_detectors/{params['job-id']}", body=body)
 
 
 class DeleteMlJobTests(TestCase):
@@ -3273,9 +3043,7 @@ class DeleteMlJobTests(TestCase):
         es.xpack.ml.delete_job.return_value = as_future()
 
         job_id = "an-ml-job"
-        params = {
-            "job-id": job_id
-        }
+        params = {"job-id": job_id}
 
         r = runner.DeleteMlJob()
         await r(es, params)
@@ -3289,19 +3057,14 @@ class DeleteMlJobTests(TestCase):
         es.transport.perform_request.return_value = as_future()
 
         job_id = "an-ml-job"
-        params = {
-            "job-id": job_id
-        }
+        params = {"job-id": job_id}
 
         r = runner.DeleteMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with("DELETE",
-                                                             f"/_xpack/ml/anomaly_detectors/{params['job-id']}",
-                                                             params={
-                                                                 "force": "false",
-                                                                 "ignore": 404
-                                                             })
+        es.transport.perform_request.assert_called_once_with(
+            "DELETE", f"/_xpack/ml/anomaly_detectors/{params['job-id']}", params={"force": "false", "ignore": 404}
+        )
 
 
 class OpenMlJobTests(TestCase):
@@ -3311,9 +3074,7 @@ class OpenMlJobTests(TestCase):
         es.xpack.ml.open_job.return_value = as_future()
 
         job_id = "an-ml-job"
-        params = {
-            "job-id": job_id
-        }
+        params = {"job-id": job_id}
 
         r = runner.OpenMlJob()
         await r(es, params)
@@ -3327,15 +3088,12 @@ class OpenMlJobTests(TestCase):
         es.transport.perform_request.return_value = as_future()
 
         job_id = "an-ml-job"
-        params = {
-            "job-id": job_id
-        }
+        params = {"job-id": job_id}
 
         r = runner.OpenMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with("POST",
-                                                             f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_open")
+        es.transport.perform_request.assert_called_once_with("POST", f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_open")
 
 
 class CloseMlJobTests(TestCase):
@@ -3346,7 +3104,7 @@ class CloseMlJobTests(TestCase):
         params = {
             "job-id": "an-ml-job",
             "force": random.choice([False, True]),
-            "timeout": "5s"
+            "timeout": "5s",
         }
 
         r = runner.CloseMlJob()
@@ -3363,18 +3121,17 @@ class CloseMlJobTests(TestCase):
         params = {
             "job-id": "an-ml-job",
             "force": random.choice([False, True]),
-            "timeout": "5s"
+            "timeout": "5s",
         }
 
         r = runner.CloseMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with("POST",
-                                                             f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_close",
-                                                             params={
-                                                                 "force": str(params["force"]).lower(),
-                                                                 "timeout": params["timeout"]
-                                                             })
+        es.transport.perform_request.assert_called_once_with(
+            "POST",
+            f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_close",
+            params={"force": str(params["force"]).lower(), "timeout": params["timeout"]},
+        )
 
 
 class RawRequestRunnerTests(TestCase):
@@ -3384,17 +3141,15 @@ class RawRequestRunnerTests(TestCase):
         es.transport.perform_request.return_value = as_future()
         r = runner.RawRequest()
 
-        params = {
-            "path": "_cat/count"
-        }
+        params = {"path": "_cat/count"}
 
         with mock.patch.object(r.logger, "error") as mocked_error_logger:
             with self.assertRaises(exceptions.RallyAssertionError) as ctx:
                 await r(es, params)
                 self.assertEqual("RawRequest [_cat/count] failed. Path parameter must begin with a '/'.", ctx.exception.args[0])
-            mocked_error_logger.assert_has_calls([
-                mock.call("RawRequest failed. Path parameter: [%s] must begin with a '/'.", params["path"])
-            ])
+            mocked_error_logger.assert_has_calls(
+                [mock.call("RawRequest failed. Path parameter: [%s] must begin with a '/'.", params["path"])]
+            )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -3402,16 +3157,10 @@ class RawRequestRunnerTests(TestCase):
         es.transport.perform_request.return_value = as_future()
         r = runner.RawRequest()
 
-        params = {
-            "path": "/_cat/count"
-        }
+        params = {"path": "/_cat/count"}
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(method="GET",
-                                                             url="/_cat/count",
-                                                             headers=None,
-                                                             body=None,
-                                                             params={})
+        es.transport.perform_request.assert_called_once_with(method="GET", url="/_cat/count", headers=None, body=None, params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -3424,16 +3173,14 @@ class RawRequestRunnerTests(TestCase):
             "path": "/twitter",
             "ignore": [400, 404],
             "request-params": {
-                "pretty": "true"
-            }
+                "pretty": "true",
+            },
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(method="DELETE",
-                                                             url="/twitter",
-                                                             headers=None,
-                                                             body=None,
-                                                             params={"ignore": [400, 404], "pretty": "true"})
+        es.transport.perform_request.assert_called_once_with(
+            method="DELETE", url="/twitter", headers=None, body=None, params={"ignore": [400, 404], "pretty": "true"}
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -3447,24 +3194,16 @@ class RawRequestRunnerTests(TestCase):
             "body": {
                 "settings": {
                     "index": {
-                        "number_of_replicas": 0
-                    }
-                }
-            }
+                        "number_of_replicas": 0,
+                    },
+                },
+            },
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(method="POST",
-                                                             url="/twitter",
-                                                             headers=None,
-                                                             body={
-                                                                 "settings": {
-                                                                     "index": {
-                                                                         "number_of_replicas": 0
-                                                                     }
-                                                                 }
-                                                             },
-                                                             params={})
+        es.transport.perform_request.assert_called_once_with(
+            method="POST", url="/twitter", headers=None, body={"settings": {"index": {"number_of_replicas": 0}}}, params={}
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -3474,28 +3213,28 @@ class RawRequestRunnerTests(TestCase):
 
         params = {
             "path": "/_msearch",
-            "headers": {
-                "Content-Type": "application/x-ndjson"
-            },
+            "headers": {"Content-Type": "application/x-ndjson"},
             "body": [
                 {"index": "test"},
                 {"query": {"match_all": {}}, "from": 0, "size": 10},
                 {"index": "test", "search_type": "dfs_query_then_fetch"},
-                {"query": {"match_all": {}}}
-            ]
+                {"query": {"match_all": {}}},
+            ],
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(method="GET",
-                                                             url="/_msearch",
-                                                             headers={"Content-Type": "application/x-ndjson"},
-                                                             body=[
-                                                                 {"index": "test"},
-                                                                 {"query": {"match_all": {}}, "from": 0, "size": 10},
-                                                                 {"index": "test", "search_type": "dfs_query_then_fetch"},
-                                                                 {"query": {"match_all": {}}}
-                                                             ],
-                                                             params={})
+        es.transport.perform_request.assert_called_once_with(
+            method="GET",
+            url="/_msearch",
+            headers={"Content-Type": "application/x-ndjson"},
+            body=[
+                {"index": "test"},
+                {"query": {"match_all": {}}, "from": 0, "size": 10},
+                {"index": "test", "search_type": "dfs_query_then_fetch"},
+                {"query": {"match_all": {}}},
+            ],
+            params={},
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -3505,31 +3244,30 @@ class RawRequestRunnerTests(TestCase):
 
         params = {
             "path": "/_msearch",
-            "headers": {
-                "Content-Type": "application/x-ndjson"
-            },
+            "headers": {"Content-Type": "application/x-ndjson"},
             "request-timeout": 3.0,
             "opaque-id": "test-id1",
             "body": [
                 {"index": "test"},
                 {"query": {"match_all": {}}, "from": 0, "size": 10},
                 {"index": "test", "search_type": "dfs_query_then_fetch"},
-                {"query": {"match_all": {}}}
-            ]
+                {"query": {"match_all": {}}},
+            ],
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(method="GET",
-                                                             url="/_msearch",
-                                                             headers={"Content-Type": "application/x-ndjson",
-                                                                      "x-opaque-id": "test-id1"},
-                                                             body=[
-                                                                 {"index": "test"},
-                                                                 {"query": {"match_all": {}}, "from": 0, "size": 10},
-                                                                 {"index": "test", "search_type": "dfs_query_then_fetch"},
-                                                                 {"query": {"match_all": {}}}
-                                                             ],
-                                                             params={"request_timeout": 3.0})
+        es.transport.perform_request.assert_called_once_with(
+            method="GET",
+            url="/_msearch",
+            headers={"Content-Type": "application/x-ndjson", "x-opaque-id": "test-id1"},
+            body=[
+                {"index": "test"},
+                {"query": {"match_all": {}}, "from": 0, "size": 10},
+                {"index": "test", "search_type": "dfs_query_then_fetch"},
+                {"query": {"match_all": {}}},
+            ],
+            params={"request_timeout": 3.0},
+        )
 
 
 class SleepTests(TestCase):
@@ -3539,9 +3277,11 @@ class SleepTests(TestCase):
     @run_async
     async def test_missing_parameter(self, sleep, es):
         r = runner.Sleep()
-        with self.assertRaisesRegex(exceptions.DataError,
-                                    "Parameter source for operation 'sleep' did not provide the mandatory parameter "
-                                    "'duration'. Add it to your parameter source and try again."):
+        with self.assertRaisesRegex(
+            exceptions.DataError,
+            "Parameter source for operation 'sleep' did not provide the mandatory parameter "
+            "'duration'. Add it to your parameter source and try again.",
+        ):
             await r(es, params={})
 
         self.assertEqual(0, es.call_count)
@@ -3568,9 +3308,7 @@ class DeleteSnapshotRepositoryTests(TestCase):
     @run_async
     async def test_delete_snapshot_repository(self, es):
         es.snapshot.delete_repository.return_value = as_future()
-        params = {
-            "repository": "backups"
-        }
+        params = {"repository": "backups"}
 
         r = runner.DeleteSnapshotRepository()
         await r(es, params)
@@ -3588,22 +3326,17 @@ class CreateSnapshotRepositoryTests(TestCase):
             "body": {
                 "type": "fs",
                 "settings": {
-                    "location": "/var/backups"
-                }
-            }
+                    "location": "/var/backups",
+                },
+            },
         }
 
         r = runner.CreateSnapshotRepository()
         await r(es, params)
 
-        es.snapshot.create_repository.assert_called_once_with(repository="backups",
-                                                              body={
-                                                                  "type": "fs",
-                                                                  "settings": {
-                                                                      "location": "/var/backups"
-                                                                  }
-                                                              },
-                                                              params={})
+        es.snapshot.create_repository.assert_called_once_with(
+            repository="backups", body={"type": "fs", "settings": {"location": "/var/backups"}}, params={}
+        )
 
 
 class CreateSnapshotTests(TestCase):
@@ -3615,76 +3348,64 @@ class CreateSnapshotTests(TestCase):
         params = {
             "repository": "backups",
             "snapshot": "snapshot-001",
-            "body": {
-                "indices": "logs-*"
-            },
+            "body": {"indices": "logs-*"},
             "wait-for-completion": False,
-            "request-params": {
-                "request_timeout": 7200
-            }
+            "request-params": {"request_timeout": 7200},
         }
 
         r = runner.CreateSnapshot()
         await r(es, params)
 
-        es.snapshot.create.assert_called_once_with(repository="backups",
-                                                   snapshot="snapshot-001",
-                                                   body={
-                                                       "indices": "logs-*"
-                                                   },
-                                                   params={"request_timeout": 7200},
-                                                   wait_for_completion=False)
+        es.snapshot.create.assert_called_once_with(
+            repository="backups",
+            snapshot="snapshot-001",
+            body={"indices": "logs-*"},
+            params={"request_timeout": 7200},
+            wait_for_completion=False,
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_create_snapshot_wait_for_completion(self, es):
-        es.snapshot.create.return_value = as_future({
-            "snapshot": {
-                "snapshot": "snapshot-001",
-                "uuid": "wjt6zFEIRua_-jutT5vrAw",
-                "version_id": 7070099,
-                "version": "7.7.0",
-                "indices": [
-                    "logs-2020-01-01"
-                ],
-                "include_global_state": False,
-                "state": "SUCCESS",
-                "start_time": "2020-06-10T07:38:53.811Z",
-                "start_time_in_millis": 1591774733811,
-                "end_time": "2020-06-10T07:38:55.015Z",
-                "end_time_in_millis": 1591774735015,
-                "duration_in_millis": 1204,
-                "failures": [],
-                "shards": {
-                    "total": 5,
-                    "failed": 0,
-                    "successful": 5
+        es.snapshot.create.return_value = as_future(
+            {
+                "snapshot": {
+                    "snapshot": "snapshot-001",
+                    "uuid": "wjt6zFEIRua_-jutT5vrAw",
+                    "version_id": 7070099,
+                    "version": "7.7.0",
+                    "indices": ["logs-2020-01-01"],
+                    "include_global_state": False,
+                    "state": "SUCCESS",
+                    "start_time": "2020-06-10T07:38:53.811Z",
+                    "start_time_in_millis": 1591774733811,
+                    "end_time": "2020-06-10T07:38:55.015Z",
+                    "end_time_in_millis": 1591774735015,
+                    "duration_in_millis": 1204,
+                    "failures": [],
+                    "shards": {"total": 5, "failed": 0, "successful": 5},
                 }
             }
-        })
+        )
 
         params = {
             "repository": "backups",
             "snapshot": "snapshot-001",
-            "body": {
-                "indices": "logs-*"
-            },
+            "body": {"indices": "logs-*"},
             "wait-for-completion": True,
-            "request-params": {
-                "request_timeout": 7200
-            }
+            "request-params": {"request_timeout": 7200},
         }
 
         r = runner.CreateSnapshot()
         await r(es, params)
 
-        es.snapshot.create.assert_called_once_with(repository="backups",
-                                                   snapshot="snapshot-001",
-                                                   body={
-                                                       "indices": "logs-*"
-                                                   },
-                                                   params={"request_timeout": 7200},
-                                                   wait_for_completion=True)
+        es.snapshot.create.assert_called_once_with(
+            repository="backups",
+            snapshot="snapshot-001",
+            body={"indices": "logs-*"},
+            params={"request_timeout": 7200},
+            wait_for_completion=True,
+        )
 
 
 class WaitForSnapshotCreateTests(TestCase):
@@ -3695,127 +3416,136 @@ class WaitForSnapshotCreateTests(TestCase):
             # empty response
             as_future({}),
             # active snapshot
-            as_future({
-                "snapshots": [{
-                    "snapshot": "restore_speed_snapshot",
-                    "repository": "restore_speed",
-                    "uuid": "92efRcQxRCCwJuuC2lb-Ow",
-                    "state": "STARTED",
-                    "include_global_state": True,
-                    "shards_stats": {
-                        "initializing": 0,
-                        "started": 10,
-                        "finalizing": 0,
-                        "done": 3,
-                        "failed": 0,
-                        "total": 13},
-                    "stats": {
-                        "incremental": {
-                            "file_count": 222,
-                            "size_in_bytes": 243468220144
-                        },
-                        "processed": {
-                            "file_count": 18,
-                            "size_in_bytes": 82839346
-                        },
-                        "total": {
-                            "file_count": 222,
-                            "size_in_bytes": 243468220144
-                        },
-                        "start_time_in_millis": 1597319858606,
-                        "time_in_millis": 6606
-                    },
-                    "indices": {
-                        # skipping content as we don"t parse this
-                    }
-                }]
-            }
+            as_future(
+                {
+                    "snapshots": [
+                        {
+                            "snapshot": "restore_speed_snapshot",
+                            "repository": "restore_speed",
+                            "uuid": "92efRcQxRCCwJuuC2lb-Ow",
+                            "state": "STARTED",
+                            "include_global_state": True,
+                            "shards_stats": {
+                                "initializing": 0,
+                                "started": 10,
+                                "finalizing": 0,
+                                "done": 3,
+                                "failed": 0,
+                                "total": 13,
+                            },
+                            "stats": {
+                                "incremental": {
+                                    "file_count": 222,
+                                    "size_in_bytes": 243468220144,
+                                },
+                                "processed": {
+                                    "file_count": 18,
+                                    "size_in_bytes": 82839346,
+                                },
+                                "total": {
+                                    "file_count": 222,
+                                    "size_in_bytes": 243468220144,
+                                },
+                                "start_time_in_millis": 1597319858606,
+                                "time_in_millis": 6606,
+                            },
+                            "indices": {
+                                # skipping content as we don"t parse this
+                            },
+                        }
+                    ]
+                }
             ),
             # completed
-            as_future({
-                "snapshots": [{
-                    "snapshot": "restore_speed_snapshot",
-                    "repository": "restore_speed",
-                    "uuid": "6gDpGbxOTpWKIutWdpWCFw",
-                    "state": "SUCCESS",
-                    "include_global_state": True,
-                    "shards_stats": {
-                        "initializing": 0,
-                        "started": 0,
-                        "finalizing": 0,
-                        "done": 13,
-                        "failed": 0,
-                        "total": 13
-                    },
-                    "stats": {
-                        "incremental": {
-                            "file_count": 204,
-                            "size_in_bytes": 243468188055
-                        },
-                        "total": {
-                            "file_count": 204,
-                            "size_in_bytes": 243468188055
-                        },
-                        "start_time_in_millis": 1597317564956,
-                        "time_in_millis": 1113462
-                    },
-                    "indices": {
-                        # skipping content here as don"t parse this
-                    }
-                }]
-            })
+            as_future(
+                {
+                    "snapshots": [
+                        {
+                            "snapshot": "restore_speed_snapshot",
+                            "repository": "restore_speed",
+                            "uuid": "6gDpGbxOTpWKIutWdpWCFw",
+                            "state": "SUCCESS",
+                            "include_global_state": True,
+                            "shards_stats": {
+                                "initializing": 0,
+                                "started": 0,
+                                "finalizing": 0,
+                                "done": 13,
+                                "failed": 0,
+                                "total": 13,
+                            },
+                            "stats": {
+                                "incremental": {
+                                    "file_count": 204,
+                                    "size_in_bytes": 243468188055,
+                                },
+                                "total": {
+                                    "file_count": 204,
+                                    "size_in_bytes": 243468188055,
+                                },
+                                "start_time_in_millis": 1597317564956,
+                                "time_in_millis": 1113462,
+                            },
+                            "indices": {
+                                # skipping content here as don"t parse this
+                            },
+                        }
+                    ]
+                }
+            ),
         ]
 
         basic_params = {
             "repository": "restore_speed",
             "snapshot": "restore_speed_snapshot",
-            "completion-recheck-wait-period": 0
+            "completion-recheck-wait-period": 0,
         }
 
         r = runner.WaitForSnapshotCreate()
         result = await r(es, basic_params)
 
-        es.snapshot.status.assert_called_with(
-            repository="restore_speed",
-            snapshot="restore_speed_snapshot",
-            ignore_unavailable=True
-        )
+        es.snapshot.status.assert_called_with(repository="restore_speed", snapshot="restore_speed_snapshot", ignore_unavailable=True)
 
-        self.assertDictEqual({
-            "weight": 243468188055,
-            "unit": "byte",
-            "success": True,
-            "duration": 1113462,
-            "file_count": 204,
-            "throughput": 218658731.10622546,
-            "start_time_millis": 1597317564956,
-            "stop_time_millis": 1597317564956 + 1113462
-        }, result)
+        self.assertDictEqual(
+            {
+                "weight": 243468188055,
+                "unit": "byte",
+                "success": True,
+                "duration": 1113462,
+                "file_count": 204,
+                "throughput": 218658731.10622546,
+                "start_time_millis": 1597317564956,
+                "stop_time_millis": 1597317564956 + 1113462,
+            },
+            result,
+        )
 
         self.assertEqual(3, es.snapshot.status.call_count)
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_wait_for_snapshot_create_immediate_success(self, es):
-        es.snapshot.status.return_value = as_future({
-            "snapshots": [
-                {
-                    "snapshot": "snapshot-001",
-                    "repository": "backups",
-                    "uuid": "5uZiG1bhRri2DsBpZxj91A",
-                    "state": "SUCCESS",
-                    "include_global_state": False,
-                    "stats": {
-                        "total": {
-                            "file_count": 70,
-                            "size_in_bytes": 9399505
+        es.snapshot.status.return_value = as_future(
+            {
+                "snapshots": [
+                    {
+                        "snapshot": "snapshot-001",
+                        "repository": "backups",
+                        "uuid": "5uZiG1bhRri2DsBpZxj91A",
+                        "state": "SUCCESS",
+                        "include_global_state": False,
+                        "stats": {
+                            "total": {
+                                "file_count": 70,
+                                "size_in_bytes": 9399505,
+                            },
+                            "start_time_in_millis": 1591776481060,
+                            "time_in_millis": 200,
                         },
-                        "start_time_in_millis": 1591776481060,
-                        "time_in_millis": 200
                     }
-                }
-            ]
-        })
+                ]
+            }
+        )
 
         params = {
             "repository": "backups",
@@ -3825,20 +3555,21 @@ class WaitForSnapshotCreateTests(TestCase):
         r = runner.WaitForSnapshotCreate()
         result = await r(es, params)
 
-        self.assertDictEqual({
-            "weight": 9399505,
-            "unit": "byte",
-            "success": True,
-            "duration": 200,
-            "file_count": 70,
-            "throughput": 46997525.0,
-            "start_time_millis": 1591776481060,
-            "stop_time_millis": 1591776481060 + 200
-        }, result)
+        self.assertDictEqual(
+            {
+                "weight": 9399505,
+                "unit": "byte",
+                "success": True,
+                "duration": 200,
+                "file_count": 70,
+                "throughput": 46997525.0,
+                "start_time_millis": 1591776481060,
+                "stop_time_millis": 1591776481060 + 200,
+            },
+            result,
+        )
 
-        es.snapshot.status.assert_called_once_with(repository="backups",
-                                                   snapshot="snapshot-001",
-                                                   ignore_unavailable=True)
+        es.snapshot.status.assert_called_once_with(repository="backups", snapshot="snapshot-001", ignore_unavailable=True)
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -3849,8 +3580,8 @@ class WaitForSnapshotCreateTests(TestCase):
                     "snapshot": "snapshot-001",
                     "repository": "backups",
                     "state": "FAILED",
-                    "include_global_state": False
-                }
+                    "include_global_state": False,
+                },
             ]
         }
         es.snapshot.status.return_value = as_future(snapshot_status)
@@ -3866,9 +3597,9 @@ class WaitForSnapshotCreateTests(TestCase):
             with self.assertRaises(exceptions.RallyAssertionError) as ctx:
                 await r(es, params)
                 self.assertEqual("Snapshot [snapshot-001] failed. Please check logs.", ctx.exception.args[0])
-            mocked_error_logger.assert_has_calls([
-                mock.call("Snapshot [%s] failed. Response:\n%s", "snapshot-001", json.dumps(snapshot_status, indent=2))
-            ])
+            mocked_error_logger.assert_has_calls(
+                [mock.call("Snapshot [%s] failed. Response:\n%s", "snapshot-001", json.dumps(snapshot_status, indent=2))]
+            )
 
 
 class RestoreSnapshotTests(TestCase):
@@ -3881,18 +3612,15 @@ class RestoreSnapshotTests(TestCase):
             "repository": "backups",
             "snapshot": "snapshot-001",
             "wait-for-completion": True,
-            "request-params": {
-                "request_timeout": 7200
-            }
+            "request-params": {"request_timeout": 7200},
         }
 
         r = runner.RestoreSnapshot()
         await r(es, params)
 
-        es.snapshot.restore.assert_called_once_with(repository="backups",
-                                                    snapshot="snapshot-001",
-                                                    wait_for_completion=True,
-                                                    params={"request_timeout": 7200})
+        es.snapshot.restore.assert_called_once_with(
+            repository="backups", snapshot="snapshot-001", wait_for_completion=True, params={"request_timeout": 7200}
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -3905,29 +3633,29 @@ class RestoreSnapshotTests(TestCase):
                 "indices": "index1,index2",
                 "include_global_state": False,
                 "index_settings": {
-                    "index.number_of_replicas": 0
-                }
+                    "index.number_of_replicas": 0,
+                },
             },
             "wait-for-completion": True,
-            "request-params": {
-                "request_timeout": 7200
-            }
+            "request-params": {"request_timeout": 7200},
         }
 
         r = runner.RestoreSnapshot()
         await r(es, params)
 
-        es.snapshot.restore.assert_called_once_with(repository="backups",
-                                                    snapshot="snapshot-001",
-                                                    body={
-                                                        "indices": "index1,index2",
-                                                        "include_global_state": False,
-                                                        "index_settings": {
-                                                            "index.number_of_replicas": 0
-                                                        }
-                                                    },
-                                                    wait_for_completion=True,
-                                                    params={"request_timeout": 7200})
+        es.snapshot.restore.assert_called_once_with(
+            repository="backups",
+            snapshot="snapshot-001",
+            body={
+                "indices": "index1,index2",
+                "include_global_state": False,
+                "index_settings": {
+                    "index.number_of_replicas": 0,
+                },
+            },
+            wait_for_completion=True,
+            params={"request_timeout": 7200},
+        )
 
 
 class IndicesRecoveryTests(TestCase):
@@ -3939,130 +3667,132 @@ class IndicesRecoveryTests(TestCase):
             # recovery did not yet start
             as_future({}),
             # recovery about to be started
-            as_future({
-                "index1": {
-                    "shards": [
-                        {
-                            "id": 0,
-                            "type": "SNAPSHOT",
-                            "stage": "INIT",
-                            "primary": True,
-                            "start_time_in_millis": 1393244159716,
-                            "index": {
-                                "size": {
-                                    "total": "75.4mb",
-                                    "total_in_bytes": 79063092,
-                                    "recovered": "0mb",
-                                    "recovered_in_bytes": 0,
-                                }
-                            }
-                        },
-                        {
-                            "id": 1,
-                            "type": "SNAPSHOT",
-                            "stage": "DONE",
-                            "primary": True,
-                            "start_time_in_millis": 1393244155000,
-                            "stop_time_in_millis": 1393244158000,
-                            "index": {
-                                "size": {
-                                    "total": "175.4mb",
-                                    "total_in_bytes": 179063092,
-                                    "recovered": "165.7mb",
-                                    "recovered_in_bytes": 168891939,
-                                }
-                            }
-                        }
-                    ]
+            as_future(
+                {
+                    "index1": {
+                        "shards": [
+                            {
+                                "id": 0,
+                                "type": "SNAPSHOT",
+                                "stage": "INIT",
+                                "primary": True,
+                                "start_time_in_millis": 1393244159716,
+                                "index": {
+                                    "size": {
+                                        "total": "75.4mb",
+                                        "total_in_bytes": 79063092,
+                                        "recovered": "0mb",
+                                        "recovered_in_bytes": 0,
+                                    }
+                                },
+                            },
+                            {
+                                "id": 1,
+                                "type": "SNAPSHOT",
+                                "stage": "DONE",
+                                "primary": True,
+                                "start_time_in_millis": 1393244155000,
+                                "stop_time_in_millis": 1393244158000,
+                                "index": {
+                                    "size": {
+                                        "total": "175.4mb",
+                                        "total_in_bytes": 179063092,
+                                        "recovered": "165.7mb",
+                                        "recovered_in_bytes": 168891939,
+                                    }
+                                },
+                            },
+                        ]
+                    }
                 }
-            }),
-
+            ),
             # active recovery - one shard is not yet finished
-            as_future({
-                "index1": {
-                    "shards": [
-                        {
-                            "id": 0,
-                            "type": "SNAPSHOT",
-                            "stage": "INDEX",
-                            "primary": True,
-                            "start_time_in_millis": 1393244159716,
-                            "stop_time_in_millis": 0,
-                            "index": {
-                                "size": {
-                                    "total": "75.4mb",
-                                    "total_in_bytes": 79063092,
-                                    "recovered": "65.7mb",
-                                    "recovered_in_bytes": 68891939,
-                                }
-                            }
-                        },
-                        {
-                            "id": 1,
-                            "type": "SNAPSHOT",
-                            "stage": "DONE",
-                            "primary": True,
-                            "start_time_in_millis": 1393244155000,
-                            "stop_time_in_millis": 1393244158000,
-                            "index": {
-                                "size": {
-                                    "total": "175.4mb",
-                                    "total_in_bytes": 179063092,
-                                    "recovered": "165.7mb",
-                                    "recovered_in_bytes": 168891939,
-                                }
-                            }
-                        }
-                    ]
+            as_future(
+                {
+                    "index1": {
+                        "shards": [
+                            {
+                                "id": 0,
+                                "type": "SNAPSHOT",
+                                "stage": "INDEX",
+                                "primary": True,
+                                "start_time_in_millis": 1393244159716,
+                                "stop_time_in_millis": 0,
+                                "index": {
+                                    "size": {
+                                        "total": "75.4mb",
+                                        "total_in_bytes": 79063092,
+                                        "recovered": "65.7mb",
+                                        "recovered_in_bytes": 68891939,
+                                    }
+                                },
+                            },
+                            {
+                                "id": 1,
+                                "type": "SNAPSHOT",
+                                "stage": "DONE",
+                                "primary": True,
+                                "start_time_in_millis": 1393244155000,
+                                "stop_time_in_millis": 1393244158000,
+                                "index": {
+                                    "size": {
+                                        "total": "175.4mb",
+                                        "total_in_bytes": 179063092,
+                                        "recovered": "165.7mb",
+                                        "recovered_in_bytes": 168891939,
+                                    }
+                                },
+                            },
+                        ]
+                    }
                 }
-            }),
+            ),
             # completed
-            as_future({
-                "index1": {
-                    "shards": [
-                        {
-                            "id": 0,
-                            "type": "SNAPSHOT",
-                            "stage": "DONE",
-                            "primary": True,
-                            "start_time_in_millis": 1393244159716,
-                            "stop_time_in_millis": 1393244160000,
-                            "index": {
-                                "size": {
-                                    "total": "75.4mb",
-                                    "total_in_bytes": 79063092,
-                                    "recovered": "65.7mb",
-                                    "recovered_in_bytes": 68891939,
-                                }
-                            }
-                        },
-                        {
-                            "id": 1,
-                            "type": "SNAPSHOT",
-                            "stage": "DONE",
-                            "primary": True,
-                            "start_time_in_millis": 1393244155000,
-                            "stop_time_in_millis": 1393244158000,
-                            "index": {
-                                "size": {
-                                    "total": "175.4mb",
-                                    "total_in_bytes": 179063092,
-                                    "recovered": "165.7mb",
-                                    "recovered_in_bytes": 168891939,
-                                }
-                            }
-                        }
-                    ]
+            as_future(
+                {
+                    "index1": {
+                        "shards": [
+                            {
+                                "id": 0,
+                                "type": "SNAPSHOT",
+                                "stage": "DONE",
+                                "primary": True,
+                                "start_time_in_millis": 1393244159716,
+                                "stop_time_in_millis": 1393244160000,
+                                "index": {
+                                    "size": {
+                                        "total": "75.4mb",
+                                        "total_in_bytes": 79063092,
+                                        "recovered": "65.7mb",
+                                        "recovered_in_bytes": 68891939,
+                                    }
+                                },
+                            },
+                            {
+                                "id": 1,
+                                "type": "SNAPSHOT",
+                                "stage": "DONE",
+                                "primary": True,
+                                "start_time_in_millis": 1393244155000,
+                                "stop_time_in_millis": 1393244158000,
+                                "index": {
+                                    "size": {
+                                        "total": "175.4mb",
+                                        "total_in_bytes": 179063092,
+                                        "recovered": "165.7mb",
+                                        "recovered_in_bytes": 168891939,
+                                    }
+                                },
+                            },
+                        ]
+                    }
                 }
-            }),
+            ),
         ]
 
         r = runner.IndicesRecovery()
 
-        result = await r(es, {
-            "completion-recheck-wait-period": 0,
-            "index": "index1"
-        })
+        result = await r(es, {"completion-recheck-wait-period": 0, "index": "index1"})
 
         # sum of both shards
         self.assertEqual(237783878, result["weight"])
@@ -4084,14 +3814,9 @@ class ShrinkIndexTests(TestCase):
     @mock.patch("asyncio.sleep", return_value=as_future())
     @run_async
     async def test_shrink_index_with_shrink_node(self, sleep, es):
-        es.indices.get.return_value = as_future({
-            "src": {}
-        })
+        es.indices.get.return_value = as_future({"src": {}})
         # cluster health API
-        es.cluster.health.return_value = as_future({
-            "status": "green",
-            "relocating_shards": 0
-        })
+        es.cluster.health.return_value = as_future({"status": "green", "relocating_shards": 0})
         es.indices.put_settings.return_value = as_future()
         es.indices.shrink.return_value = as_future()
 
@@ -4102,80 +3827,64 @@ class ShrinkIndexTests(TestCase):
             "target-body": {
                 "settings": {
                     "index.number_of_replicas": 2,
-                    "index.number_of_shards": 0
-                }
+                    "index.number_of_shards": 0,
+                },
             },
-            "shrink-node": "rally-node-0"
+            "shrink-node": "rally-node-0",
         }
 
         await r(es, params)
 
-        es.indices.put_settings.assert_called_once_with(index="src",
-                                                        body={
-                                                            "settings": {
-                                                                "index.routing.allocation.require._name": "rally-node-0",
-                                                                "index.blocks.write": "true"
-                                                            }
-                                                        },
-                                                        preserve_existing=True)
+        es.indices.put_settings.assert_called_once_with(
+            index="src",
+            body={
+                "settings": {
+                    "index.routing.allocation.require._name": "rally-node-0",
+                    "index.blocks.write": "true",
+                },
+            },
+            preserve_existing=True,
+        )
 
-        es.cluster.health.assert_has_calls([
-            mock.call(index="src", params={"wait_for_no_relocating_shards": "true"}),
-            mock.call(index="target", params={"wait_for_no_relocating_shards": "true"}),
-        ])
+        es.cluster.health.assert_has_calls(
+            [
+                mock.call(index="src", params={"wait_for_no_relocating_shards": "true"}),
+                mock.call(index="target", params={"wait_for_no_relocating_shards": "true"}),
+            ]
+        )
 
-        es.indices.shrink.assert_called_once_with(index="src", target="target", body={
-            "settings": {
-                "index.number_of_replicas": 2,
-                "index.number_of_shards": 0,
-                "index.routing.allocation.require._name": None,
-                "index.blocks.write": None
-            }
-        })
+        es.indices.shrink.assert_called_once_with(
+            index="src",
+            target="target",
+            body={
+                "settings": {
+                    "index.number_of_replicas": 2,
+                    "index.number_of_shards": 0,
+                    "index.routing.allocation.require._name": None,
+                    "index.blocks.write": None,
+                }
+            },
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     # To avoid real sleeps in unit tests
     @mock.patch("asyncio.sleep", return_value=as_future())
     @run_async
     async def test_shrink_index_derives_shrink_node(self, sleep, es):
-        es.indices.get.return_value = as_future({
-            "src": {}
-        })
+        es.indices.get.return_value = as_future({"src": {}})
         # cluster health API
-        es.cluster.health.return_value = as_future({
-            "status": "green",
-            "relocating_shards": 0
-        })
-        es.nodes.info.return_value = as_future({
-            "_nodes": {
-                "total": 3,
-                "successful": 3,
-                "failed": 0
-            },
-            "cluster_name": "elasticsearch",
-            "nodes": {
-                "lsM0-tKnQqKEGVw-OZU5og": {
-                    "name": "node0",
-                    "roles": [
-                        "master",
-                        "data",
-                        "ingest"
-                    ]
+        es.cluster.health.return_value = as_future({"status": "green", "relocating_shards": 0})
+        es.nodes.info.return_value = as_future(
+            {
+                "_nodes": {"total": 3, "successful": 3, "failed": 0},
+                "cluster_name": "elasticsearch",
+                "nodes": {
+                    "lsM0-tKnQqKEGVw-OZU5og": {"name": "node0", "roles": ["master", "data", "ingest"]},
+                    "kxM0-tKnQqKEGVw-OZU5og": {"name": "node1", "roles": ["master"]},
+                    "yyM0-tKnQqKEGVw-OZU5og": {"name": "node0", "roles": ["ingest"]},
                 },
-                "kxM0-tKnQqKEGVw-OZU5og": {
-                    "name": "node1",
-                    "roles": [
-                        "master"
-                    ]
-                },
-                "yyM0-tKnQqKEGVw-OZU5og": {
-                    "name": "node0",
-                    "roles": [
-                        "ingest"
-                    ]
-                }
             }
-        })
+        )
         es.indices.put_settings.return_value = as_future()
         es.indices.shrink.return_value = as_future()
 
@@ -4183,53 +3892,51 @@ class ShrinkIndexTests(TestCase):
         params = {
             "source-index": "src",
             "target-index": "target",
-            "target-body": {
-                "settings": {
-                    "index.number_of_replicas": 2,
-                    "index.number_of_shards": 0
-                }
-            }
+            "target-body": {"settings": {"index.number_of_replicas": 2, "index.number_of_shards": 0}},
         }
 
         await r(es, params)
 
-        es.indices.put_settings.assert_called_once_with(index="src",
-                                                        body={
-                                                            "settings": {
-                                                                # the only data node in the cluster was chosen
-                                                                "index.routing.allocation.require._name": "node0",
-                                                                "index.blocks.write": "true"
-                                                            }
-                                                        },
-                                                        preserve_existing=True)
+        es.indices.put_settings.assert_called_once_with(
+            index="src",
+            body={
+                "settings": {
+                    # the only data node in the cluster was chosen
+                    "index.routing.allocation.require._name": "node0",
+                    "index.blocks.write": "true",
+                }
+            },
+            preserve_existing=True,
+        )
 
-        es.cluster.health.assert_has_calls([
-            mock.call(index="src", params={"wait_for_no_relocating_shards": "true"}),
-            mock.call(index="target", params={"wait_for_no_relocating_shards": "true"}),
-        ])
+        es.cluster.health.assert_has_calls(
+            [
+                mock.call(index="src", params={"wait_for_no_relocating_shards": "true"}),
+                mock.call(index="target", params={"wait_for_no_relocating_shards": "true"}),
+            ]
+        )
 
-        es.indices.shrink.assert_called_once_with(index="src", target="target", body={
-            "settings": {
-                "index.number_of_replicas": 2,
-                "index.number_of_shards": 0,
-                "index.routing.allocation.require._name": None,
-                "index.blocks.write": None
-            }
-        })
+        es.indices.shrink.assert_called_once_with(
+            index="src",
+            target="target",
+            body={
+                "settings": {
+                    "index.number_of_replicas": 2,
+                    "index.number_of_shards": 0,
+                    "index.routing.allocation.require._name": None,
+                    "index.blocks.write": None,
+                }
+            },
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     # To avoid real sleeps in unit tests
     @mock.patch("asyncio.sleep", return_value=as_future())
     @run_async
     async def test_shrink_index_pattern_with_shrink_node(self, sleep, es):
-        es.indices.get.return_value = as_future({
-            "src1": {}, "src2": {}, "src-2020": {}
-        })
+        es.indices.get.return_value = as_future({"src1": {}, "src2": {}, "src-2020": {}})
         # cluster health API
-        es.cluster.health.return_value = as_future({
-            "status": "green",
-            "relocating_shards": 0
-        })
+        es.cluster.health.return_value = as_future({"status": "green", "relocating_shards": 0})
         es.indices.put_settings.return_value = as_future()
         es.indices.shrink.return_value = as_future()
 
@@ -4237,80 +3944,83 @@ class ShrinkIndexTests(TestCase):
         params = {
             "source-index": "src*",
             "target-index": "target",
-            "target-body": {
-                "settings": {
-                    "index.number_of_replicas": 2,
-                    "index.number_of_shards": 0
-                }
-            },
-            "shrink-node": "rally-node-0"
+            "target-body": {"settings": {"index.number_of_replicas": 2, "index.number_of_shards": 0}},
+            "shrink-node": "rally-node-0",
         }
 
         await r(es, params)
 
-        es.indices.put_settings.assert_has_calls([
-            mock.call(index="src1",
-                      body={
-                          "settings": {
-                              "index.routing.allocation.require._name": "rally-node-0",
-                              "index.blocks.write": "true"
-                          }
-                      },
-                      preserve_existing=True),
-            mock.call(index="src2",
-                      body={
-                          "settings": {
-                              "index.routing.allocation.require._name": "rally-node-0",
-                              "index.blocks.write": "true"
-                          }
-                      },
-                      preserve_existing=True),
-            mock.call(index="src-2020",
-                      body={
-                          "settings": {
-                              "index.routing.allocation.require._name": "rally-node-0",
-                              "index.blocks.write": "true"
-                          }
-                      },
-                      preserve_existing=True)])
+        es.indices.put_settings.assert_has_calls(
+            [
+                mock.call(
+                    index="src1",
+                    body={"settings": {"index.routing.allocation.require._name": "rally-node-0", "index.blocks.write": "true"}},
+                    preserve_existing=True,
+                ),
+                mock.call(
+                    index="src2",
+                    body={"settings": {"index.routing.allocation.require._name": "rally-node-0", "index.blocks.write": "true"}},
+                    preserve_existing=True,
+                ),
+                mock.call(
+                    index="src-2020",
+                    body={"settings": {"index.routing.allocation.require._name": "rally-node-0", "index.blocks.write": "true"}},
+                    preserve_existing=True,
+                ),
+            ]
+        )
 
-        es.cluster.health.assert_has_calls([
-            mock.call(index="src1", params={"wait_for_no_relocating_shards": "true"}),
-            mock.call(index="target1", params={"wait_for_no_relocating_shards": "true"}),
-            mock.call(index="src2", params={"wait_for_no_relocating_shards": "true"}),
-            mock.call(index="target2", params={"wait_for_no_relocating_shards": "true"}),
-            mock.call(index="src-2020", params={"wait_for_no_relocating_shards": "true"}),
-            mock.call(index="target-2020", params={"wait_for_no_relocating_shards": "true"}),
-        ])
+        es.cluster.health.assert_has_calls(
+            [
+                mock.call(index="src1", params={"wait_for_no_relocating_shards": "true"}),
+                mock.call(index="target1", params={"wait_for_no_relocating_shards": "true"}),
+                mock.call(index="src2", params={"wait_for_no_relocating_shards": "true"}),
+                mock.call(index="target2", params={"wait_for_no_relocating_shards": "true"}),
+                mock.call(index="src-2020", params={"wait_for_no_relocating_shards": "true"}),
+                mock.call(index="target-2020", params={"wait_for_no_relocating_shards": "true"}),
+            ]
+        )
 
-        es.indices.shrink.assert_has_calls([
-            mock.call(
-                index="src1", target="target1", body={
-                    "settings": {
-                        "index.number_of_replicas": 2,
-                        "index.number_of_shards": 0,
-                        "index.routing.allocation.require._name": None,
-                        "index.blocks.write": None
-                    }
-                }),
-            mock.call(
-                index="src2", target="target2", body={
-                    "settings": {
-                        "index.number_of_replicas": 2,
-                        "index.number_of_shards": 0,
-                        "index.routing.allocation.require._name": None,
-                        "index.blocks.write": None
-                    }
-                }),
-            mock.call(
-                index="src-2020", target="target-2020", body={
-                    "settings": {
-                        "index.number_of_replicas": 2,
-                        "index.number_of_shards": 0,
-                        "index.routing.allocation.require._name": None,
-                        "index.blocks.write": None
-                    }
-                })])
+        es.indices.shrink.assert_has_calls(
+            [
+                mock.call(
+                    index="src1",
+                    target="target1",
+                    body={
+                        "settings": {
+                            "index.number_of_replicas": 2,
+                            "index.number_of_shards": 0,
+                            "index.routing.allocation.require._name": None,
+                            "index.blocks.write": None,
+                        }
+                    },
+                ),
+                mock.call(
+                    index="src2",
+                    target="target2",
+                    body={
+                        "settings": {
+                            "index.number_of_replicas": 2,
+                            "index.number_of_shards": 0,
+                            "index.routing.allocation.require._name": None,
+                            "index.blocks.write": None,
+                        }
+                    },
+                ),
+                mock.call(
+                    index="src-2020",
+                    target="target-2020",
+                    body={
+                        "settings": {
+                            "index.number_of_replicas": 2,
+                            "index.number_of_shards": 0,
+                            "index.routing.allocation.require._name": None,
+                            "index.blocks.write": None,
+                        }
+                    },
+                ),
+            ]
+        )
 
 
 class PutSettingsTests(TestCase):
@@ -4318,22 +4028,12 @@ class PutSettingsTests(TestCase):
     @run_async
     async def test_put_settings(self, es):
         es.cluster.put_settings.return_value = as_future()
-        params = {
-            "body": {
-                "transient": {
-                    "indices.recovery.max_bytes_per_sec": "20mb"
-                }
-            }
-        }
+        params = {"body": {"transient": {"indices.recovery.max_bytes_per_sec": "20mb"}}}
 
         r = runner.PutSettings()
         await r(es, params)
 
-        es.cluster.put_settings.assert_called_once_with(body={
-            "transient": {
-                "indices.recovery.max_bytes_per_sec": "20mb"
-            }
-        })
+        es.cluster.put_settings.assert_called_once_with(body={"transient": {"indices.recovery.max_bytes_per_sec": "20mb"}})
 
 
 class CreateTransformTests(TestCase):
@@ -4345,38 +4045,23 @@ class CreateTransformTests(TestCase):
         params = {
             "transform-id": "a-transform",
             "body": {
-                "source": {
-                    "index": "source"
-                },
+                "source": {"index": "source"},
                 "pivot": {
-                    "group_by": {
-                        "event_id": {
-                            "terms": {
-                                "field": "event_id"
-                            }
-                        }
-                    },
-                    "aggregations": {
-                        "max_metric": {
-                            "max": {
-                                "field": "metric"
-                            }
-                        }
-                    }
+                    "group_by": {"event_id": {"terms": {"field": "event_id"}}},
+                    "aggregations": {"max_metric": {"max": {"field": "metric"}}},
                 },
                 "description": "an example transform",
-                "dest": {
-                    "index": "dest"
-                }
+                "dest": {"index": "dest"},
             },
-            "defer-validation": random.choice([False, True])
+            "defer-validation": random.choice([False, True]),
         }
 
         r = runner.CreateTransform()
         await r(es, params)
 
-        es.transform.put_transform.assert_called_once_with(transform_id=params["transform-id"], body=params["body"],
-                                                           defer_validation=params["defer-validation"])
+        es.transform.put_transform.assert_called_once_with(
+            transform_id=params["transform-id"], body=params["body"], defer_validation=params["defer-validation"]
+        )
 
 
 class StartTransformTests(TestCase):
@@ -4386,10 +4071,7 @@ class StartTransformTests(TestCase):
         es.transform.start_transform.return_value = as_future()
 
         transform_id = "a-transform"
-        params = {
-            "transform-id": transform_id,
-            "timeout": "5s"
-        }
+        params = {"transform-id": transform_id, "timeout": "5s"}
 
         r = runner.StartTransform()
         await r(es, params)
@@ -4411,39 +4093,35 @@ class WaitForTransformTests(TestCase):
             "wait-for-checkpoint": random.choice([False, True]),
         }
 
-        es.transform.get_transform_stats.return_value = as_future({
-            "count": 1,
-            "transforms": [
-                {
-                    "id": "a-transform",
-                    "state": "stopped",
-                    "stats": {
-                        "pages_processed": 1,
-                        "documents_processed": 2,
-                        "documents_indexed": 3,
-                        "trigger_count": 4,
-                        "index_time_in_ms": 5,
-                        "index_total": 6,
-                        "index_failures": 7,
-                        "search_time_in_ms": 8,
-                        "search_total": 9,
-                        "search_failures": 10,
-                        "processing_time_in_ms": 11,
-                        "processing_total": 12,
-                        "exponential_avg_checkpoint_duration_ms": 13.13,
-                        "exponential_avg_documents_indexed": 14.14,
-                        "exponential_avg_documents_processed": 15.15
-                    },
-                    "checkpointing": {
-                        "last": {
-                            "checkpoint": 1,
-                            "timestamp_millis": 16
+        es.transform.get_transform_stats.return_value = as_future(
+            {
+                "count": 1,
+                "transforms": [
+                    {
+                        "id": "a-transform",
+                        "state": "stopped",
+                        "stats": {
+                            "pages_processed": 1,
+                            "documents_processed": 2,
+                            "documents_indexed": 3,
+                            "trigger_count": 4,
+                            "index_time_in_ms": 5,
+                            "index_total": 6,
+                            "index_failures": 7,
+                            "search_time_in_ms": 8,
+                            "search_total": 9,
+                            "search_failures": 10,
+                            "processing_time_in_ms": 11,
+                            "processing_total": 12,
+                            "exponential_avg_checkpoint_duration_ms": 13.13,
+                            "exponential_avg_documents_indexed": 14.14,
+                            "exponential_avg_documents_processed": 15.15,
                         },
-                        "changes_last_detected_at": 16
+                        "checkpointing": {"last": {"checkpoint": 1, "timestamp_millis": 16}, "changes_last_detected_at": 16},
                     }
-                }
-            ]
-        })
+                ],
+            }
+        )
 
         r = runner.WaitForTransform()
         self.assertFalse(r.completed)
@@ -4456,11 +4134,13 @@ class WaitForTransformTests(TestCase):
         self.assertEqual(2, result["weight"], 2)
         self.assertEqual(result["unit"], "docs")
 
-        es.transform.stop_transform.assert_called_once_with(transform_id=transform_id, force=params["force"],
-                                                            timeout=params["timeout"],
-                                                            wait_for_completion=False,
-                                                            wait_for_checkpoint=params["wait-for-checkpoint"]
-                                                            )
+        es.transform.stop_transform.assert_called_once_with(
+            transform_id=transform_id,
+            force=params["force"],
+            timeout=params["timeout"],
+            wait_for_completion=False,
+            wait_for_checkpoint=params["wait-for-checkpoint"],
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -4470,155 +4150,139 @@ class WaitForTransformTests(TestCase):
         params = {
             "transform-id": transform_id,
             "force": random.choice([False, True]),
-            "timeout": "5s"
+            "timeout": "5s",
         }
 
         # return 4 times, simulating progress
         es.transform.get_transform_stats.side_effect = [
-            as_future({
-                "count": 1,
-                "transforms": [
-                    {
-                        "id": "a-transform",
-                        "state": "indexing",
-                        "stats": {
-                            "pages_processed": 1,
-                            "documents_processed": 10000,
-                            "documents_indexed": 3,
-                            "trigger_count": 4,
-                            "index_time_in_ms": 200,
-                            "index_total": 6,
-                            "index_failures": 7,
-                            "search_time_in_ms": 300,
-                            "search_total": 9,
-                            "search_failures": 10,
-                            "processing_time_in_ms": 50,
-                            "processing_total": 12,
-                            "exponential_avg_checkpoint_duration_ms": 13.13,
-                            "exponential_avg_documents_indexed": 14.14,
-                            "exponential_avg_documents_processed": 15.15
-                        },
-                        "checkpointing": {
-                            "last": {},
-                            "next": {
-                                "checkpoint": 1,
-                                "timestamp_millis": 16,
-                                "checkpoint_progress": {
-                                    "percent_complete": 10.20
-                                }
+            as_future(
+                {
+                    "count": 1,
+                    "transforms": [
+                        {
+                            "id": "a-transform",
+                            "state": "indexing",
+                            "stats": {
+                                "pages_processed": 1,
+                                "documents_processed": 10000,
+                                "documents_indexed": 3,
+                                "trigger_count": 4,
+                                "index_time_in_ms": 200,
+                                "index_total": 6,
+                                "index_failures": 7,
+                                "search_time_in_ms": 300,
+                                "search_total": 9,
+                                "search_failures": 10,
+                                "processing_time_in_ms": 50,
+                                "processing_total": 12,
+                                "exponential_avg_checkpoint_duration_ms": 13.13,
+                                "exponential_avg_documents_indexed": 14.14,
+                                "exponential_avg_documents_processed": 15.15,
                             },
-                            "changes_last_detected_at": 16
-                        }
-                    }
-                ]
-            }),
-            as_future({
-                "count": 1,
-                "transforms": [
-                    {
-                        "id": "a-transform",
-                        "state": "indexing",
-                        "stats": {
-                            "pages_processed": 2,
-                            "documents_processed": 20000,
-                            "documents_indexed": 3,
-                            "trigger_count": 4,
-                            "index_time_in_ms": 500,
-                            "index_total": 6,
-                            "index_failures": 7,
-                            "search_time_in_ms": 1500,
-                            "search_total": 9,
-                            "search_failures": 10,
-                            "processing_time_in_ms": 300,
-                            "processing_total": 12,
-                            "exponential_avg_checkpoint_duration_ms": 13.13,
-                            "exponential_avg_documents_indexed": 14.14,
-                            "exponential_avg_documents_processed": 15.15
-                        },
-                        "checkpointing": {
-                            "last": {},
-                            "next": {
-                                "checkpoint": 1,
-                                "timestamp_millis": 16,
-                                "checkpoint_progress": {
-                                    "percent_complete": 20.40
-                                }
+                            "checkpointing": {
+                                "last": {},
+                                "next": {"checkpoint": 1, "timestamp_millis": 16, "checkpoint_progress": {"percent_complete": 10.20}},
+                                "changes_last_detected_at": 16,
                             },
-                            "changes_last_detected_at": 16
                         }
-                    }
-                ]
-            }),
-            as_future({
-                "count": 1,
-                "transforms": [
-                    {
-                        "id": "a-transform",
-                        "state": "started",
-                        "stats": {
-                            "pages_processed": 1,
-                            "documents_processed": 30000,
-                            "documents_indexed": 3,
-                            "trigger_count": 4,
-                            "index_time_in_ms": 1000,
-                            "index_total": 6,
-                            "index_failures": 7,
-                            "search_time_in_ms": 2000,
-                            "search_total": 9,
-                            "search_failures": 10,
-                            "processing_time_in_ms": 600,
-                            "processing_total": 12,
-                            "exponential_avg_checkpoint_duration_ms": 13.13,
-                            "exponential_avg_documents_indexed": 14.14,
-                            "exponential_avg_documents_processed": 15.15
-                        },
-                        "checkpointing": {
-                            "last": {},
-                            "next": {
-                                "checkpoint": 1,
-                                "timestamp_millis": 16,
-                                "checkpoint_progress": {
-                                    "percent_complete": 30.60
-                                }
+                    ],
+                }
+            ),
+            as_future(
+                {
+                    "count": 1,
+                    "transforms": [
+                        {
+                            "id": "a-transform",
+                            "state": "indexing",
+                            "stats": {
+                                "pages_processed": 2,
+                                "documents_processed": 20000,
+                                "documents_indexed": 3,
+                                "trigger_count": 4,
+                                "index_time_in_ms": 500,
+                                "index_total": 6,
+                                "index_failures": 7,
+                                "search_time_in_ms": 1500,
+                                "search_total": 9,
+                                "search_failures": 10,
+                                "processing_time_in_ms": 300,
+                                "processing_total": 12,
+                                "exponential_avg_checkpoint_duration_ms": 13.13,
+                                "exponential_avg_documents_indexed": 14.14,
+                                "exponential_avg_documents_processed": 15.15,
                             },
-                            "changes_last_detected_at": 16
-                        }
-                    }
-                ]
-            }),
-            as_future({
-                "count": 1,
-                "transforms": [
-                    {
-                        "id": "a-transform",
-                        "state": "stopped",
-                        "stats": {
-                            "pages_processed": 1,
-                            "documents_processed": 60000,
-                            "documents_indexed": 3,
-                            "trigger_count": 4,
-                            "index_time_in_ms": 1500,
-                            "index_total": 6,
-                            "index_failures": 7,
-                            "search_time_in_ms": 3000,
-                            "search_total": 9,
-                            "search_failures": 10,
-                            "processing_time_in_ms": 1000,
-                            "processing_total": 12,
-                            "exponential_avg_checkpoint_duration_ms": 13.13,
-                            "exponential_avg_documents_indexed": 14.14,
-                            "exponential_avg_documents_processed": 15.15
-                        },
-                        "checkpointing": {
-                            "last": {
-                                "checkpoint": 1,
-                                "timestamp_millis": 16
+                            "checkpointing": {
+                                "last": {},
+                                "next": {"checkpoint": 1, "timestamp_millis": 16, "checkpoint_progress": {"percent_complete": 20.40}},
+                                "changes_last_detected_at": 16,
                             },
-                            "changes_last_detected_at": 16
                         }
-                    }
-                ]
-            })
+                    ],
+                }
+            ),
+            as_future(
+                {
+                    "count": 1,
+                    "transforms": [
+                        {
+                            "id": "a-transform",
+                            "state": "started",
+                            "stats": {
+                                "pages_processed": 1,
+                                "documents_processed": 30000,
+                                "documents_indexed": 3,
+                                "trigger_count": 4,
+                                "index_time_in_ms": 1000,
+                                "index_total": 6,
+                                "index_failures": 7,
+                                "search_time_in_ms": 2000,
+                                "search_total": 9,
+                                "search_failures": 10,
+                                "processing_time_in_ms": 600,
+                                "processing_total": 12,
+                                "exponential_avg_checkpoint_duration_ms": 13.13,
+                                "exponential_avg_documents_indexed": 14.14,
+                                "exponential_avg_documents_processed": 15.15,
+                            },
+                            "checkpointing": {
+                                "last": {},
+                                "next": {"checkpoint": 1, "timestamp_millis": 16, "checkpoint_progress": {"percent_complete": 30.60}},
+                                "changes_last_detected_at": 16,
+                            },
+                        }
+                    ],
+                }
+            ),
+            as_future(
+                {
+                    "count": 1,
+                    "transforms": [
+                        {
+                            "id": "a-transform",
+                            "state": "stopped",
+                            "stats": {
+                                "pages_processed": 1,
+                                "documents_processed": 60000,
+                                "documents_indexed": 3,
+                                "trigger_count": 4,
+                                "index_time_in_ms": 1500,
+                                "index_total": 6,
+                                "index_failures": 7,
+                                "search_time_in_ms": 3000,
+                                "search_total": 9,
+                                "search_failures": 10,
+                                "processing_time_in_ms": 1000,
+                                "processing_total": 12,
+                                "exponential_avg_checkpoint_duration_ms": 13.13,
+                                "exponential_avg_documents_indexed": 14.14,
+                                "exponential_avg_documents_processed": 15.15,
+                            },
+                            "checkpointing": {"last": {"checkpoint": 1, "timestamp_millis": 16}, "changes_last_detected_at": 16},
+                        }
+                    ],
+                }
+            ),
         ]
 
         r = runner.WaitForTransform()
@@ -4638,11 +4302,9 @@ class WaitForTransformTests(TestCase):
         self.assertEqual(result["weight"], 60000)
         self.assertEqual(result["unit"], "docs")
 
-        es.transform.stop_transform.assert_called_once_with(transform_id=transform_id, force=params["force"],
-                                                            timeout=params["timeout"],
-                                                            wait_for_completion=False,
-                                                            wait_for_checkpoint=True
-                                                            )
+        es.transform.stop_transform.assert_called_once_with(
+            transform_id=transform_id, force=params["force"], timeout=params["timeout"], wait_for_completion=False, wait_for_checkpoint=True
+        )
 
 
 class DeleteTransformTests(TestCase):
@@ -4652,16 +4314,12 @@ class DeleteTransformTests(TestCase):
         es.transform.delete_transform.return_value = as_future()
 
         transform_id = "a-transform"
-        params = {
-            "transform-id": transform_id,
-            "force": random.choice([False, True])
-        }
+        params = {"transform-id": transform_id, "force": random.choice([False, True])}
 
         r = runner.DeleteTransform()
         await r(es, params)
 
-        es.transform.delete_transform.assert_called_once_with(transform_id=transform_id, force=params["force"],
-                                                              ignore=[404])
+        es.transform.delete_transform.assert_called_once_with(transform_id=transform_id, force=params["force"], ignore=[404])
 
 
 class TransformStatsRunnerTests(TestCase):
@@ -4671,55 +4329,70 @@ class TransformStatsRunnerTests(TestCase):
         es.transform.get_transform_stats.return_value = as_future({})
         transform_stats = runner.TransformStats()
         transform_id = "a-transform"
-        result = await transform_stats(es, params={"transform-id": transform_id,
-                                                   "request-timeout": 3.0,
-                                                   "headers": {"header1": "value1"},
-                                                   "opaque-id": "test-id1"})
+        result = await transform_stats(
+            es,
+            params={
+                "transform-id": transform_id,
+                "request-timeout": 3.0,
+                "headers": {"header1": "value1"},
+                "opaque-id": "test-id1",
+            },
+        )
         self.assertEqual(1, result["weight"])
         self.assertEqual("ops", result["unit"])
         self.assertTrue(result["success"])
 
-        es.transform.get_transform_stats.assert_called_once_with(transform_id=transform_id,
-                                                                 headers={"header1": "value1"},
-                                                                 opaque_id="test-id1",
-                                                                 request_timeout=3.0)
+        es.transform.get_transform_stats.assert_called_once_with(
+            transform_id=transform_id,
+            headers={"header1": "value1"},
+            opaque_id="test-id1",
+            request_timeout=3.0,
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_transform_stats_with_failed_condition(self, es):
         transform_id = "a-transform"
-        es.transform.get_transform_stats.return_value = as_future({
-            "count": 3,
-            "transforms": [
-                {
-                    "id": transform_id,
-                    "state": "started",
-                    "stats": {},
-                    "checkpointing": {
-                        "last": {},
-                        "operations_behind": 10000
+        es.transform.get_transform_stats.return_value = as_future(
+            {
+                "count": 3,
+                "transforms": [
+                    {
+                        "id": transform_id,
+                        "state": "started",
+                        "stats": {},
+                        "checkpointing": {
+                            "last": {},
+                            "operations_behind": 10000,
+                        },
                     }
-                }
-            ]
-        })
+                ],
+            }
+        )
 
         transform_stats = runner.TransformStats()
 
-        result = await transform_stats(es, params={
-            "transform-id": transform_id,
-            "condition": {
-                "path": "checkpointing.operations_behind",
-                "expected-value": None
-            }
-        })
+        result = await transform_stats(
+            es,
+            params={
+                "transform-id": transform_id,
+                "condition": {
+                    "path": "checkpointing.operations_behind",
+                    "expected-value": None,
+                },
+            },
+        )
         self.assertEqual(1, result["weight"])
         self.assertEqual("ops", result["unit"])
         self.assertFalse(result["success"])
-        self.assertDictEqual({
-            "path": "checkpointing.operations_behind",
-            "actual-value": "10000",
-            "expected-value": None
-        }, result["condition"])
+        self.assertDictEqual(
+            {
+                "path": "checkpointing.operations_behind",
+                "actual-value": "10000",
+                "expected-value": None,
+            },
+            result["condition"],
+        )
 
         es.transform.get_transform_stats.assert_called_once_with(transform_id=transform_id)
 
@@ -4727,37 +4400,45 @@ class TransformStatsRunnerTests(TestCase):
     @run_async
     async def test_transform_stats_with_successful_condition(self, es):
         transform_id = "a-transform"
-        es.transform.get_transform_stats.return_value = as_future({
-            "count": 3,
-            "transforms": [
-                {
-                    "id": transform_id,
-                    "state": "started",
-                    "stats": {},
-                    "checkpointing": {
-                        "last": {}
+        es.transform.get_transform_stats.return_value = as_future(
+            {
+                "count": 3,
+                "transforms": [
+                    {
+                        "id": transform_id,
+                        "state": "started",
+                        "stats": {},
+                        "checkpointing": {
+                            "last": {},
+                        },
                     }
-                }
-            ]
-        })
+                ],
+            }
+        )
 
         transform_stats = runner.TransformStats()
 
-        result = await transform_stats(es, params={
-            "transform-id": transform_id,
-            "condition": {
-                "path": "checkpointing.operations_behind",
-                "expected-value": None
-            }
-        })
+        result = await transform_stats(
+            es,
+            params={
+                "transform-id": transform_id,
+                "condition": {
+                    "path": "checkpointing.operations_behind",
+                    "expected-value": None,
+                },
+            },
+        )
         self.assertEqual(1, result["weight"])
         self.assertEqual("ops", result["unit"])
         self.assertTrue(result["success"])
-        self.assertDictEqual({
-            "path": "checkpointing.operations_behind",
-            "actual-value": None,
-            "expected-value": None
-        }, result["condition"])
+        self.assertDictEqual(
+            {
+                "path": "checkpointing.operations_behind",
+                "actual-value": None,
+                "expected-value": None,
+            },
+            result["condition"],
+        )
 
         es.transform.get_transform_stats.assert_called_once_with(transform_id=transform_id)
 
@@ -4765,37 +4446,45 @@ class TransformStatsRunnerTests(TestCase):
     @run_async
     async def test_transform_stats_with_non_existing_path(self, es):
         transform_id = "a-transform"
-        es.transform.get_transform_stats.return_value = as_future({
-            "count": 3,
-            "transforms": [
-                {
-                    "id": transform_id,
-                    "state": "started",
-                    "stats": {},
-                    "checkpointing": {
-                        "last": {}
+        es.transform.get_transform_stats.return_value = as_future(
+            {
+                "count": 3,
+                "transforms": [
+                    {
+                        "id": transform_id,
+                        "state": "started",
+                        "stats": {},
+                        "checkpointing": {
+                            "last": {},
+                        },
                     }
-                }
-            ]
-        })
+                ],
+            }
+        )
 
         transform_stats = runner.TransformStats()
 
-        result = await transform_stats(es, params={
-            "transform-id": transform_id,
-            "condition": {
-                "path": "checkpointing.last.checkpoint",
-                "expected-value": 42
-            }
-        })
+        result = await transform_stats(
+            es,
+            params={
+                "transform-id": transform_id,
+                "condition": {
+                    "path": "checkpointing.last.checkpoint",
+                    "expected-value": 42,
+                },
+            },
+        )
         self.assertEqual(1, result["weight"])
         self.assertEqual("ops", result["unit"])
         self.assertFalse(result["success"])
-        self.assertDictEqual({
-            "path": "checkpointing.last.checkpoint",
-            "actual-value": None,
-            "expected-value": "42"
-        }, result["condition"])
+        self.assertDictEqual(
+            {
+                "path": "checkpointing.last.checkpoint",
+                "actual-value": None,
+                "expected-value": "42",
+            },
+            result["condition"],
+        )
 
         es.transform.get_transform_stats.assert_called_once_with(transform_id=transform_id)
 
@@ -4810,10 +4499,10 @@ class SubmitAsyncSearchTests(TestCase):
             "name": "search-1",
             "body": {
                 "query": {
-                    "match_all": {}
-                }
+                    "match_all": {},
+                },
             },
-            "index": "_all"
+            "index": "_all",
         }
 
         async with runner.CompositeContext():
@@ -4821,51 +4510,50 @@ class SubmitAsyncSearchTests(TestCase):
             # search id is registered in context
             self.assertEqual("12345", runner.CompositeContext.get("search-1"))
 
-        es.async_search.submit.assert_called_once_with(body={
-            "query": {
-                "match_all": {}
-            }
-        }, index="_all", params={})
+        es.async_search.submit.assert_called_once_with(body={"query": {"match_all": {}}}, index="_all", params={})
 
 
 class GetAsyncSearchTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_get_async_search(self, es):
-        es.async_search.get.return_value = as_future({
-            "is_running": False,
-            "response": {
-                "took": 1122,
-                "timed_out": False,
-                "hits": {
-                    "total": {
-                        "value": 1520,
-                        "relation": "eq"
-                    }
-                }
+        es.async_search.get.return_value = as_future(
+            {
+                "is_running": False,
+                "response": {
+                    "took": 1122,
+                    "timed_out": False,
+                    "hits": {
+                        "total": {
+                            "value": 1520,
+                            "relation": "eq",
+                        },
+                    },
+                },
             }
-        })
+        )
         r = runner.GetAsyncSearch()
-        params = {
-            "retrieve-results-for": "search-1"
-        }
+        params = {"retrieve-results-for": "search-1"}
 
         async with runner.CompositeContext():
             runner.CompositeContext.put("search-1", "12345")
             response = await r(es, params)
-            self.assertDictEqual(response, {
-                "weight": 1,
-                "unit": "ops",
-                "success": True,
-                "stats": {
-                    "search-1": {
-                        "hits": 1520,
-                        "hits_relation": "eq",
-                        "timed_out": False,
-                        "took": 1122
-                    }
-                }
-            })
+            self.assertDictEqual(
+                response,
+                {
+                    "weight": 1,
+                    "unit": "ops",
+                    "success": True,
+                    "stats": {
+                        "search-1": {
+                            "hits": 1520,
+                            "hits_relation": "eq",
+                            "timed_out": False,
+                            "took": 1122,
+                        },
+                    },
+                },
+            )
 
         es.async_search.get.assert_called_once_with(id="12345", params={})
 
@@ -4874,14 +4562,9 @@ class DeleteAsyncSearchTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_delete_async_search(self, es):
-        es.async_search.delete.side_effect = [
-            as_future({}),
-            as_future({})
-        ]
+        es.async_search.delete.side_effect = [as_future({}), as_future({})]
         r = runner.DeleteAsyncSearch()
-        params = {
-            "delete-results-for": ["search-1", "search-2", "search-3"]
-        }
+        params = {"delete-results-for": ["search-1", "search-2", "search-3"]}
 
         async with runner.CompositeContext():
             runner.CompositeContext.put("search-1", "12345")
@@ -4889,10 +4572,12 @@ class DeleteAsyncSearchTests(TestCase):
             runner.CompositeContext.put("search-3", "6789")
             await r(es, params)
 
-        es.async_search.delete.assert_has_calls([
-            mock.call(id="12345"),
-            mock.call(id="6789"),
-        ])
+        es.async_search.delete.assert_has_calls(
+            [
+                mock.call(id="12345"),
+                mock.call(id="6789"),
+            ]
+        )
 
 
 class OpenPointInTimeTests(TestCase):
@@ -4900,10 +4585,7 @@ class OpenPointInTimeTests(TestCase):
     @run_async
     async def test_creates_point_in_time(self, es):
         pit_id = "0123456789abcdef"
-        params = {
-            "name": "open-pit-test",
-            "index": "test-index"
-        }
+        params = {"name": "open-pit-test", "index": "test-index"}
 
         es.open_point_in_time.return_value = as_future({"id": pit_id})
 
@@ -4916,10 +4598,7 @@ class OpenPointInTimeTests(TestCase):
     @run_async
     async def test_can_only_be_run_in_composite(self, es):
         pit_id = "0123456789abcdef"
-        params = {
-            "name": "open-pit-test",
-            "index": "test-index"
-        }
+        params = {"name": "open-pit-test", "index": "test-index"}
 
         es.open_point_in_time.return_value = as_future({"id": pit_id})
 
@@ -4928,6 +4607,7 @@ class OpenPointInTimeTests(TestCase):
             await r(es, params)
 
         self.assertEqual("This operation is only allowed inside a composite operation.", ctx.exception.args[0])
+
 
 class ClosePointInTimeTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
@@ -4938,7 +4618,7 @@ class ClosePointInTimeTests(TestCase):
             "name": "close-pit-test",
             "with-point-in-time-from": "open-pit-task1",
         }
-        es.close_point_in_time.return_value=(as_future())
+        es.close_point_in_time.return_value = as_future()
         r = runner.ClosePointInTime()
         async with runner.CompositeContext():
             runner.CompositeContext.put("open-pit-task1", pit_id)
@@ -4961,9 +4641,13 @@ class QueryWithSearchAfterScrollTests(TestCase):
             "pages": "all",
             "results-per-page": 2,
             "body": {
-                "sort": [{"timestamp": "asc", "tie_breaker_id": "asc"}],
-                "query": {"match-all": {}}
-            }
+                "sort": [
+                    {"timestamp": "asc", "tie_breaker_id": "asc"},
+                ],
+                "query": {
+                    "match-all": {},
+                },
+            },
         }
 
         page_1 = {
@@ -4971,43 +4655,30 @@ class QueryWithSearchAfterScrollTests(TestCase):
             "took": 10,
             "timed_out": False,
             "hits": {
-                "total": {
-                    "value": 3,
-                    "relation": "eq"
-                },
+                "total": {"value": 3, "relation": "eq"},
                 "hits": [
-                    {
-                        "_id": "1",
-                         "timestamp": 1609780186,
-                         "sort": [1609780186, "1"]
-                    },
-                    {
-                        "_id": "2",
-                         "timestamp": 1609780186,
-                         "sort": [1609780186, "2"]
-                    }
-                ]
-            }
+                    {"_id": "1", "timestamp": 1609780186, "sort": [1609780186, "1"]},
+                    {"_id": "2", "timestamp": 1609780186, "sort": [1609780186, "2"]},
+                ],
+            },
         }
 
-        page_2 = {"pit_id": "fedcba9876543211",
-                 "took": 10,
-                 "timed_out": False,
-                 "hits": {
-                     "total": {
-                         "value": "3",
-                         "relation": "eq"
-                     },
-                     "hits": [
-                         {"_id": "3",
-                          "timestamp": 1609780187,
-                          "sort": [1609780187, "3"]
-                          }
-                     ]
-                 }}
+        page_2 = {
+            "pit_id": "fedcba9876543211",
+            "took": 10,
+            "timed_out": False,
+            "hits": {
+                "total": {"value": "3", "relation": "eq"},
+                "hits": [
+                    {"_id": "3", "timestamp": 1609780187, "sort": [1609780187, "3"]},
+                ],
+            },
+        }
 
-        es.transport.perform_request.side_effect = [as_future(io.BytesIO(json.dumps(page_1).encode())),
-                                                    as_future(io.BytesIO(json.dumps(page_2).encode()))]
+        es.transport.perform_request.side_effect = [
+            as_future(io.BytesIO(json.dumps(page_1).encode())),
+            as_future(io.BytesIO(json.dumps(page_2).encode())),
+        ]
 
         r = runner.Query()
 
@@ -5017,39 +4688,55 @@ class QueryWithSearchAfterScrollTests(TestCase):
             # make sure pit_id is updated afterward
             self.assertEqual("fedcba9876543211", runner.CompositeContext.get(pit_op))
 
-        es.transport.perform_request.assert_has_calls([mock.call("GET", "/_search", params={},
-                                                                 body={
-                                                                     "query": {
-                                                                         "match-all": {}
-                                                                       },
-                                                                     "sort": [{
-                                                                         "timestamp": "asc",
-                                                                         "tie_breaker_id": "asc"
-                                                                     }],
-                                                                     "size": 2,
-                                                                     "pit": {
-                                                                         "id": "0123456789abcdef",
-                                                                         "keep_alive": "1m"
-                                                                     }
-                                                                 },
-                                                                 headers=None),
-                                                       mock.call("GET", "/_search", params={},
-                                                                 body={
-                                                                     "query": {
-                                                                         "match-all": {}
-                                                                     },
-                                                                     "sort": [{
-                                                                         "timestamp": "asc",
-                                                                         "tie_breaker_id": "asc"
-                                                                     }],
-                                                                     "size": 2,
-                                                                     "pit": {
-                                                                         "id": "fedcba9876543210",
-                                                                         "keep_alive": "1m"
-                                                                     },
-                                                                     "search_after": [1609780186, "2"]
-                                                                 },
-                                                                 headers=None)])
+        es.transport.perform_request.assert_has_calls(
+            [
+                mock.call(
+                    "GET",
+                    "/_search",
+                    params={},
+                    body={
+                        "query": {
+                            "match-all": {},
+                        },
+                        "sort": [
+                            {
+                                "timestamp": "asc",
+                                "tie_breaker_id": "asc",
+                            }
+                        ],
+                        "size": 2,
+                        "pit": {
+                            "id": "0123456789abcdef",
+                            "keep_alive": "1m",
+                        },
+                    },
+                    headers=None,
+                ),
+                mock.call(
+                    "GET",
+                    "/_search",
+                    params={},
+                    body={
+                        "query": {
+                            "match-all": {},
+                        },
+                        "sort": [
+                            {
+                                "timestamp": "asc",
+                                "tie_breaker_id": "asc",
+                            }
+                        ],
+                        "size": 2,
+                        "pit": {
+                            "id": "fedcba9876543210",
+                            "keep_alive": "1m",
+                        },
+                        "search_after": [1609780186, "2"],
+                    },
+                    headers=None,
+                ),
+            ]
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -5062,8 +4749,10 @@ class QueryWithSearchAfterScrollTests(TestCase):
             "results-per-page": 2,
             "body": {
                 "sort": [{"timestamp": "asc", "tie_breaker_id": "asc"}],
-                "query": {"match-all": {}}
-            }
+                "query": {
+                    "match-all": {},
+                },
+            },
         }
         page_1 = {
             "took": 10,
@@ -5071,61 +4760,71 @@ class QueryWithSearchAfterScrollTests(TestCase):
             "hits": {
                 "total": {
                     "value": 3,
-                    "relation": "eq"
+                    "relation": "eq",
                 },
                 "hits": [
-                    {
-                        "_id": "1",
-                        "timestamp": 1609780186,
-                        "sort": [1609780186, "1"]
-                    },
-                    {
-                        "_id": "2",
-                        "timestamp": 1609780186,
-                        "sort": [1609780186, "2"]
-                    }
-                ]
-            }
+                    {"_id": "1", "timestamp": 1609780186, "sort": [1609780186, "1"]},
+                    {"_id": "2", "timestamp": 1609780186, "sort": [1609780186, "2"]},
+                ],
+            },
         }
 
         page_2 = {
             "took": 10,
             "timed_out": False,
             "hits": {
-              "total": {
-                  "value": 3,
-                  "relation": "eq"
-              },
-              "hits": [
-                  {"_id": "3",
-                   "timestamp": 1609780187,
-                   "sort": [1609780187, "3"]
-                   }
-              ]
-            }
+                "total": {
+                    "value": 3,
+                    "relation": "eq",
+                },
+                "hits": [
+                    {"_id": "3", "timestamp": 1609780187, "sort": [1609780187, "3"]},
+                ],
+            },
         }
 
-        es.transport.perform_request.side_effect = [as_future(io.BytesIO(json.dumps(page_1).encode())),
-                                                    as_future(io.BytesIO(json.dumps(page_2).encode()))]
+        es.transport.perform_request.side_effect = [
+            as_future(io.BytesIO(json.dumps(page_1).encode())),
+            as_future(io.BytesIO(json.dumps(page_2).encode())),
+        ]
         r = runner.Query()
         await r(es, params)
 
-        es.transport.perform_request.assert_has_calls([mock.call("GET", "/test-index-1/_search", params={},
-                                                                 body={"query": {"match-all": {}},
-                                                                       "sort": [
-                                                                           {"timestamp": "asc",
-                                                                            "tie_breaker_id": "asc"}],
-                                                                       "size": 2},
-                                                                 headers=None),
-                                                       mock.call("GET", "/test-index-1/_search", params={},
-                                                                 body={"query": {"match-all": {}},
-                                                                       "sort": [
-                                                                           {"timestamp": "asc",
-                                                                            "tie_breaker_id": "asc"}],
-                                                                       "size": 2,
-                                                                       "search_after": [1609780186, "2"]},
-                                                                 headers=None)]
-                                                      )
+        es.transport.perform_request.assert_has_calls(
+            [
+                mock.call(
+                    "GET",
+                    "/test-index-1/_search",
+                    params={},
+                    body={
+                        "query": {
+                            "match-all": {},
+                        },
+                        "sort": [
+                            {"timestamp": "asc", "tie_breaker_id": "asc"},
+                        ],
+                        "size": 2,
+                    },
+                    headers=None,
+                ),
+                mock.call(
+                    "GET",
+                    "/test-index-1/_search",
+                    params={},
+                    body={
+                        "query": {
+                            "match-all": {},
+                        },
+                        "sort": [
+                            {"timestamp": "asc", "tie_breaker_id": "asc"},
+                        ],
+                        "size": 2,
+                        "search_after": [1609780186, "2"],
+                    },
+                    headers=None,
+                ),
+            ]
+        )
 
 
 class SearchAfterExtractorTests(TestCase):
@@ -5155,11 +4854,7 @@ class SearchAfterExtractorTests(TestCase):
     def test_extract_all_properties(self):
         target = runner.SearchAfterExtractor()
         props, last_sort = target(response=self.response, get_point_in_time=True, hits_total=None)
-        expected_props = {"hits.total.relation": "eq",
-                    "hits.total.value": 2,
-                    "pit_id": "fedcba9876543210",
-                    "timed_out": False,
-                    "took": 10}
+        expected_props = {"hits.total.relation": "eq", "hits.total.value": 2, "pit_id": "fedcba9876543210", "timed_out": False, "took": 10}
         expected_sort_value = [1609780186, "2"]
         self.assertEqual(expected_props, props)
         self.assertEqual(expected_sort_value, last_sort)
@@ -5167,10 +4862,7 @@ class SearchAfterExtractorTests(TestCase):
     def test_extract_ignore_point_in_time(self):
         target = runner.SearchAfterExtractor()
         props, last_sort = target(response=self.response, get_point_in_time=False, hits_total=None)
-        expected_props = {"hits.total.relation": "eq",
-                          "hits.total.value": 2,
-                          "timed_out": False,
-                          "took": 10}
+        expected_props = {"hits.total.relation": "eq", "hits.total.value": 2, "timed_out": False, "took": 10}
         expected_sort_value = [1609780186, "2"]
         self.assertEqual(expected_props, props)
         self.assertEqual(expected_sort_value, last_sort)
@@ -5179,10 +4871,7 @@ class SearchAfterExtractorTests(TestCase):
         target = runner.SearchAfterExtractor()
         # we use an incorrect hits_total just to prove we didn't extract it from the response
         props, last_sort = target(response=self.response, get_point_in_time=False, hits_total=10)
-        expected_props = {"hits.total.relation": "eq",
-                          "hits.total.value": 10,
-                          "timed_out": False,
-                          "took": 10}
+        expected_props = {"hits.total.relation": "eq", "hits.total.value": 10, "timed_out": False, "took": 10}
         expected_sort_value = [1609780186, "2"]
         self.assertEqual(expected_props, props)
         self.assertEqual(expected_sort_value, last_sort)
@@ -5194,8 +4883,7 @@ class SearchAfterExtractorTests(TestCase):
         target = runner.SearchAfterExtractor()
         with self.assertRaises(exceptions.RallyAssertionError) as ctx:
             target(response=response_copy_bytesio, get_point_in_time=True, hits_total=None)
-        self.assertEqual("Paginated query failure: pit_id was expected but not found in the response.",
-                         ctx.exception.args[0])
+        self.assertEqual("Paginated query failure: pit_id was expected but not found in the response.", ctx.exception.args[0])
 
     def test_extract_missing_ignored_point_in_time(self):
         response_copy = json.loads(self.response_text)
@@ -5203,10 +4891,7 @@ class SearchAfterExtractorTests(TestCase):
         response_copy_bytesio = io.BytesIO(json.dumps(response_copy).encode())
         target = runner.SearchAfterExtractor()
         props, last_sort = target(response=response_copy_bytesio, get_point_in_time=False, hits_total=None)
-        expected_props = {"hits.total.relation": "eq",
-                          "hits.total.value": 2,
-                          "timed_out": False,
-                          "took": 10}
+        expected_props = {"hits.total.relation": "eq", "hits.total.value": 2, "timed_out": False, "took": 10}
         expected_sort_value = [1609780186, "2"]
         self.assertEqual(expected_props, props)
         self.assertEqual(expected_sort_value, last_sort)
@@ -5231,8 +4916,7 @@ class CompositeContextTests(TestCase):
         async with runner.CompositeContext():
             with self.assertRaises(KeyError) as ctx:
                 runner.CompositeContext.get("don't clear this key")
-            self.assertEqual("Unknown property [don't clear this key]. Currently recognized properties are [].",
-                             ctx.exception.args[0])
+            self.assertEqual("Unknown property [don't clear this key]. Currently recognized properties are [].", ctx.exception.args[0])
 
     @run_async
     async def test_fails_to_read_unknown_key(self):
@@ -5240,8 +4924,7 @@ class CompositeContextTests(TestCase):
             with self.assertRaises(KeyError) as ctx:
                 runner.CompositeContext.put("test", 1)
                 runner.CompositeContext.get("unknown")
-            self.assertEqual("Unknown property [unknown]. Currently recognized properties are [test].",
-                             ctx.exception.args[0])
+            self.assertEqual("Unknown property [unknown]. Currently recognized properties are [test].", ctx.exception.args[0])
 
     @run_async
     async def test_fails_to_remove_unknown_key(self):
@@ -5249,8 +4932,7 @@ class CompositeContextTests(TestCase):
             with self.assertRaises(KeyError) as ctx:
                 runner.CompositeContext.put("test", 1)
                 runner.CompositeContext.remove("unknown")
-            self.assertEqual("Unknown property [unknown]. Currently recognized properties are [test].",
-                             ctx.exception.args[0])
+            self.assertEqual("Unknown property [unknown]. Currently recognized properties are [test].", ctx.exception.args[0])
 
 
 class CompositeTests(TestCase):
@@ -5301,14 +4983,20 @@ class CompositeTests(TestCase):
             # raw-request
             as_future(),
             # search
-            as_future(io.StringIO(json.dumps({
-                "hits": {
-                    "total": {
-                        "value": 10,
-                        "relation": "eq"
-                    }
-                }
-            })))
+            as_future(
+                io.StringIO(
+                    json.dumps(
+                        {
+                            "hits": {
+                                "total": {
+                                    "value": 10,
+                                    "relation": "eq",
+                                },
+                            },
+                        },
+                    ),
+                ),
+            ),
         ]
 
         params = {
@@ -5319,7 +5007,7 @@ class CompositeTests(TestCase):
                         {
                             "operation-type": "raw-request",
                             "path": "/",
-                            "body": {}
+                            "body": {},
                         },
                         {
                             "operation-type": "search",
@@ -5329,61 +5017,57 @@ class CompositeTests(TestCase):
                                 {
                                     "property": "hits",
                                     "condition": ">",
-                                    "value": 0
+                                    "value": 0,
                                 }
                             ],
                             "body": {
                                 "query": {
-                                    "match_all": {}
+                                    "match_all": {},
                                 }
-                            }
-                        }
+                            },
+                        },
                     ]
                 },
                 {
                     "stream": [
                         {
                             "operation-type": "sleep",
-                            "duration": 0.1
+                            "duration": 0.1,
                         }
                     ]
-                }
-            ]
+                },
+            ],
         }
 
         r = runner.Composite()
         await r(es, params)
 
-        es.transport.perform_request.assert_has_calls([
-            mock.call(method="GET",
-                      url="/",
-                      headers=None,
-                      body={},
-                      params={}),
-            mock.call("GET",
-                      "/test/_search",
-                      params={},
-                      body={
-                          "query": {
-                              "match_all": {}
-                          }
-                      },
-                      headers=None)
-        ])
+        es.transport.perform_request.assert_has_calls(
+            [
+                mock.call(method="GET", url="/", headers=None, body={}, params={}),
+                mock.call("GET", "/test/_search", params={}, body={"query": {"match_all": {}}}, headers=None),
+            ]
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_propagates_violated_assertions(self, es):
         es.transport.perform_request.side_effect = [
             # search
-            as_future(io.StringIO(json.dumps({
-                "hits": {
-                    "total": {
-                        "value": 0,
-                        "relation": "eq"
-                    }
-                }
-            })))
+            as_future(
+                io.StringIO(
+                    json.dumps(
+                        {
+                            "hits": {
+                                "total": {
+                                    "value": 0,
+                                    "relation": "eq",
+                                },
+                            }
+                        }
+                    )
+                )
+            )
         ]
 
         params = {
@@ -5399,36 +5083,39 @@ class CompositeTests(TestCase):
                                 {
                                     "property": "hits",
                                     "condition": ">",
-                                    "value": 0
+                                    "value": 0,
                                 }
                             ],
                             "body": {
                                 "query": {
-                                    "match_all": {}
+                                    "match_all": {},
                                 }
-                            }
+                            },
                         }
                     ]
                 }
-            ]
+            ],
         }
 
         r = runner.Composite()
-        with self.assertRaisesRegex(exceptions.RallyTaskAssertionError,
-                                    r"Expected \[hits\] to be > \[0\] but was \[0\]."):
+        with self.assertRaisesRegex(exceptions.RallyTaskAssertionError, r"Expected \[hits\] to be > \[0\] but was \[0\]."):
             await r(es, params)
 
-        es.transport.perform_request.assert_has_calls([
-            mock.call("GET",
-                      "/test/_search",
-                      params={},
-                      body={
-                          "query": {
-                              "match_all": {}
-                          }
-                      },
-                      headers=None)
-        ])
+        es.transport.perform_request.assert_has_calls(
+            [
+                mock.call(
+                    "GET",
+                    "/test/_search",
+                    params={},
+                    body={
+                        "query": {
+                            "match_all": {},
+                        }
+                    },
+                    headers=None,
+                )
+            ]
+        )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
@@ -5481,7 +5168,6 @@ class CompositeTests(TestCase):
                     "name": "call-after-stream-cd",
                     "operation-type": "call-recorder",
                 },
-
             ]
         }
 
@@ -5489,15 +5175,20 @@ class CompositeTests(TestCase):
         r.supported_op_types = ["call-recorder"]
         await r(es, params)
 
-        self.assertEqual([
-            "initial-call",
-            # concurrent
-            "stream-a", "stream-b",
-            "call-after-stream-ab",
-            # concurrent
-            "stream-c", "stream-d",
-            "call-after-stream-cd"
-        ], self.call_recorder_runner.calls)
+        self.assertEqual(
+            [
+                "initial-call",
+                # stream-a and stream-b are concurrent
+                "stream-a",
+                "stream-b",
+                "call-after-stream-ab",
+                # stream-c and stream-d are concurrent
+                "stream-c",
+                "stream-d",
+                "call-after-stream-cd",
+            ],
+            self.call_recorder_runner.calls,
+        )
 
     @run_async
     async def test_adds_request_timings(self):
@@ -5510,14 +5201,14 @@ class CompositeTests(TestCase):
                 {
                     "name": "initial-call",
                     "operation-type": "sleep",
-                    "duration": 0.1
+                    "duration": 0.1,
                 },
                 {
                     "stream": [
                         {
                             "name": "stream-a",
                             "operation-type": "sleep",
-                            "duration": 0.2
+                            "duration": 0.2,
                         }
                     ]
                 },
@@ -5526,10 +5217,10 @@ class CompositeTests(TestCase):
                         {
                             "name": "stream-b",
                             "operation-type": "sleep",
-                            "duration": 0.1
+                            "duration": 0.1,
                         }
                     ]
-                }
+                },
             ]
         }
 
@@ -5567,26 +5258,25 @@ class CompositeTests(TestCase):
                 {
                     "stream": [
                         {
-                            "operation-type": "counter"
+                            "operation-type": "counter",
                         }
                     ]
                 },
                 {
                     "stream": [
                         {
-                            "operation-type": "counter"
+                            "operation-type": "counter",
                         }
-
                     ]
                 },
                 {
                     "stream": [
                         {
-                            "operation-type": "counter"
+                            "operation-type": "counter",
                         }
                     ]
-                }
-            ]
+                },
+            ],
         }
 
         r = runner.Composite()
@@ -5602,23 +5292,7 @@ class CompositeTests(TestCase):
         # params contains a "streams" property (plural) but it should be "stream" (singular)
         params = {
             "max-connections": 2,
-            "requests": [
-                {
-                    "stream": [
-                        {
-                            "operation-type": "counter"
-                        }
-                    ]
-                },
-                {
-                    "streams": [
-                        {
-                            "operation-type": "counter"
-                        }
-
-                    ]
-                }
-            ]
+            "requests": [{"stream": [{"operation-type": "counter"}]}, {"streams": [{"operation-type": "counter"}]}],
         }
 
         r = runner.Composite()
@@ -5630,25 +5304,18 @@ class CompositeTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_rejects_unsupported_operations(self, es):
-        params = {
-            "requests": [
-                {
-                    "stream": [
-                        {
-                            "operation-type": "bulk"
-                        }
-                    ]
-                }
-            ]
-        }
+        params = {"requests": [{"stream": [{"operation-type": "bulk"}]}]}
 
         r = runner.Composite()
         with self.assertRaises(exceptions.RallyAssertionError) as ctx:
             await r(es, params)
 
-        self.assertEqual("Unsupported operation-type [bulk]. Use one of [open-point-in-time, close-point-in-time, "
-                         "search, raw-request, sleep, submit-async-search, get-async-search, delete-async-search].",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Unsupported operation-type [bulk]. Use one of [open-point-in-time, close-point-in-time, "
+            "search, raw-request, sleep, submit-async-search, get-async-search, delete-async-search].",
+            ctx.exception.args[0],
+        )
+
 
 class RequestTimingTests(TestCase):
     class StaticRequestTiming:
@@ -5678,15 +5345,8 @@ class RequestTimingTests(TestCase):
         multi_cluster_client = {"default": es}
         es.new_request_context.return_value = RequestTimingTests.StaticRequestTiming(task_start=2)
 
-        delegate = mock.Mock(return_value=as_future({
-            "weight": 5,
-            "unit": "ops",
-            "success": True
-        }))
-        params = {
-            "name": "unit-test-operation",
-            "operation-type": "test-op"
-        }
+        delegate = mock.Mock(return_value=as_future({"weight": 5, "unit": "ops", "success": True}))
+        params = {"name": "unit-test-operation", "operation-type": "test-op"}
         timer = runner.RequestTiming(delegate)
 
         response = await timer(multi_cluster_client, params)
@@ -5713,10 +5373,7 @@ class RequestTimingTests(TestCase):
 
         # a simple runner without a return value
         delegate = mock.Mock(return_value=as_future())
-        params = {
-            "name": "unit-test-operation",
-            "operation-type": "test-op"
-        }
+        params = {"name": "unit-test-operation", "operation-type": "test-op"}
         timer = runner.RequestTiming(delegate)
 
         response = await timer(multi_cluster_client, params)
@@ -5786,12 +5443,7 @@ class RetryTests(TestCase):
     async def test_is_does_not_retry_on_success(self):
         delegate = mock.Mock(return_value=as_future())
         es = None
-        params = {
-            "retries": 3,
-            "retry-wait-period": 0.1,
-            "retry-on-timeout": True,
-            "retry-on-error": True
-        }
+        params = {"retries": 3, "retry-wait-period": 0.1, "retry-on-timeout": True, "retry-on-error": True}
         retrier = runner.Retry(delegate)
 
         await retrier(es, params)
@@ -5800,56 +5452,51 @@ class RetryTests(TestCase):
 
     @run_async
     async def test_retries_on_timeout_if_wanted_and_raises_if_no_recovery(self):
-        delegate = mock.Mock(side_effect=[
-            as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host")),
-            as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host")),
-            as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host")),
-            as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host"))
-        ])
+        delegate = mock.Mock(
+            side_effect=[
+                as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host")),
+                as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host")),
+                as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host")),
+                as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host")),
+            ]
+        )
         es = None
-        params = {
-            "retries": 3,
-            "retry-wait-period": 0.01,
-            "retry-on-timeout": True,
-            "retry-on-error": True
-        }
+        params = {"retries": 3, "retry-wait-period": 0.01, "retry-on-timeout": True, "retry-on-error": True}
         retrier = runner.Retry(delegate)
 
         with self.assertRaises(elasticsearch.ConnectionError):
             await retrier(es, params)
 
-        delegate.assert_has_calls([
-            mock.call(es, params),
-            mock.call(es, params),
-            mock.call(es, params)
-        ])
+        delegate.assert_has_calls(
+            [
+                mock.call(es, params),
+                mock.call(es, params),
+                mock.call(es, params),
+            ]
+        )
 
     @run_async
     async def test_retries_on_timeout_if_wanted_and_returns_first_call(self):
         failed_return_value = {"weight": 1, "unit": "ops", "success": False}
 
-        delegate = mock.Mock(side_effect=[
-            as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host")),
-            as_future(failed_return_value)
-        ])
+        delegate = mock.Mock(
+            side_effect=[as_future(exception=elasticsearch.ConnectionError("N/A", "no route to host")), as_future(failed_return_value)]
+        )
         es = None
-        params = {
-            "retries": 3,
-            "retry-wait-period": 0.01,
-            "retry-on-timeout": True,
-            "retry-on-error": False
-        }
+        params = {"retries": 3, "retry-wait-period": 0.01, "retry-on-timeout": True, "retry-on-error": False}
         retrier = runner.Retry(delegate)
 
         result = await retrier(es, params)
         self.assertEqual(failed_return_value, result)
 
-        delegate.assert_has_calls([
-            # has returned a connection error
-            mock.call(es, params),
-            # has returned normally
-            mock.call(es, params)
-        ])
+        delegate.assert_has_calls(
+            [
+                # has returned a connection error
+                mock.call(es, params),
+                # has returned normally
+                mock.call(es, params),
+            ]
+        )
 
     @run_async
     async def test_retries_mixed_timeout_and_application_errors(self):
@@ -5857,52 +5504,51 @@ class RetryTests(TestCase):
         failed_return_value = {"weight": 1, "unit": "ops", "success": False}
         success_return_value = {"weight": 1, "unit": "ops", "success": False}
 
-        delegate = mock.Mock(side_effect=[
-            as_future(exception=connection_error),
-            as_future(failed_return_value),
-            as_future(exception=connection_error),
-            as_future(exception=connection_error),
-            as_future(failed_return_value),
-            as_future(success_return_value)
-        ])
+        delegate = mock.Mock(
+            side_effect=[
+                as_future(exception=connection_error),
+                as_future(failed_return_value),
+                as_future(exception=connection_error),
+                as_future(exception=connection_error),
+                as_future(failed_return_value),
+                as_future(success_return_value),
+            ]
+        )
         es = None
         params = {
             # we try exactly as often as there are errors to also test the semantics of "retry".
             "retries": 5,
             "retry-wait-period": 0.01,
             "retry-on-timeout": True,
-            "retry-on-error": True
+            "retry-on-error": True,
         }
         retrier = runner.Retry(delegate)
 
         result = await retrier(es, params)
         self.assertEqual(success_return_value, result)
 
-        delegate.assert_has_calls([
-            # connection error
-            mock.call(es, params),
-            # application error
-            mock.call(es, params),
-            # connection error
-            mock.call(es, params),
-            # connection error
-            mock.call(es, params),
-            # application error
-            mock.call(es, params),
-            # success
-            mock.call(es, params)
-        ])
+        delegate.assert_has_calls(
+            [
+                # connection error
+                mock.call(es, params),
+                # application error
+                mock.call(es, params),
+                # connection error
+                mock.call(es, params),
+                # connection error
+                mock.call(es, params),
+                # application error
+                mock.call(es, params),
+                # success
+                mock.call(es, params),
+            ]
+        )
 
     @run_async
     async def test_does_not_retry_on_timeout_if_not_wanted(self):
         delegate = mock.Mock(side_effect=as_future(exception=elasticsearch.ConnectionTimeout(408, "timed out")))
         es = None
-        params = {
-            "retries": 3,
-            "retry-wait-period": 0.01,
-            "retry-on-timeout": False,
-            "retry-on-error": True
-        }
+        params = {"retries": 3, "retry-wait-period": 0.01, "retry-on-timeout": False, "retry-on-error": True}
         retrier = runner.Retry(delegate)
 
         with self.assertRaises(elasticsearch.ConnectionTimeout):
@@ -5915,28 +5561,22 @@ class RetryTests(TestCase):
         failed_return_value = {"weight": 1, "unit": "ops", "success": False}
         success_return_value = {"weight": 1, "unit": "ops", "success": True}
 
-        delegate = mock.Mock(side_effect=[
-            as_future(failed_return_value),
-            as_future(success_return_value)
-        ])
+        delegate = mock.Mock(side_effect=[as_future(failed_return_value), as_future(success_return_value)])
         es = None
-        params = {
-            "retries": 3,
-            "retry-wait-period": 0.01,
-            "retry-on-timeout": False,
-            "retry-on-error": True
-        }
+        params = {"retries": 3, "retry-wait-period": 0.01, "retry-on-timeout": False, "retry-on-error": True}
         retrier = runner.Retry(delegate)
 
         result = await retrier(es, params)
 
         self.assertEqual(success_return_value, result)
 
-        delegate.assert_has_calls([
-            mock.call(es, params),
-            # one retry
-            mock.call(es, params)
-        ])
+        delegate.assert_has_calls(
+            [
+                mock.call(es, params),
+                # one retry
+                mock.call(es, params),
+            ]
+        )
 
     @run_async
     async def test_does_not_retry_on_application_error_if_not_wanted(self):
@@ -5944,12 +5584,7 @@ class RetryTests(TestCase):
 
         delegate = mock.Mock(return_value=as_future(failed_return_value))
         es = None
-        params = {
-            "retries": 3,
-            "retry-wait-period": 0.01,
-            "retry-on-timeout": True,
-            "retry-on-error": False
-        }
+        params = {"retries": 3, "retry-wait-period": 0.01, "retry-on-timeout": True, "retry-on-error": False}
         retrier = runner.Retry(delegate)
 
         result = await retrier(es, params)
@@ -5962,12 +5597,7 @@ class RetryTests(TestCase):
     async def test_assumes_success_if_runner_returns_non_dict(self):
         delegate = mock.Mock(return_value=as_future(result=(1, "ops")))
         es = None
-        params = {
-            "retries": 3,
-            "retry-wait-period": 0.01,
-            "retry-on-timeout": True,
-            "retry-on-error": True
-        }
+        params = {"retries": 3, "retry-wait-period": 0.01, "retry-on-timeout": True, "retry-on-error": True}
         retrier = runner.Retry(delegate)
 
         result = await retrier(es, params)
@@ -5989,10 +5619,7 @@ class RetryTests(TestCase):
 
         delegate = mock.Mock(side_effect=responses)
         es = None
-        params = {
-            "retry-until-success": True,
-            "retry-wait-period": 0.01
-        }
+        params = {"retry-until-success": True, "retry-wait-period": 0.01}
         retrier = runner.Retry(delegate)
 
         result = await retrier(es, params)

--- a/tests/driver/scheduler_test.py
+++ b/tests/driver/scheduler_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -40,10 +40,16 @@ class SchedulerTestCase(TestCase):
         expected_lower_bound = (1.0 - relative_delta) * expected_average_rate
         expected_upper_bound = (1.0 + relative_delta) * expected_average_rate
 
-        self.assertGreaterEqual(actual_average_rate, expected_lower_bound,
-                                f"{msg}: expected target rate to be >= [{expected_lower_bound}] but was [{actual_average_rate}].")
-        self.assertLessEqual(actual_average_rate, expected_upper_bound,
-                             f"{msg}: expected target rate to be <= [{expected_upper_bound}] but was [{actual_average_rate}].")
+        self.assertGreaterEqual(
+            actual_average_rate,
+            expected_lower_bound,
+            f"{msg}: expected target rate to be >= [{expected_lower_bound}] but was [{actual_average_rate}].",
+        )
+        self.assertLessEqual(
+            actual_average_rate,
+            expected_upper_bound,
+            f"{msg}: expected target rate to be <= [{expected_upper_bound}] but was [{actual_average_rate}].",
+        )
 
 
 class DeterministicSchedulerTests(SchedulerTestCase):
@@ -65,30 +71,28 @@ class PoissonSchedulerTests(SchedulerTestCase):
 
 class UnitAwareSchedulerTests(TestCase):
     def test_scheduler_rejects_differing_throughput_units(self):
-        task = track.Task(name="bulk-index",
-                          operation=track.Operation(
-                              name="bulk-index",
-                              operation_type=track.OperationType.Bulk.to_hyphenated_string()),
-                          clients=4,
-                          params={
-                              "target-throughput": "5000 MB/s"
-                          })
+        task = track.Task(
+            name="bulk-index",
+            operation=track.Operation(name="bulk-index", operation_type=track.OperationType.Bulk.to_hyphenated_string()),
+            clients=4,
+            params={"target-throughput": "5000 MB/s"},
+        )
 
         s = scheduler.UnitAwareScheduler(task=task, scheduler_class=scheduler.DeterministicScheduler)
         with self.assertRaises(exceptions.RallyAssertionError) as ex:
             s.after_request(now=None, weight=1000, unit="docs", request_meta_data=None)
-        self.assertEqual("Target throughput for [bulk-index] is specified in [MB/s] but the task throughput "
-                         "is measured in [docs/s].", ex.exception.args[0])
+        self.assertEqual(
+            "Target throughput for [bulk-index] is specified in [MB/s] but the task throughput is measured in [docs/s].",
+            ex.exception.args[0],
+        )
 
     def test_scheduler_adapts_to_changed_weights(self):
-        task = track.Task(name="bulk-index",
-                          operation=track.Operation(
-                              name="bulk-index",
-                              operation_type=track.OperationType.Bulk.to_hyphenated_string()),
-                          clients=4,
-                          params={
-                              "target-throughput": "5000 docs/s"
-                          })
+        task = track.Task(
+            name="bulk-index",
+            operation=track.Operation(name="bulk-index", operation_type=track.OperationType.Bulk.to_hyphenated_string()),
+            clients=4,
+            params={"target-throughput": "5000 docs/s"},
+        )
 
         s = scheduler.UnitAwareScheduler(task=task, scheduler_class=scheduler.DeterministicScheduler)
         # first request is unthrottled
@@ -108,15 +112,15 @@ class UnitAwareSchedulerTests(TestCase):
         self.assertEqual(2 * task.clients, s.next(0))
 
     def test_scheduler_accepts_differing_units_pages_and_ops(self):
-        task = track.Task(name="scroll-query",
-                          operation=track.Operation(
-                              name="scroll-query",
-                              operation_type=track.OperationType.Search.to_hyphenated_string()),
-                          clients=1,
-                          params={
-                              # implicitly: ops/s
-                              "target-throughput": 10
-                          })
+        task = track.Task(
+            name="scroll-query",
+            operation=track.Operation(name="scroll-query", operation_type=track.OperationType.Search.to_hyphenated_string()),
+            clients=1,
+            params={
+                # implicitly: ops/s
+                "target-throughput": 10
+            },
+        )
 
         s = scheduler.UnitAwareScheduler(task=task, scheduler_class=scheduler.DeterministicScheduler)
         # first request is unthrottled
@@ -131,15 +135,15 @@ class UnitAwareSchedulerTests(TestCase):
         self.assertEqual(0.1 * task.clients, s.next(0))
 
     def test_scheduler_does_not_change_throughput_for_empty_requests(self):
-        task = track.Task(name="match-all-query",
-                          operation=track.Operation(
-                              name="query",
-                              operation_type=track.OperationType.Search.to_hyphenated_string()),
-                          clients=1,
-                          params={
-                              # implicitly: ops/s
-                              "target-throughput": 10
-                          })
+        task = track.Task(
+            name="match-all-query",
+            operation=track.Operation(name="query", operation_type=track.OperationType.Search.to_hyphenated_string()),
+            clients=1,
+            params={
+                # implicitly: ops/s
+                "target-throughput": 10
+            },
+        )
 
         s = scheduler.UnitAwareScheduler(task=task, scheduler_class=scheduler.DeterministicScheduler)
         # first request is unthrottled...
@@ -230,12 +234,12 @@ class LegacyWrappingSchedulerTests(TestCase):
         scheduler.remove_scheduler("simple")
 
     def test_legacy_scheduler(self):
-        task = track.Task(name="raw-request",
-                          operation=track.Operation(
-                              name="raw",
-                              operation_type=track.OperationType.RawRequest.to_hyphenated_string()),
-                          clients=1,
-                          schedule="simple")
+        task = track.Task(
+            name="raw-request",
+            operation=track.Operation(name="raw", operation_type=track.OperationType.RawRequest.to_hyphenated_string()),
+            clients=1,
+            schedule="simple",
+        )
 
         s = scheduler.scheduler_for(task)
 

--- a/tests/mechanic/__init__.py
+++ b/tests/mechanic/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tests/mechanic/data/cars/v1/hook2/config.py
+++ b/tests/mechanic/data/cars/v1/hook2/config.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tests/mechanic/data/cars/v1/with_hook/config.py
+++ b/tests/mechanic/data/cars/v1/with_hook/config.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tests/mechanic/java_resolver_test.py
+++ b/tests/mechanic/java_resolver_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -26,9 +26,7 @@ class JavaResolverTests(TestCase):
     @mock.patch("esrally.utils.jvm.resolve_path")
     def test_resolves_java_home_for_default_runtime_jdk(self, resolve_jvm_path):
         resolve_jvm_path.return_value = (12, "/opt/jdk12")
-        major, java_home = java_resolver.java_home("12,11,10,9,8",
-                                                   specified_runtime_jdk=None,
-                                                   provides_bundled_jdk=True)
+        major, java_home = java_resolver.java_home("12,11,10,9,8", specified_runtime_jdk=None, provides_bundled_jdk=True)
 
         self.assertEqual(major, 12)
         self.assertEqual(java_home, "/opt/jdk12")
@@ -36,18 +34,14 @@ class JavaResolverTests(TestCase):
     @mock.patch("esrally.utils.jvm.resolve_path")
     def test_resolves_java_home_for_specific_runtime_jdk(self, resolve_jvm_path):
         resolve_jvm_path.return_value = (8, "/opt/jdk8")
-        major, java_home = java_resolver.java_home("12,11,10,9,8",
-                                                   specified_runtime_jdk=8,
-                                                   provides_bundled_jdk=True)
+        major, java_home = java_resolver.java_home("12,11,10,9,8", specified_runtime_jdk=8, provides_bundled_jdk=True)
 
         self.assertEqual(major, 8)
         self.assertEqual(java_home, "/opt/jdk8")
         resolve_jvm_path.assert_called_with([8])
 
     def test_resolves_java_home_for_bundled_jdk(self):
-        major, java_home = java_resolver.java_home("12,11,10,9,8",
-                                                   specified_runtime_jdk="bundled",
-                                                   provides_bundled_jdk=True)
+        major, java_home = java_resolver.java_home("12,11,10,9,8", specified_runtime_jdk="bundled", provides_bundled_jdk=True)
 
         # assumes most recent JDK
         self.assertEqual(major, 12)
@@ -57,5 +51,6 @@ class JavaResolverTests(TestCase):
     def test_disallowed_bundled_jdk(self):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             java_resolver.java_home("12,11,10,9,8", specified_runtime_jdk="bundled")
-        self.assertEqual("This Elasticsearch version does not contain a bundled JDK. Please specify a different runtime JDK.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "This Elasticsearch version does not contain a bundled JDK. Please specify a different runtime JDK.", ctx.exception.args[0]
+        )

--- a/tests/mechanic/mechanic_test.py
+++ b/tests/mechanic/mechanic_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -34,11 +34,14 @@ class HostHandlingTests(TestCase):
             {"host": "site.example.com", "port": 9200},
         ]
 
-        self.assertEqual([
-            ("127.0.0.1", 9200),
-            ("10.16.23.5", 9200),
-            ("11.22.33.44", 9200),
-        ], mechanic.to_ip_port(hosts))
+        self.assertEqual(
+            [
+                ("127.0.0.1", 9200),
+                ("10.16.23.5", 9200),
+                ("11.22.33.44", 9200),
+            ],
+            mechanic.to_ip_port(hosts),
+        )
 
     @mock.patch("esrally.utils.net.resolve")
     def test_rejects_hosts_with_unexpected_properties(self, resolver):
@@ -52,8 +55,11 @@ class HostHandlingTests(TestCase):
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             mechanic.to_ip_port(hosts)
-        self.assertEqual("When specifying nodes to be managed by Rally you can only supply hostname:port pairs (e.g. 'localhost:9200'), "
-                         "any additional options cannot be supported.", ctx.exception.args[0])
+        self.assertEqual(
+            "When specifying nodes to be managed by Rally you can only supply hostname:port pairs (e.g. 'localhost:9200'), "
+            "any additional options cannot be supported.",
+            ctx.exception.args[0],
+        )
 
     def test_groups_nodes_by_host(self):
         ip_port = [
@@ -70,8 +76,8 @@ class HostHandlingTests(TestCase):
                 ("127.0.0.1", 9200): [0, 1, 2],
                 ("10.16.23.5", 9200): [3],
                 ("11.22.33.44", 9200): [4, 5],
-
-            }, mechanic.nodes_by_host(ip_port)
+            },
+            mechanic.nodes_by_host(ip_port),
         )
 
     def test_extract_all_node_ips(self):
@@ -83,8 +89,7 @@ class HostHandlingTests(TestCase):
             ("11.22.33.44", 9200),
             ("11.22.33.44", 9200),
         ]
-        self.assertSetEqual({"127.0.0.1", "10.16.23.5", "11.22.33.44"},
-                            mechanic.extract_all_node_ips(ip_port))
+        self.assertSetEqual({"127.0.0.1", "10.16.23.5", "11.22.33.44"}, mechanic.extract_all_node_ips(ip_port))
 
 
 class MechanicTests(TestCase):

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -38,23 +38,27 @@ class BareProvisionerTests(TestCase):
         def null_apply_config(source_root_path, target_root_path, config_vars):
             apply_config_calls.append((source_root_path, target_root_path, config_vars))
 
-        installer = provisioner.ElasticsearchInstaller(car=
-        team.Car(
-            names="unit-test-car",
-            root_path=None,
-            config_paths=[HOME_DIR + "/.rally/benchmarks/teams/default/my-car"],
-            variables={"heap": "4g", "runtime.jdk": "8", "runtime.jdk.bundled": "true"}),
+        installer = provisioner.ElasticsearchInstaller(
+            car=team.Car(
+                names="unit-test-car",
+                root_path=None,
+                config_paths=[HOME_DIR + "/.rally/benchmarks/teams/default/my-car"],
+                variables={
+                    "heap": "4g",
+                    "runtime.jdk": "8",
+                    "runtime.jdk.bundled": "true",
+                },
+            ),
             java_home="/usr/local/javas/java8",
             node_name="rally-node-0",
             node_root_dir=HOME_DIR + "/.rally/benchmarks/races/unittest",
             all_node_ips=["10.17.22.22", "10.17.22.23"],
             all_node_names=["rally-node-0", "rally-node-1"],
             ip="10.17.22.23",
-            http_port=9200)
+            http_port=9200,
+        )
 
-        p = provisioner.BareProvisioner(es_installer=installer,
-                                        plugin_installers=[],
-                                        apply_config=null_apply_config)
+        p = provisioner.BareProvisioner(es_installer=installer, plugin_installers=[], apply_config=null_apply_config)
 
         node_config = p.prepare({"elasticsearch": "/opt/elasticsearch-5.0.0.tar.gz"})
         self.assertEqual("8", node_config.car_runtime_jdks)
@@ -66,26 +70,28 @@ class BareProvisionerTests(TestCase):
 
         self.assertEqual(HOME_DIR + "/.rally/benchmarks/teams/default/my-car", source_root_path)
         self.assertEqual("/opt/elasticsearch-5.0.0", target_root_path)
-        self.assertEqual({
-            "cluster_settings": {
+        self.assertEqual(
+            {
+                "cluster_settings": {},
+                "heap": "4g",
+                "runtime.jdk": "8",
+                "runtime.jdk.bundled": "true",
+                "cluster_name": "rally-benchmark",
+                "node_name": "rally-node-0",
+                "data_paths": ["/opt/elasticsearch-5.0.0/data"],
+                "log_path": HOME_DIR + "/.rally/benchmarks/races/unittest/logs/server",
+                "heap_dump_path": HOME_DIR + "/.rally/benchmarks/races/unittest/heapdump",
+                "node_ip": "10.17.22.23",
+                "network_host": "10.17.22.23",
+                "http_port": "9200",
+                "transport_port": "9300",
+                "all_node_ips": '["10.17.22.22","10.17.22.23"]',
+                "all_node_names": '["rally-node-0","rally-node-1"]',
+                "minimum_master_nodes": 2,
+                "install_root_path": "/opt/elasticsearch-5.0.0",
             },
-            "heap": "4g",
-            "runtime.jdk": "8",
-            "runtime.jdk.bundled": "true",
-            "cluster_name": "rally-benchmark",
-            "node_name": "rally-node-0",
-            "data_paths": ["/opt/elasticsearch-5.0.0/data"],
-            "log_path": HOME_DIR + "/.rally/benchmarks/races/unittest/logs/server",
-            "heap_dump_path": HOME_DIR + "/.rally/benchmarks/races/unittest/heapdump",
-            "node_ip": "10.17.22.23",
-            "network_host": "10.17.22.23",
-            "http_port": "9200",
-            "transport_port": "9300",
-            "all_node_ips": "[\"10.17.22.22\",\"10.17.22.23\"]",
-            "all_node_names": "[\"rally-node-0\",\"rally-node-1\"]",
-            "minimum_master_nodes": 2,
-            "install_root_path": "/opt/elasticsearch-5.0.0"
-        }, config_vars)
+            config_vars,
+        )
 
     class NoopHookHandler:
         def __init__(self, plugin):
@@ -95,27 +101,23 @@ class BareProvisionerTests(TestCase):
             return False
 
         def invoke(self, phase, variables, **kwargs):
-            self.hook_calls[phase] = {
-                "variables": variables,
-                "kwargs": kwargs
-            }
+            self.hook_calls[phase] = {"variables": variables, "kwargs": kwargs}
 
     class MockRallyTeamXPackPlugin:
         """
         Mock XPackPlugin settings as found in rally-team repo:
         https://github.com/elastic/rally-teams/blob/6/plugins/x_pack/security.ini
         """
+
         def __init__(self):
             self.name = "x-pack"
             self.core_plugin = False
-            self.config = {
-                'base': 'internal_base,security'
-            }
+            self.config = {"base": "internal_base,security"}
             self.root_path = None
             self.config_paths = []
             self.variables = {
-                'xpack_security_enabled': True,
-                'plugin_name': 'x-pack-security'
+                "xpack_security_enabled": True,
+                "plugin_name": "x-pack-security",
             }
 
         def __str__(self):
@@ -144,28 +146,38 @@ class BareProvisionerTests(TestCase):
         def null_apply_config(source_root_path, target_root_path, config_vars):
             apply_config_calls.append((source_root_path, target_root_path, config_vars))
 
-        installer = provisioner.ElasticsearchInstaller(car=
-        team.Car(
-            names="unit-test-car",
-            root_path=None,
-            config_paths=[HOME_DIR + "/.rally/benchmarks/teams/default/my-car"],
-            variables={"heap": "4g", "runtime.jdk": "8", "runtime.jdk.bundled": "true"}),
+        installer = provisioner.ElasticsearchInstaller(
+            car=team.Car(
+                names="unit-test-car",
+                root_path=None,
+                config_paths=[HOME_DIR + "/.rally/benchmarks/teams/default/my-car"],
+                variables={
+                    "heap": "4g",
+                    "runtime.jdk": "8",
+                    "runtime.jdk.bundled": "true",
+                },
+            ),
             java_home="/usr/local/javas/java8",
             node_name="rally-node-0",
             node_root_dir=HOME_DIR + "/.rally/benchmarks/races/unittest",
             all_node_ips=["10.17.22.22", "10.17.22.23"],
             all_node_names=["rally-node-0", "rally-node-1"],
             ip="10.17.22.23",
-            http_port=9200)
+            http_port=9200,
+        )
 
-        p = provisioner.BareProvisioner(es_installer=installer,
-                                        plugin_installers=[
-                                            provisioner.PluginInstaller(BareProvisionerTests.MockRallyTeamXPackPlugin(),
-                                                                        java_home="/usr/local/javas/java8",
-                                                                        hook_handler_class=BareProvisionerTests.NoopHookHandler)
-                                        ],
-                                        distribution_version="6.2.3",
-                                        apply_config=null_apply_config)
+        p = provisioner.BareProvisioner(
+            es_installer=installer,
+            plugin_installers=[
+                provisioner.PluginInstaller(
+                    BareProvisionerTests.MockRallyTeamXPackPlugin(),
+                    java_home="/usr/local/javas/java8",
+                    hook_handler_class=BareProvisionerTests.NoopHookHandler,
+                )
+            ],
+            distribution_version="6.2.3",
+            apply_config=null_apply_config,
+        )
 
         node_config = p.prepare({"elasticsearch": "/opt/elasticsearch-5.0.0.tar.gz"})
         self.assertEqual("8", node_config.car_runtime_jdks)
@@ -180,30 +192,30 @@ class BareProvisionerTests(TestCase):
 
         self.maxDiff = None
 
-        self.assertEqual({
-            "cluster_settings": {
-                "plugin.mandatory": ["x-pack-security"]
+        self.assertEqual(
+            {
+                "cluster_settings": {"plugin.mandatory": ["x-pack-security"]},
+                "heap": "4g",
+                "runtime.jdk": "8",
+                "runtime.jdk.bundled": "true",
+                "cluster_name": "rally-benchmark",
+                "node_name": "rally-node-0",
+                "data_paths": ["/opt/elasticsearch-5.0.0/data"],
+                "log_path": HOME_DIR + "/.rally/benchmarks/races/unittest/logs/server",
+                "heap_dump_path": HOME_DIR + "/.rally/benchmarks/races/unittest/heapdump",
+                "node_ip": "10.17.22.23",
+                "network_host": "10.17.22.23",
+                "http_port": "9200",
+                "transport_port": "9300",
+                "all_node_ips": '["10.17.22.22","10.17.22.23"]',
+                "all_node_names": '["rally-node-0","rally-node-1"]',
+                "minimum_master_nodes": 2,
+                "install_root_path": "/opt/elasticsearch-5.0.0",
+                "plugin_name": "x-pack-security",
+                "xpack_security_enabled": True,
             },
-            "heap": "4g",
-            "runtime.jdk": "8",
-            "runtime.jdk.bundled": "true",
-            "cluster_name": "rally-benchmark",
-            "node_name": "rally-node-0",
-            "data_paths": ["/opt/elasticsearch-5.0.0/data"],
-            "log_path": HOME_DIR + "/.rally/benchmarks/races/unittest/logs/server",
-            "heap_dump_path": HOME_DIR + "/.rally/benchmarks/races/unittest/heapdump",
-            "node_ip": "10.17.22.23",
-            "network_host": "10.17.22.23",
-            "http_port": "9200",
-            "transport_port": "9300",
-            "all_node_ips": "[\"10.17.22.22\",\"10.17.22.23\"]",
-            "all_node_names": "[\"rally-node-0\",\"rally-node-1\"]",
-            "minimum_master_nodes": 2,
-            "install_root_path": "/opt/elasticsearch-5.0.0",
-            "plugin_name": "x-pack-security",
-            "xpack_security_enabled": True
-
-        }, config_vars)
+            config_vars,
+        )
 
     @mock.patch("glob.glob", lambda p: ["/opt/elasticsearch-6.3.0"])
     @mock.patch("esrally.utils.io.decompress")
@@ -222,28 +234,38 @@ class BareProvisionerTests(TestCase):
         def null_apply_config(source_root_path, target_root_path, config_vars):
             apply_config_calls.append((source_root_path, target_root_path, config_vars))
 
-        installer = provisioner.ElasticsearchInstaller(car=
-        team.Car(
-            names="unit-test-car",
-            root_path=None,
-            config_paths=[HOME_DIR + "/.rally/benchmarks/teams/default/my-car"],
-            variables={"heap": "4g", "runtime.jdk": "8", "runtime.jdk.bundled": "true"}),
+        installer = provisioner.ElasticsearchInstaller(
+            car=team.Car(
+                names="unit-test-car",
+                root_path=None,
+                config_paths=[HOME_DIR + "/.rally/benchmarks/teams/default/my-car"],
+                variables={
+                    "heap": "4g",
+                    "runtime.jdk": "8",
+                    "runtime.jdk.bundled": "true",
+                },
+            ),
             java_home="/usr/local/javas/java8",
             node_name="rally-node-0",
             node_root_dir=HOME_DIR + "/.rally/benchmarks/races/unittest",
             all_node_ips=["10.17.22.22", "10.17.22.23"],
             all_node_names=["rally-node-0", "rally-node-1"],
             ip="10.17.22.23",
-            http_port=9200)
+            http_port=9200,
+        )
 
-        p = provisioner.BareProvisioner(es_installer=installer,
-                                        plugin_installers=[
-                                            provisioner.PluginInstaller(BareProvisionerTests.MockRallyTeamXPackPlugin(),
-                                                                        java_home="/usr/local/javas/java8",
-                                                                        hook_handler_class=BareProvisionerTests.NoopHookHandler)
-                                        ],
-                                        distribution_version="6.3.0",
-                                        apply_config=null_apply_config)
+        p = provisioner.BareProvisioner(
+            es_installer=installer,
+            plugin_installers=[
+                provisioner.PluginInstaller(
+                    BareProvisionerTests.MockRallyTeamXPackPlugin(),
+                    java_home="/usr/local/javas/java8",
+                    hook_handler_class=BareProvisionerTests.NoopHookHandler,
+                )
+            ],
+            distribution_version="6.3.0",
+            apply_config=null_apply_config,
+        )
 
         node_config = p.prepare({"elasticsearch": "/opt/elasticsearch-6.3.0.tar.gz"})
         self.assertEqual("8", node_config.car_runtime_jdks)
@@ -258,30 +280,30 @@ class BareProvisionerTests(TestCase):
 
         self.maxDiff = None
 
-        self.assertEqual({
-            "cluster_settings": {
-                "plugin.mandatory": ["x-pack"]
+        self.assertEqual(
+            {
+                "cluster_settings": {"plugin.mandatory": ["x-pack"]},
+                "heap": "4g",
+                "runtime.jdk": "8",
+                "runtime.jdk.bundled": "true",
+                "cluster_name": "rally-benchmark",
+                "node_name": "rally-node-0",
+                "data_paths": ["/opt/elasticsearch-6.3.0/data"],
+                "log_path": HOME_DIR + "/.rally/benchmarks/races/unittest/logs/server",
+                "heap_dump_path": HOME_DIR + "/.rally/benchmarks/races/unittest/heapdump",
+                "node_ip": "10.17.22.23",
+                "network_host": "10.17.22.23",
+                "http_port": "9200",
+                "transport_port": "9300",
+                "all_node_ips": '["10.17.22.22","10.17.22.23"]',
+                "all_node_names": '["rally-node-0","rally-node-1"]',
+                "minimum_master_nodes": 2,
+                "install_root_path": "/opt/elasticsearch-6.3.0",
+                "plugin_name": "x-pack-security",
+                "xpack_security_enabled": True,
             },
-            "heap": "4g",
-            "runtime.jdk": "8",
-            "runtime.jdk.bundled": "true",
-            "cluster_name": "rally-benchmark",
-            "node_name": "rally-node-0",
-            "data_paths": ["/opt/elasticsearch-6.3.0/data"],
-            "log_path": HOME_DIR + "/.rally/benchmarks/races/unittest/logs/server",
-            "heap_dump_path": HOME_DIR + "/.rally/benchmarks/races/unittest/heapdump",
-            "node_ip": "10.17.22.23",
-            "network_host": "10.17.22.23",
-            "http_port": "9200",
-            "transport_port": "9300",
-            "all_node_ips": "[\"10.17.22.22\",\"10.17.22.23\"]",
-            "all_node_names": "[\"rally-node-0\",\"rally-node-1\"]",
-            "minimum_master_nodes": 2,
-            "install_root_path": "/opt/elasticsearch-6.3.0",
-            "plugin_name": "x-pack-security",
-            "xpack_security_enabled": True
-
-        }, config_vars)
+            config_vars,
+        )
 
 
 class NoopHookHandler:
@@ -304,35 +326,38 @@ class ElasticsearchInstallerTests(TestCase):
     @mock.patch("esrally.utils.io.ensure_dir")
     @mock.patch("shutil.rmtree")
     def test_prepare_default_data_paths(self, mock_rm, mock_ensure_dir, mock_decompress):
-        installer = provisioner.ElasticsearchInstaller(car=team.Car(names="defaults",
-                                                                    root_path=None,
-                                                                    config_paths="/tmp"),
-                                                       java_home="/usr/local/javas/java8",
-                                                       node_name="rally-node-0",
-                                                       all_node_ips=["10.17.22.22", "10.17.22.23"],
-                                                       all_node_names=["rally-node-0", "rally-node-1"],
-                                                       ip="10.17.22.23",
-                                                       http_port=9200,
-                                                       node_root_dir=HOME_DIR + "/.rally/benchmarks/races/unittest")
+        installer = provisioner.ElasticsearchInstaller(
+            car=team.Car(names="defaults", root_path=None, config_paths="/tmp"),
+            java_home="/usr/local/javas/java8",
+            node_name="rally-node-0",
+            all_node_ips=["10.17.22.22", "10.17.22.23"],
+            all_node_names=["rally-node-0", "rally-node-1"],
+            ip="10.17.22.23",
+            http_port=9200,
+            node_root_dir=HOME_DIR + "/.rally/benchmarks/races/unittest",
+        )
 
         installer.install("/data/builds/distributions")
         self.assertEqual(installer.es_home_path, "/install/elasticsearch-5.0.0-SNAPSHOT")
 
-        self.assertEqual({
-            "cluster_name": "rally-benchmark",
-            "node_name": "rally-node-0",
-            "data_paths": ["/install/elasticsearch-5.0.0-SNAPSHOT/data"],
-            "log_path": HOME_DIR + "/.rally/benchmarks/races/unittest/logs/server",
-            "heap_dump_path": HOME_DIR + "/.rally/benchmarks/races/unittest/heapdump",
-            "node_ip": "10.17.22.23",
-            "network_host": "10.17.22.23",
-            "http_port": "9200",
-            "transport_port": "9300",
-            "all_node_ips": "[\"10.17.22.22\",\"10.17.22.23\"]",
-            "all_node_names": "[\"rally-node-0\",\"rally-node-1\"]",
-            "minimum_master_nodes": 2,
-            "install_root_path": "/install/elasticsearch-5.0.0-SNAPSHOT"
-        }, installer.variables)
+        self.assertEqual(
+            {
+                "cluster_name": "rally-benchmark",
+                "node_name": "rally-node-0",
+                "data_paths": ["/install/elasticsearch-5.0.0-SNAPSHOT/data"],
+                "log_path": HOME_DIR + "/.rally/benchmarks/races/unittest/logs/server",
+                "heap_dump_path": HOME_DIR + "/.rally/benchmarks/races/unittest/heapdump",
+                "node_ip": "10.17.22.23",
+                "network_host": "10.17.22.23",
+                "http_port": "9200",
+                "transport_port": "9300",
+                "all_node_ips": '["10.17.22.22","10.17.22.23"]',
+                "all_node_names": '["rally-node-0","rally-node-1"]',
+                "minimum_master_nodes": 2,
+                "install_root_path": "/install/elasticsearch-5.0.0-SNAPSHOT",
+            },
+            installer.variables,
+        )
 
         self.assertEqual(installer.data_paths, ["/install/elasticsearch-5.0.0-SNAPSHOT/data"])
 
@@ -341,73 +366,93 @@ class ElasticsearchInstallerTests(TestCase):
     @mock.patch("esrally.utils.io.ensure_dir")
     @mock.patch("shutil.rmtree")
     def test_prepare_user_provided_data_path(self, mock_rm, mock_ensure_dir, mock_decompress):
-        installer = provisioner.ElasticsearchInstaller(car=team.Car(names="defaults",
-                                                                    root_path=None,
-                                                                    config_paths="/tmp",
-                                                                    variables={"data_paths": "/tmp/some/data-path-dir"}),
-                                                       java_home="/usr/local/javas/java8",
-                                                       node_name="rally-node-0",
-                                                       all_node_ips=["10.17.22.22", "10.17.22.23"],
-                                                       all_node_names=["rally-node-0", "rally-node-1"],
-                                                       ip="10.17.22.23",
-                                                       http_port=9200,
-                                                       node_root_dir="~/.rally/benchmarks/races/unittest")
+        installer = provisioner.ElasticsearchInstaller(
+            car=team.Car(
+                names="defaults",
+                root_path=None,
+                config_paths="/tmp",
+                variables={
+                    "data_paths": "/tmp/some/data-path-dir",
+                },
+            ),
+            java_home="/usr/local/javas/java8",
+            node_name="rally-node-0",
+            all_node_ips=["10.17.22.22", "10.17.22.23"],
+            all_node_names=["rally-node-0", "rally-node-1"],
+            ip="10.17.22.23",
+            http_port=9200,
+            node_root_dir="~/.rally/benchmarks/races/unittest",
+        )
 
         installer.install("/data/builds/distributions")
         self.assertEqual(installer.es_home_path, "/install/elasticsearch-5.0.0-SNAPSHOT")
 
-        self.assertEqual({
-            "cluster_name": "rally-benchmark",
-            "node_name": "rally-node-0",
-            "data_paths": ["/tmp/some/data-path-dir"],
-            "log_path": "~/.rally/benchmarks/races/unittest/logs/server",
-            "heap_dump_path": "~/.rally/benchmarks/races/unittest/heapdump",
-            "node_ip": "10.17.22.23",
-            "network_host": "10.17.22.23",
-            "http_port": "9200",
-            "transport_port": "9300",
-            "all_node_ips": "[\"10.17.22.22\",\"10.17.22.23\"]",
-            "all_node_names": "[\"rally-node-0\",\"rally-node-1\"]",
-            "minimum_master_nodes": 2,
-            "install_root_path": "/install/elasticsearch-5.0.0-SNAPSHOT"
-        }, installer.variables)
+        self.assertEqual(
+            {
+                "cluster_name": "rally-benchmark",
+                "node_name": "rally-node-0",
+                "data_paths": ["/tmp/some/data-path-dir"],
+                "log_path": "~/.rally/benchmarks/races/unittest/logs/server",
+                "heap_dump_path": "~/.rally/benchmarks/races/unittest/heapdump",
+                "node_ip": "10.17.22.23",
+                "network_host": "10.17.22.23",
+                "http_port": "9200",
+                "transport_port": "9300",
+                "all_node_ips": '["10.17.22.22","10.17.22.23"]',
+                "all_node_names": '["rally-node-0","rally-node-1"]',
+                "minimum_master_nodes": 2,
+                "install_root_path": "/install/elasticsearch-5.0.0-SNAPSHOT",
+            },
+            installer.variables,
+        )
 
         self.assertEqual(installer.data_paths, ["/tmp/some/data-path-dir"])
 
     def test_invokes_hook_with_java_home(self):
-        installer = provisioner.ElasticsearchInstaller(car=team.Car(names="defaults",
-                                                                    root_path="/tmp",
-                                                                    config_paths="/tmp/templates",
-                                                                    variables={"data_paths": "/tmp/some/data-path-dir"}),
-                                                       java_home="/usr/local/javas/java8",
-                                                       node_name="rally-node-0",
-                                                       all_node_ips=["10.17.22.22", "10.17.22.23"],
-                                                       all_node_names=["rally-node-0", "rally-node-1"],
-                                                       ip="10.17.22.23",
-                                                       http_port=9200,
-                                                       node_root_dir="~/.rally/benchmarks/races/unittest",
-                                                       hook_handler_class=NoopHookHandler)
+        installer = provisioner.ElasticsearchInstaller(
+            car=team.Car(
+                names="defaults",
+                root_path="/tmp",
+                config_paths="/tmp/templates",
+                variables={
+                    "data_paths": "/tmp/some/data-path-dir",
+                },
+            ),
+            java_home="/usr/local/javas/java8",
+            node_name="rally-node-0",
+            all_node_ips=["10.17.22.22", "10.17.22.23"],
+            all_node_names=["rally-node-0", "rally-node-1"],
+            ip="10.17.22.23",
+            http_port=9200,
+            node_root_dir="~/.rally/benchmarks/races/unittest",
+            hook_handler_class=NoopHookHandler,
+        )
 
         self.assertEqual(0, len(installer.hook_handler.hook_calls))
         installer.invoke_install_hook(team.BootstrapPhase.post_install, {"foo": "bar"})
         self.assertEqual(1, len(installer.hook_handler.hook_calls))
         self.assertEqual({"foo": "bar"}, installer.hook_handler.hook_calls["post_install"]["variables"])
-        self.assertEqual({"env": {"JAVA_HOME": "/usr/local/javas/java8"}},
-                         installer.hook_handler.hook_calls["post_install"]["kwargs"])
+        self.assertEqual({"env": {"JAVA_HOME": "/usr/local/javas/java8"}}, installer.hook_handler.hook_calls["post_install"]["kwargs"])
 
     def test_invokes_hook_no_java_home(self):
-        installer = provisioner.ElasticsearchInstaller(car=team.Car(names="defaults",
-                                                                    root_path="/tmp",
-                                                                    config_paths="/tmp/templates",
-                                                                    variables={"data_paths": "/tmp/some/data-path-dir"}),
-                                                       java_home=None,
-                                                       node_name="rally-node-0",
-                                                       all_node_ips=["10.17.22.22", "10.17.22.23"],
-                                                       all_node_names=["rally-node-0", "rally-node-1"],
-                                                       ip="10.17.22.23",
-                                                       http_port=9200,
-                                                       node_root_dir="~/.rally/benchmarks/races/unittest",
-                                                       hook_handler_class=NoopHookHandler)
+        installer = provisioner.ElasticsearchInstaller(
+            car=team.Car(
+                names="defaults",
+                root_path="/tmp",
+                config_paths="/tmp/templates",
+                variables={
+                    "data_paths": "/tmp/some/data-path-dir",
+                },
+            ),
+            java_home=None,
+            node_name="rally-node-0",
+            all_node_ips=["10.17.22.22", "10.17.22.23"],
+            all_node_names=["rally-node-0", "rally-node-1"],
+            ip="10.17.22.23",
+            http_port=9200,
+            node_root_dir="~/.rally/benchmarks/races/unittest",
+            hook_handler_class=NoopHookHandler,
+        )
 
         self.assertEqual(0, len(installer.hook_handler.hook_calls))
         installer.invoke_install_hook(team.BootstrapPhase.post_install, {"foo": "bar"})
@@ -421,32 +466,46 @@ class PluginInstallerTests(TestCase):
     def test_install_plugin_successfully(self, installer_subprocess):
         installer_subprocess.return_value = 0
 
-        plugin = team.PluginDescriptor(name="unit-test-plugin", config="default", variables={"active": True})
-        installer = provisioner.PluginInstaller(plugin,
-                                                java_home="/usr/local/javas/java8",
-                                                hook_handler_class=NoopHookHandler)
+        plugin = team.PluginDescriptor(
+            name="unit-test-plugin",
+            config="default",
+            variables={
+                "active": True,
+            },
+        )
+        installer = provisioner.PluginInstaller(plugin, java_home="/usr/local/javas/java8", hook_handler_class=NoopHookHandler)
 
         installer.install(es_home_path="/opt/elasticsearch")
 
         installer_subprocess.assert_called_with(
             '/opt/elasticsearch/bin/elasticsearch-plugin install --batch "unit-test-plugin"',
-            env={"JAVA_HOME": "/usr/local/javas/java8"})
+            env={"JAVA_HOME": "/usr/local/javas/java8"},
+        )
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_install_plugin_with_bundled_jdk(self, installer_subprocess):
         installer_subprocess.return_value = 0
 
-        plugin = team.PluginDescriptor(name="unit-test-plugin", config="default", variables={"active": True})
-        installer = provisioner.PluginInstaller(plugin,
-                                                # bundled JDK
-                                                java_home=None,
-                                                hook_handler_class=NoopHookHandler)
+        plugin = team.PluginDescriptor(
+            name="unit-test-plugin",
+            config="default",
+            variables={
+                "active": True,
+            },
+        )
+        installer = provisioner.PluginInstaller(
+            plugin,
+            # bundled JDK
+            java_home=None,
+            hook_handler_class=NoopHookHandler,
+        )
 
         installer.install(es_home_path="/opt/elasticsearch")
 
         installer_subprocess.assert_called_with(
             '/opt/elasticsearch/bin/elasticsearch-plugin install --batch "unit-test-plugin"',
-            env={})
+            env={},
+        )
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_install_unknown_plugin(self, installer_subprocess):
@@ -454,9 +513,7 @@ class PluginInstallerTests(TestCase):
         installer_subprocess.return_value = 64
 
         plugin = team.PluginDescriptor(name="unknown")
-        installer = provisioner.PluginInstaller(plugin,
-                                                java_home="/usr/local/javas/java8",
-                                                hook_handler_class=NoopHookHandler)
+        installer = provisioner.PluginInstaller(plugin, java_home="/usr/local/javas/java8", hook_handler_class=NoopHookHandler)
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             installer.install(es_home_path="/opt/elasticsearch")
@@ -464,7 +521,8 @@ class PluginInstallerTests(TestCase):
 
         installer_subprocess.assert_called_with(
             '/opt/elasticsearch/bin/elasticsearch-plugin install --batch "unknown"',
-            env={"JAVA_HOME": "/usr/local/javas/java8"})
+            env={"JAVA_HOME": "/usr/local/javas/java8"},
+        )
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_install_plugin_with_io_error(self, installer_subprocess):
@@ -472,9 +530,7 @@ class PluginInstallerTests(TestCase):
         installer_subprocess.return_value = 74
 
         plugin = team.PluginDescriptor(name="simple")
-        installer = provisioner.PluginInstaller(plugin,
-                                                java_home="/usr/local/javas/java8",
-                                                hook_handler_class=NoopHookHandler)
+        installer = provisioner.PluginInstaller(plugin, java_home="/usr/local/javas/java8", hook_handler_class=NoopHookHandler)
 
         with self.assertRaises(exceptions.SupplyError) as ctx:
             installer.install(es_home_path="/opt/elasticsearch")
@@ -482,7 +538,8 @@ class PluginInstallerTests(TestCase):
 
         installer_subprocess.assert_called_with(
             '/opt/elasticsearch/bin/elasticsearch-plugin install --batch "simple"',
-            env={"JAVA_HOME": "/usr/local/javas/java8"})
+            env={"JAVA_HOME": "/usr/local/javas/java8"},
+        )
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_install_plugin_with_unknown_error(self, installer_subprocess):
@@ -490,56 +547,61 @@ class PluginInstallerTests(TestCase):
         installer_subprocess.return_value = 12987
 
         plugin = team.PluginDescriptor(name="simple")
-        installer = provisioner.PluginInstaller(plugin,
-                                                java_home="/usr/local/javas/java8",
-                                                hook_handler_class=NoopHookHandler)
+        installer = provisioner.PluginInstaller(plugin, java_home="/usr/local/javas/java8", hook_handler_class=NoopHookHandler)
 
         with self.assertRaises(exceptions.RallyError) as ctx:
             installer.install(es_home_path="/opt/elasticsearch")
-        self.assertEqual("Unknown error while trying to install [simple] (installer return code [12987]). Please check the logs.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Unknown error while trying to install [simple] (installer return code [12987]). Please check the logs.", ctx.exception.args[0]
+        )
 
         installer_subprocess.assert_called_with(
             '/opt/elasticsearch/bin/elasticsearch-plugin install --batch "simple"',
-            env={"JAVA_HOME": "/usr/local/javas/java8"})
+            env={"JAVA_HOME": "/usr/local/javas/java8"},
+        )
 
     def test_pass_plugin_properties(self):
-        plugin = team.PluginDescriptor(name="unit-test-plugin",
-                                       config="default",
-                                       config_paths=["/etc/plugin"],
-                                       variables={"active": True})
-        installer = provisioner.PluginInstaller(plugin,
-                                                java_home="/usr/local/javas/java8",
-                                                hook_handler_class=NoopHookHandler)
+        plugin = team.PluginDescriptor(
+            name="unit-test-plugin",
+            config="default",
+            config_paths=["/etc/plugin"],
+            variables={
+                "active": True,
+            },
+        )
+        installer = provisioner.PluginInstaller(plugin, java_home="/usr/local/javas/java8", hook_handler_class=NoopHookHandler)
 
         self.assertEqual("unit-test-plugin", installer.plugin_name)
         self.assertEqual({"active": True}, installer.variables)
         self.assertEqual(["/etc/plugin"], installer.config_source_paths)
 
     def test_invokes_hook_with_java_home(self):
-        plugin = team.PluginDescriptor(name="unit-test-plugin",
-                                       config="default",
-                                       config_paths=["/etc/plugin"],
-                                       variables={"active": True})
-        installer = provisioner.PluginInstaller(plugin,
-                                                java_home="/usr/local/javas/java8",
-                                                hook_handler_class=NoopHookHandler)
+        plugin = team.PluginDescriptor(
+            name="unit-test-plugin",
+            config="default",
+            config_paths=["/etc/plugin"],
+            variables={
+                "active": True,
+            },
+        )
+        installer = provisioner.PluginInstaller(plugin, java_home="/usr/local/javas/java8", hook_handler_class=NoopHookHandler)
 
         self.assertEqual(0, len(installer.hook_handler.hook_calls))
         installer.invoke_install_hook(team.BootstrapPhase.post_install, {"foo": "bar"})
         self.assertEqual(1, len(installer.hook_handler.hook_calls))
         self.assertEqual({"foo": "bar"}, installer.hook_handler.hook_calls["post_install"]["variables"])
-        self.assertEqual({"env": {"JAVA_HOME": "/usr/local/javas/java8"}},
-                         installer.hook_handler.hook_calls["post_install"]["kwargs"])
+        self.assertEqual({"env": {"JAVA_HOME": "/usr/local/javas/java8"}}, installer.hook_handler.hook_calls["post_install"]["kwargs"])
 
     def test_invokes_hook_no_java_home(self):
-        plugin = team.PluginDescriptor(name="unit-test-plugin",
-                                       config="default",
-                                       config_paths=["/etc/plugin"],
-                                       variables={"active": True})
-        installer = provisioner.PluginInstaller(plugin,
-                                                java_home=None,
-                                                hook_handler_class=NoopHookHandler)
+        plugin = team.PluginDescriptor(
+            name="unit-test-plugin",
+            config="default",
+            config_paths=["/etc/plugin"],
+            variables={
+                "active": True,
+            },
+        )
+        installer = provisioner.PluginInstaller(plugin, java_home=None, hook_handler_class=NoopHookHandler)
 
         self.assertEqual(0, len(installer.hook_handler.hook_calls))
         installer.invoke_install_hook(team.BootstrapPhase.post_install, {"foo": "bar"})
@@ -559,48 +621,60 @@ class DockerProvisionerTests(TestCase):
 
         rally_root = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir, "esrally"))
 
-        c = team.Car("unit-test-car", None, "/tmp", variables={
-            "docker_image": "docker.elastic.co/elasticsearch/elasticsearch-oss"
-        })
-
-        docker = provisioner.DockerProvisioner(car=c,
-                                               node_name="rally-node-0",
-                                               ip="10.17.22.33",
-                                               http_port=39200,
-                                               node_root_dir=node_root_dir,
-                                               distribution_version="6.3.0",
-                                               rally_root=rally_root)
-
-        self.assertDictEqual({
-            "cluster_name": "rally-benchmark",
-            "node_name": "rally-node-0",
-            "install_root_path": "/usr/share/elasticsearch",
-            "data_paths": ["/usr/share/elasticsearch/data"],
-            "log_path": "/var/log/elasticsearch",
-            "heap_dump_path": "/usr/share/elasticsearch/heapdump",
-            "discovery_type": "single-node",
-            "network_host": "0.0.0.0",
-            "http_port": "39200",
-            "transport_port": "39300",
-            "cluster_settings": {
+        c = team.Car(
+            "unit-test-car",
+            None,
+            "/tmp",
+            variables={
+                "docker_image": "docker.elastic.co/elasticsearch/elasticsearch-oss",
             },
-            "docker_image": "docker.elastic.co/elasticsearch/elasticsearch-oss"
-        }, docker.config_vars)
+        )
 
-        self.assertDictEqual({
-            "es_data_dir": data_dir,
-            "es_log_dir": log_dir,
-            "es_heap_dump_dir": heap_dump_dir,
-            "es_version": "6.3.0",
-            "docker_image": "docker.elastic.co/elasticsearch/elasticsearch-oss",
-            "http_port": 39200,
-            "mounts": {}
-        }, docker.docker_vars(mounts={}))
+        docker = provisioner.DockerProvisioner(
+            car=c,
+            node_name="rally-node-0",
+            ip="10.17.22.33",
+            http_port=39200,
+            node_root_dir=node_root_dir,
+            distribution_version="6.3.0",
+            rally_root=rally_root,
+        )
+
+        self.assertDictEqual(
+            {
+                "cluster_name": "rally-benchmark",
+                "node_name": "rally-node-0",
+                "install_root_path": "/usr/share/elasticsearch",
+                "data_paths": ["/usr/share/elasticsearch/data"],
+                "log_path": "/var/log/elasticsearch",
+                "heap_dump_path": "/usr/share/elasticsearch/heapdump",
+                "discovery_type": "single-node",
+                "network_host": "0.0.0.0",
+                "http_port": "39200",
+                "transport_port": "39300",
+                "cluster_settings": {},
+                "docker_image": "docker.elastic.co/elasticsearch/elasticsearch-oss",
+            },
+            docker.config_vars,
+        )
+
+        self.assertDictEqual(
+            {
+                "es_data_dir": data_dir,
+                "es_log_dir": log_dir,
+                "es_heap_dump_dir": heap_dump_dir,
+                "es_version": "6.3.0",
+                "docker_image": "docker.elastic.co/elasticsearch/elasticsearch-oss",
+                "http_port": 39200,
+                "mounts": {},
+            },
+            docker.docker_vars(mounts={}),
+        )
 
         docker_cfg = docker._render_template_from_file(docker.docker_vars(mounts={}))
 
         self.assertEqual(
-"""version: '2.2'
+            """version: '2.2'
 services:
   elasticsearch1:
     cap_add:
@@ -623,7 +697,10 @@ services:
       test: nc -z 127.0.0.1 39200
       interval: 5s
       timeout: 2s
-      retries: 10""" % (data_dir, log_dir, heap_dump_dir), docker_cfg)
+      retries: 10"""
+            % (data_dir, log_dir, heap_dump_dir),
+            docker_cfg,
+        )
 
     @mock.patch("uuid.uuid4")
     def test_provisioning_with_variables(self, uuid4):
@@ -635,24 +712,31 @@ services:
 
         rally_root = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir, "esrally"))
 
-        c = team.Car("unit-test-car", None, "/tmp", variables={
-            "docker_image": "docker.elastic.co/elasticsearch/elasticsearch",
-            "docker_mem_limit": "256m",
-            "docker_cpu_count": 2
-        })
+        c = team.Car(
+            "unit-test-car",
+            None,
+            "/tmp",
+            variables={
+                "docker_image": "docker.elastic.co/elasticsearch/elasticsearch",
+                "docker_mem_limit": "256m",
+                "docker_cpu_count": 2,
+            },
+        )
 
-        docker = provisioner.DockerProvisioner(car=c,
-                                               node_name="rally-node-0",
-                                               ip="10.17.22.33",
-                                               http_port=39200,
-                                               node_root_dir=node_root_dir,
-                                               distribution_version="6.3.0",
-                                               rally_root=rally_root)
+        docker = provisioner.DockerProvisioner(
+            car=c,
+            node_name="rally-node-0",
+            ip="10.17.22.33",
+            http_port=39200,
+            node_root_dir=node_root_dir,
+            distribution_version="6.3.0",
+            rally_root=rally_root,
+        )
 
         docker_cfg = docker._render_template_from_file(docker.docker_vars(mounts={}))
 
         self.assertEqual(
-"""version: '2.2'
+            """version: '2.2'
 services:
   elasticsearch1:
     cap_add:
@@ -677,7 +761,10 @@ services:
       test: nc -z 127.0.0.1 39200
       interval: 5s
       timeout: 2s
-      retries: 10""" % (data_dir, log_dir, heap_dump_dir), docker_cfg)
+      retries: 10"""
+            % (data_dir, log_dir, heap_dump_dir),
+            docker_cfg,
+        )
 
 
 class CleanupTests(TestCase):

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -21,7 +21,7 @@ import datetime
 import unittest.mock as mock
 from unittest import TestCase
 
-from esrally import exceptions, config
+from esrally import config, exceptions
 from esrally.mechanic import supplier, team
 
 
@@ -29,12 +29,16 @@ class RevisionExtractorTests(TestCase):
     def test_single_revision(self):
         self.assertDictEqual({"elasticsearch": "67c2f42", "all": "67c2f42"}, supplier._extract_revisions("67c2f42"))
         self.assertDictEqual({"elasticsearch": "current", "all": "current"}, supplier._extract_revisions("current"))
-        self.assertDictEqual({"elasticsearch": "@2015-01-01-01:00:00", "all": "@2015-01-01-01:00:00"},
-                             supplier._extract_revisions("@2015-01-01-01:00:00"))
+        self.assertDictEqual(
+            {"elasticsearch": "@2015-01-01-01:00:00", "all": "@2015-01-01-01:00:00"},
+            supplier._extract_revisions("@2015-01-01-01:00:00"),
+        )
 
     def test_multiple_revisions(self):
-        self.assertDictEqual({"elasticsearch": "67c2f42", "x-pack": "@2015-01-01-01:00:00", "some-plugin": "current"},
-                             supplier._extract_revisions("elasticsearch:67c2f42,x-pack:@2015-01-01-01:00:00,some-plugin:current"))
+        self.assertDictEqual(
+            {"elasticsearch": "67c2f42", "x-pack": "@2015-01-01-01:00:00", "some-plugin": "current"},
+            supplier._extract_revisions("elasticsearch:67c2f42,x-pack:@2015-01-01-01:00:00,some-plugin:current"),
+        )
 
     def test_invalid_revisions(self):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
@@ -74,8 +78,7 @@ class SourceRepositoryTests(TestCase):
         mock_is_working_copy.assert_called_with("/src")
         self.assertEqual(0, mock_clone.call_count)
         self.assertEqual(0, mock_pull.call_count)
-        mock_head_revision.assert_called_with("/src")\
-
+        mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
     @mock.patch("esrally.utils.git.checkout")
@@ -174,15 +177,19 @@ class BuilderTests(TestCase):
 class TemplateRendererTests(TestCase):
     def test_uses_provided_values(self):
         renderer = supplier.TemplateRenderer(version="1.2.3", os_name="Windows", arch="arm7")
-        self.assertEqual("This is version 1.2.3 on Windows with a arm7 CPU.",
-                         renderer.render("This is version {{VERSION}} on {{OSNAME}} with a {{ARCH}} CPU."))
+        self.assertEqual(
+            "This is version 1.2.3 on Windows with a arm7 CPU.",
+            renderer.render("This is version {{VERSION}} on {{OSNAME}} with a {{ARCH}} CPU."),
+        )
 
     @mock.patch("esrally.utils.sysstats.os_name", return_value="Linux")
     @mock.patch("esrally.utils.sysstats.cpu_arch", return_value="X86_64")
     def test_uses_derived_values(self, os_name, cpu_arch):
         renderer = supplier.TemplateRenderer(version="1.2.3")
-        self.assertEqual("This is version 1.2.3 on linux with a x86_64 CPU.",
-                         renderer.render("This is version {{VERSION}} on {{OSNAME}} with a {{ARCH}} CPU."))
+        self.assertEqual(
+            "This is version 1.2.3 on linux with a x86_64 CPU.",
+            renderer.render("This is version {{VERSION}} on {{OSNAME}} with a {{ARCH}} CPU."),
+        )
 
 
 class CachedElasticsearchSourceSupplierTests(TestCase):
@@ -201,15 +208,10 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
 
         dist_cfg = {
             "runtime.jdk.bundled": "true",
-            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz"
+            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz",
         }
-        file_resolver = supplier.ElasticsearchFileNameResolver(
-            distribution_config=dist_cfg,
-            template_renderer=renderer
-        )
-        cached_supplier = supplier.CachedSourceSupplier(distributions_root="/tmp",
-                                                        source_supplier=es,
-                                                        file_resolver=file_resolver)
+        file_resolver = supplier.ElasticsearchFileNameResolver(distribution_config=dist_cfg, template_renderer=renderer)
+        cached_supplier = supplier.CachedSourceSupplier(distributions_root="/tmp", source_supplier=es, file_resolver=file_resolver)
 
         cached_supplier.fetch()
         cached_supplier.prepare()
@@ -232,15 +234,10 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
 
         dist_cfg = {
             "runtime.jdk.bundled": "true",
-            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz"
+            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz",
         }
-        file_resolver = supplier.ElasticsearchFileNameResolver(
-            distribution_config=dist_cfg,
-            template_renderer=renderer
-        )
-        cached_supplier = supplier.CachedSourceSupplier(distributions_root="/tmp",
-                                                        source_supplier=es,
-                                                        file_resolver=file_resolver)
+        file_resolver = supplier.ElasticsearchFileNameResolver(distribution_config=dist_cfg, template_renderer=renderer)
+        cached_supplier = supplier.CachedSourceSupplier(distributions_root="/tmp", source_supplier=es, file_resolver=file_resolver)
 
         cached_supplier.fetch()
         cached_supplier.prepare()
@@ -273,15 +270,14 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
 
         dist_cfg = {
             "runtime.jdk.bundled": "true",
-            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz"
+            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz",
         }
 
-        cached_supplier = supplier.CachedSourceSupplier(distributions_root="/tmp",
-                                                        source_supplier=es,
-                                                        file_resolver=supplier.ElasticsearchFileNameResolver(
-                                                            distribution_config=dist_cfg,
-                                                            template_renderer=renderer
-                                                        ))
+        cached_supplier = supplier.CachedSourceSupplier(
+            distributions_root="/tmp",
+            source_supplier=es,
+            file_resolver=supplier.ElasticsearchFileNameResolver(distribution_config=dist_cfg, template_renderer=renderer),
+        )
         cached_supplier.fetch()
         cached_supplier.prepare()
 
@@ -326,15 +322,14 @@ class CachedElasticsearchSourceSupplierTests(TestCase):
 
         dist_cfg = {
             "runtime.jdk.bundled": "true",
-            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz"
+            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz",
         }
 
-        cached_supplier = supplier.CachedSourceSupplier(distributions_root="/tmp",
-                                                        source_supplier=es,
-                                                        file_resolver=supplier.ElasticsearchFileNameResolver(
-                                                            distribution_config=dist_cfg,
-                                                            template_renderer=renderer
-                                                        ))
+        cached_supplier = supplier.CachedSourceSupplier(
+            distributions_root="/tmp",
+            source_supplier=es,
+            file_resolver=supplier.ElasticsearchFileNameResolver(distribution_config=dist_cfg, template_renderer=renderer),
+        )
         cached_supplier.fetch()
         cached_supplier.prepare()
 
@@ -357,13 +352,10 @@ class ElasticsearchFileNameResolverTests(TestCase):
 
         dist_cfg = {
             "runtime.jdk.bundled": "true",
-            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz"
+            "jdk.bundled.release_url": "https://elstc.co/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz",
         }
 
-        self.resolver = supplier.ElasticsearchFileNameResolver(
-            distribution_config=dist_cfg,
-            template_renderer=renderer
-        )
+        self.resolver = supplier.ElasticsearchFileNameResolver(distribution_config=dist_cfg, template_renderer=renderer)
 
     def test_resolve(self):
         self.resolver.revision = "abc123"
@@ -435,7 +427,7 @@ class PruneTests(TestCase):
             # elasticsearch-6.8.0.tar.gz
             PruneTests.LStat(st_ctime=int(ten_days_ago.timestamp())),
             # elasticsearch-7.3.0-darwin-x86_64.tar.gz
-            PruneTests.LStat(st_ctime=int(one_day_ago.timestamp()))
+            PruneTests.LStat(st_ctime=int(one_day_ago.timestamp())),
         ]
 
         supplier._prune(root_path="/tmp/test", max_age_days=7)
@@ -445,70 +437,71 @@ class PruneTests(TestCase):
 
 class ElasticsearchSourceSupplierTests(TestCase):
     def test_no_build(self):
-        car = team.Car("default", root_path=None, config_paths=[], variables={
-            "clean_command": "./gradlew clean",
-            "system.build_command": "./gradlew assemble"
-        })
+        car = team.Car(
+            "default",
+            root_path=None,
+            config_paths=[],
+            variables={"clean_command": "./gradlew clean", "system.build_command": "./gradlew assemble"},
+        )
         renderer = supplier.TemplateRenderer(version=None)
-        es = supplier.ElasticsearchSourceSupplier(revision="abc",
-                                                  es_src_dir="/src",
-                                                  remote_url="",
-                                                  car=car,
-                                                  builder=None,
-                                                  template_renderer=renderer)
+        es = supplier.ElasticsearchSourceSupplier(
+            revision="abc", es_src_dir="/src", remote_url="", car=car, builder=None, template_renderer=renderer
+        )
         es.prepare()
         # nothing has happened (intentionally) because there is no builder
 
     def test_build(self):
-        car = team.Car("default", root_path=None, config_paths=[], variables={
-            "clean_command": "./gradlew clean",
-            "system.build_command": "./gradlew assemble"
-        })
+        car = team.Car(
+            "default",
+            root_path=None,
+            config_paths=[],
+            variables={"clean_command": "./gradlew clean", "system.build_command": "./gradlew assemble"},
+        )
         builder = mock.create_autospec(supplier.Builder)
         renderer = supplier.TemplateRenderer(version="abc")
-        es = supplier.ElasticsearchSourceSupplier(revision="abc",
-                                                  es_src_dir="/src",
-                                                  remote_url="",
-                                                  car=car,
-                                                  builder=builder,
-                                                  template_renderer=renderer)
+        es = supplier.ElasticsearchSourceSupplier(
+            revision="abc", es_src_dir="/src", remote_url="", car=car, builder=builder, template_renderer=renderer
+        )
         es.prepare()
 
         builder.build.assert_called_once_with(["./gradlew clean", "./gradlew assemble"])
 
     def test_raises_error_on_missing_car_variable(self):
-        car = team.Car("default", root_path=None, config_paths=[], variables={
-            "clean_command": "./gradlew clean",
-            # system.build_command is not defined
-        })
+        car = team.Car(
+            "default",
+            root_path=None,
+            config_paths=[],
+            variables={
+                "clean_command": "./gradlew clean",
+                # system.build_command is not defined
+            },
+        )
         renderer = supplier.TemplateRenderer(version="abc")
         builder = mock.create_autospec(supplier.Builder)
-        es = supplier.ElasticsearchSourceSupplier(revision="abc",
-                                                  es_src_dir="/src",
-                                                  remote_url="",
-                                                  car=car,
-                                                  builder=builder,
-                                                  template_renderer=renderer)
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    "Car \"default\" requires config key \"system.build_command\""):
+        es = supplier.ElasticsearchSourceSupplier(
+            revision="abc", es_src_dir="/src", remote_url="", car=car, builder=builder, template_renderer=renderer
+        )
+        with self.assertRaisesRegex(exceptions.SystemSetupError, 'Car "default" requires config key "system.build_command"'):
             es.prepare()
 
         self.assertEqual(0, builder.build.call_count)
 
     @mock.patch("glob.glob", lambda p: ["elasticsearch.tar.gz"])
     def test_add_elasticsearch_binary(self):
-        car = team.Car("default", root_path=None, config_paths=[], variables={
-            "clean_command": "./gradlew clean",
-            "system.build_command": "./gradlew assemble",
-            "system.artifact_path_pattern": "distribution/archives/tar/build/distributions/*.tar.gz"
-        })
+        car = team.Car(
+            "default",
+            root_path=None,
+            config_paths=[],
+            variables={
+                "clean_command": "./gradlew clean",
+                "system.build_command": "./gradlew assemble",
+                "system.artifact_path_pattern": "distribution/archives/tar/build/distributions/*.tar.gz",
+            },
+        )
         renderer = supplier.TemplateRenderer(version="abc")
-        es = supplier.ElasticsearchSourceSupplier(revision="abc",
-                                                  es_src_dir="/src",
-                                                  remote_url="",
-                                                  car=car,
-                                                  builder=None,
-                                                  template_renderer=renderer)
+        es = supplier.ElasticsearchSourceSupplier(
+            revision="abc", es_src_dir="/src", remote_url="", car=car, builder=None, template_renderer=renderer
+        )
         binaries = {}
         es.add(binaries=binaries)
         self.assertEqual(binaries, {"elasticsearch": "elasticsearch.tar.gz"})
@@ -521,52 +514,64 @@ class ExternalPluginSourceSupplierTests(TestCase):
         self.standalone = None
 
     def setUp(self):
-        self.along_es = supplier.ExternalPluginSourceSupplier(plugin=team.PluginDescriptor("some-plugin", core_plugin=False),
-                                                              revision="abc",
-                                                              # built along-side ES
-                                                              src_dir="/src",
-                                                              src_config={
-                                                                  "plugin.some-plugin.src.subdir": "elasticsearch-extra/some-plugin",
-                                                                  "plugin.some-plugin.build.artifact.subdir": "plugin/build/distributions"
-                                                              },
-                                                              builder=None)
+        self.along_es = supplier.ExternalPluginSourceSupplier(
+            plugin=team.PluginDescriptor("some-plugin", core_plugin=False),
+            revision="abc",
+            # built along-side ES
+            src_dir="/src",
+            src_config={
+                "plugin.some-plugin.src.subdir": "elasticsearch-extra/some-plugin",
+                "plugin.some-plugin.build.artifact.subdir": "plugin/build/distributions",
+            },
+            builder=None,
+        )
 
-        self.standalone = supplier.ExternalPluginSourceSupplier(plugin=team.PluginDescriptor("some-plugin", core_plugin=False),
-                                                                revision="abc",
-                                                                # built separately
-                                                                src_dir=None,
-                                                                src_config={
-                                                                    "plugin.some-plugin.src.dir": "/Projects/src/some-plugin",
-                                                                    "plugin.some-plugin.build.artifact.subdir": "build/distributions"
-                                                                },
-                                                                builder=None)
+        self.standalone = supplier.ExternalPluginSourceSupplier(
+            plugin=team.PluginDescriptor("some-plugin", core_plugin=False),
+            revision="abc",
+            # built separately
+            src_dir=None,
+            src_config={
+                "plugin.some-plugin.src.dir": "/Projects/src/some-plugin",
+                "plugin.some-plugin.build.artifact.subdir": "build/distributions",
+            },
+            builder=None,
+        )
 
     def test_invalid_config_no_source(self):
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    "Neither plugin.some-plugin.src.dir nor plugin.some-plugin.src.subdir are set for plugin some-plugin."):
-            supplier.ExternalPluginSourceSupplier(plugin=team.PluginDescriptor("some-plugin", core_plugin=False),
-                                                  revision="abc",
-                                                  # built separately
-                                                  src_dir=None,
-                                                  src_config={
-                                                      # but no source config
-                                                      # "plugin.some-plugin.src.dir": "/Projects/src/some-plugin",
-                                                      "plugin.some-plugin.build.artifact.subdir": "build/distributions"
-                                                  },
-                                                  builder=None)
+        with self.assertRaisesRegex(
+            exceptions.SystemSetupError,
+            "Neither plugin.some-plugin.src.dir nor plugin.some-plugin.src.subdir are set for plugin some-plugin.",
+        ):
+            supplier.ExternalPluginSourceSupplier(
+                plugin=team.PluginDescriptor("some-plugin", core_plugin=False),
+                revision="abc",
+                # built separately
+                src_dir=None,
+                src_config={
+                    # but no source config
+                    # "plugin.some-plugin.src.dir": "/Projects/src/some-plugin",
+                    "plugin.some-plugin.build.artifact.subdir": "build/distributions"
+                },
+                builder=None,
+            )
 
     def test_invalid_config_duplicate_source(self):
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    "Can only specify one of plugin.duplicate.src.dir and plugin.duplicate.src.subdir but both are set."):
-            supplier.ExternalPluginSourceSupplier(plugin=team.PluginDescriptor("duplicate", core_plugin=False),
-                                                  revision="abc",
-                                                  src_dir=None,
-                                                  src_config={
-                                                      "plugin.duplicate.src.subdir": "elasticsearch-extra/some-plugin",
-                                                      "plugin.duplicate.src.dir": "/Projects/src/some-plugin",
-                                                      "plugin.duplicate.build.artifact.subdir": "build/distributions"
-                                                  },
-                                                  builder=None)
+        with self.assertRaisesRegex(
+            exceptions.SystemSetupError,
+            "Can only specify one of plugin.duplicate.src.dir and plugin.duplicate.src.subdir but both are set.",
+        ):
+            supplier.ExternalPluginSourceSupplier(
+                plugin=team.PluginDescriptor("duplicate", core_plugin=False),
+                revision="abc",
+                src_dir=None,
+                src_config={
+                    "plugin.duplicate.src.subdir": "elasticsearch-extra/some-plugin",
+                    "plugin.duplicate.src.dir": "/Projects/src/some-plugin",
+                    "plugin.duplicate.build.artifact.subdir": "build/distributions",
+                },
+                builder=None,
+            )
 
     def test_standalone_plugin_overrides_build_dir(self):
         self.assertEqual("/Projects/src/some-plugin", self.standalone.override_build_dir)
@@ -578,24 +583,26 @@ class ExternalPluginSourceSupplierTests(TestCase):
     def test_add_binary_built_along_elasticsearch(self):
         binaries = {}
         self.along_es.add(binaries)
-        self.assertDictEqual(binaries,
-                             {"some-plugin": "file:///src/elasticsearch-extra/some-plugin/plugin/build/distributions/some-plugin.zip"})
+        self.assertDictEqual(
+            binaries, {"some-plugin": "file:///src/elasticsearch-extra/some-plugin/plugin/build/distributions/some-plugin.zip"}
+        )
 
     @mock.patch("glob.glob", lambda p: ["/Projects/src/some-plugin/build/distributions/some-plugin.zip"])
     def test_resolve_plugin_binary_built_standalone(self):
         binaries = {}
         self.along_es.add(binaries)
-        self.assertDictEqual(binaries,
-                             {"some-plugin": "file:///Projects/src/some-plugin/build/distributions/some-plugin.zip"})
+        self.assertDictEqual(binaries, {"some-plugin": "file:///Projects/src/some-plugin/build/distributions/some-plugin.zip"})
 
 
 class CorePluginSourceSupplierTests(TestCase):
     @mock.patch("glob.glob", lambda p: ["/src/elasticsearch/core-plugin/build/distributions/core-plugin.zip"])
     def test_resolve_plugin_binary(self):
-        s = supplier.CorePluginSourceSupplier(plugin=team.PluginDescriptor("core-plugin", core_plugin=True),
-                                              # built separately
-                                              es_src_dir="/src/elasticsearch",
-                                              builder=None)
+        s = supplier.CorePluginSourceSupplier(
+            plugin=team.PluginDescriptor("core-plugin", core_plugin=True),
+            # built separately
+            es_src_dir="/src/elasticsearch",
+            builder=None,
+        )
         binaries = {}
         s.add(binaries)
         self.assertDictEqual(binaries, {"core-plugin": "file:///src/elasticsearch/core-plugin/build/distributions/core-plugin.zip"})
@@ -605,10 +612,10 @@ class PluginDistributionSupplierTests(TestCase):
     def test_resolve_plugin_url(self):
         v = {"plugin_custom-analyzer_release_url": "http://example.org/elasticearch/custom-analyzer-{{VERSION}}.zip"}
         renderer = supplier.TemplateRenderer(version="6.3.0")
-        s = supplier.PluginDistributionSupplier(repo=supplier.DistributionRepository(name="release",
-                                                                                     distribution_config=v,
-                                                                                     template_renderer=renderer),
-                                                plugin=team.PluginDescriptor("custom-analyzer"))
+        s = supplier.PluginDistributionSupplier(
+            repo=supplier.DistributionRepository(name="release", distribution_config=v, template_renderer=renderer),
+            plugin=team.PluginDescriptor("custom-analyzer"),
+        )
         binaries = {}
         s.add(binaries)
         self.assertDictEqual(binaries, {"custom-analyzer": "http://example.org/elasticearch/custom-analyzer-6.3.0.zip"})
@@ -618,13 +625,15 @@ class CreateSupplierTests(TestCase):
     def test_derive_supply_requirements_es_source_build(self):
         # corresponds to --revision="abc"
         requirements = supplier._supply_requirements(
-            sources=True, distribution=False, plugins=[], revisions={"elasticsearch": "abc"}, distribution_version=None)
+            sources=True, distribution=False, plugins=[], revisions={"elasticsearch": "abc"}, distribution_version=None
+        )
         self.assertDictEqual({"elasticsearch": ("source", "abc", True)}, requirements)
 
     def test_derive_supply_requirements_es_distribution(self):
         # corresponds to --distribution-version=6.0.0
         requirements = supplier._supply_requirements(
-            sources=False, distribution=True, plugins=[], revisions={}, distribution_version="6.0.0")
+            sources=False, distribution=True, plugins=[], revisions={}, distribution_version="6.0.0"
+        )
         self.assertDictEqual({"elasticsearch": ("distribution", "6.0.0", False)}, requirements)
 
     def test_derive_supply_requirements_es_and_plugin_source_build(self):
@@ -632,31 +641,45 @@ class CreateSupplierTests(TestCase):
         core_plugin = team.PluginDescriptor("analysis-icu", core_plugin=True)
         external_plugin = team.PluginDescriptor("community-plugin", core_plugin=False)
 
-        requirements = supplier._supply_requirements(sources=True, distribution=False, plugins=[core_plugin, external_plugin],
-                                                     revisions={"elasticsearch": "abc", "all": "abc", "community-plugin": "effab"},
-                                                     distribution_version=None)
-        self.assertDictEqual({
-            "elasticsearch": ("source", "abc", True),
-            # core plugin configuration is forced to be derived from ES
-            "analysis-icu": ("source", "abc", True),
-            "community-plugin": ("source", "effab", True),
-        }, requirements)
+        requirements = supplier._supply_requirements(
+            sources=True,
+            distribution=False,
+            plugins=[core_plugin, external_plugin],
+            revisions={"elasticsearch": "abc", "all": "abc", "community-plugin": "effab"},
+            distribution_version=None,
+        )
+        self.assertDictEqual(
+            {
+                "elasticsearch": ("source", "abc", True),
+                # core plugin configuration is forced to be derived from ES
+                "analysis-icu": ("source", "abc", True),
+                "community-plugin": ("source", "effab", True),
+            },
+            requirements,
+        )
 
     def test_derive_supply_requirements_es_distribution_and_plugin_source_build(self):
         # corresponds to --revision="community-plugin:effab" --distribution-version="6.0.0"
         core_plugin = team.PluginDescriptor("analysis-icu", core_plugin=True)
         external_plugin = team.PluginDescriptor("community-plugin", core_plugin=False)
 
-        requirements = supplier._supply_requirements(sources=False, distribution=True, plugins=[core_plugin, external_plugin],
-                                                     revisions={"community-plugin": "effab"},
-                                                     distribution_version="6.0.0")
+        requirements = supplier._supply_requirements(
+            sources=False,
+            distribution=True,
+            plugins=[core_plugin, external_plugin],
+            revisions={"community-plugin": "effab"},
+            distribution_version="6.0.0",
+        )
         # core plugin is not contained, its configured is forced to be derived by ES
-        self.assertDictEqual({
-            "elasticsearch": ("distribution", "6.0.0", False),
-            # core plugin configuration is forced to be derived from ES
-            "analysis-icu": ("distribution", "6.0.0", False),
-            "community-plugin": ("source", "effab", True),
-        }, requirements)
+        self.assertDictEqual(
+            {
+                "elasticsearch": ("distribution", "6.0.0", False),
+                # core plugin configuration is forced to be derived from ES
+                "analysis-icu": ("distribution", "6.0.0", False),
+                "community-plugin": ("source", "effab", True),
+            },
+            requirements,
+        )
 
     def test_create_suppliers_for_es_only_config(self):
         cfg = config.Config()
@@ -664,8 +687,12 @@ class CreateSupplierTests(TestCase):
         # default value from command line
         cfg.add(config.Scope.application, "mechanic", "source.revision", "current")
         cfg.add(config.Scope.application, "mechanic", "distribution.repository", "release")
-        cfg.add(config.Scope.application, "distributions", "release.url",
-                "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz")
+        cfg.add(
+            config.Scope.application,
+            "distributions",
+            "release.url",
+            "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
+        )
         cfg.add(config.Scope.application, "distributions", "release.cache", True)
         cfg.add(config.Scope.application, "node", "root.dir", "/opt/rally")
 
@@ -683,8 +710,12 @@ class CreateSupplierTests(TestCase):
         # default value from command line
         cfg.add(config.Scope.application, "mechanic", "source.revision", "community-plugin:current")
         cfg.add(config.Scope.application, "mechanic", "distribution.repository", "release")
-        cfg.add(config.Scope.application, "distributions", "release.url",
-                "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz")
+        cfg.add(
+            config.Scope.application,
+            "distributions",
+            "release.url",
+            "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
+        )
         cfg.add(config.Scope.application, "distributions", "release.cache", True)
         cfg.add(config.Scope.application, "node", "root.dir", "/opt/rally")
         cfg.add(config.Scope.application, "node", "src.root.dir", "/opt/rally/src")
@@ -696,10 +727,7 @@ class CreateSupplierTests(TestCase):
         external_plugin = team.PluginDescriptor("community-plugin", core_plugin=False)
 
         # --revision="community-plugin:effab" --distribution-version="6.0.0"
-        composite_supplier = supplier.create(cfg, sources=False, distribution=True, car=car, plugins=[
-            core_plugin,
-            external_plugin
-        ])
+        composite_supplier = supplier.create(cfg, sources=False, distribution=True, car=car, plugins=[core_plugin, external_plugin])
 
         self.assertEqual(3, len(composite_supplier.suppliers))
         self.assertIsInstance(composite_supplier.suppliers[0], supplier.ElasticsearchDistributionSupplier)
@@ -714,8 +742,12 @@ class CreateSupplierTests(TestCase):
         cfg = config.Config()
         cfg.add(config.Scope.application, "mechanic", "source.revision", "elasticsearch:abc,community-plugin:current")
         cfg.add(config.Scope.application, "mechanic", "distribution.repository", "release")
-        cfg.add(config.Scope.application, "distributions", "release.url",
-                "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz")
+        cfg.add(
+            config.Scope.application,
+            "distributions",
+            "release.url",
+            "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
+        )
         cfg.add(config.Scope.application, "distributions", "release.cache", True)
         cfg.add(config.Scope.application, "node", "root.dir", "/opt/rally")
         cfg.add(config.Scope.application, "node", "src.root.dir", "/opt/rally/src")
@@ -723,19 +755,17 @@ class CreateSupplierTests(TestCase):
         cfg.add(config.Scope.application, "source", "remote.repo.url", "https://github.com/elastic/elasticsearch.git")
         cfg.add(config.Scope.application, "source", "plugin.community-plugin.src.subdir", "elasticsearch-extra/community-plugin")
 
-        car = team.Car("default", root_path=None, config_paths=[], variables={
-            "clean_command": "./gradlew clean",
-            "build_command": "./gradlew assemble",
-            "build.jdk": "11"
-        })
+        car = team.Car(
+            "default",
+            root_path=None,
+            config_paths=[],
+            variables={"clean_command": "./gradlew clean", "build_command": "./gradlew assemble", "build.jdk": "11"},
+        )
         core_plugin = team.PluginDescriptor("analysis-icu", core_plugin=True)
         external_plugin = team.PluginDescriptor("community-plugin", core_plugin=False)
 
         # --revision="elasticsearch:abc,community-plugin:effab"
-        composite_supplier = supplier.create(cfg, sources=True, distribution=False, car=car, plugins=[
-            core_plugin,
-            external_plugin
-        ])
+        composite_supplier = supplier.create(cfg, sources=True, distribution=False, car=car, plugins=[core_plugin, external_plugin])
 
         self.assertEqual(3, len(composite_supplier.suppliers))
         self.assertIsInstance(composite_supplier.suppliers[0].source_supplier, supplier.ElasticsearchSourceSupplier)
@@ -751,36 +781,49 @@ class DistributionRepositoryTests(TestCase):
     @mock.patch("esrally.utils.sysstats.cpu_arch", return_value="X86_64")
     def test_release_repo_config_with_default_url(self, os_name, cpu_arch):
         renderer = supplier.TemplateRenderer(version="7.3.2")
-        repo = supplier.DistributionRepository(name="release", distribution_config={
-            "runtime.jdk.bundled": "true",
-            "jdk.bundled.release_url":
-                "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz",
-            "release.cache": "true"
-        }, template_renderer=renderer)
+        repo = supplier.DistributionRepository(
+            name="release",
+            distribution_config={
+                "runtime.jdk.bundled": "true",
+                "jdk.bundled.release_url": (
+                    "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz"
+                ),
+                "release.cache": "true",
+            },
+            template_renderer=renderer,
+        )
         self.assertEqual("https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.3.2-linux-x86_64.tar.gz", repo.download_url)
         self.assertEqual("elasticsearch-7.3.2-linux-x86_64.tar.gz", repo.file_name)
         self.assertTrue(repo.cache)
 
     def test_release_repo_config_with_user_url(self):
         renderer = supplier.TemplateRenderer(version="2.4.3")
-        repo = supplier.DistributionRepository(name="release", distribution_config={
-            "jdk.unbundled.release_url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
-            "runtime.jdk.bundled": "false",
-            # user override
-            "release.url": "https://es-mirror.example.org/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
-            "release.cache": "false"
-        }, template_renderer=renderer)
+        repo = supplier.DistributionRepository(
+            name="release",
+            distribution_config={
+                "jdk.unbundled.release_url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
+                "runtime.jdk.bundled": "false",
+                # user override
+                "release.url": "https://es-mirror.example.org/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
+                "release.cache": "false",
+            },
+            template_renderer=renderer,
+        )
         self.assertEqual("https://es-mirror.example.org/downloads/elasticsearch/elasticsearch-2.4.3.tar.gz", repo.download_url)
         self.assertEqual("elasticsearch-2.4.3.tar.gz", repo.file_name)
         self.assertFalse(repo.cache)
 
     def test_missing_url(self):
         renderer = supplier.TemplateRenderer(version="2.4.3")
-        repo = supplier.DistributionRepository(name="miss", distribution_config={
-            "jdk.unbundled.release_url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
-            "runtime.jdk.bundled": "false",
-            "release.cache": "true"
-        }, template_renderer=renderer)
+        repo = supplier.DistributionRepository(
+            name="miss",
+            distribution_config={
+                "jdk.unbundled.release_url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
+                "runtime.jdk.bundled": "false",
+                "release.cache": "true",
+            },
+            template_renderer=renderer,
+        )
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             # pylint: disable=pointless-statement
             # noinspection PyStatementEffect
@@ -789,10 +832,14 @@ class DistributionRepositoryTests(TestCase):
 
     def test_missing_cache(self):
         renderer = supplier.TemplateRenderer(version="2.4.3")
-        repo = supplier.DistributionRepository(name="release", distribution_config={
-            "jdk.unbundled.release.url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
-            "runtime.jdk.bundled": "false"
-        }, template_renderer=renderer)
+        repo = supplier.DistributionRepository(
+            name="release",
+            distribution_config={
+                "jdk.unbundled.release.url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
+                "runtime.jdk.bundled": "false",
+            },
+            template_renderer=renderer,
+        )
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             # pylint: disable=pointless-statement
             # noinspection PyStatementEffect
@@ -801,11 +848,15 @@ class DistributionRepositoryTests(TestCase):
 
     def test_invalid_cache_value(self):
         renderer = supplier.TemplateRenderer(version="2.4.3")
-        repo = supplier.DistributionRepository(name="release", distribution_config={
-            "jdk.unbundled.release.url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
-            "runtime.jdk.bundled": "false",
-            "release.cache": "Invalid"
-        }, template_renderer=renderer)
+        repo = supplier.DistributionRepository(
+            name="release",
+            distribution_config={
+                "jdk.unbundled.release.url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}.tar.gz",
+                "runtime.jdk.bundled": "false",
+                "release.cache": "Invalid",
+            },
+            template_renderer=renderer,
+        )
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             # pylint: disable=pointless-statement
             # noinspection PyStatementEffect
@@ -814,25 +865,37 @@ class DistributionRepositoryTests(TestCase):
 
     def test_plugin_config_with_default_url(self):
         renderer = supplier.TemplateRenderer(version="5.5.0")
-        repo = supplier.DistributionRepository(name="release", distribution_config={
-            "runtime.jdk.bundled": "false",
-            "plugin_example_release_url": "https://artifacts.example.org/downloads/plugins/example-{{VERSION}}.zip"
-        }, template_renderer=renderer)
+        repo = supplier.DistributionRepository(
+            name="release",
+            distribution_config={
+                "runtime.jdk.bundled": "false",
+                "plugin_example_release_url": "https://artifacts.example.org/downloads/plugins/example-{{VERSION}}.zip",
+            },
+            template_renderer=renderer,
+        )
         self.assertEqual("https://artifacts.example.org/downloads/plugins/example-5.5.0.zip", repo.plugin_download_url("example"))
 
     def test_plugin_config_with_user_url(self):
         renderer = supplier.TemplateRenderer(version="5.5.0")
-        repo = supplier.DistributionRepository(name="release", distribution_config={
-            "runtime.jdk.bundled": "false",
-            "plugin_example_release_url": "https://artifacts.example.org/downloads/plugins/example-{{VERSION}}.zip",
-            # user override
-            "plugin.example.release.url": "https://mirror.example.org/downloads/plugins/example-{{VERSION}}.zip"
-        }, template_renderer=renderer)
+        repo = supplier.DistributionRepository(
+            name="release",
+            distribution_config={
+                "runtime.jdk.bundled": "false",
+                "plugin_example_release_url": "https://artifacts.example.org/downloads/plugins/example-{{VERSION}}.zip",
+                # user override
+                "plugin.example.release.url": "https://mirror.example.org/downloads/plugins/example-{{VERSION}}.zip",
+            },
+            template_renderer=renderer,
+        )
         self.assertEqual("https://mirror.example.org/downloads/plugins/example-5.5.0.zip", repo.plugin_download_url("example"))
 
     def test_missing_plugin_config(self):
         renderer = supplier.TemplateRenderer(version="5.5.0")
-        repo = supplier.DistributionRepository(name="release", distribution_config={
-            "runtime.jdk.bundled": "false",
-        }, template_renderer=renderer)
+        repo = supplier.DistributionRepository(
+            name="release",
+            distribution_config={
+                "runtime.jdk.bundled": "false",
+            },
+            template_renderer=renderer,
+        )
         self.assertIsNone(repo.plugin_download_url("not existing"))

--- a/tests/mechanic/team_test.py
+++ b/tests/mechanic/team_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -38,7 +38,7 @@ class CarLoaderTests(TestCase):
         # contrary to the name this assertion compares contents but does not care about order.
         self.assertCountEqual(
             ["default", "with_hook", "32gheap", "missing_cfg_base", "empty_cfg_base", "ea", "verbose", "multi_hook", "another_with_hook"],
-            self.loader.car_names()
+            self.loader.car_names(),
         )
 
     def test_load_known_car(self):
@@ -46,11 +46,9 @@ class CarLoaderTests(TestCase):
         self.assertEqual("default", car.name)
         self.assertEqual([os.path.join(current_dir, "data", "cars", "v1", "vanilla", "templates")], car.config_paths)
         self.assertIsNone(car.root_path)
-        self.assertDictEqual({
-            "heap_size": "1g",
-            "clean_command": "./gradlew clean",
-            "data_paths": ["/mnt/disk0", "/mnt/disk1"]
-        }, car.variables)
+        self.assertDictEqual(
+            {"heap_size": "1g", "clean_command": "./gradlew clean", "data_paths": ["/mnt/disk0", "/mnt/disk1"]}, car.variables
+        )
         self.assertIsNone(car.root_path)
 
     def test_load_car_with_mixin_single_config_base(self):
@@ -58,56 +56,52 @@ class CarLoaderTests(TestCase):
         self.assertEqual("32gheap+ea", car.name)
         self.assertEqual([os.path.join(current_dir, "data", "cars", "v1", "vanilla", "templates")], car.config_paths)
         self.assertIsNone(car.root_path)
-        self.assertEqual({
-            "heap_size": "32g",
-            "clean_command": "./gradlew clean",
-            "assertions": "true"
-        }, car.variables)
+        self.assertEqual({"heap_size": "32g", "clean_command": "./gradlew clean", "assertions": "true"}, car.variables)
         self.assertIsNone(car.root_path)
 
     def test_load_car_with_mixin_multiple_config_bases(self):
         car = team.load_car(self.team_dir, ["32gheap", "ea", "verbose"])
         self.assertEqual("32gheap+ea+verbose", car.name)
-        self.assertEqual([
-            os.path.join(current_dir, "data", "cars", "v1", "vanilla", "templates"),
-            os.path.join(current_dir, "data", "cars", "v1", "verbose_logging", "templates"),
-        ], car.config_paths)
+        self.assertEqual(
+            [
+                os.path.join(current_dir, "data", "cars", "v1", "vanilla", "templates"),
+                os.path.join(current_dir, "data", "cars", "v1", "verbose_logging", "templates"),
+            ],
+            car.config_paths,
+        )
         self.assertIsNone(car.root_path)
-        self.assertEqual({
-            "heap_size": "32g",
-            "clean_command": "./gradlew clean",
-            "verbose_logging": "true",
-            "assertions": "true"
-        }, car.variables)
+        self.assertEqual(
+            {"heap_size": "32g", "clean_command": "./gradlew clean", "verbose_logging": "true", "assertions": "true"}, car.variables
+        )
 
     def test_load_car_with_install_hook(self):
         car = team.load_car(self.team_dir, ["default", "with_hook"], car_params={"data_paths": ["/mnt/disk0", "/mnt/disk1"]})
         self.assertEqual("default+with_hook", car.name)
-        self.assertEqual([
-            os.path.join(current_dir, "data", "cars", "v1", "vanilla", "templates"),
-            os.path.join(current_dir, "data", "cars", "v1", "with_hook", "templates"),
-        ], car.config_paths)
+        self.assertEqual(
+            [
+                os.path.join(current_dir, "data", "cars", "v1", "vanilla", "templates"),
+                os.path.join(current_dir, "data", "cars", "v1", "with_hook", "templates"),
+            ],
+            car.config_paths,
+        )
         self.assertEqual(os.path.join(current_dir, "data", "cars", "v1", "with_hook"), car.root_path)
-        self.assertDictEqual({
-            "heap_size": "1g",
-            "clean_command": "./gradlew clean",
-            "data_paths": ["/mnt/disk0", "/mnt/disk1"]
-        }, car.variables)
+        self.assertDictEqual(
+            {"heap_size": "1g", "clean_command": "./gradlew clean", "data_paths": ["/mnt/disk0", "/mnt/disk1"]}, car.variables
+        )
 
     def test_load_car_with_multiple_bases_referring_same_install_hook(self):
         car = team.load_car(self.team_dir, ["with_hook", "another_with_hook"])
         self.assertEqual("with_hook+another_with_hook", car.name)
-        self.assertEqual([
-            os.path.join(current_dir, "data", "cars", "v1", "vanilla", "templates"),
-            os.path.join(current_dir, "data", "cars", "v1", "with_hook", "templates"),
-            os.path.join(current_dir, "data", "cars", "v1", "verbose_logging", "templates")
-        ], car.config_paths)
+        self.assertEqual(
+            [
+                os.path.join(current_dir, "data", "cars", "v1", "vanilla", "templates"),
+                os.path.join(current_dir, "data", "cars", "v1", "with_hook", "templates"),
+                os.path.join(current_dir, "data", "cars", "v1", "verbose_logging", "templates"),
+            ],
+            car.config_paths,
+        )
         self.assertEqual(os.path.join(current_dir, "data", "cars", "v1", "with_hook"), car.root_path)
-        self.assertDictEqual({
-            "heap_size": "16g",
-            "clean_command": "./gradlew clean",
-            "verbose_logging": "true"
-        }, car.variables)
+        self.assertDictEqual({"heap_size": "16g", "clean_command": "./gradlew clean", "verbose_logging": "true"}, car.variables)
 
     def test_raises_error_on_unknown_car(self):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
@@ -145,12 +139,16 @@ class PluginLoaderTests(TestCase):
                 team.PluginDescriptor(name="complex-plugin", config="config-b"),
                 team.PluginDescriptor(name="my-analysis-plugin", core_plugin=True),
                 team.PluginDescriptor(name="my-ingest-plugin", core_plugin=True),
-                team.PluginDescriptor(name="my-core-plugin-with-config", core_plugin=True)
-            ], self.loader.plugins())
+                team.PluginDescriptor(name="my-core-plugin-with-config", core_plugin=True),
+            ],
+            self.loader.plugins(),
+        )
 
     def test_loads_core_plugin(self):
-        self.assertEqual(team.PluginDescriptor(name="my-analysis-plugin", core_plugin=True, variables={"dbg": True}),
-                         self.loader.load_plugin("my-analysis-plugin", config_names=None, plugin_params={"dbg": True}))
+        self.assertEqual(
+            team.PluginDescriptor(name="my-analysis-plugin", core_plugin=True, variables={"dbg": True}),
+            self.loader.load_plugin("my-analysis-plugin", config_names=None, plugin_params={"dbg": True}),
+        )
 
     def test_loads_core_plugin_with_config(self):
         plugin = self.loader.load_plugin("my-core-plugin-with-config", config_names=None, plugin_params={"dbg": True})
@@ -162,17 +160,23 @@ class PluginLoaderTests(TestCase):
         self.assertEqual(expected_root_path, plugin.root_path)
         self.assertEqual(0, len(plugin.config_paths))
 
-        self.assertEqual({
-            # from plugin params
-            "dbg": True
-        }, plugin.variables)
+        self.assertEqual(
+            {
+                # from plugin params
+                "dbg": True
+            },
+            plugin.variables,
+        )
 
     def test_cannot_load_plugin_with_missing_config(self):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             self.loader.load_plugin("my-analysis-plugin", ["missing-config"])
-        self.assertRegex(ctx.exception.args[0], r"Plugin \[my-analysis-plugin\] does not provide configuration \[missing-config\]. List the"
-                                                r" available plugins and configurations with [^\s]+ list elasticsearch-plugins "
-                                                r"--distribution-version=VERSION.")
+        self.assertRegex(
+            ctx.exception.args[0],
+            r"Plugin \[my-analysis-plugin\] does not provide configuration \[missing-config\]. List the"
+            r" available plugins and configurations with [^\s]+ list elasticsearch-plugins "
+            r"--distribution-version=VERSION.",
+        )
 
     def test_loads_community_plugin_without_configuration(self):
         self.assertEqual(team.PluginDescriptor("my-community-plugin"), self.loader.load_plugin("my-community-plugin", None))
@@ -180,8 +184,11 @@ class PluginLoaderTests(TestCase):
     def test_cannot_load_community_plugin_with_missing_config(self):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             self.loader.load_plugin("my-community-plugin", "some-configuration")
-        self.assertRegex(ctx.exception.args[0], r"Unknown plugin \[my-community-plugin\]. List the available plugins with [^\s]+ list "
-                                                r"elasticsearch-plugins --distribution-version=VERSION.")
+        self.assertRegex(
+            ctx.exception.args[0],
+            r"Unknown plugin \[my-community-plugin\]. List the available plugins with [^\s]+ list "
+            r"elasticsearch-plugins --distribution-version=VERSION.",
+        )
 
     def test_loads_configured_plugin(self):
         plugin = self.loader.load_plugin("complex-plugin", ["config-a", "config-b"], plugin_params={"dbg": True})
@@ -193,19 +200,25 @@ class PluginLoaderTests(TestCase):
 
         self.assertEqual(expected_root_path, plugin.root_path)
         # order does matter here! We should not swap it
-        self.assertListEqual([
-            os.path.join(expected_root_path, "default", "templates"),
-            os.path.join(expected_root_path, "special", "templates"),
-        ], plugin.config_paths)
+        self.assertListEqual(
+            [
+                os.path.join(expected_root_path, "default", "templates"),
+                os.path.join(expected_root_path, "special", "templates"),
+            ],
+            plugin.config_paths,
+        )
 
-        self.assertEqual({
-            "foo": "bar",
-            "baz": "foo",
-            "var": "0",
-            "hello": "true",
-            # from plugin params
-            "dbg": True
-        }, plugin.variables)
+        self.assertEqual(
+            {
+                "foo": "bar",
+                "baz": "foo",
+                "var": "0",
+                "hello": "true",
+                # from plugin params
+                "dbg": True,
+            },
+            plugin.variables,
+        )
 
 
 class BootstrapHookHandlerTests(TestCase):
@@ -253,5 +266,6 @@ class BootstrapHookHandlerTests(TestCase):
         handler.loader.registration_function = hook
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             handler.load()
-        self.assertEqual("Unknown bootstrap phase [this_is_an_unknown_install_phase]. Valid phases are: ['post_install'].",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Unknown bootstrap phase [this_is_an_unknown_install_phase]. Valid phases are: ['post_install'].", ctx.exception.args[0]
+        )

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -52,8 +52,7 @@ def unittest_pipeline():
 def test_finds_available_pipelines():
     expected = [
         ["from-sources", "Builds and provisions Elasticsearch, runs a benchmark and reports results."],
-        ["from-distribution",
-         "Downloads an Elasticsearch distribution, provisions it, runs a benchmark and reports results."],
+        ["from-distribution", "Downloads an Elasticsearch distribution, provisions it, runs a benchmark and reports results."],
         ["benchmark-only", "Assumes an already running Elasticsearch instance, runs a benchmark and reports results"],
     ]
 
@@ -67,8 +66,8 @@ def test_prevents_running_an_unknown_pipeline():
     cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", "5.0.0")
 
     with pytest.raises(
-            exceptions.SystemSetupError,
-            match=r"Unknown pipeline \[invalid]. List the available pipelines with [\S]+? list pipelines."):
+        exceptions.SystemSetupError, match=r"Unknown pipeline \[invalid]. List the available pipelines with [\S]+? list pipelines."
+    ):
         racecontrol.run(cfg)
 
 
@@ -88,13 +87,14 @@ def test_fails_without_benchmark_only_pipeline_in_docker(running_in_docker, unit
     cfg.add(config.Scope.benchmark, "race", "pipeline", "unit-test-pipeline")
 
     with pytest.raises(
-            exceptions.SystemSetupError,
-            match=re.escape(
-                "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n"
-                "Add --pipeline=benchmark-only in your Rally arguments and try again.\n"
-                "For more details read the docs for the benchmark-only pipeline in "
-                "https://esrally.readthedocs.io/en/latest/pipelines.html#benchmark-only\n"
-            )):
+        exceptions.SystemSetupError,
+        match=re.escape(
+            "Only the [benchmark-only] pipeline is supported by the Rally Docker image.\n"
+            "Add --pipeline=benchmark-only in your Rally arguments and try again.\n"
+            "For more details read the docs for the benchmark-only pipeline in "
+            "https://esrally.readthedocs.io/en/latest/pipelines.html#benchmark-only\n"
+        ),
+    ):
         racecontrol.run(cfg)
 
 

--- a/tests/reporter_test.py
+++ b/tests/reporter_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -29,7 +29,7 @@ class FormatterTests(TestCase):
         self.metrics_data = [
             ["Min Throughput", "index", "17300", "18000", "700", "ops/s"],
             ["Median Throughput", "index", "17500", "18500", "1000", "ops/s"],
-            ["Max Throughput", "index", "17700", "19000", "1300", "ops/s"]
+            ["Max Throughput", "index", "17700", "19000", "1300", "ops/s"],
         ]
         self.numbers_align = "right"
 

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -27,7 +27,7 @@ from unittest.mock import call
 import elasticsearch
 import pytest
 
-from esrally import config, metrics, exceptions, telemetry
+from esrally import config, exceptions, metrics, telemetry
 from esrally.mechanic import cluster
 from esrally.metrics import MetaInfoScope
 from esrally.utils import console
@@ -71,7 +71,7 @@ class TelemetryTests(TestCase):
         devices = [
             MockTelemetryDevice(["-Xms256M"]),
             MockTelemetryDevice(["-Xmx512M"]),
-            MockTelemetryDevice(["-Des.network.host=127.0.0.1"])
+            MockTelemetryDevice(["-Des.network.host=127.0.0.1"]),
         ]
 
         t = telemetry.Telemetry(enabled_devices=None, devices=devices)
@@ -172,51 +172,90 @@ class JfrTests(TestCase):
     def test_sets_options_for_pre_java_9_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(0, 8))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
-                          "-XX:+FlightRecorder", "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,"
-                          "dumponexitpath=/var/log/test-recording.jfr", "-XX:StartFlightRecording=defaultrecording=true"], java_opts)
+        self.assertEqual(
+            [
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+DebugNonSafepoints",
+                "-XX:+UnlockCommercialFeatures",
+                "-XX:+FlightRecorder",
+                "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath=/var/log/test-recording.jfr",
+                "-XX:StartFlightRecording=defaultrecording=true",
+            ],
+            java_opts,
+        )
 
     def test_sets_options_for_java_9_or_10_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(9, 10))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
-                          "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,"
-                          "dumponexit=true,filename=/var/log/test-recording.jfr"], java_opts)
+        self.assertEqual(
+            [
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+DebugNonSafepoints",
+                "-XX:+UnlockCommercialFeatures",
+                "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr",
+            ],
+            java_opts,
+        )
 
     def test_sets_options_for_java_11_or_above_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(11, 999))
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints",
-                          "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,"
-                          "dumponexit=true,filename=/var/log/test-recording.jfr"], java_opts)
+        self.assertEqual(
+            [
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+DebugNonSafepoints",
+                "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr",
+            ],
+            java_opts,
+        )
 
     def test_sets_options_for_pre_java_9_custom_recording_template(self):
-        jfr = telemetry.FlightRecorder(telemetry_params={"recording-template": "profile"},
-                                       log_root="/var/log",
-                                       java_major_version=random.randint(0, 8))
+        jfr = telemetry.FlightRecorder(
+            telemetry_params={"recording-template": "profile"}, log_root="/var/log", java_major_version=random.randint(0, 8)
+        )
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
-                          "-XX:+FlightRecorder", "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,"
-                          "dumponexitpath=/var/log/test-recording.jfr",
-                          "-XX:StartFlightRecording=defaultrecording=true,settings=profile"], java_opts)
+        self.assertEqual(
+            [
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+DebugNonSafepoints",
+                "-XX:+UnlockCommercialFeatures",
+                "-XX:+FlightRecorder",
+                "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath=/var/log/test-recording.jfr",
+                "-XX:StartFlightRecording=defaultrecording=true,settings=profile",
+            ],
+            java_opts,
+        )
 
     def test_sets_options_for_java_9_or_10_custom_recording_template(self):
-        jfr = telemetry.FlightRecorder(telemetry_params={"recording-template": "profile"},
-                                       log_root="/var/log",
-                                       java_major_version=random.randint(9, 10))
+        jfr = telemetry.FlightRecorder(
+            telemetry_params={"recording-template": "profile"}, log_root="/var/log", java_major_version=random.randint(9, 10)
+        )
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:+UnlockCommercialFeatures",
-                          "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
-                          "filename=/var/log/test-recording.jfr,settings=profile"], java_opts)
+        self.assertEqual(
+            [
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+DebugNonSafepoints",
+                "-XX:+UnlockCommercialFeatures",
+                "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
+                "filename=/var/log/test-recording.jfr,settings=profile",
+            ],
+            java_opts,
+        )
 
     def test_sets_options_for_java_11_or_above_custom_recording_template(self):
-        jfr = telemetry.FlightRecorder(telemetry_params={"recording-template": "profile"},
-                                       log_root="/var/log",
-                                       java_major_version=random.randint(11, 999))
+        jfr = telemetry.FlightRecorder(
+            telemetry_params={"recording-template": "profile"}, log_root="/var/log", java_major_version=random.randint(11, 999)
+        )
         java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints",
-                          "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
-                          "filename=/var/log/test-recording.jfr,settings=profile"], java_opts)
+        self.assertEqual(
+            [
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+DebugNonSafepoints",
+                "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
+                "filename=/var/log/test-recording.jfr,settings=profile",
+            ],
+            java_opts,
+        )
 
 
 class GcTests(TestCase):
@@ -224,9 +263,18 @@ class GcTests(TestCase):
         gc = telemetry.Gc(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(0, 8))
         gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
         self.assertEqual(7, len(gc_java_opts))
-        self.assertEqual(["-Xloggc:/var/log/defaults-node-0.gc.log", "-XX:+PrintGCDetails", "-XX:+PrintGCDateStamps",
-                          "-XX:+PrintGCTimeStamps", "-XX:+PrintGCApplicationStoppedTime", "-XX:+PrintGCApplicationConcurrentTime",
-                          "-XX:+PrintTenuringDistribution"], gc_java_opts)
+        self.assertEqual(
+            [
+                "-Xloggc:/var/log/defaults-node-0.gc.log",
+                "-XX:+PrintGCDetails",
+                "-XX:+PrintGCDateStamps",
+                "-XX:+PrintGCTimeStamps",
+                "-XX:+PrintGCApplicationStoppedTime",
+                "-XX:+PrintGCApplicationConcurrentTime",
+                "-XX:+PrintTenuringDistribution",
+            ],
+            gc_java_opts,
+        )
 
     def test_sets_options_for_java_9_or_above(self):
         gc = telemetry.Gc(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(9, 999))
@@ -234,17 +282,18 @@ class GcTests(TestCase):
         self.assertEqual(1, len(gc_java_opts))
         self.assertEqual(
             ["-Xlog:gc*=info,safepoint=info,age*=trace:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"],
-            gc_java_opts)
+            gc_java_opts,
+        )
 
     def test_can_override_options_for_java_9_or_above(self):
-        gc = telemetry.Gc(telemetry_params={"gc-log-config": "gc,safepoint"},
-                          log_root="/var/log",
-                          java_major_version=random.randint(9, 999))
+        gc = telemetry.Gc(
+            telemetry_params={"gc-log-config": "gc,safepoint"}, log_root="/var/log", java_major_version=random.randint(9, 999)
+        )
         gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
         self.assertEqual(1, len(gc_java_opts))
         self.assertEqual(
-            ["-Xlog:gc,safepoint:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"],
-            gc_java_opts)
+            ["-Xlog:gc,safepoint:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"], gc_java_opts
+        )
 
 
 class HeapdumpTests(TestCase):
@@ -274,12 +323,14 @@ class SegmentStatsTests(TestCase):
         segment_stats = telemetry.SegmentStats("/var/log", es)
         segment_stats.on_benchmark_stop()
         es.cat.segments.assert_called_with(index="_all", v=True)
-        file_mock.assert_has_calls([
-            call("/var/log/segment_stats.log", "wt"),
-            call().__enter__(),
-            call().write(stats_response),
-            call().__exit__(None, None, None)
-        ])
+        file_mock.assert_has_calls(
+            [
+                call("/var/log/segment_stats.log", "wt"),
+                call().__enter__(),
+                call().write(stats_response),
+                call().__exit__(None, None, None),
+            ]
+        )
 
 
 class CcrStatsTests(TestCase):
@@ -287,11 +338,10 @@ class CcrStatsTests(TestCase):
         clients = {"default": Client(), "cluster_b": Client()}
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        telemetry_params = {
-            "ccr-stats-sample-interval": -1 * random.random()
-        }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    r"The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was .*\."):
+        telemetry_params = {"ccr-stats-sample-interval": -1 * random.random()}
+        with self.assertRaisesRegex(
+            exceptions.SystemSetupError, r"The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was .*\."
+        ):
             telemetry.CcrStats(telemetry_params, clients, metrics_store)
 
     def test_wrong_cluster_name_in_ccr_stats_indices_forbidden(self):
@@ -299,30 +349,33 @@ class CcrStatsTests(TestCase):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {
-            "ccr-stats-indices":{
+            "ccr-stats-indices": {
                 "default": ["leader"],
-                "wrong_cluster_name": ["follower"]
-            }
+                "wrong_cluster_name": ["follower"],
+            },
         }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    r"The telemetry parameter 'ccr-stats-indices' must be a JSON Object with keys matching "
-                                    r"the cluster names \[{}] specified in --target-hosts "
-                                    r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys())))
-                                    ):
+        with self.assertRaisesRegex(
+            exceptions.SystemSetupError,
+            r"The telemetry parameter 'ccr-stats-indices' must be a JSON Object with keys matching "
+            r"the cluster names \[{}] specified in --target-hosts "
+            r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys()))),
+        ):
             telemetry.CcrStats(telemetry_params, clients, metrics_store)
 
 
 class CcrStatsRecorderTests(TestCase):
-    java_signed_maxlong = (2**63) - 1
+    java_signed_maxlong = (2 ** 63) - 1
 
     def test_raises_exception_on_transport_error(self):
         client = Client(transport_client=TransportClient(response={}, force_error=True))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        with self.assertRaisesRegex(exceptions.RallyError,
-                                    r"A transport error occurred while collecting CCR stats from the endpoint "
-                                    r"\[/_ccr/stats\?filter_path=follow_stats\] on "
-                                    r"cluster \[remote\]"):
+        with self.assertRaisesRegex(
+            exceptions.RallyError,
+            r"A transport error occurred while collecting CCR stats from the endpoint "
+            r"\[/_ccr/stats\?filter_path=follow_stats\] on "
+            r"cluster \[remote\]",
+        ):
             telemetry.CcrStatsRecorder(cluster_name="remote", client=client, metrics_store=metrics_store, sample_interval=1).record()
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
@@ -360,7 +413,7 @@ class CcrStatsRecorderTests(TestCase):
                 "number_of_failed_follow_indices": 0,
                 "number_of_failed_remote_cluster_state_requests": 0,
                 "number_of_successful_follow_indices": 0,
-                "recent_auto_follow_errors": []
+                "recent_auto_follow_errors": [],
             },
             "follow_stats": {
                 "indices": [
@@ -394,10 +447,10 @@ class CcrStatsRecorderTests(TestCase):
                                 "read_exceptions": read_exceptions,
                                 "time_since_last_read_millis": time_since_last_read_millis,
                             }
-                        ]
+                        ],
                     }
                 ]
-            }
+            },
         }
 
         ccr_stats_filtered_follower_response = {"follow_stats": ccr_stats_follower_response["follow_stats"]}
@@ -408,18 +461,15 @@ class CcrStatsRecorderTests(TestCase):
         recorder = telemetry.CcrStatsRecorder(cluster_name="remote", client=client, metrics_store=metrics_store, sample_interval=1)
         recorder.record()
 
-        shard_metadata = {
-            "cluster": "remote",
-            "index": follower_index
-        }
+        shard_metadata = {"cluster": "remote", "index": follower_index}
 
         metrics_store_put_doc.assert_called_with(
             {
                 "name": "ccr-stats",
-                "shard": ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][0]
+                "shard": ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][0],
             },
             level=MetaInfoScope.cluster,
-            meta_data=shard_metadata
+            meta_data=shard_metadata,
         )
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
@@ -457,7 +507,7 @@ class CcrStatsRecorderTests(TestCase):
                 "number_of_failed_follow_indices": 0,
                 "number_of_failed_remote_cluster_state_requests": 0,
                 "number_of_successful_follow_indices": 0,
-                "recent_auto_follow_errors": []
+                "recent_auto_follow_errors": [],
             },
             "follow_stats": {
                 "indices": [
@@ -490,11 +540,12 @@ class CcrStatsRecorderTests(TestCase):
                                 "operations_written": operations_written[shard_id],
                                 "read_exceptions": read_exceptions[shard_id],
                                 "time_since_last_read_millis": time_since_last_read_millis[shard_id],
-                            } for shard_id in shard_range
-                        ]
+                            }
+                            for shard_id in shard_range
+                        ],
                     }
                 ]
-            }
+            },
         }
 
         ccr_stats_filtered_follower_response = {"follow_stats": ccr_stats_follower_response["follow_stats"]}
@@ -508,31 +559,28 @@ class CcrStatsRecorderTests(TestCase):
         shard_metadata = [
             {
                 "cluster": "remote",
-                "index": "follower"
+                "index": "follower",
             },
             {
                 "cluster": "remote",
-                "index": "follower"
-            }
+                "index": "follower",
+            },
         ]
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call(
-                {
-                    "name": "ccr-stats",
-                    "shard": ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][0]
-                },
-                level=MetaInfoScope.cluster,
-                meta_data=shard_metadata[0]),
-            mock.call(
-                {
-                    "name": "ccr-stats",
-                    "shard": ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][1]
-                },
-                level=MetaInfoScope.cluster,
-                meta_data=shard_metadata[1])
+        metrics_store_put_doc.assert_has_calls(
+            [
+                mock.call(
+                    {"name": "ccr-stats", "shard": ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][0]},
+                    level=MetaInfoScope.cluster,
+                    meta_data=shard_metadata[0],
+                ),
+                mock.call(
+                    {"name": "ccr-stats", "shard": ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][1]},
+                    level=MetaInfoScope.cluster,
+                    meta_data=shard_metadata[1],
+                ),
             ],
-            any_order=True
+            any_order=True,
         )
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
@@ -571,7 +619,7 @@ class CcrStatsRecorderTests(TestCase):
                 "number_of_failed_follow_indices": 0,
                 "number_of_failed_remote_cluster_state_requests": 0,
                 "number_of_successful_follow_indices": 0,
-                "recent_auto_follow_errors": []
+                "recent_auto_follow_errors": [],
             },
             "follow_stats": {
                 "indices": [
@@ -605,7 +653,7 @@ class CcrStatsRecorderTests(TestCase):
                                 "read_exceptions": read_exceptions,
                                 "time_since_last_read_millis": time_since_last_read_millis,
                             }
-                        ]
+                        ],
                     },
                     {
                         "index": follower_index2,
@@ -637,11 +685,10 @@ class CcrStatsRecorderTests(TestCase):
                                 "read_exceptions": read_exceptions,
                                 "time_since_last_read_millis": time_since_last_read_millis,
                             }
-
-                        ]
-                    }
+                        ],
+                    },
                 ]
-            }
+            },
         }
 
         ccr_stats_filtered_follower_response = {"follow_stats": ccr_stats_follower_response["follow_stats"]}
@@ -651,21 +698,20 @@ class CcrStatsRecorderTests(TestCase):
         recorder = telemetry.CcrStatsRecorder("remote", client, metrics_store, 1, indices=[follower_index1])
         recorder.record()
 
-        shard_metadata = {
-            "cluster": "remote",
-            "index": follower_index1
-        }
+        shard_metadata = {"cluster": "remote", "index": follower_index1}
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call(
-                {
-                    "name": "ccr-stats",
-                    "shard": ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][0]
-                },
-                level=MetaInfoScope.cluster,
-                meta_data=shard_metadata)
+        metrics_store_put_doc.assert_has_calls(
+            [
+                mock.call(
+                    {
+                        "name": "ccr-stats",
+                        "shard": ccr_stats_filtered_follower_response["follow_stats"]["indices"][0]["shards"][0],
+                    },
+                    level=MetaInfoScope.cluster,
+                    meta_data=shard_metadata,
+                )
             ],
-            any_order=True
+            any_order=True,
         )
 
 
@@ -676,11 +722,9 @@ class RecoveryStatsTests(TestCase):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         client = Client(indices=SubClient(recovery=response))
-        recorder = telemetry.RecoveryStatsRecorder(cluster_name="leader",
-                                                   client=client,
-                                                   metrics_store=metrics_store,
-                                                   sample_interval=1,
-                                                   indices=["index1"])
+        recorder = telemetry.RecoveryStatsRecorder(
+            cluster_name="leader", client=client, metrics_store=metrics_store, sample_interval=1, indices=["index1"]
+        )
         recorder.record()
 
         self.assertEqual(0, metrics_store_put_doc.call_count)
@@ -689,69 +733,65 @@ class RecoveryStatsTests(TestCase):
     def test_stores_single_shard_stats(self, metrics_store_put_doc):
         response = {
             "index1": {
-                "shards": [{
-                    "id": 0,
-                    "type": "STORE",
-                    "stage": "DONE",
-                    "primary": True,
-                    "start_time": "2014-02-24T12:38:06.349",
-                    "start_time_in_millis": "1393245486349",
-                    "stop_time": "2014-02-24T12:38:08.464",
-                    "stop_time_in_millis": "1393245488464",
-                    "total_time": "2.1s",
-                    "total_time_in_millis": 2115,
-                    "source": {
-                        "id": "RGMdRc-yQWWKIBM4DGvwqQ",
-                        "host": "my.fqdn",
-                        "transport_address": "my.fqdn",
-                        "ip": "10.0.1.7",
-                        "name": "my_es_node"
-                    },
-                    "target": {
-                        "id": "RGMdRc-yQWWKIBM4DGvwqQ",
-                        "host": "my.fqdn",
-                        "transport_address": "my.fqdn",
-                        "ip": "10.0.1.7",
-                        "name": "my_es_node"
-                    },
-                    "index": {
-                        "size": {
-                            "total": "24.7mb",
-                            "total_in_bytes": 26001617,
-                            "reused": "24.7mb",
-                            "reused_in_bytes": 26001617,
-                            "recovered": "0b",
-                            "recovered_in_bytes": 0,
-                            "percent": "100.0%"
+                "shards": [
+                    {
+                        "id": 0,
+                        "type": "STORE",
+                        "stage": "DONE",
+                        "primary": True,
+                        "start_time": "2014-02-24T12:38:06.349",
+                        "start_time_in_millis": "1393245486349",
+                        "stop_time": "2014-02-24T12:38:08.464",
+                        "stop_time_in_millis": "1393245488464",
+                        "total_time": "2.1s",
+                        "total_time_in_millis": 2115,
+                        "source": {
+                            "id": "RGMdRc-yQWWKIBM4DGvwqQ",
+                            "host": "my.fqdn",
+                            "transport_address": "my.fqdn",
+                            "ip": "10.0.1.7",
+                            "name": "my_es_node",
                         },
-                        "files": {
-                            "total": 26,
-                            "reused": 26,
-                            "recovered": 0,
-                            "percent": "100.0%"
+                        "target": {
+                            "id": "RGMdRc-yQWWKIBM4DGvwqQ",
+                            "host": "my.fqdn",
+                            "transport_address": "my.fqdn",
+                            "ip": "10.0.1.7",
+                            "name": "my_es_node",
                         },
-                        "total_time": "2ms",
-                        "total_time_in_millis": 2,
-                        "source_throttle_time": "0s",
-                        "source_throttle_time_in_millis": 0,
-                        "target_throttle_time": "0s",
-                        "target_throttle_time_in_millis": 0
-                    },
-                    "translog": {
-                        "recovered": 71,
-                        "total": 0,
-                        "percent": "100.0%",
-                        "total_on_start": 0,
-                        "total_time": "2.0s",
-                        "total_time_in_millis": 2025
-                    },
-                    "verify_index": {
-                        "check_index_time": 0,
-                        "check_index_time_in_millis": 0,
-                        "total_time": "88ms",
-                        "total_time_in_millis": 88
+                        "index": {
+                            "size": {
+                                "total": "24.7mb",
+                                "total_in_bytes": 26001617,
+                                "reused": "24.7mb",
+                                "reused_in_bytes": 26001617,
+                                "recovered": "0b",
+                                "recovered_in_bytes": 0,
+                                "percent": "100.0%",
+                            },
+                            "files": {"total": 26, "reused": 26, "recovered": 0, "percent": "100.0%"},
+                            "total_time": "2ms",
+                            "total_time_in_millis": 2,
+                            "source_throttle_time": "0s",
+                            "source_throttle_time_in_millis": 0,
+                            "target_throttle_time": "0s",
+                            "target_throttle_time_in_millis": 0,
+                        },
+                        "translog": {
+                            "recovered": 71,
+                            "total": 0,
+                            "percent": "100.0%",
+                            "total_on_start": 0,
+                            "total_time": "2.0s",
+                            "total_time_in_millis": 2025,
+                        },
+                        "verify_index": {
+                            "check_index_time": 0,
+                            "check_index_time_in_millis": 0,
+                            "total_time": "88ms",
+                            "total_time_in_millis": 88,
+                        },
                     }
-                }
                 ]
             }
         }
@@ -759,25 +799,23 @@ class RecoveryStatsTests(TestCase):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         client = Client(indices=SubClient(recovery=response))
-        recorder = telemetry.RecoveryStatsRecorder(cluster_name="leader",
-                                                   client=client,
-                                                   metrics_store=metrics_store,
-                                                   sample_interval=1,
-                                                   indices=["index1"])
+        recorder = telemetry.RecoveryStatsRecorder(
+            cluster_name="leader", client=client, metrics_store=metrics_store, sample_interval=1, indices=["index1"]
+        )
         recorder.record()
 
-        shard_metadata = {
-            "cluster": "leader",
-            "index": "index1",
-            "shard": 0
-        }
+        shard_metadata = {"cluster": "leader", "index": "index1", "shard": 0}
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index1"]["shards"][0]
-            }, level=MetaInfoScope.cluster, meta_data=shard_metadata)
-        ],  any_order=True)
+        metrics_store_put_doc.assert_has_calls(
+            [
+                mock.call(
+                    {"name": "recovery-stats", "shard": response["index1"]["shards"][0]},
+                    level=MetaInfoScope.cluster,
+                    meta_data=shard_metadata,
+                )
+            ],
+            any_order=True,
+        )
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_multi_index_multi_shard_stats(self, metrics_store_put_doc):
@@ -790,15 +828,15 @@ class RecoveryStatsTests(TestCase):
                         "type": "STORE",
                         "stage": "DONE",
                         "primary": True,
-                        "total_time_in_millis": 100
+                        "total_time_in_millis": 100,
                     },
                     {
                         "id": 1,
                         "type": "STORE",
                         "stage": "DONE",
                         "primary": True,
-                        "total_time_in_millis": 200
-                    }
+                        "total_time_in_millis": 200,
+                    },
                 ]
             },
             "index2": {
@@ -808,82 +846,102 @@ class RecoveryStatsTests(TestCase):
                         "type": "STORE",
                         "stage": "DONE",
                         "primary": True,
-                        "total_time_in_millis": 300
+                        "total_time_in_millis": 300,
                     },
                     {
                         "id": 1,
                         "type": "STORE",
                         "stage": "DONE",
                         "primary": True,
-                        "total_time_in_millis": 400
+                        "total_time_in_millis": 400,
                     },
                     {
                         "id": 2,
                         "type": "STORE",
                         "stage": "DONE",
                         "primary": True,
-                        "total_time_in_millis": 500
-                    }
+                        "total_time_in_millis": 500,
+                    },
                 ]
-            }
+            },
         }
 
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         client = Client(indices=SubClient(recovery=response))
-        recorder = telemetry.RecoveryStatsRecorder(cluster_name="leader",
-                                                   client=client,
-                                                   metrics_store=metrics_store,
-                                                   sample_interval=1,
-                                                   indices=["index1", "index2"])
+        recorder = telemetry.RecoveryStatsRecorder(
+            cluster_name="leader", client=client, metrics_store=metrics_store, sample_interval=1, indices=["index1", "index2"]
+        )
         recorder.record()
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index1"]["shards"][0]
-            }, level=MetaInfoScope.cluster, meta_data={
-                "cluster": "leader",
-                "index": "index1",
-                "shard": 0
-            }),
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index1"]["shards"][1]
-            }, level=MetaInfoScope.cluster, meta_data={
-                "cluster": "leader",
-                "index": "index1",
-                "shard": 1
-            }),
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index2"]["shards"][0]
-            }, level=MetaInfoScope.cluster, meta_data={
-                "cluster": "leader",
-                "index": "index2",
-                "shard": 0
-            }),
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index2"]["shards"][1]
-            }, level=MetaInfoScope.cluster, meta_data={
-                "cluster": "leader",
-                "index": "index2",
-                "shard": 1
-            }),
-            mock.call({
-                "name": "recovery-stats",
-                "shard": response["index2"]["shards"][2]
-            }, level=MetaInfoScope.cluster, meta_data={
-                "cluster": "leader",
-                "index": "index2",
-                "shard": 2
-            }),
-        ],  any_order=True)
+        metrics_store_put_doc.assert_has_calls(
+            [
+                mock.call(
+                    {
+                        "name": "recovery-stats",
+                        "shard": response["index1"]["shards"][0],
+                    },
+                    level=MetaInfoScope.cluster,
+                    meta_data={
+                        "cluster": "leader",
+                        "index": "index1",
+                        "shard": 0,
+                    },
+                ),
+                mock.call(
+                    {
+                        "name": "recovery-stats",
+                        "shard": response["index1"]["shards"][1],
+                    },
+                    level=MetaInfoScope.cluster,
+                    meta_data={
+                        "cluster": "leader",
+                        "index": "index1",
+                        "shard": 1,
+                    },
+                ),
+                mock.call(
+                    {
+                        "name": "recovery-stats",
+                        "shard": response["index2"]["shards"][0],
+                    },
+                    level=MetaInfoScope.cluster,
+                    meta_data={
+                        "cluster": "leader",
+                        "index": "index2",
+                        "shard": 0,
+                    },
+                ),
+                mock.call(
+                    {
+                        "name": "recovery-stats",
+                        "shard": response["index2"]["shards"][1],
+                    },
+                    level=MetaInfoScope.cluster,
+                    meta_data={
+                        "cluster": "leader",
+                        "index": "index2",
+                        "shard": 1,
+                    },
+                ),
+                mock.call(
+                    {
+                        "name": "recovery-stats",
+                        "shard": response["index2"]["shards"][2],
+                    },
+                    level=MetaInfoScope.cluster,
+                    meta_data={
+                        "cluster": "leader",
+                        "index": "index2",
+                        "shard": 2,
+                    },
+                ),
+            ],
+            any_order=True,
+        )
 
 
 class ShardStatsTests(TestCase):
-
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_single_shard_stats(self, metrics_store_put_doc):
         node_stats_response = {
@@ -898,83 +956,85 @@ class ShardStatsTests(TestCase):
                     "roles": [
                         "master",
                         "data",
-                        "ingest"
+                        "ingest",
                     ],
                     "indices": {
                         "docs": {
                             "count": 76892364,
-                            "deleted": 324530
+                            "deleted": 324530,
                         },
                         "store": {
-                            "size_in_bytes": 983409834
+                            "size_in_bytes": 983409834,
                         },
-                        "shards" : {
-                             "geonames": [
-                            {
-                              "0" : {
-                                "routing" : {
-                                  "state" : "STARTED",
-                                  "primary" : True,
-                                  "node" : "gHQpKO-IT5uo8WVTPmAZXw",
-                                  "relocating_node" : None
-                                },
-                                "docs" : {
-                                  "count" : 1000,
-                                  "deleted" : 0
-                                },
-                                "store" : {
-                                  "size_in_bytes" : 212027,
-                                  "reserved_in_bytes" : 0
-                                },
-                                "segments" : {
-                                  "count" : 8,
-                                  "memory_in_bytes" : 46872,
-                                  "terms_memory_in_bytes" : 13056,
-                                  "stored_fields_memory_in_bytes" : 3904,
-                                  "term_vectors_memory_in_bytes" : 0,
-                                  "norms_memory_in_bytes" : 0,
-                                  "points_memory_in_bytes" : 0,
-                                  "doc_values_memory_in_bytes" : 29912,
-                                  "index_writer_memory_in_bytes" : 0,
-                                  "version_map_memory_in_bytes" : 0,
-                                  "fixed_bit_set_memory_in_bytes" : 0,
-                                  "max_unsafe_auto_id_timestamp" : -1,
-                                  "file_sizes" : { }
+                        "shards": {
+                            "geonames": [
+                                {
+                                    "0": {
+                                        "routing": {
+                                            "state": "STARTED",
+                                            "primary": True,
+                                            "node": "gHQpKO-IT5uo8WVTPmAZXw",
+                                            "relocating_node": None,
+                                        },
+                                        "docs": {
+                                            "count": 1000,
+                                            "deleted": 0,
+                                        },
+                                        "store": {
+                                            "size_in_bytes": 212027,
+                                            "reserved_in_bytes": 0,
+                                        },
+                                        "segments": {
+                                            "count": 8,
+                                            "memory_in_bytes": 46872,
+                                            "terms_memory_in_bytes": 13056,
+                                            "stored_fields_memory_in_bytes": 3904,
+                                            "term_vectors_memory_in_bytes": 0,
+                                            "norms_memory_in_bytes": 0,
+                                            "points_memory_in_bytes": 0,
+                                            "doc_values_memory_in_bytes": 29912,
+                                            "index_writer_memory_in_bytes": 0,
+                                            "version_map_memory_in_bytes": 0,
+                                            "fixed_bit_set_memory_in_bytes": 0,
+                                            "max_unsafe_auto_id_timestamp": -1,
+                                            "file_sizes": {},
+                                        },
+                                    }
                                 }
-                              }
-                            }
-                          ]
-                        }
-                    }
+                            ]
+                        },
+                    },
                 }
-            }
+            },
         }
 
         client = Client(nodes=SubClient(stats=node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        recorder = telemetry.ShardStatsRecorder(cluster_name="remote",
-                                                   client=client,
-                                                   metrics_store=metrics_store,
-                                                   sample_interval=53)
+        recorder = telemetry.ShardStatsRecorder(cluster_name="remote", client=client, metrics_store=metrics_store, sample_interval=53)
         recorder.record()
 
-        shard_metadata = {
-            "cluster": "remote"
-        }
+        shard_metadata = {"cluster": "remote"}
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call({
-                "name": "shard-stats",
-                "shard-id": "0",
-                "index": "geonames",
-                "primary": True,
-                "docs": 1000,
-                "store": 212027,
-                "segments-count": 8,
-                "node": "rally0"
-            }, level=MetaInfoScope.cluster, meta_data=shard_metadata)
-        ],  any_order=True)
+        metrics_store_put_doc.assert_has_calls(
+            [
+                mock.call(
+                    {
+                        "name": "shard-stats",
+                        "shard-id": "0",
+                        "index": "geonames",
+                        "primary": True,
+                        "docs": 1000,
+                        "store": 212027,
+                        "segments-count": 8,
+                        "node": "rally0",
+                    },
+                    level=MetaInfoScope.cluster,
+                    meta_data=shard_metadata,
+                )
+            ],
+            any_order=True,
+        )
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_missing_properties_shard_stats(self, metrics_store_put_doc):
@@ -990,434 +1050,437 @@ class ShardStatsTests(TestCase):
                     "roles": [
                         "master",
                         "data",
-                        "ingest"
+                        "ingest",
                     ],
                     "indices": {
                         "docs": {
                             "count": 76892364,
-                            "deleted": 324530
+                            "deleted": 324530,
                         },
                         "store": {
-                            "size_in_bytes": 983409834
+                            "size_in_bytes": 983409834,
                         },
-                        "shards" : {
-                             "geonames": [
-                            {
-                              "0" : {
-                                "routing" : {
-                                  "state" : "STARTED",
-                                  "primary" : True,
-                                  "node" : "gHQpKO-IT5uo8WVTPmAZXw",
-                                  "relocating_node" : None
-                                },
-                                "store" : {
-                                  "size_in_bytes" : 212027,
-                                  "reserved_in_bytes" : 0
+                        "shards": {
+                            "geonames": [
+                                {
+                                    "0": {
+                                        "routing": {
+                                            "state": "STARTED",
+                                            "primary": True,
+                                            "node": "gHQpKO-IT5uo8WVTPmAZXw",
+                                            "relocating_node": None,
+                                        },
+                                        "store": {
+                                            "size_in_bytes": 212027,
+                                            "reserved_in_bytes": 0,
+                                        },
+                                    }
                                 }
-                              }
-                            }
-                          ]
-                        }
-                    }
+                            ]
+                        },
+                    },
                 }
-            }
+            },
         }
 
         client = Client(nodes=SubClient(stats=node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        recorder = telemetry.ShardStatsRecorder(cluster_name="remote",
-                                                   client=client,
-                                                   metrics_store=metrics_store,
-                                                   sample_interval=53)
+        recorder = telemetry.ShardStatsRecorder(cluster_name="remote", client=client, metrics_store=metrics_store, sample_interval=53)
         recorder.record()
 
-        shard_metadata = {
-            "cluster": "remote"
-        }
+        shard_metadata = {"cluster": "remote"}
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call({
-                "name": "shard-stats",
-                "shard-id": "0",
-                "index": "geonames",
-                "primary": True,
-                "docs": -1,
-                "store": 212027,
-                "segments-count": -1,
-                "node": "rally0"
-            }, level=MetaInfoScope.cluster, meta_data=shard_metadata)
-        ],  any_order=True)
+        metrics_store_put_doc.assert_has_calls(
+            [
+                mock.call(
+                    {
+                        "name": "shard-stats",
+                        "shard-id": "0",
+                        "index": "geonames",
+                        "primary": True,
+                        "docs": -1,
+                        "store": 212027,
+                        "segments-count": -1,
+                        "node": "rally0",
+                    },
+                    level=MetaInfoScope.cluster,
+                    meta_data=shard_metadata,
+                )
+            ],
+            any_order=True,
+        )
+
 
 class TestSearchableSnapshotsStats:
     response_fragment_total = [
-            {
-                "file_ext": "fnm",
-                "num_files": 50,
-                "total_size": 279900,
-                "open_count": 274,
-                "close_count": 274,
-                "contiguous_bytes_read": {
-                    "count": 1644,
-                    "sum": 1533852,
-                    "min": 478,
-                    "max": 1024
-                },
-                "non_contiguous_bytes_read": {
-                    "count": 0,
-                    "sum": 0,
-                    "min": 0,
-                    "max": 0
-                },
-                "cached_bytes_read": {
-                    "count": 1613,
-                    "sum": 1502108,
-                    "min": 478,
-                    "max": 1024
-                },
-                "index_cache_bytes_read": {
-                    "count": 31,
-                    "sum": 173538,
-                    "min": 0,
-                    "max": 5598
-                },
-                "cached_bytes_written": {
-                    "count": 81,
-                    "sum": 453438,
-                    "min": 5598,
-                    "max": 5598,
-                    "time": "1.6s",
-                    "time_in_nanos": 1607457548
-                },
-                "direct_bytes_read": {
-                    "count": 0,
-                    "sum": 0,
-                    "min": 0,
-                    "max": 0,
-                    "time": "0s",
-                    "time_in_nanos": 0
-                },
-                "optimized_bytes_read": {
-                    "count": 0,
-                    "sum": 0,
-                    "min": 0,
-                    "max": 0,
-                    "time": "0s",
-                    "time_in_nanos": 0
-                },
-                "forward_seeks": {
-                    "small": {
-                        "count": 0,
-                        "sum": 0,
-                        "min": 0,
-                        "max": 0
-                    },
-                    "large": {
-                        "count": 0,
-                        "sum": 0,
-                        "min": 0,
-                        "max": 0
-                    }
-                },
-                "backward_seeks": {
-                    "small": {
-                        "count": 0,
-                        "sum": 0,
-                        "min": 0,
-                        "max": 0
-                    },
-                    "large": {
-                        "count": 0,
-                        "sum": 0,
-                        "min": 0,
-                        "max": 0
-                    }
-                },
-                "blob_store_bytes_requested": {
-                    "count": 50,
-                    "sum": 279900,
-                    "min": 5598,
-                    "max": 5598
-                },
-                "current_index_cache_fills": 0
+        {
+            "file_ext": "fnm",
+            "num_files": 50,
+            "total_size": 279900,
+            "open_count": 274,
+            "close_count": 274,
+            "contiguous_bytes_read": {
+                "count": 1644,
+                "sum": 1533852,
+                "min": 478,
+                "max": 1024,
             },
-            {
-                "file_ext": "kdd",
-                "num_files": 50,
-                "total_size": 356841728759,
-                "open_count": 174,
-                "close_count": 174,
-                "contiguous_bytes_read": {
-                    "count": 184852,
-                    "sum": 189288448,
-                    "min": 1024,
-                    "max": 1024
-                },
-                "non_contiguous_bytes_read": {
-                    "count": 2228,
-                    "sum": 2281472,
-                    "min": 0,
-                    "max": 1024
-                },
-                "cached_bytes_read": {
-                    "count": 187049,
-                    "sum": 191538176,
-                    "min": 1024,
-                    "max": 1024
-                },
-                "index_cache_bytes_read": {
-                    "count": 31,
-                    "sum": 31744,
-                    "min": 0,
-                    "max": 1024
-                },
-                "cached_bytes_written": {
-                    "count": 122,
-                    "sum": 274173997,
-                    "min": 1024,
-                    "max": 7942949,
-                    "time": "22.2s",
-                    "time_in_nanos": 22277973991
-                },
-                "direct_bytes_read": {
+            "non_contiguous_bytes_read": {
+                "count": 0,
+                "sum": 0,
+                "min": 0,
+                "max": 0,
+            },
+            "cached_bytes_read": {
+                "count": 1613,
+                "sum": 1502108,
+                "min": 478,
+                "max": 1024,
+            },
+            "index_cache_bytes_read": {
+                "count": 31,
+                "sum": 173538,
+                "min": 0,
+                "max": 5598,
+            },
+            "cached_bytes_written": {
+                "count": 81,
+                "sum": 453438,
+                "min": 5598,
+                "max": 5598,
+                "time": "1.6s",
+                "time_in_nanos": 1607457548,
+            },
+            "direct_bytes_read": {
+                "count": 0,
+                "sum": 0,
+                "min": 0,
+                "max": 0,
+                "time": "0s",
+                "time_in_nanos": 0,
+            },
+            "optimized_bytes_read": {
+                "count": 0,
+                "sum": 0,
+                "min": 0,
+                "max": 0,
+                "time": "0s",
+                "time_in_nanos": 0,
+            },
+            "forward_seeks": {
+                "small": {
                     "count": 0,
                     "sum": 0,
                     "min": 0,
                     "max": 0,
-                    "time": "0s",
-                    "time_in_nanos": 0
                 },
-                "optimized_bytes_read": {
+                "large": {
                     "count": 0,
                     "sum": 0,
                     "min": 0,
                     "max": 0,
-                    "time": "0s",
-                    "time_in_nanos": 0
                 },
-                "forward_seeks": {
-                    "small": {
-                        "count": 2114,
-                        "sum": 11467,
-                        "min": 0,
-                        "max": 10
-                    },
-                    "large": {
-                        "count": 174,
-                        "sum": 1241804830245,
-                        "min": 7134354745,
-                        "max": 7139204589
-                    }
+            },
+            "backward_seeks": {
+                "small": {
+                    "count": 0,
+                    "sum": 0,
+                    "min": 0,
+                    "max": 0,
                 },
-                "backward_seeks": {
-                    "small": {
-                        "count": 114,
-                        "sum": 192303474,
-                        "min": 0,
-                        "max": 1689340
-                    },
-                    "large": {
-                        "count": 0,
-                        "sum": 0,
-                        "min": 0,
-                        "max": 0
-                    }
+                "large": {
+                    "count": 0,
+                    "sum": 0,
+                    "min": 0,
+                    "max": 0,
                 },
-                "blob_store_bytes_requested": {
-                    "count": 91,
-                    "sum": 274142253,
-                    "min": 131072,
-                    "max": 7942949
+            },
+            "blob_store_bytes_requested": {
+                "count": 50,
+                "sum": 279900,
+                "min": 5598,
+                "max": 5598,
+            },
+            "current_index_cache_fills": 0,
+        },
+        {
+            "file_ext": "kdd",
+            "num_files": 50,
+            "total_size": 356841728759,
+            "open_count": 174,
+            "close_count": 174,
+            "contiguous_bytes_read": {
+                "count": 184852,
+                "sum": 189288448,
+                "min": 1024,
+                "max": 1024,
+            },
+            "non_contiguous_bytes_read": {
+                "count": 2228,
+                "sum": 2281472,
+                "min": 0,
+                "max": 1024,
+            },
+            "cached_bytes_read": {
+                "count": 187049,
+                "sum": 191538176,
+                "min": 1024,
+                "max": 1024,
+            },
+            "index_cache_bytes_read": {
+                "count": 31,
+                "sum": 31744,
+                "min": 0,
+                "max": 1024,
+            },
+            "cached_bytes_written": {
+                "count": 122,
+                "sum": 274173997,
+                "min": 1024,
+                "max": 7942949,
+                "time": "22.2s",
+                "time_in_nanos": 22277973991,
+            },
+            "direct_bytes_read": {
+                "count": 0,
+                "sum": 0,
+                "min": 0,
+                "max": 0,
+                "time": "0s",
+                "time_in_nanos": 0,
+            },
+            "optimized_bytes_read": {
+                "count": 0,
+                "sum": 0,
+                "min": 0,
+                "max": 0,
+                "time": "0s",
+                "time_in_nanos": 0,
+            },
+            "forward_seeks": {
+                "small": {
+                    "count": 2114,
+                    "sum": 11467,
+                    "min": 0,
+                    "max": 10,
                 },
-                "current_index_cache_fills": 0
-            }
-        ]
+                "large": {
+                    "count": 174,
+                    "sum": 1241804830245,
+                    "min": 7134354745,
+                    "max": 7139204589,
+                },
+            },
+            "backward_seeks": {
+                "small": {
+                    "count": 114,
+                    "sum": 192303474,
+                    "min": 0,
+                    "max": 1689340,
+                },
+                "large": {
+                    "count": 0,
+                    "sum": 0,
+                    "min": 0,
+                    "max": 0,
+                },
+            },
+            "blob_store_bytes_requested": {
+                "count": 91,
+                "sum": 274142253,
+                "min": 131072,
+                "max": 7942949,
+            },
+            "current_index_cache_fills": 0,
+        },
+    ]
 
     response_fragment_indices = {
         "elasticlogs-2020-01-01": {
-                                      "total": [
-                                          {
-                                              "file_ext": "fnm",
-                                              "num_files": 5,
-                                              "total_size": 27990,
-                                              "open_count": 20,
-                                              "close_count": 20,
-                                              "contiguous_bytes_read": {
-                                                  "count": 120,
-                                                  "sum": 111960,
-                                                  "min": 478,
-                                                  "max": 1024
-                                              },
-                                              "non_contiguous_bytes_read": {
-                                                  "count": 0,
-                                                  "sum": 0,
-                                                  "min": 0,
-                                                  "max": 0
-                                              },
-                                              "cached_bytes_read": {
-                                                  "count": 120,
-                                                  "sum": 111960,
-                                                  "min": 478,
-                                                  "max": 1024
-                                              },
-                                              "index_cache_bytes_read": {
-                                                  "count": 0,
-                                                  "sum": 0,
-                                                  "min": 0,
-                                                  "max": 0
-                                              },
-                                              "cached_bytes_written": {
-                                                  "count": 5,
-                                                  "sum": 27990,
-                                                  "min": 5598,
-                                                  "max": 5598,
-                                                  "time": "193.9ms",
-                                                  "time_in_nanos": 193930007
-                                              },
-                                              "direct_bytes_read": {
-                                                  "count": 0,
-                                                  "sum": 0,
-                                                  "min": 0,
-                                                  "max": 0,
-                                                  "time": "0s",
-                                                  "time_in_nanos": 0
-                                              },
-                                              "optimized_bytes_read": {
-                                                  "count": 0,
-                                                  "sum": 0,
-                                                  "min": 0,
-                                                  "max": 0,
-                                                  "time": "0s",
-                                                  "time_in_nanos": 0
-                                              },
-                                              "forward_seeks": {
-                                                  "small": {
-                                                      "count": 0,
-                                                      "sum": 0,
-                                                      "min": 0,
-                                                      "max": 0
-                                                  },
-                                                  "large": {
-                                                      "count": 0,
-                                                      "sum": 0,
-                                                      "min": 0,
-                                                      "max": 0
-                                                  }
-                                              },
-                                              "backward_seeks": {
-                                                  "small": {
-                                                      "count": 0,
-                                                      "sum": 0,
-                                                      "min": 0,
-                                                      "max": 0
-                                                  },
-                                                  "large": {
-                                                      "count": 0,
-                                                      "sum": 0,
-                                                      "min": 0,
-                                                      "max": 0
-                                                  }
-                                              },
-                                              "blob_store_bytes_requested": {
-                                                  "count": 5,
-                                                  "sum": 27990,
-                                                  "min": 5598,
-                                                  "max": 5598
-                                              },
-                                              "current_index_cache_fills": 0
-                                          },
-                                          {
-                                              "file_ext": "kdd",
-                                              "num_files": 5,
-                                              "total_size": 35672988421,
-                                              "open_count": 10,
-                                              "close_count": 10,
-                                              "contiguous_bytes_read": {
-                                                  "count": 10,
-                                                  "sum": 10240,
-                                                  "min": 1024,
-                                                  "max": 1024
-                                              },
-                                              "non_contiguous_bytes_read": {
-                                                  "count": 0,
-                                                  "sum": 0,
-                                                  "min": 0,
-                                                  "max": 0
-                                              },
-                                              "cached_bytes_read": {
-                                                  "count": 10,
-                                                  "sum": 10240,
-                                                  "min": 1024,
-                                                  "max": 1024
-                                              },
-                                              "index_cache_bytes_read": {
-                                                  "count": 0,
-                                                  "sum": 0,
-                                                  "min": 0,
-                                                  "max": 0
-                                              },
-                                              "cached_bytes_written": {
-                                                  "count": 5,
-                                                  "sum": 655360,
-                                                  "min": 131072,
-                                                  "max": 131072,
-                                                  "time": "414.4ms",
-                                                  "time_in_nanos": 414455967
-                                              },
-                                              "direct_bytes_read": {
-                                                  "count": 0,
-                                                  "sum": 0,
-                                                  "min": 0,
-                                                  "max": 0,
-                                                  "time": "0s",
-                                                  "time_in_nanos": 0
-                                              },
-                                              "optimized_bytes_read": {
-                                                  "count": 0,
-                                                  "sum": 0,
-                                                  "min": 0,
-                                                  "max": 0,
-                                                  "time": "0s",
-                                                  "time_in_nanos": 0
-                                              },
-                                              "forward_seeks": {
-                                                  "small": {
-                                                      "count": 0,
-                                                      "sum": 0,
-                                                      "min": 0,
-                                                      "max": 0
-                                                  },
-                                                  "large": {
-                                                      "count": 10,
-                                                      "sum": 71345966442,
-                                                      "min": 7134354745,
-                                                      "max": 7134854030
-                                                  }
-                                              },
-                                              "backward_seeks": {
-                                                  "small": {
-                                                      "count": 0,
-                                                      "sum": 0,
-                                                      "min": 0,
-                                                      "max": 0
-                                                  },
-                                                  "large": {
-                                                      "count": 0,
-                                                      "sum": 0,
-                                                      "min": 0,
-                                                      "max": 0
-                                                  }
-                                              },
-                                              "blob_store_bytes_requested": {
-                                                  "count": 5,
-                                                  "sum": 655360,
-                                                  "min": 131072,
-                                                  "max": 131072
-                                              },
-                                              "current_index_cache_fills": 0
-                                          }
-                                          ]
-                                  }
+            "total": [
+                {
+                    "file_ext": "fnm",
+                    "num_files": 5,
+                    "total_size": 27990,
+                    "open_count": 20,
+                    "close_count": 20,
+                    "contiguous_bytes_read": {
+                        "count": 120,
+                        "sum": 111960,
+                        "min": 478,
+                        "max": 1024,
+                    },
+                    "non_contiguous_bytes_read": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0,
+                    },
+                    "cached_bytes_read": {
+                        "count": 120,
+                        "sum": 111960,
+                        "min": 478,
+                        "max": 1024,
+                    },
+                    "index_cache_bytes_read": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0,
+                    },
+                    "cached_bytes_written": {
+                        "count": 5,
+                        "sum": 27990,
+                        "min": 5598,
+                        "max": 5598,
+                        "time": "193.9ms",
+                        "time_in_nanos": 193930007,
+                    },
+                    "direct_bytes_read": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0,
+                        "time": "0s",
+                        "time_in_nanos": 0,
+                    },
+                    "optimized_bytes_read": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0,
+                        "time": "0s",
+                        "time_in_nanos": 0,
+                    },
+                    "forward_seeks": {
+                        "small": {
+                            "count": 0,
+                            "sum": 0,
+                            "min": 0,
+                            "max": 0,
+                        },
+                        "large": {
+                            "count": 0,
+                            "sum": 0,
+                            "min": 0,
+                            "max": 0,
+                        },
+                    },
+                    "backward_seeks": {
+                        "small": {
+                            "count": 0,
+                            "sum": 0,
+                            "min": 0,
+                            "max": 0,
+                        },
+                        "large": {
+                            "count": 0,
+                            "sum": 0,
+                            "min": 0,
+                            "max": 0,
+                        },
+                    },
+                    "blob_store_bytes_requested": {
+                        "count": 5,
+                        "sum": 27990,
+                        "min": 5598,
+                        "max": 5598,
+                    },
+                    "current_index_cache_fills": 0,
+                },
+                {
+                    "file_ext": "kdd",
+                    "num_files": 5,
+                    "total_size": 35672988421,
+                    "open_count": 10,
+                    "close_count": 10,
+                    "contiguous_bytes_read": {
+                        "count": 10,
+                        "sum": 10240,
+                        "min": 1024,
+                        "max": 1024,
+                    },
+                    "non_contiguous_bytes_read": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0,
+                    },
+                    "cached_bytes_read": {
+                        "count": 10,
+                        "sum": 10240,
+                        "min": 1024,
+                        "max": 1024,
+                    },
+                    "index_cache_bytes_read": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0,
+                    },
+                    "cached_bytes_written": {
+                        "count": 5,
+                        "sum": 655360,
+                        "min": 131072,
+                        "max": 131072,
+                        "time": "414.4ms",
+                        "time_in_nanos": 414455967,
+                    },
+                    "direct_bytes_read": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0,
+                        "time": "0s",
+                        "time_in_nanos": 0,
+                    },
+                    "optimized_bytes_read": {
+                        "count": 0,
+                        "sum": 0,
+                        "min": 0,
+                        "max": 0,
+                        "time": "0s",
+                        "time_in_nanos": 0,
+                    },
+                    "forward_seeks": {
+                        "small": {
+                            "count": 0,
+                            "sum": 0,
+                            "min": 0,
+                            "max": 0,
+                        },
+                        "large": {
+                            "count": 10,
+                            "sum": 71345966442,
+                            "min": 7134354745,
+                            "max": 7134854030,
+                        },
+                    },
+                    "backward_seeks": {
+                        "small": {
+                            "count": 0,
+                            "sum": 0,
+                            "min": 0,
+                            "max": 0,
+                        },
+                        "large": {
+                            "count": 0,
+                            "sum": 0,
+                            "min": 0,
+                            "max": 0,
+                        },
+                    },
+                    "blob_store_bytes_requested": {
+                        "count": 5,
+                        "sum": 655360,
+                        "min": 131072,
+                        "max": 131072,
+                    },
+                    "current_index_cache_fills": 0,
+                },
+            ]
+        }
     }
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
@@ -1427,11 +1490,8 @@ class TestSearchableSnapshotsStats:
         metrics_store = metrics.EsMetricsStore(cfg)
         client = Client(transport_client=TransportClient(response=response))
         recorder = telemetry.SearchableSnapshotsStatsRecorder(
-            cluster_name="default",
-            client=client,
-            metrics_store=metrics_store,
-            sample_interval=1,
-            indices=["logs*"])
+            cluster_name="default", client=client, metrics_store=metrics_store, sample_interval=1, indices=["logs*"]
+        )
 
         recorder.record()
 
@@ -1441,19 +1501,14 @@ class TestSearchableSnapshotsStats:
     def test_no_metrics_if_no_searchable_snapshots_stats(self, metrics_store_put_doc):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        client = Client(transport_client=TransportClient(
-            force_error=True,
-            error=elasticsearch.NotFoundError(
-                "",
-                "",
-                {"error": {"reason": "No searchable snapshots indices found"}})
-        ))
+        client = Client(
+            transport_client=TransportClient(
+                force_error=True, error=elasticsearch.NotFoundError("", "", {"error": {"reason": "No searchable snapshots indices found"}})
+            )
+        )
         recorder = telemetry.SearchableSnapshotsStatsRecorder(
-            cluster_name="default",
-            client=client,
-            metrics_store=metrics_store,
-            sample_interval=1,
-            indices=["logs*"])
+            cluster_name="default", client=client, metrics_store=metrics_store, sample_interval=1, indices=["logs*"]
+        )
 
         logger = logging.getLogger("esrally.telemetry")
         with mock.patch.object(logger, "info") as mocked_info:
@@ -1464,33 +1519,27 @@ class TestSearchableSnapshotsStats:
 
         assert metrics_store_put_doc.call_count == 0
 
-
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_total_stats(self, metrics_store_put_doc):
-        response = {
-            "total": copy.deepcopy(TestSearchableSnapshotsStats.response_fragment_total)
-        }
+        response = {"total": copy.deepcopy(TestSearchableSnapshotsStats.response_fragment_total)}
 
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         client = Client(transport_client=TransportClient(response=response))
 
         recorder = telemetry.SearchableSnapshotsStatsRecorder(
-            cluster_name="leader",
-            client=client,
-            metrics_store=metrics_store,
-            sample_interval=1)
+            cluster_name="leader", client=client, metrics_store=metrics_store, sample_interval=1
+        )
         recorder.record()
 
         expected_calls = [
-            call({
-                "name": "searchable-snapshots-stats",
-                "lucene_file_type": stat["file_ext"],
-                "stats": stat},
+            call(
+                {"name": "searchable-snapshots-stats", "lucene_file_type": stat["file_ext"], "stats": stat},
                 level=MetaInfoScope.cluster,
-                meta_data={
-                    "cluster": "leader", "level": "cluster"})
-            for stat in TestSearchableSnapshotsStats.response_fragment_total]
+                meta_data={"cluster": "leader", "level": "cluster"},
+            )
+            for stat in TestSearchableSnapshotsStats.response_fragment_total
+        ]
 
         metrics_store_put_doc.assert_has_calls(expected_calls, any_order=True)
 
@@ -1500,7 +1549,7 @@ class TestSearchableSnapshotsStats:
         random.seed(seed)
         response = {
             "total": copy.deepcopy(TestSearchableSnapshotsStats.response_fragment_total),
-            "indices": copy.deepcopy(TestSearchableSnapshotsStats.response_fragment_indices)
+            "indices": copy.deepcopy(TestSearchableSnapshotsStats.response_fragment_indices),
         }
 
         cfg = create_config()
@@ -1512,34 +1561,34 @@ class TestSearchableSnapshotsStats:
             client=client,
             metrics_store=metrics_store,
             sample_interval=1,
-            indices=random.choice([
-                ["elasticlogs*"],
-                ["elasticlogs-2020-01-01"]
-            ])
+            indices=random.choice([["elasticlogs*"], ["elasticlogs-2020-01-01"]]),
         )
         recorder.record()
 
         expected_calls = [
-            call({
-                "name": "searchable-snapshots-stats",
-                "lucene_file_type": stat["file_ext"],
-                "stats": stat},
+            call(
+                {"name": "searchable-snapshots-stats", "lucene_file_type": stat["file_ext"], "stats": stat},
                 level=MetaInfoScope.cluster,
-                meta_data={
-                    "cluster": "default", "level": "cluster"})
-            for stat in TestSearchableSnapshotsStats.response_fragment_total]
+                meta_data={"cluster": "default", "level": "cluster"},
+            )
+            for stat in TestSearchableSnapshotsStats.response_fragment_total
+        ]
 
-        expected_calls.extend([
-            call({
-                "name": "searchable-snapshots-stats",
-                "lucene_file_type": stat["file_ext"],
-                "stats": stat,
-                "index": "elasticlogs-2020-01-01"
-                },
-                level=MetaInfoScope.cluster,
-                meta_data={
-                    "cluster": "default", "level": "index"})
-            for stat in TestSearchableSnapshotsStats.response_fragment_indices["elasticlogs-2020-01-01"]["total"]])
+        expected_calls.extend(
+            [
+                call(
+                    {
+                        "name": "searchable-snapshots-stats",
+                        "lucene_file_type": stat["file_ext"],
+                        "stats": stat,
+                        "index": "elasticlogs-2020-01-01",
+                    },
+                    level=MetaInfoScope.cluster,
+                    meta_data={"cluster": "default", "level": "index"},
+                )
+                for stat in TestSearchableSnapshotsStats.response_fragment_indices["elasticlogs-2020-01-01"]["total"]
+            ]
+        )
 
         metrics_store_put_doc.assert_has_calls(expected_calls, any_order=True)
 
@@ -1555,17 +1604,12 @@ class NodeStatsTests(TestCase):
         clients = {"default": Client(info={"version": {"number": "7.1.0"}})}
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        telemetry_params = {
-            "node-stats-sample-interval": random.randint(1, 100)
-        }
+        telemetry_params = {"node-stats-sample-interval": random.randint(1, 100)}
         t = telemetry.NodeStats(telemetry_params, clients, metrics_store)
 
         with mock.patch.object(console, "warn") as mocked_console_warn:
             t.on_benchmark_start()
-        mocked_console_warn.assert_called_once_with(
-            NodeStatsTests.warning,
-            logger=t.logger
-        )
+        mocked_console_warn.assert_called_once_with(NodeStatsTests.warning, logger=t.logger)
 
     @mock.patch("esrally.telemetry.NodeStatsRecorder", mock.Mock())
     @mock.patch("esrally.telemetry.SamplerThread", mock.Mock())
@@ -1573,9 +1617,7 @@ class NodeStatsTests(TestCase):
         clients = {"default": Client(info={"version": {"number": "7.2.0"}})}
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        telemetry_params = {
-            "node-stats-sample-interval": random.randint(1, 100)
-        }
+        telemetry_params = {"node-stats-sample-interval": random.randint(1, 100)}
         t = telemetry.NodeStats(telemetry_params, clients, metrics_store)
 
         with mock.patch.object(console, "warn") as mocked_console_warn:
@@ -1596,34 +1638,34 @@ class NodeStatsRecorderTests(TestCase):
                 "roles": [
                     "master",
                     "data",
-                    "ingest"
+                    "ingest",
                 ],
                 "indices": {
                     "docs": {
                         "count": 0,
-                        "deleted": 0
+                        "deleted": 0,
                     },
                     "store": {
-                        "size_in_bytes": 0
+                        "size_in_bytes": 0,
                     },
                     "indexing": {
                         "is_throttled": False,
-                        "throttle_time_in_millis": 0
+                        "throttle_time_in_millis": 0,
                     },
                     "search": {
                         "open_contexts": 0,
                         "query_total": 0,
-                        "query_time_in_millis": 0
+                        "query_time_in_millis": 0,
                     },
                     "merges": {
                         "current": 0,
                         "current_docs": 0,
-                        "current_size_in_bytes": 0
+                        "current_size_in_bytes": 0,
                     },
                     "refresh": {
                         "total": 747,
                         "total_time_in_millis": 277382,
-                        "listeners": 0
+                        "listeners": 0,
                     },
                     "query_cache": {
                         "memory_size_in_bytes": 0,
@@ -1632,52 +1674,50 @@ class NodeStatsRecorderTests(TestCase):
                         "miss_count": 0,
                         "cache_size": 0,
                         "cache_count": 0,
-                        "evictions": 0
+                        "evictions": 0,
                     },
-                    "completion": {
-                        "size_in_bytes": 0
-                    },
+                    "completion": {"size_in_bytes": 0},
                     "segments": {
                         "count": 0,
                         "memory_in_bytes": 0,
                         "max_unsafe_auto_id_timestamp": -9223372036854775808,
-                        "file_sizes": {}
+                        "file_sizes": {},
                     },
                     "translog": {
                         "operations": 0,
                         "size_in_bytes": 0,
                         "uncommitted_operations": 0,
-                        "uncommitted_size_in_bytes": 0
+                        "uncommitted_size_in_bytes": 0,
                     },
                     "request_cache": {
                         "memory_size_in_bytes": 0,
                         "evictions": 0,
                         "hit_count": 0,
-                        "miss_count": 0
+                        "miss_count": 0,
                     },
                     "recovery": {
                         "current_as_source": 0,
                         "current_as_target": 0,
-                        "throttle_time_in_millis": 0
-                    }
+                        "throttle_time_in_millis": 0,
+                    },
                 },
                 "jvm": {
                     "buffer_pools": {
                         "mapped": {
                             "count": 7,
                             "used_in_bytes": 3120,
-                            "total_capacity_in_bytes": 9999
+                            "total_capacity_in_bytes": 9999,
                         },
                         "direct": {
                             "count": 6,
                             "used_in_bytes": 73868,
-                            "total_capacity_in_bytes": 73867
-                        }
+                            "total_capacity_in_bytes": 73867,
+                        },
                     },
                     "classes": {
                         "current_loaded_count": 9992,
                         "total_loaded_count": 9992,
-                        "total_unloaded_count": 0
+                        "total_unloaded_count": 0,
                     },
                     "mem": {
                         "heap_used_in_bytes": 119073552,
@@ -1691,34 +1731,34 @@ class NodeStatsRecorderTests(TestCase):
                                 "used_in_bytes": 66378576,
                                 "max_in_bytes": 139591680,
                                 "peak_used_in_bytes": 139591680,
-                                "peak_max_in_bytes": 139591680
+                                "peak_max_in_bytes": 139591680,
                             },
                             "survivor": {
                                 "used_in_bytes": 358496,
                                 "max_in_bytes": 17432576,
                                 "peak_used_in_bytes": 17432576,
-                                "peak_max_in_bytes": 17432576
+                                "peak_max_in_bytes": 17432576,
                             },
                             "old": {
                                 "used_in_bytes": 52336480,
                                 "max_in_bytes": 469368832,
                                 "peak_used_in_bytes": 52336480,
-                                "peak_max_in_bytes": 469368832
-                            }
-                        }
+                                "peak_max_in_bytes": 469368832,
+                            },
+                        },
                     },
                     "gc": {
                         "collectors": {
                             "young": {
                                 "collection_count": 3,
-                                "collection_time_in_millis": 309
+                                "collection_time_in_millis": 309,
                             },
                             "old": {
                                 "collection_count": 2,
-                                "collection_time_in_millis": 229
-                            }
+                                "collection_time_in_millis": 229,
+                            },
                         }
-                    }
+                    },
                 },
                 "process": {
                     "timestamp": 1526045135857,
@@ -1726,11 +1766,11 @@ class NodeStatsRecorderTests(TestCase):
                     "max_file_descriptors": 1048576,
                     "cpu": {
                         "percent": 10,
-                        "total_in_millis": 56520
+                        "total_in_millis": 56520,
                     },
                     "mem": {
-                        "total_virtual_in_bytes": 2472173568
-                    }
+                        "total_virtual_in_bytes": 2472173568,
+                    },
                 },
                 "thread_pool": {
                     "generic": {
@@ -1739,8 +1779,8 @@ class NodeStatsRecorderTests(TestCase):
                         "active": 0,
                         "rejected": 0,
                         "largest": 4,
-                        "completed": 8
-                    }
+                        "completed": 8,
+                    },
                 },
                 "breakers": {
                     "parent": {
@@ -1749,7 +1789,7 @@ class NodeStatsRecorderTests(TestCase):
                         "estimated_size_in_bytes": 0,
                         "estimated_size": "0b",
                         "overhead": 1.0,
-                        "tripped": 0
+                        "tripped": 0,
                     }
                 },
                 "indexing_pressure": {
@@ -1759,7 +1799,7 @@ class NodeStatsRecorderTests(TestCase):
                             "coordinating_in_bytes": 0,
                             "primary_in_bytes": 0,
                             "replica_in_bytes": 0,
-                            "all_in_bytes": 0
+                            "all_in_bytes": 0,
                         },
                         "total": {
                             "combined_coordinating_and_primary_in_bytes": 0,
@@ -1769,117 +1809,120 @@ class NodeStatsRecorderTests(TestCase):
                             "all_in_bytes": 0,
                             "coordinating_rejections": 0,
                             "primary_rejections": 0,
-                            "replica_rejections": 0
-                        }
+                            "replica_rejections": 0,
+                        },
                     }
-                }
+                },
             }
-        }
+        },
     }
 
-    indices_stats_response_flattened = collections.OrderedDict({
-        "indices_docs_count": 0,
-        "indices_docs_deleted": 0,
-        "indices_store_size_in_bytes": 0,
-        "indices_indexing_throttle_time_in_millis": 0,
-        "indices_search_open_contexts": 0,
-        "indices_search_query_total": 0,
-        "indices_search_query_time_in_millis": 0,
-        "indices_merges_current": 0,
-        "indices_merges_current_docs": 0,
-        "indices_merges_current_size_in_bytes": 0,
-        "indices_refresh_total": 747,
-        "indices_refresh_total_time_in_millis": 277382,
-        "indices_refresh_listeners": 0,
-        "indices_query_cache_memory_size_in_bytes": 0,
-        "indices_query_cache_total_count": 0,
-        "indices_query_cache_hit_count": 0,
-        "indices_query_cache_miss_count": 0,
-        "indices_query_cache_cache_size": 0,
-        "indices_query_cache_cache_count": 0,
-        "indices_query_cache_evictions": 0,
-        "indices_completion_size_in_bytes": 0,
-        "indices_segments_count": 0,
-        "indices_segments_memory_in_bytes": 0,
-        "indices_segments_max_unsafe_auto_id_timestamp": -9223372036854775808,
-        "indices_translog_operations": 0,
-        "indices_translog_size_in_bytes": 0,
-        "indices_translog_uncommitted_operations": 0,
-        "indices_translog_uncommitted_size_in_bytes": 0,
-        "indices_request_cache_memory_size_in_bytes": 0,
-        "indices_request_cache_evictions": 0,
-        "indices_request_cache_hit_count": 0,
-        "indices_request_cache_miss_count": 0,
-        "indices_recovery_current_as_source": 0,
-        "indices_recovery_current_as_target": 0,
-        "indices_recovery_throttle_time_in_millis": 0
-    })
+    indices_stats_response_flattened = collections.OrderedDict(
+        {
+            "indices_docs_count": 0,
+            "indices_docs_deleted": 0,
+            "indices_store_size_in_bytes": 0,
+            "indices_indexing_throttle_time_in_millis": 0,
+            "indices_search_open_contexts": 0,
+            "indices_search_query_total": 0,
+            "indices_search_query_time_in_millis": 0,
+            "indices_merges_current": 0,
+            "indices_merges_current_docs": 0,
+            "indices_merges_current_size_in_bytes": 0,
+            "indices_refresh_total": 747,
+            "indices_refresh_total_time_in_millis": 277382,
+            "indices_refresh_listeners": 0,
+            "indices_query_cache_memory_size_in_bytes": 0,
+            "indices_query_cache_total_count": 0,
+            "indices_query_cache_hit_count": 0,
+            "indices_query_cache_miss_count": 0,
+            "indices_query_cache_cache_size": 0,
+            "indices_query_cache_cache_count": 0,
+            "indices_query_cache_evictions": 0,
+            "indices_completion_size_in_bytes": 0,
+            "indices_segments_count": 0,
+            "indices_segments_memory_in_bytes": 0,
+            "indices_segments_max_unsafe_auto_id_timestamp": -9223372036854775808,
+            "indices_translog_operations": 0,
+            "indices_translog_size_in_bytes": 0,
+            "indices_translog_uncommitted_operations": 0,
+            "indices_translog_uncommitted_size_in_bytes": 0,
+            "indices_request_cache_memory_size_in_bytes": 0,
+            "indices_request_cache_evictions": 0,
+            "indices_request_cache_hit_count": 0,
+            "indices_request_cache_miss_count": 0,
+            "indices_recovery_current_as_source": 0,
+            "indices_recovery_current_as_target": 0,
+            "indices_recovery_throttle_time_in_millis": 0,
+        }
+    )
 
-    default_stats_response_flattened = collections.OrderedDict({
-        "jvm_buffer_pools_mapped_count": 7,
-        "jvm_buffer_pools_mapped_used_in_bytes": 3120,
-        "jvm_buffer_pools_mapped_total_capacity_in_bytes": 9999,
-        "jvm_buffer_pools_direct_count": 6,
-        "jvm_buffer_pools_direct_used_in_bytes": 73868,
-        "jvm_buffer_pools_direct_total_capacity_in_bytes": 73867,
-        "jvm_mem_heap_used_in_bytes": 119073552,
-        "jvm_mem_heap_used_percent": 19,
-        "jvm_mem_heap_committed_in_bytes": 626393088,
-        "jvm_mem_heap_max_in_bytes": 626393088,
-        "jvm_mem_non_heap_used_in_bytes": 110250424,
-        "jvm_mem_non_heap_committed_in_bytes": 118108160,
-        "jvm_mem_pools_young_used_in_bytes": 66378576,
-        "jvm_mem_pools_young_max_in_bytes": 139591680,
-        "jvm_mem_pools_young_peak_used_in_bytes": 139591680,
-        "jvm_mem_pools_young_peak_max_in_bytes": 139591680,
-        "jvm_mem_pools_survivor_used_in_bytes": 358496,
-        "jvm_mem_pools_survivor_max_in_bytes": 17432576,
-        "jvm_mem_pools_survivor_peak_used_in_bytes": 17432576,
-        "jvm_mem_pools_survivor_peak_max_in_bytes": 17432576,
-        "jvm_mem_pools_old_used_in_bytes": 52336480,
-        "jvm_mem_pools_old_max_in_bytes": 469368832,
-        "jvm_mem_pools_old_peak_used_in_bytes": 52336480,
-        "jvm_mem_pools_old_peak_max_in_bytes": 469368832,
-        "jvm_gc_collectors_young_collection_count": 3,
-        "jvm_gc_collectors_young_collection_time_in_millis": 309,
-        "jvm_gc_collectors_old_collection_count": 2,
-        "jvm_gc_collectors_old_collection_time_in_millis": 229,
-        "process_cpu_percent": 10,
-        "process_cpu_total_in_millis": 56520,
-        "breakers_parent_limit_size_in_bytes": 726571417,
-        "breakers_parent_estimated_size_in_bytes": 0,
-        "breakers_parent_overhead": 1.0,
-        "breakers_parent_tripped": 0,
-        "thread_pool_generic_threads": 4,
-        "thread_pool_generic_queue": 0,
-        "thread_pool_generic_active": 0,
-        "thread_pool_generic_rejected": 0,
-        "thread_pool_generic_largest": 4,
-        "thread_pool_generic_completed": 8,
-        "indexing_pressure_memory_current_combined_coordinating_and_primary_in_bytes": 0,
-        "indexing_pressure_memory_current_coordinating_in_bytes": 0,
-        "indexing_pressure_memory_current_primary_in_bytes": 0,
-        "indexing_pressure_memory_current_replica_in_bytes": 0,
-        "indexing_pressure_memory_current_all_in_bytes": 0,
-        "indexing_pressure_memory_total_combined_coordinating_and_primary_in_bytes": 0,
-        "indexing_pressure_memory_total_coordinating_in_bytes": 0,
-        "indexing_pressure_memory_total_primary_in_bytes": 0,
-        "indexing_pressure_memory_total_replica_in_bytes": 0,
-        "indexing_pressure_memory_total_all_in_bytes": 0,
-        "indexing_pressure_memory_total_coordinating_rejections": 0,
-        "indexing_pressure_memory_total_primary_rejections": 0,
-        "indexing_pressure_memory_total_replica_rejections": 0
-    })
+    default_stats_response_flattened = collections.OrderedDict(
+        {
+            "jvm_buffer_pools_mapped_count": 7,
+            "jvm_buffer_pools_mapped_used_in_bytes": 3120,
+            "jvm_buffer_pools_mapped_total_capacity_in_bytes": 9999,
+            "jvm_buffer_pools_direct_count": 6,
+            "jvm_buffer_pools_direct_used_in_bytes": 73868,
+            "jvm_buffer_pools_direct_total_capacity_in_bytes": 73867,
+            "jvm_mem_heap_used_in_bytes": 119073552,
+            "jvm_mem_heap_used_percent": 19,
+            "jvm_mem_heap_committed_in_bytes": 626393088,
+            "jvm_mem_heap_max_in_bytes": 626393088,
+            "jvm_mem_non_heap_used_in_bytes": 110250424,
+            "jvm_mem_non_heap_committed_in_bytes": 118108160,
+            "jvm_mem_pools_young_used_in_bytes": 66378576,
+            "jvm_mem_pools_young_max_in_bytes": 139591680,
+            "jvm_mem_pools_young_peak_used_in_bytes": 139591680,
+            "jvm_mem_pools_young_peak_max_in_bytes": 139591680,
+            "jvm_mem_pools_survivor_used_in_bytes": 358496,
+            "jvm_mem_pools_survivor_max_in_bytes": 17432576,
+            "jvm_mem_pools_survivor_peak_used_in_bytes": 17432576,
+            "jvm_mem_pools_survivor_peak_max_in_bytes": 17432576,
+            "jvm_mem_pools_old_used_in_bytes": 52336480,
+            "jvm_mem_pools_old_max_in_bytes": 469368832,
+            "jvm_mem_pools_old_peak_used_in_bytes": 52336480,
+            "jvm_mem_pools_old_peak_max_in_bytes": 469368832,
+            "jvm_gc_collectors_young_collection_count": 3,
+            "jvm_gc_collectors_young_collection_time_in_millis": 309,
+            "jvm_gc_collectors_old_collection_count": 2,
+            "jvm_gc_collectors_old_collection_time_in_millis": 229,
+            "process_cpu_percent": 10,
+            "process_cpu_total_in_millis": 56520,
+            "breakers_parent_limit_size_in_bytes": 726571417,
+            "breakers_parent_estimated_size_in_bytes": 0,
+            "breakers_parent_overhead": 1.0,
+            "breakers_parent_tripped": 0,
+            "thread_pool_generic_threads": 4,
+            "thread_pool_generic_queue": 0,
+            "thread_pool_generic_active": 0,
+            "thread_pool_generic_rejected": 0,
+            "thread_pool_generic_largest": 4,
+            "thread_pool_generic_completed": 8,
+            "indexing_pressure_memory_current_combined_coordinating_and_primary_in_bytes": 0,
+            "indexing_pressure_memory_current_coordinating_in_bytes": 0,
+            "indexing_pressure_memory_current_primary_in_bytes": 0,
+            "indexing_pressure_memory_current_replica_in_bytes": 0,
+            "indexing_pressure_memory_current_all_in_bytes": 0,
+            "indexing_pressure_memory_total_combined_coordinating_and_primary_in_bytes": 0,
+            "indexing_pressure_memory_total_coordinating_in_bytes": 0,
+            "indexing_pressure_memory_total_primary_in_bytes": 0,
+            "indexing_pressure_memory_total_replica_in_bytes": 0,
+            "indexing_pressure_memory_total_all_in_bytes": 0,
+            "indexing_pressure_memory_total_coordinating_rejections": 0,
+            "indexing_pressure_memory_total_primary_rejections": 0,
+            "indexing_pressure_memory_total_replica_rejections": 0,
+        }
+    )
 
     def test_negative_sample_interval_forbidden(self):
         client = Client()
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        telemetry_params = {
-            "node-stats-sample-interval": -1 * random.random()
-        }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    r"The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was .*\."):
+        telemetry_params = {"node-stats-sample-interval": -1 * random.random()}
+        with self.assertRaisesRegex(
+            exceptions.SystemSetupError, r"The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was .*\."
+        ):
             telemetry.NodeStatsRecorder(telemetry_params, cluster_name="default", client=client, metrics_store=metrics_store)
 
     def test_flatten_indices_fields(self):
@@ -1890,7 +1933,7 @@ class NodeStatsRecorderTests(TestCase):
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         flattened_fields = recorder.flatten_stats_fields(
             prefix="indices",
-            stats=NodeStatsRecorderTests.node_stats_response["nodes"]["Zbl_e8EyRXmiR47gbHgPfg"]["indices"]
+            stats=NodeStatsRecorderTests.node_stats_response["nodes"]["Zbl_e8EyRXmiR47gbHgPfg"]["indices"],
         )
         self.assertDictEqual(NodeStatsRecorderTests.indices_stats_response_flattened, flattened_fields)
 
@@ -1899,8 +1942,10 @@ class NodeStatsRecorderTests(TestCase):
         client = Client(nodes=SubClient(stats=NodeStatsRecorderTests.node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        node_name = [NodeStatsRecorderTests.node_stats_response["nodes"][node]["name"]
-                     for node in NodeStatsRecorderTests.node_stats_response["nodes"]][0]
+        node_name = [
+            NodeStatsRecorderTests.node_stats_response["nodes"][node]["name"]
+            for node in NodeStatsRecorderTests.node_stats_response["nodes"]
+        ][0]
         metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
 
         telemetry_params = {}
@@ -1911,10 +1956,9 @@ class NodeStatsRecorderTests(TestCase):
         expected_doc["name"] = "node-stats"
         expected_doc.update(NodeStatsRecorderTests.default_stats_response_flattened)
 
-        metrics_store_put_doc.assert_called_once_with(expected_doc,
-                                                      level=MetaInfoScope.node,
-                                                      node_name="rally0",
-                                                      meta_data=metrics_store_meta_data)
+        metrics_store_put_doc.assert_called_once_with(
+            expected_doc, level=MetaInfoScope.node, node_name="rally0", meta_data=metrics_store_meta_data
+        )
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_all_nodes_stats(self, metrics_store_put_doc):
@@ -1930,34 +1974,34 @@ class NodeStatsRecorderTests(TestCase):
                     "roles": [
                         "master",
                         "data",
-                        "ingest"
+                        "ingest",
                     ],
                     "indices": {
                         "docs": {
                             "count": 76892364,
-                            "deleted": 324530
+                            "deleted": 324530,
                         },
                         "store": {
-                            "size_in_bytes": 983409834
+                            "size_in_bytes": 983409834,
                         },
                         "indexing": {
                             "is_throttled": False,
-                            "throttle_time_in_millis": 0
+                            "throttle_time_in_millis": 0,
                         },
                         "search": {
                             "open_contexts": 0,
                             "query_total": 0,
-                            "query_time_in_millis": 0
+                            "query_time_in_millis": 0,
                         },
                         "merges": {
                             "current": 0,
                             "current_docs": 0,
-                            "current_size_in_bytes": 0
+                            "current_size_in_bytes": 0,
                         },
                         "refresh": {
                             "total": 747,
                             "total_time_in_millis": 277382,
-                            "listeners": 0
+                            "listeners": 0,
                         },
                         "query_cache": {
                             "memory_size_in_bytes": 0,
@@ -1966,56 +2010,56 @@ class NodeStatsRecorderTests(TestCase):
                             "miss_count": 0,
                             "cache_size": 0,
                             "cache_count": 0,
-                            "evictions": 0
+                            "evictions": 0,
                         },
                         "fielddata": {
                             "memory_size_in_bytes": 6936,
-                            "evictions": 17
+                            "evictions": 17,
                         },
                         "completion": {
-                            "size_in_bytes": 0
+                            "size_in_bytes": 0,
                         },
                         "segments": {
                             "count": 0,
                             "memory_in_bytes": 0,
                             "max_unsafe_auto_id_timestamp": -9223372036854775808,
-                            "file_sizes": {}
+                            "file_sizes": {},
                         },
                         "translog": {
                             "operations": 0,
                             "size_in_bytes": 0,
                             "uncommitted_operations": 0,
-                            "uncommitted_size_in_bytes": 0
+                            "uncommitted_size_in_bytes": 0,
                         },
                         "request_cache": {
                             "memory_size_in_bytes": 0,
                             "evictions": 0,
                             "hit_count": 0,
-                            "miss_count": 0
+                            "miss_count": 0,
                         },
                         "recovery": {
                             "current_as_source": 0,
                             "current_as_target": 0,
-                            "throttle_time_in_millis": 0
-                        }
+                            "throttle_time_in_millis": 0,
+                        },
                     },
                     "jvm": {
                         "buffer_pools": {
                             "mapped": {
                                 "count": 7,
                                 "used_in_bytes": 3120,
-                                "total_capacity_in_bytes": 9999
+                                "total_capacity_in_bytes": 9999,
                             },
                             "direct": {
                                 "count": 6,
                                 "used_in_bytes": 73868,
-                                "total_capacity_in_bytes": 73867
-                            }
+                                "total_capacity_in_bytes": 73867,
+                            },
                         },
                         "classes": {
                             "current_loaded_count": 9992,
                             "total_loaded_count": 9992,
-                            "total_unloaded_count": 0
+                            "total_unloaded_count": 0,
                         },
                         "mem": {
                             "heap_used_in_bytes": 119073552,
@@ -2029,34 +2073,34 @@ class NodeStatsRecorderTests(TestCase):
                                     "used_in_bytes": 66378576,
                                     "max_in_bytes": 139591680,
                                     "peak_used_in_bytes": 139591680,
-                                    "peak_max_in_bytes": 139591680
+                                    "peak_max_in_bytes": 139591680,
                                 },
                                 "survivor": {
                                     "used_in_bytes": 358496,
                                     "max_in_bytes": 17432576,
                                     "peak_used_in_bytes": 17432576,
-                                    "peak_max_in_bytes": 17432576
+                                    "peak_max_in_bytes": 17432576,
                                 },
                                 "old": {
                                     "used_in_bytes": 52336480,
                                     "max_in_bytes": 469368832,
                                     "peak_used_in_bytes": 52336480,
-                                    "peak_max_in_bytes": 469368832
-                                }
-                            }
+                                    "peak_max_in_bytes": 469368832,
+                                },
+                            },
                         },
                         "gc": {
                             "collectors": {
                                 "young": {
                                     "collection_count": 3,
-                                    "collection_time_in_millis": 309
+                                    "collection_time_in_millis": 309,
                                 },
                                 "old": {
                                     "collection_count": 2,
-                                    "collection_time_in_millis": 229
-                                }
+                                    "collection_time_in_millis": 229,
+                                },
                             }
-                        }
+                        },
                     },
                     "process": {
                         "timestamp": 1526045135857,
@@ -2064,11 +2108,11 @@ class NodeStatsRecorderTests(TestCase):
                         "max_file_descriptors": 1048576,
                         "cpu": {
                             "percent": 10,
-                            "total_in_millis": 56520
+                            "total_in_millis": 56520,
                         },
                         "mem": {
-                            "total_virtual_in_bytes": 2472173568
-                        }
+                            "total_virtual_in_bytes": 2472173568,
+                        },
                     },
                     "thread_pool": {
                         "generic": {
@@ -2077,15 +2121,15 @@ class NodeStatsRecorderTests(TestCase):
                             "active": 0,
                             "rejected": 0,
                             "largest": 4,
-                            "completed": 8
-                        }
+                            "completed": 8,
+                        },
                     },
                     "transport": {
                         "server_open": 12,
                         "rx_count": 77,
                         "rx_size_in_bytes": 98723498,
                         "tx_count": 88,
-                        "tx_size_in_bytes": 23879803
+                        "tx_size_in_bytes": 23879803,
                     },
                     "breakers": {
                         "parent": {
@@ -2094,7 +2138,7 @@ class NodeStatsRecorderTests(TestCase):
                             "estimated_size_in_bytes": 0,
                             "estimated_size": "0b",
                             "overhead": 1.0,
-                            "tripped": 0
+                            "tripped": 0,
                         }
                     },
                     "indexing_pressure": {
@@ -2104,7 +2148,7 @@ class NodeStatsRecorderTests(TestCase):
                                 "coordinating_in_bytes": 0,
                                 "primary_in_bytes": 0,
                                 "replica_in_bytes": 0,
-                                "all_in_bytes": 0
+                                "all_in_bytes": 0,
                             },
                             "total": {
                                 "combined_coordinating_and_primary_in_bytes": 0,
@@ -2114,12 +2158,12 @@ class NodeStatsRecorderTests(TestCase):
                                 "all_in_bytes": 0,
                                 "coordinating_rejections": 0,
                                 "primary_rejections": 0,
-                                "replica_rejections": 0
-                            }
+                                "replica_rejections": 0,
+                            },
                         }
-                    }
+                    },
                 }
-            }
+            },
         }
 
         client = Client(nodes=SubClient(stats=node_stats_response))
@@ -2127,105 +2171,106 @@ class NodeStatsRecorderTests(TestCase):
         metrics_store = metrics.EsMetricsStore(cfg)
         node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
         metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
-        telemetry_params = {
-            "node-stats-include-indices": True
-        }
+        telemetry_params = {"node-stats-include-indices": True}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         recorder.record()
 
         metrics_store_put_doc.assert_called_once_with(
-            {"name": "node-stats",
-             "indices_docs_count": 76892364,
-             "indices_docs_deleted": 324530,
-             "indices_fielddata_evictions": 17,
-             "indices_fielddata_memory_size_in_bytes": 6936,
-             "indices_indexing_throttle_time_in_millis": 0,
-             "indices_merges_current": 0,
-             "indices_merges_current_docs": 0,
-             "indices_merges_current_size_in_bytes": 0,
-             "indices_query_cache_cache_count": 0,
-             "indices_query_cache_cache_size": 0,
-             "indices_query_cache_evictions": 0,
-             "indices_query_cache_hit_count": 0,
-             "indices_query_cache_memory_size_in_bytes": 0,
-             "indices_query_cache_miss_count": 0,
-             "indices_query_cache_total_count": 0,
-             "indices_request_cache_evictions": 0,
-             "indices_request_cache_hit_count": 0,
-             "indices_request_cache_memory_size_in_bytes": 0,
-             "indices_request_cache_miss_count": 0,
-             "indices_search_open_contexts": 0,
-             "indices_search_query_time_in_millis": 0,
-             "indices_search_query_total": 0,
-             "indices_segments_count": 0,
-             "indices_segments_max_unsafe_auto_id_timestamp": -9223372036854775808,
-             "indices_segments_memory_in_bytes": 0,
-             "indices_store_size_in_bytes": 983409834,
-             "indices_translog_operations": 0,
-             "indices_translog_size_in_bytes": 0,
-             "indices_translog_uncommitted_operations": 0,
-             "indices_translog_uncommitted_size_in_bytes": 0,
-             "thread_pool_generic_active": 0,
-             "thread_pool_generic_completed": 8,
-             "thread_pool_generic_largest": 4,
-             "thread_pool_generic_queue": 0,
-             "thread_pool_generic_rejected": 0,
-             "thread_pool_generic_threads": 4,
-             "breakers_parent_estimated_size_in_bytes": 0,
-             "breakers_parent_limit_size_in_bytes": 726571417,
-             "breakers_parent_overhead": 1.0,
-             "breakers_parent_tripped": 0,
-             "jvm_buffer_pools_direct_count": 6,
-             "jvm_buffer_pools_direct_total_capacity_in_bytes": 73867,
-             "jvm_buffer_pools_direct_used_in_bytes": 73868,
-             "jvm_buffer_pools_mapped_count": 7,
-             "jvm_buffer_pools_mapped_total_capacity_in_bytes": 9999,
-             "jvm_buffer_pools_mapped_used_in_bytes": 3120,
-             "jvm_mem_heap_committed_in_bytes": 626393088,
-             "jvm_mem_heap_max_in_bytes": 626393088,
-             "jvm_mem_heap_used_in_bytes": 119073552,
-             "jvm_mem_heap_used_percent": 19,
-             "jvm_mem_non_heap_committed_in_bytes": 118108160,
-             "jvm_mem_non_heap_used_in_bytes": 110250424,
-             "jvm_mem_pools_old_max_in_bytes": 469368832,
-             "jvm_mem_pools_old_peak_max_in_bytes": 469368832,
-             "jvm_mem_pools_old_peak_used_in_bytes": 52336480,
-             "jvm_mem_pools_old_used_in_bytes": 52336480,
-             "jvm_mem_pools_survivor_max_in_bytes": 17432576,
-             "jvm_mem_pools_survivor_peak_max_in_bytes": 17432576,
-             "jvm_mem_pools_survivor_peak_used_in_bytes": 17432576,
-             "jvm_mem_pools_survivor_used_in_bytes": 358496,
-             "jvm_mem_pools_young_max_in_bytes": 139591680,
-             "jvm_mem_pools_young_peak_max_in_bytes": 139591680,
-             "jvm_mem_pools_young_peak_used_in_bytes": 139591680,
-             "jvm_mem_pools_young_used_in_bytes": 66378576,
-             "jvm_gc_collectors_young_collection_count": 3,
-             "jvm_gc_collectors_young_collection_time_in_millis": 309,
-             "jvm_gc_collectors_old_collection_count": 2,
-             "jvm_gc_collectors_old_collection_time_in_millis": 229,
-             "transport_rx_count": 77,
-             "transport_rx_size_in_bytes": 98723498,
-             "transport_server_open": 12,
-             "transport_tx_count": 88,
-             "transport_tx_size_in_bytes": 23879803,
-             "process_cpu_percent": 10,
-             "process_cpu_total_in_millis": 56520,
-             "indexing_pressure_memory_current_combined_coordinating_and_primary_in_bytes": 0,
-             "indexing_pressure_memory_current_coordinating_in_bytes": 0,
-             "indexing_pressure_memory_current_primary_in_bytes": 0,
-             "indexing_pressure_memory_current_replica_in_bytes": 0,
-             "indexing_pressure_memory_current_all_in_bytes": 0,
-             "indexing_pressure_memory_total_combined_coordinating_and_primary_in_bytes": 0,
-             "indexing_pressure_memory_total_coordinating_in_bytes": 0,
-             "indexing_pressure_memory_total_primary_in_bytes": 0,
-             "indexing_pressure_memory_total_replica_in_bytes": 0,
-             "indexing_pressure_memory_total_all_in_bytes": 0,
-             "indexing_pressure_memory_total_coordinating_rejections": 0,
-             "indexing_pressure_memory_total_primary_rejections": 0,
-             "indexing_pressure_memory_total_replica_rejections": 0},
+            {
+                "name": "node-stats",
+                "indices_docs_count": 76892364,
+                "indices_docs_deleted": 324530,
+                "indices_fielddata_evictions": 17,
+                "indices_fielddata_memory_size_in_bytes": 6936,
+                "indices_indexing_throttle_time_in_millis": 0,
+                "indices_merges_current": 0,
+                "indices_merges_current_docs": 0,
+                "indices_merges_current_size_in_bytes": 0,
+                "indices_query_cache_cache_count": 0,
+                "indices_query_cache_cache_size": 0,
+                "indices_query_cache_evictions": 0,
+                "indices_query_cache_hit_count": 0,
+                "indices_query_cache_memory_size_in_bytes": 0,
+                "indices_query_cache_miss_count": 0,
+                "indices_query_cache_total_count": 0,
+                "indices_request_cache_evictions": 0,
+                "indices_request_cache_hit_count": 0,
+                "indices_request_cache_memory_size_in_bytes": 0,
+                "indices_request_cache_miss_count": 0,
+                "indices_search_open_contexts": 0,
+                "indices_search_query_time_in_millis": 0,
+                "indices_search_query_total": 0,
+                "indices_segments_count": 0,
+                "indices_segments_max_unsafe_auto_id_timestamp": -9223372036854775808,
+                "indices_segments_memory_in_bytes": 0,
+                "indices_store_size_in_bytes": 983409834,
+                "indices_translog_operations": 0,
+                "indices_translog_size_in_bytes": 0,
+                "indices_translog_uncommitted_operations": 0,
+                "indices_translog_uncommitted_size_in_bytes": 0,
+                "thread_pool_generic_active": 0,
+                "thread_pool_generic_completed": 8,
+                "thread_pool_generic_largest": 4,
+                "thread_pool_generic_queue": 0,
+                "thread_pool_generic_rejected": 0,
+                "thread_pool_generic_threads": 4,
+                "breakers_parent_estimated_size_in_bytes": 0,
+                "breakers_parent_limit_size_in_bytes": 726571417,
+                "breakers_parent_overhead": 1.0,
+                "breakers_parent_tripped": 0,
+                "jvm_buffer_pools_direct_count": 6,
+                "jvm_buffer_pools_direct_total_capacity_in_bytes": 73867,
+                "jvm_buffer_pools_direct_used_in_bytes": 73868,
+                "jvm_buffer_pools_mapped_count": 7,
+                "jvm_buffer_pools_mapped_total_capacity_in_bytes": 9999,
+                "jvm_buffer_pools_mapped_used_in_bytes": 3120,
+                "jvm_mem_heap_committed_in_bytes": 626393088,
+                "jvm_mem_heap_max_in_bytes": 626393088,
+                "jvm_mem_heap_used_in_bytes": 119073552,
+                "jvm_mem_heap_used_percent": 19,
+                "jvm_mem_non_heap_committed_in_bytes": 118108160,
+                "jvm_mem_non_heap_used_in_bytes": 110250424,
+                "jvm_mem_pools_old_max_in_bytes": 469368832,
+                "jvm_mem_pools_old_peak_max_in_bytes": 469368832,
+                "jvm_mem_pools_old_peak_used_in_bytes": 52336480,
+                "jvm_mem_pools_old_used_in_bytes": 52336480,
+                "jvm_mem_pools_survivor_max_in_bytes": 17432576,
+                "jvm_mem_pools_survivor_peak_max_in_bytes": 17432576,
+                "jvm_mem_pools_survivor_peak_used_in_bytes": 17432576,
+                "jvm_mem_pools_survivor_used_in_bytes": 358496,
+                "jvm_mem_pools_young_max_in_bytes": 139591680,
+                "jvm_mem_pools_young_peak_max_in_bytes": 139591680,
+                "jvm_mem_pools_young_peak_used_in_bytes": 139591680,
+                "jvm_mem_pools_young_used_in_bytes": 66378576,
+                "jvm_gc_collectors_young_collection_count": 3,
+                "jvm_gc_collectors_young_collection_time_in_millis": 309,
+                "jvm_gc_collectors_old_collection_count": 2,
+                "jvm_gc_collectors_old_collection_time_in_millis": 229,
+                "transport_rx_count": 77,
+                "transport_rx_size_in_bytes": 98723498,
+                "transport_server_open": 12,
+                "transport_tx_count": 88,
+                "transport_tx_size_in_bytes": 23879803,
+                "process_cpu_percent": 10,
+                "process_cpu_total_in_millis": 56520,
+                "indexing_pressure_memory_current_combined_coordinating_and_primary_in_bytes": 0,
+                "indexing_pressure_memory_current_coordinating_in_bytes": 0,
+                "indexing_pressure_memory_current_primary_in_bytes": 0,
+                "indexing_pressure_memory_current_replica_in_bytes": 0,
+                "indexing_pressure_memory_current_all_in_bytes": 0,
+                "indexing_pressure_memory_total_combined_coordinating_and_primary_in_bytes": 0,
+                "indexing_pressure_memory_total_coordinating_in_bytes": 0,
+                "indexing_pressure_memory_total_primary_in_bytes": 0,
+                "indexing_pressure_memory_total_replica_in_bytes": 0,
+                "indexing_pressure_memory_total_all_in_bytes": 0,
+                "indexing_pressure_memory_total_coordinating_rejections": 0,
+                "indexing_pressure_memory_total_primary_rejections": 0,
+                "indexing_pressure_memory_total_replica_rejections": 0,
+            },
             level=MetaInfoScope.node,
             node_name="rally0",
-            meta_data=metrics_store_meta_data)
+            meta_data=metrics_store_meta_data,
+        )
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_selected_indices_metrics_from_nodes_stats(self, metrics_store_put_doc):
@@ -2241,34 +2286,34 @@ class NodeStatsRecorderTests(TestCase):
                     "roles": [
                         "master",
                         "data",
-                        "ingest"
+                        "ingest",
                     ],
                     "indices": {
                         "docs": {
                             "count": 76892364,
-                            "deleted": 324530
+                            "deleted": 324530,
                         },
                         "store": {
-                            "size_in_bytes": 983409834
+                            "size_in_bytes": 983409834,
                         },
                         "indexing": {
                             "is_throttled": False,
-                            "throttle_time_in_millis": 0
+                            "throttle_time_in_millis": 0,
                         },
                         "search": {
                             "open_contexts": 0,
                             "query_total": 0,
-                            "query_time_in_millis": 0
+                            "query_time_in_millis": 0,
                         },
                         "merges": {
                             "current": 0,
                             "current_docs": 0,
-                            "current_size_in_bytes": 0
+                            "current_size_in_bytes": 0,
                         },
                         "refresh": {
                             "total": 747,
                             "total_time_in_millis": 277382,
-                            "listeners": 0
+                            "listeners": 0,
                         },
                         "query_cache": {
                             "memory_size_in_bytes": 0,
@@ -2277,56 +2322,54 @@ class NodeStatsRecorderTests(TestCase):
                             "miss_count": 0,
                             "cache_size": 0,
                             "cache_count": 0,
-                            "evictions": 0
+                            "evictions": 0,
                         },
                         "fielddata": {
                             "memory_size_in_bytes": 6936,
-                            "evictions": 17
+                            "evictions": 17,
                         },
-                        "completion": {
-                            "size_in_bytes": 0
-                        },
+                        "completion": {"size_in_bytes": 0},
                         "segments": {
                             "count": 0,
                             "memory_in_bytes": 0,
                             "max_unsafe_auto_id_timestamp": -9223372036854775808,
-                            "file_sizes": {}
+                            "file_sizes": {},
                         },
                         "translog": {
                             "operations": 0,
                             "size_in_bytes": 0,
                             "uncommitted_operations": 0,
-                            "uncommitted_size_in_bytes": 0
+                            "uncommitted_size_in_bytes": 0,
                         },
                         "request_cache": {
                             "memory_size_in_bytes": 0,
                             "evictions": 0,
                             "hit_count": 0,
-                            "miss_count": 0
+                            "miss_count": 0,
                         },
                         "recovery": {
                             "current_as_source": 0,
                             "current_as_target": 0,
-                            "throttle_time_in_millis": 0
-                        }
+                            "throttle_time_in_millis": 0,
+                        },
                     },
                     "jvm": {
                         "buffer_pools": {
                             "mapped": {
                                 "count": 7,
                                 "used_in_bytes": 3120,
-                                "total_capacity_in_bytes": 9999
+                                "total_capacity_in_bytes": 9999,
                             },
                             "direct": {
                                 "count": 6,
                                 "used_in_bytes": 73868,
-                                "total_capacity_in_bytes": 73867
-                            }
+                                "total_capacity_in_bytes": 73867,
+                            },
                         },
                         "classes": {
                             "current_loaded_count": 9992,
                             "total_loaded_count": 9992,
-                            "total_unloaded_count": 0
+                            "total_unloaded_count": 0,
                         },
                         "mem": {
                             "heap_used_in_bytes": 119073552,
@@ -2340,46 +2383,41 @@ class NodeStatsRecorderTests(TestCase):
                                     "used_in_bytes": 66378576,
                                     "max_in_bytes": 139591680,
                                     "peak_used_in_bytes": 139591680,
-                                    "peak_max_in_bytes": 139591680
+                                    "peak_max_in_bytes": 139591680,
                                 },
                                 "survivor": {
                                     "used_in_bytes": 358496,
                                     "max_in_bytes": 17432576,
                                     "peak_used_in_bytes": 17432576,
-                                    "peak_max_in_bytes": 17432576
+                                    "peak_max_in_bytes": 17432576,
                                 },
                                 "old": {
                                     "used_in_bytes": 52336480,
                                     "max_in_bytes": 469368832,
                                     "peak_used_in_bytes": 52336480,
-                                    "peak_max_in_bytes": 469368832
-                                }
-                            }
+                                    "peak_max_in_bytes": 469368832,
+                                },
+                            },
                         },
                         "gc": {
                             "collectors": {
                                 "young": {
                                     "collection_count": 3,
-                                    "collection_time_in_millis": 309
+                                    "collection_time_in_millis": 309,
                                 },
                                 "old": {
                                     "collection_count": 2,
-                                    "collection_time_in_millis": 229
-                                }
+                                    "collection_time_in_millis": 229,
+                                },
                             }
-                        }
+                        },
                     },
                     "process": {
                         "timestamp": 1526045135857,
                         "open_file_descriptors": 312,
                         "max_file_descriptors": 1048576,
-                        "cpu": {
-                            "percent": 10,
-                            "total_in_millis": 56520
-                        },
-                        "mem": {
-                            "total_virtual_in_bytes": 2472173568
-                        }
+                        "cpu": {"percent": 10, "total_in_millis": 56520},
+                        "mem": {"total_virtual_in_bytes": 2472173568},
                     },
                     "thread_pool": {
                         "generic": {
@@ -2388,15 +2426,15 @@ class NodeStatsRecorderTests(TestCase):
                             "active": 0,
                             "rejected": 0,
                             "largest": 4,
-                            "completed": 8
-                        }
+                            "completed": 8,
+                        },
                     },
                     "transport": {
                         "server_open": 12,
                         "rx_count": 77,
                         "rx_size_in_bytes": 98723498,
                         "tx_count": 88,
-                        "tx_size_in_bytes": 23879803
+                        "tx_size_in_bytes": 23879803,
                     },
                     "breakers": {
                         "parent": {
@@ -2405,7 +2443,7 @@ class NodeStatsRecorderTests(TestCase):
                             "estimated_size_in_bytes": 0,
                             "estimated_size": "0b",
                             "overhead": 1.0,
-                            "tripped": 0
+                            "tripped": 0,
                         }
                     },
                     "indexing_pressure": {
@@ -2415,7 +2453,7 @@ class NodeStatsRecorderTests(TestCase):
                                 "coordinating_in_bytes": 0,
                                 "primary_in_bytes": 0,
                                 "replica_in_bytes": 0,
-                                "all_in_bytes": 0
+                                "all_in_bytes": 0,
                             },
                             "total": {
                                 "combined_coordinating_and_primary_in_bytes": 0,
@@ -2425,12 +2463,12 @@ class NodeStatsRecorderTests(TestCase):
                                 "all_in_bytes": 0,
                                 "coordinating_rejections": 0,
                                 "primary_rejections": 0,
-                                "replica_rejections": 0
-                            }
+                                "replica_rejections": 0,
+                            },
                         }
-                    }
+                    },
                 }
-            }
+            },
         }
 
         client = Client(nodes=SubClient(stats=node_stats_response))
@@ -2438,80 +2476,81 @@ class NodeStatsRecorderTests(TestCase):
         metrics_store = metrics.EsMetricsStore(cfg)
         node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
         metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
-        telemetry_params = {
-            "node-stats-include-indices-metrics": "refresh,docs"
-        }
+        telemetry_params = {"node-stats-include-indices-metrics": "refresh,docs"}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         recorder.record()
 
         metrics_store_put_doc.assert_called_once_with(
-            {"name": "node-stats",
-             "indices_docs_count": 76892364,
-             "indices_docs_deleted": 324530,
-             "indices_refresh_total": 747,
-             "indices_refresh_total_time_in_millis": 277382,
-             "indices_refresh_listeners": 0,
-             "thread_pool_generic_active": 0,
-             "thread_pool_generic_completed": 8,
-             "thread_pool_generic_largest": 4,
-             "thread_pool_generic_queue": 0,
-             "thread_pool_generic_rejected": 0,
-             "thread_pool_generic_threads": 4,
-             "breakers_parent_estimated_size_in_bytes": 0,
-             "breakers_parent_limit_size_in_bytes": 726571417,
-             "breakers_parent_overhead": 1.0,
-             "breakers_parent_tripped": 0,
-             "jvm_buffer_pools_direct_count": 6,
-             "jvm_buffer_pools_direct_total_capacity_in_bytes": 73867,
-             "jvm_buffer_pools_direct_used_in_bytes": 73868,
-             "jvm_buffer_pools_mapped_count": 7,
-             "jvm_buffer_pools_mapped_total_capacity_in_bytes": 9999,
-             "jvm_buffer_pools_mapped_used_in_bytes": 3120,
-             "jvm_mem_heap_committed_in_bytes": 626393088,
-             "jvm_mem_heap_max_in_bytes": 626393088,
-             "jvm_mem_heap_used_in_bytes": 119073552,
-             "jvm_mem_heap_used_percent": 19,
-             "jvm_mem_non_heap_committed_in_bytes": 118108160,
-             "jvm_mem_non_heap_used_in_bytes": 110250424,
-             "jvm_mem_pools_old_max_in_bytes": 469368832,
-             "jvm_mem_pools_old_peak_max_in_bytes": 469368832,
-             "jvm_mem_pools_old_peak_used_in_bytes": 52336480,
-             "jvm_mem_pools_old_used_in_bytes": 52336480,
-             "jvm_mem_pools_survivor_max_in_bytes": 17432576,
-             "jvm_mem_pools_survivor_peak_max_in_bytes": 17432576,
-             "jvm_mem_pools_survivor_peak_used_in_bytes": 17432576,
-             "jvm_mem_pools_survivor_used_in_bytes": 358496,
-             "jvm_mem_pools_young_max_in_bytes": 139591680,
-             "jvm_mem_pools_young_peak_max_in_bytes": 139591680,
-             "jvm_mem_pools_young_peak_used_in_bytes": 139591680,
-             "jvm_mem_pools_young_used_in_bytes": 66378576,
-             "jvm_gc_collectors_young_collection_count": 3,
-             "jvm_gc_collectors_young_collection_time_in_millis": 309,
-             "jvm_gc_collectors_old_collection_count": 2,
-             "jvm_gc_collectors_old_collection_time_in_millis": 229,
-             "transport_rx_count": 77,
-             "transport_rx_size_in_bytes": 98723498,
-             "transport_server_open": 12,
-             "transport_tx_count": 88,
-             "transport_tx_size_in_bytes": 23879803,
-             "process_cpu_percent": 10,
-             "process_cpu_total_in_millis": 56520,
-             "indexing_pressure_memory_current_combined_coordinating_and_primary_in_bytes": 0,
-             "indexing_pressure_memory_current_coordinating_in_bytes": 0,
-             "indexing_pressure_memory_current_primary_in_bytes": 0,
-             "indexing_pressure_memory_current_replica_in_bytes": 0,
-             "indexing_pressure_memory_current_all_in_bytes": 0,
-             "indexing_pressure_memory_total_combined_coordinating_and_primary_in_bytes": 0,
-             "indexing_pressure_memory_total_coordinating_in_bytes": 0,
-             "indexing_pressure_memory_total_primary_in_bytes": 0,
-             "indexing_pressure_memory_total_replica_in_bytes": 0,
-             "indexing_pressure_memory_total_all_in_bytes": 0,
-             "indexing_pressure_memory_total_coordinating_rejections": 0,
-             "indexing_pressure_memory_total_primary_rejections": 0,
-             "indexing_pressure_memory_total_replica_rejections": 0},
+            {
+                "name": "node-stats",
+                "indices_docs_count": 76892364,
+                "indices_docs_deleted": 324530,
+                "indices_refresh_total": 747,
+                "indices_refresh_total_time_in_millis": 277382,
+                "indices_refresh_listeners": 0,
+                "thread_pool_generic_active": 0,
+                "thread_pool_generic_completed": 8,
+                "thread_pool_generic_largest": 4,
+                "thread_pool_generic_queue": 0,
+                "thread_pool_generic_rejected": 0,
+                "thread_pool_generic_threads": 4,
+                "breakers_parent_estimated_size_in_bytes": 0,
+                "breakers_parent_limit_size_in_bytes": 726571417,
+                "breakers_parent_overhead": 1.0,
+                "breakers_parent_tripped": 0,
+                "jvm_buffer_pools_direct_count": 6,
+                "jvm_buffer_pools_direct_total_capacity_in_bytes": 73867,
+                "jvm_buffer_pools_direct_used_in_bytes": 73868,
+                "jvm_buffer_pools_mapped_count": 7,
+                "jvm_buffer_pools_mapped_total_capacity_in_bytes": 9999,
+                "jvm_buffer_pools_mapped_used_in_bytes": 3120,
+                "jvm_mem_heap_committed_in_bytes": 626393088,
+                "jvm_mem_heap_max_in_bytes": 626393088,
+                "jvm_mem_heap_used_in_bytes": 119073552,
+                "jvm_mem_heap_used_percent": 19,
+                "jvm_mem_non_heap_committed_in_bytes": 118108160,
+                "jvm_mem_non_heap_used_in_bytes": 110250424,
+                "jvm_mem_pools_old_max_in_bytes": 469368832,
+                "jvm_mem_pools_old_peak_max_in_bytes": 469368832,
+                "jvm_mem_pools_old_peak_used_in_bytes": 52336480,
+                "jvm_mem_pools_old_used_in_bytes": 52336480,
+                "jvm_mem_pools_survivor_max_in_bytes": 17432576,
+                "jvm_mem_pools_survivor_peak_max_in_bytes": 17432576,
+                "jvm_mem_pools_survivor_peak_used_in_bytes": 17432576,
+                "jvm_mem_pools_survivor_used_in_bytes": 358496,
+                "jvm_mem_pools_young_max_in_bytes": 139591680,
+                "jvm_mem_pools_young_peak_max_in_bytes": 139591680,
+                "jvm_mem_pools_young_peak_used_in_bytes": 139591680,
+                "jvm_mem_pools_young_used_in_bytes": 66378576,
+                "jvm_gc_collectors_young_collection_count": 3,
+                "jvm_gc_collectors_young_collection_time_in_millis": 309,
+                "jvm_gc_collectors_old_collection_count": 2,
+                "jvm_gc_collectors_old_collection_time_in_millis": 229,
+                "transport_rx_count": 77,
+                "transport_rx_size_in_bytes": 98723498,
+                "transport_server_open": 12,
+                "transport_tx_count": 88,
+                "transport_tx_size_in_bytes": 23879803,
+                "process_cpu_percent": 10,
+                "process_cpu_total_in_millis": 56520,
+                "indexing_pressure_memory_current_combined_coordinating_and_primary_in_bytes": 0,
+                "indexing_pressure_memory_current_coordinating_in_bytes": 0,
+                "indexing_pressure_memory_current_primary_in_bytes": 0,
+                "indexing_pressure_memory_current_replica_in_bytes": 0,
+                "indexing_pressure_memory_current_all_in_bytes": 0,
+                "indexing_pressure_memory_total_combined_coordinating_and_primary_in_bytes": 0,
+                "indexing_pressure_memory_total_coordinating_in_bytes": 0,
+                "indexing_pressure_memory_total_primary_in_bytes": 0,
+                "indexing_pressure_memory_total_replica_in_bytes": 0,
+                "indexing_pressure_memory_total_all_in_bytes": 0,
+                "indexing_pressure_memory_total_coordinating_rejections": 0,
+                "indexing_pressure_memory_total_primary_rejections": 0,
+                "indexing_pressure_memory_total_replica_rejections": 0,
+            },
             level=MetaInfoScope.node,
             node_name="rally0",
-            meta_data=metrics_store_meta_data)
+            meta_data=metrics_store_meta_data,
+        )
 
     def test_exception_when_include_indices_metrics_not_valid(self):
         node_stats_response = {}
@@ -2519,12 +2558,11 @@ class NodeStatsRecorderTests(TestCase):
         client = Client(nodes=SubClient(stats=node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        telemetry_params = {
-            "node-stats-include-indices-metrics": {"bad": "input"}
-        }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    "The telemetry parameter 'node-stats-include-indices-metrics' must be "
-                                    "a comma-separated string but was <class 'dict'>"):
+        telemetry_params = {"node-stats-include-indices-metrics": {"bad": "input"}}
+        with self.assertRaisesRegex(
+            exceptions.SystemSetupError,
+            "The telemetry parameter 'node-stats-include-indices-metrics' must be a comma-separated string but was <class 'dict'>",
+        ):
             telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
 
 
@@ -2533,28 +2571,23 @@ class TransformStatsTests(TestCase):
         clients = {"default": Client(), "cluster_b": Client()}
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        telemetry_params = {
-            "transform-stats-sample-interval": -1 * random.random()
-        }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    r"The telemetry parameter 'transform-stats-sample-interval' must be greater than zero but was .*\."):
+        telemetry_params = {"transform-stats-sample-interval": -1 * random.random()}
+        with self.assertRaisesRegex(
+            exceptions.SystemSetupError, r"The telemetry parameter 'transform-stats-sample-interval' must be greater than zero but was .*\."
+        ):
             telemetry.TransformStats(telemetry_params, clients, metrics_store)
 
     def test_wrong_cluster_name_in_transform_stats_indices_forbidden(self):
         clients = {"default": Client(), "cluster_b": Client()}
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        telemetry_params = {
-            "transform-stats-transforms": {
-                "default": ["leader"],
-                "wrong_cluster_name": ["follower"]
-            }
-        }
-        with self.assertRaisesRegex(exceptions.SystemSetupError,
-                                    r"The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys matching "
-                                    r"the cluster names \[{}] specified in --target-hosts "
-                                    r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys())))
-                                    ):
+        telemetry_params = {"transform-stats-transforms": {"default": ["leader"], "wrong_cluster_name": ["follower"]}}
+        with self.assertRaisesRegex(
+            exceptions.SystemSetupError,
+            r"The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys matching "
+            r"the cluster names \[{}] specified in --target-hosts "
+            r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys()))),
+        ):
             telemetry.TransformStats(telemetry_params, clients, metrics_store)
 
 
@@ -2587,51 +2620,48 @@ class TransformStatsRecorderTests(TestCase):
                     "processing_total": 12,
                     "exponential_avg_checkpoint_duration_ms": random.uniform(1.0, 100.0),
                     "exponential_avg_documents_indexed": random.uniform(1.0, 1000.0),
-                    "exponential_avg_documents_processed": random.uniform(1.0, 10000.0)
+                    "exponential_avg_documents_processed": random.uniform(1.0, 10000.0),
                 },
                 "checkpointing": {
                     "last": {
                         "checkpoint": random.randint(0, java_signed_maxlong),
-                        "timestamp_millis": random.randint(0, java_signed_maxlong)
+                        "timestamp_millis": random.randint(0, java_signed_maxlong),
                     },
-                    "changes_last_detected_at": random.randint(0, java_signed_maxlong)
-                }
+                    "changes_last_detected_at": random.randint(0, java_signed_maxlong),
+                },
             }
             transforms.append(transform)
 
-        TransformStatsRecorderTests.transform_stats_response = {
-            "count": count,
-            "transforms": transforms
-        }
+        TransformStatsRecorderTests.transform_stats_response = {"count": count, "transforms": transforms}
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     def test_stores_default_stats(self, metrics_store_put_value):
         client = Client(transform=SubClient(transform_stats=TransformStatsRecorderTests.transform_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        recorder = telemetry.TransformStatsRecorder(cluster_name="transform_cluster", client=client,
-                                                    metrics_store=metrics_store,
-                                                    sample_interval=1)
+        recorder = telemetry.TransformStatsRecorder(
+            cluster_name="transform_cluster", client=client, metrics_store=metrics_store, sample_interval=1
+        )
         recorder.record()
 
-        meta_data = {
-            "transform_id": "transform_job_0"
-        }
+        meta_data = {"transform_id": "transform_job_0"}
 
-        metrics_store_put_value.assert_has_calls([
-            mock.call("transform_pages_processed", 1, meta_data=meta_data),
-            mock.call("transform_documents_processed", 240, meta_data=meta_data),
-            mock.call("transform_documents_indexed", 3, meta_data=meta_data),
-            mock.call("transform_index_total", 6, meta_data=meta_data),
-            mock.call("transform_index_failures", 7, meta_data=meta_data),
-            mock.call("transform_search_total", 9, meta_data=meta_data),
-            mock.call("transform_search_failures", 10, meta_data=meta_data),
-            mock.call("transform_processing_total", 12, meta_data=meta_data),
-            mock.call("transform_search_time", 8, "ms", meta_data=meta_data),
-            mock.call("transform_index_time", 5, "ms", meta_data=meta_data),
-            mock.call("transform_processing_time", 11, "ms", meta_data=meta_data),
-            mock.call("transform_throughput", 10000, "docs/s", meta_data=meta_data)
-        ])
+        metrics_store_put_value.assert_has_calls(
+            [
+                mock.call("transform_pages_processed", 1, meta_data=meta_data),
+                mock.call("transform_documents_processed", 240, meta_data=meta_data),
+                mock.call("transform_documents_indexed", 3, meta_data=meta_data),
+                mock.call("transform_index_total", 6, meta_data=meta_data),
+                mock.call("transform_index_failures", 7, meta_data=meta_data),
+                mock.call("transform_search_total", 9, meta_data=meta_data),
+                mock.call("transform_search_failures", 10, meta_data=meta_data),
+                mock.call("transform_processing_total", 12, meta_data=meta_data),
+                mock.call("transform_search_time", 8, "ms", meta_data=meta_data),
+                mock.call("transform_index_time", 5, "ms", meta_data=meta_data),
+                mock.call("transform_processing_time", 11, "ms", meta_data=meta_data),
+                mock.call("transform_throughput", 10000, "docs/s", meta_data=meta_data),
+            ]
+        )
 
 
 class ClusterEnvironmentInfoTests(TestCase):
@@ -2642,16 +2672,16 @@ class ClusterEnvironmentInfoTests(TestCase):
             "name": "rally0",
             "host": "127.0.0.1",
             "attributes": {
-                "group": "cold_nodes"
+                "group": "cold_nodes",
             },
             "os": {
                 "name": "Mac OS X",
                 "version": "10.11.4",
-                "available_processors": 8
+                "available_processors": 8,
             },
             "jvm": {
                 "version": "1.8.0_74",
-                "vm_vendor": "Oracle Corporation"
+                "vm_vendor": "Oracle Corporation",
             },
             "plugins": [
                 {
@@ -2659,24 +2689,24 @@ class ClusterEnvironmentInfoTests(TestCase):
                     "version": "5.0.0",
                     "description": "Ingest processor that uses looksup geo data ...",
                     "classname": "org.elasticsearch.ingest.geoip.IngestGeoIpPlugin",
-                    "has_native_controller": False
+                    "has_native_controller": False,
                 }
-            ]
+            ],
         }
         nodes_info["nodes"]["EEEjozkeTiOpN-SI88YEcg"] = {
             "name": "rally1",
             "host": "127.0.0.1",
             "attributes": {
-                "group": "hot_nodes"
+                "group": "hot_nodes",
             },
             "os": {
                 "name": "Mac OS X",
                 "version": "10.11.5",
-                "available_processors": 8
+                "available_processors": 8,
             },
             "jvm": {
                 "version": "1.8.0_102",
-                "vm_vendor": "Oracle Corporation"
+                "vm_vendor": "Oracle Corporation",
             },
             "plugins": [
                 {
@@ -2684,17 +2714,16 @@ class ClusterEnvironmentInfoTests(TestCase):
                     "version": "5.0.0",
                     "description": "Ingest processor that uses looksup geo data ...",
                     "classname": "org.elasticsearch.ingest.geoip.IngestGeoIpPlugin",
-                    "has_native_controller": False
+                    "has_native_controller": False,
                 }
-            ]
+            ],
         }
 
         cluster_info = {
-            "version":
-                {
-                    "build_hash": "abc123",
-                    "number": "6.0.0-alpha1"
-                }
+            "version": {
+                "build_hash": "abc123",
+                "number": "6.0.0-alpha1",
+            },
         }
 
         cfg = create_config()
@@ -2740,8 +2769,9 @@ class NodeEnvironmentInfoTests(TestCase):
     @mock.patch("esrally.utils.sysstats.logical_cpu_cores")
     @mock.patch("esrally.utils.sysstats.physical_cpu_cores")
     @mock.patch("esrally.utils.sysstats.cpu_model")
-    def test_stores_node_level_metrics(self, cpu_model, physical_cpu_cores, logical_cpu_cores,
-                                       os_version, os_name, metrics_store_add_meta_info):
+    def test_stores_node_level_metrics(
+        self, cpu_model, physical_cpu_cores, logical_cpu_cores, os_version, os_name, metrics_store_add_meta_info
+    ):
         cpu_model.return_value = "Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz"
         physical_cpu_cores.return_value = 4
         logical_cpu_cores.return_value = 8
@@ -2776,9 +2806,9 @@ class ExternalEnvironmentInfoTests(TestCase):
             "nodes": {
                 "FCFjozkeTiOpN-SI88YEcg": {
                     "name": "rally0",
-                    "host": "127.0.0.1"
-                }
-            }
+                    "host": "127.0.0.1",
+                },
+            },
         }
 
         nodes_info = {
@@ -2787,16 +2817,16 @@ class ExternalEnvironmentInfoTests(TestCase):
                     "name": "rally0",
                     "host": "127.0.0.1",
                     "attributes": {
-                        "az": "us_east1"
+                        "az": "us_east1",
                     },
                     "os": {
                         "name": "Mac OS X",
                         "version": "10.11.4",
-                        "available_processors": 8
+                        "available_processors": 8,
                     },
                     "jvm": {
                         "version": "1.8.0_74",
-                        "vm_vendor": "Oracle Corporation"
+                        "vm_vendor": "Oracle Corporation",
                     },
                     "plugins": [
                         {
@@ -2804,19 +2834,17 @@ class ExternalEnvironmentInfoTests(TestCase):
                             "version": "5.0.0",
                             "description": "Ingest processor that uses looksup geo data ...",
                             "classname": "org.elasticsearch.ingest.geoip.IngestGeoIpPlugin",
-                            "has_native_controller": False
+                            "has_native_controller": False,
                         }
-                    ]
+                    ],
                 }
             }
         }
         cluster_info = {
-            "version":
-                {
-                    "build_hash": "253032b",
-                    "number": "5.0.0"
-
-                }
+            "version": {
+                "build_hash": "253032b",
+                "number": "5.0.0",
+            },
         }
         client = Client(nodes=SubClient(stats=nodes_stats, info=nodes_info), info=cluster_info)
         metrics_store = metrics.EsMetricsStore(self.cfg)
@@ -2854,25 +2882,16 @@ class ExternalEnvironmentInfoTests(TestCase):
             "nodes": {
                 "FCFjozkeTiOpN-SI88YEcg": {
                     "name": "rally0",
-                    "os": {
-                        "name": "Mac OS X",
-                        "version": "10.11.4",
-                        "available_processors": 8
-                    },
-                    "jvm": {
-                        "version": "1.8.0_74",
-                        "vm_vendor": "Oracle Corporation"
-                    }
+                    "os": {"name": "Mac OS X", "version": "10.11.4", "available_processors": 8},
+                    "jvm": {"version": "1.8.0_74", "vm_vendor": "Oracle Corporation"},
                 }
             }
         }
         cluster_info = {
-            "version":
-                {
-                    "build_hash": "253032b",
-                    "number": "5.0.0"
-
-                }
+            "version": {
+                "build_hash": "253032b",
+                "number": "5.0.0",
+            },
         }
         client = Client(nodes=SubClient(stats=nodes_stats, info=nodes_info), info=cluster_info)
         metrics_store = metrics.EsMetricsStore(self.cfg)
@@ -2887,7 +2906,7 @@ class ExternalEnvironmentInfoTests(TestCase):
             mock.call(metrics.MetaInfoScope.node, "rally0", "os_version", "10.11.4"),
             mock.call(metrics.MetaInfoScope.node, "rally0", "cpu_logical_cores", 8),
             mock.call(metrics.MetaInfoScope.node, "rally0", "jvm_vendor", "Oracle Corporation"),
-            mock.call(metrics.MetaInfoScope.node, "rally0", "jvm_version", "1.8.0_74")
+            mock.call(metrics.MetaInfoScope.node, "rally0", "jvm_version", "1.8.0_74"),
         ]
         metrics_store_add_meta_info.assert_has_calls(calls)
 
@@ -2903,7 +2922,6 @@ class ExternalEnvironmentInfoTests(TestCase):
 
 
 class DiskIoTests(TestCase):
-
     @mock.patch("esrally.utils.sysstats.process_io_counters")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
     def test_diskio_process_io_counters(self, metrics_store_node_count, process_io_counters):
@@ -2926,11 +2944,12 @@ class DiskIoTests(TestCase):
         t.detach_from_node(node, running=False)
         t.store_system_metrics(node, metrics_store)
 
-        metrics_store_node_count.assert_has_calls([
-            mock.call("rally0", "disk_io_write_bytes", 1, "byte"),
-            mock.call("rally0", "disk_io_read_bytes", 1, "byte")
-
-        ])
+        metrics_store_node_count.assert_has_calls(
+            [
+                mock.call("rally0", "disk_io_write_bytes", 1, "byte"),
+                mock.call("rally0", "disk_io_read_bytes", 1, "byte"),
+            ]
+        )
 
     @mock.patch("esrally.utils.sysstats.disk_io_counters")
     @mock.patch("esrally.utils.sysstats.process_io_counters")
@@ -2958,10 +2977,12 @@ class DiskIoTests(TestCase):
 
         # expected result is 1 byte because there are two nodes on the machine. Result is calculated
         # with total_bytes / node_count
-        metrics_store_node_count.assert_has_calls([
-            mock.call("rally0", "disk_io_write_bytes", 1, "byte"),
-            mock.call("rally0", "disk_io_read_bytes", 1, "byte")
-        ])
+        metrics_store_node_count.assert_has_calls(
+            [
+                mock.call("rally0", "disk_io_write_bytes", 1, "byte"),
+                mock.call("rally0", "disk_io_read_bytes", 1, "byte"),
+            ]
+        )
 
     @mock.patch("esrally.utils.sysstats.disk_io_counters")
     @mock.patch("esrally.utils.sysstats.process_io_counters")
@@ -2987,20 +3008,19 @@ class DiskIoTests(TestCase):
         t.detach_from_node(node, running=False)
         t.store_system_metrics(node, metrics_store)
 
-        metrics_store_node_count.assert_has_calls([
-            mock.call("rally0", "disk_io_write_bytes", 3, "byte"),
-            mock.call("rally0", "disk_io_read_bytes", 0, "byte"),
-        ])
+        metrics_store_node_count.assert_has_calls(
+            [
+                mock.call("rally0", "disk_io_write_bytes", 3, "byte"),
+                mock.call("rally0", "disk_io_read_bytes", 0, "byte"),
+            ]
+        )
 
 
 class JvmStatsSummaryTests(TestCase):
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
-    def test_stores_only_diff_of_gc_times(self,
-                                          metrics_store_node_level,
-                                          metrics_store_cluster_level,
-                                          metrics_store_put_doc):
+    def test_stores_only_diff_of_gc_times(self, metrics_store_node_level, metrics_store_cluster_level, metrics_store_put_doc):
         nodes_stats_at_start = {
             "nodes": {
                 "FCFjozkeTiOpN-SI88YEcg": {
@@ -3017,22 +3037,22 @@ class JvmStatsSummaryTests(TestCase):
                                 },
                                 "old": {
                                     "peak_used_in_bytes": 300008222,
-                                }
+                                },
                             }
                         },
                         "gc": {
                             "collectors": {
                                 "old": {
                                     "collection_time_in_millis": 1000,
-                                    "collection_count": 1
+                                    "collection_count": 1,
                                 },
                                 "young": {
                                     "collection_time_in_millis": 500,
-                                    "collection_count": 20
-                                }
+                                    "collection_count": 20,
+                                },
                             }
-                        }
-                    }
+                        },
+                    },
                 }
             }
         }
@@ -3061,90 +3081,95 @@ class JvmStatsSummaryTests(TestCase):
                                 },
                                 "old": {
                                     "peak_used_in_bytes": 3084912096,
-                                }
+                                },
                             }
                         },
                         "gc": {
                             "collectors": {
                                 "old": {
                                     "collection_time_in_millis": 2500,
-                                    "collection_count": 2
+                                    "collection_count": 2,
                                 },
                                 "young": {
                                     "collection_time_in_millis": 1200,
-                                    "collection_count": 4000
-                                }
+                                    "collection_count": 4000,
+                                },
                             }
-                        }
-                    }
+                        },
+                    },
                 }
             }
         }
         client.nodes = SubClient(nodes_stats_at_end)
         t.on_benchmark_stop()
 
-        metrics_store_node_level.assert_has_calls([
-            mock.call("rally0", "node_young_gen_gc_time", 700, "ms"),
-            mock.call("rally0", "node_young_gen_gc_count", 3980),
-            mock.call("rally0", "node_old_gen_gc_time", 1500, "ms"),
-            mock.call("rally0", "node_old_gen_gc_count", 1),
-        ])
+        metrics_store_node_level.assert_has_calls(
+            [
+                mock.call("rally0", "node_young_gen_gc_time", 700, "ms"),
+                mock.call("rally0", "node_young_gen_gc_count", 3980),
+                mock.call("rally0", "node_old_gen_gc_time", 1500, "ms"),
+                mock.call("rally0", "node_old_gen_gc_count", 1),
+            ]
+        )
 
-        metrics_store_cluster_level.assert_has_calls([
-            mock.call("node_total_young_gen_gc_time", 700, "ms"),
-            mock.call("node_total_young_gen_gc_count", 3980),
-            mock.call("node_total_old_gen_gc_time", 1500, "ms"),
-            mock.call("node_total_old_gen_gc_count", 1),
-        ])
+        metrics_store_cluster_level.assert_has_calls(
+            [
+                mock.call("node_total_young_gen_gc_time", 700, "ms"),
+                mock.call("node_total_young_gen_gc_count", 3980),
+                mock.call("node_total_old_gen_gc_time", 1500, "ms"),
+                mock.call("node_total_old_gen_gc_count", 1),
+            ]
+        )
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call({
-                "name": "jvm_memory_pool_stats",
-                "young": {
-                    "peak_usage": 558432256,
-                    "unit": "byte"
-                },
-                "survivor": {
-                    "peak_usage": 69730304,
-                    "unit": "byte"
-                },
-                "old": {
-                    "peak_usage": 3084912096,
-                    "unit": "byte"
-                },
-            }, level=MetaInfoScope.node, node_name="rally0"),
-        ])
+        metrics_store_put_doc.assert_has_calls(
+            [
+                mock.call(
+                    {
+                        "name": "jvm_memory_pool_stats",
+                        "young": {"peak_usage": 558432256, "unit": "byte"},
+                        "survivor": {"peak_usage": 69730304, "unit": "byte"},
+                        "old": {"peak_usage": 3084912096, "unit": "byte"},
+                    },
+                    level=MetaInfoScope.node,
+                    node_name="rally0",
+                ),
+            ]
+        )
 
 
 class IndexStatsTests(TestCase):
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     def test_stores_available_index_stats(self, metrics_store_cluster_value, metrics_store_put_doc):
-        client = Client(indices=SubClient({
-            "_all": {
-                "primaries": {
-                    "segments": {
-                        "count": 0
-                    },
-                    "merges": {
-                        "total_time_in_millis": 0,
-                        "total_throttled_time_in_millis": 0,
-                        "total": 0
-                    },
-                    "indexing": {
-                        "index_time_in_millis": 0
-                    },
-                    "refresh": {
-                        "total_time_in_millis": 0,
-                        "total": 0
-                    },
-                    "flush": {
-                        "total_time_in_millis": 0,
-                        "total": 0
+        client = Client(
+            indices=SubClient(
+                {
+                    "_all": {
+                        "primaries": {
+                            "segments": {
+                                "count": 0,
+                            },
+                            "merges": {
+                                "total_time_in_millis": 0,
+                                "total_throttled_time_in_millis": 0,
+                                "total": 0,
+                            },
+                            "indexing": {
+                                "index_time_in_millis": 0,
+                            },
+                            "refresh": {
+                                "total_time_in_millis": 0,
+                                "total": 0,
+                            },
+                            "flush": {
+                                "total_time_in_millis": 0,
+                                "total": 0,
+                            },
+                        }
                     }
                 }
-            }
-        }))
+            )
+        )
         cfg = create_config()
 
         metrics_store = metrics.EsMetricsStore(cfg)
@@ -3161,62 +3186,60 @@ class IndexStatsTests(TestCase):
                         "stored_fields_memory_in_bytes": 1024,
                         "doc_values_memory_in_bytes": 128,
                         "terms_memory_in_bytes": 256,
-                        "points_memory_in_bytes": 512
+                        "points_memory_in_bytes": 512,
                     },
                     "merges": {
                         "total_time_in_millis": 509341,
                         "total_throttled_time_in_millis": 98925,
-                        "total": 3
+                        "total": 3,
                     },
                     "indexing": {
-                        "index_time_in_millis": 1065688
+                        "index_time_in_millis": 1065688,
                     },
                     "refresh": {
                         "total_time_in_millis": 158465,
-                        "total": 10
+                        "total": 10,
                     },
                     "flush": {
                         "total_time_in_millis": 0,
-                        "total": 0
-                    }
+                        "total": 0,
+                    },
                 },
                 "total": {
                     "store": {
-                        "size_in_bytes": 2113867510
+                        "size_in_bytes": 2113867510,
                     },
                     "translog": {
                         "operations": 6840000,
                         "size_in_bytes": 2647984713,
                         "uncommitted_operations": 0,
-                        "uncommitted_size_in_bytes": 430
-                    }
-                }
+                        "uncommitted_size_in_bytes": 430,
+                    },
+                },
             },
             "indices": {
                 "idx-001": {
                     "shards": {
                         "0": [
                             {
-                                "routing": {
-                                    "primary": False
-                                },
+                                "routing": {"primary": False},
                                 "indexing": {
                                     "index_total": 2280171,
                                     "index_time_in_millis": 533662,
-                                    "throttle_time_in_millis": 0
+                                    "throttle_time_in_millis": 0,
                                 },
                                 "merges": {
                                     "total_time_in_millis": 280689,
                                     "total_stopped_time_in_millis": 0,
                                     "total_throttled_time_in_millis": 58846,
-                                    "total_auto_throttle_in_bytes": 8085428
+                                    "total_auto_throttle_in_bytes": 8085428,
                                 },
                                 "refresh": {
-                                    "total_time_in_millis": 81004
+                                    "total_time_in_millis": 81004,
                                 },
                                 "flush": {
-                                    "total_time_in_millis": 0
-                                }
+                                    "total_time_in_millis": 0,
+                                },
                             }
                         ],
                         "1": [
@@ -3235,10 +3258,10 @@ class IndexStatsTests(TestCase):
                                     "total_time_in_millis": 77461,
                                 },
                                 "flush": {
-                                    "total_time_in_millis": 0
-                                }
+                                    "total_time_in_millis": 0,
+                                },
                             }
-                        ]
+                        ],
                     }
                 },
                 "idx-002": {
@@ -3259,8 +3282,8 @@ class IndexStatsTests(TestCase):
                                     "total_time_in_millis": 81004,
                                 },
                                 "flush": {
-                                    "total_time_in_millis": 0
-                                }
+                                    "total_time_in_millis": 0,
+                                },
                             }
                         ],
                         "1": [
@@ -3270,7 +3293,7 @@ class IndexStatsTests(TestCase):
                                 },
                                 "indexing": {
                                     "index_time_in_millis": 532026,
-                                    "throttle_time_in_millis": 296
+                                    "throttle_time_in_millis": 296,
                                 },
                                 "merges": {
                                     "total_time_in_millis": 228652,
@@ -3280,13 +3303,13 @@ class IndexStatsTests(TestCase):
                                     "total_time_in_millis": 77461,
                                 },
                                 "flush": {
-                                    "total_time_in_millis": 0
-                                }
+                                    "total_time_in_millis": 0,
+                                },
                             }
-                        ]
+                        ],
                     }
-                }
-            }
+                },
+            },
         }
 
         client.indices = SubClient(response)
@@ -3301,66 +3324,77 @@ class IndexStatsTests(TestCase):
                     if shard_metrics["routing"]["primary"]:
                         primary_shards.append(shard_metrics)
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call(doc={
-                "name": "merges_total_time",
-                "value": 509341,
-                "unit": "ms",
-                # [228652, 280689]
-                "per-shard": [s["merges"]["total_time_in_millis"] for s in primary_shards]
-            }, level=metrics.MetaInfoScope.cluster),
-            mock.call(doc={
-                "name": "merges_total_throttled_time",
-                "value": 98925,
-                "unit": "ms",
-                # [40079, 58846]
-                "per-shard": [s["merges"]["total_throttled_time_in_millis"] for s in primary_shards]
-            }, level=metrics.MetaInfoScope.cluster),
-            mock.call(doc={
-                "name": "indexing_total_time",
-                "value": 1065688,
-                "unit": "ms",
-                # [532026, 533662]
-                "per-shard": [s["indexing"]["index_time_in_millis"] for s in primary_shards]
-            }, level=metrics.MetaInfoScope.cluster),
-            mock.call(doc={
-                "name": "refresh_total_time",
-                "value": 158465,
-                "unit": "ms",
-                # [77461, 81004]
-                "per-shard": [s["refresh"]["total_time_in_millis"] for s in primary_shards]
-            }, level=metrics.MetaInfoScope.cluster),
-            mock.call(doc={
-                "name": "flush_total_time",
-                "value": 0,
-                "unit": "ms",
-                # [0, 0]
-                "per-shard": [s["flush"]["total_time_in_millis"] for s in primary_shards]
-            }, level=metrics.MetaInfoScope.cluster),
-            mock.call(doc={
-                "name": "merges_total_count",
-                "value": 3
-            }, level=metrics.MetaInfoScope.cluster),
-            mock.call(doc={
-                "name": "refresh_total_count",
-                "value": 10
-            }, level=metrics.MetaInfoScope.cluster),
-            mock.call(doc={
-                "name": "flush_total_count",
-                "value": 0
-            }, level=metrics.MetaInfoScope.cluster),
-        ])
+        metrics_store_put_doc.assert_has_calls(
+            [
+                mock.call(
+                    doc={
+                        "name": "merges_total_time",
+                        "value": 509341,
+                        "unit": "ms",
+                        # [228652, 280689]
+                        "per-shard": [s["merges"]["total_time_in_millis"] for s in primary_shards],
+                    },
+                    level=metrics.MetaInfoScope.cluster,
+                ),
+                mock.call(
+                    doc={
+                        "name": "merges_total_throttled_time",
+                        "value": 98925,
+                        "unit": "ms",
+                        # [40079, 58846]
+                        "per-shard": [s["merges"]["total_throttled_time_in_millis"] for s in primary_shards],
+                    },
+                    level=metrics.MetaInfoScope.cluster,
+                ),
+                mock.call(
+                    doc={
+                        "name": "indexing_total_time",
+                        "value": 1065688,
+                        "unit": "ms",
+                        # [532026, 533662]
+                        "per-shard": [s["indexing"]["index_time_in_millis"] for s in primary_shards],
+                    },
+                    level=metrics.MetaInfoScope.cluster,
+                ),
+                mock.call(
+                    doc={
+                        "name": "refresh_total_time",
+                        "value": 158465,
+                        "unit": "ms",
+                        # [77461, 81004]
+                        "per-shard": [s["refresh"]["total_time_in_millis"] for s in primary_shards],
+                    },
+                    level=metrics.MetaInfoScope.cluster,
+                ),
+                mock.call(
+                    doc={
+                        "name": "flush_total_time",
+                        "value": 0,
+                        "unit": "ms",
+                        # [0, 0]
+                        "per-shard": [s["flush"]["total_time_in_millis"] for s in primary_shards],
+                    },
+                    level=metrics.MetaInfoScope.cluster,
+                ),
+                mock.call(doc={"name": "merges_total_count", "value": 3}, level=metrics.MetaInfoScope.cluster),
+                mock.call(doc={"name": "refresh_total_count", "value": 10}, level=metrics.MetaInfoScope.cluster),
+                mock.call(doc={"name": "flush_total_count", "value": 0}, level=metrics.MetaInfoScope.cluster),
+            ]
+        )
 
-        metrics_store_cluster_value.assert_has_calls([
-            mock.call("segments_count", 5),
-            mock.call("segments_memory_in_bytes", 2048, "byte"),
-            mock.call("segments_doc_values_memory_in_bytes", 128, "byte"),
-            mock.call("segments_stored_fields_memory_in_bytes", 1024, "byte"),
-            mock.call("segments_terms_memory_in_bytes", 256, "byte"),
-            # we don't have norms, so nothing should have been called
-            mock.call("store_size_in_bytes", 2113867510, "byte"),
-            mock.call("translog_size_in_bytes", 2647984713, "byte"),
-        ], any_order=True)
+        metrics_store_cluster_value.assert_has_calls(
+            [
+                mock.call("segments_count", 5),
+                mock.call("segments_memory_in_bytes", 2048, "byte"),
+                mock.call("segments_doc_values_memory_in_bytes", 128, "byte"),
+                mock.call("segments_stored_fields_memory_in_bytes", 1024, "byte"),
+                mock.call("segments_terms_memory_in_bytes", 256, "byte"),
+                # we don't have norms, so nothing should have been called
+                mock.call("store_size_in_bytes", 2113867510, "byte"),
+                mock.call("translog_size_in_bytes", 2647984713, "byte"),
+            ],
+            any_order=True,
+        )
 
 
 class MlBucketProcessingTimeTests(TestCase):
@@ -3382,9 +3416,9 @@ class MlBucketProcessingTimeTests(TestCase):
         es.search.return_value = {
             "aggregations": {
                 "jobs": {
-                    "buckets": []
-                }
-            }
+                    "buckets": [],
+                },
+            },
         }
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
@@ -3404,39 +3438,19 @@ class MlBucketProcessingTimeTests(TestCase):
                         {
                             "key": "benchmark_ml_job_1",
                             "doc_count": 4775,
-                            "max_pt": {
-                                "value": 36.0
-                            },
-                            "mean_pt": {
-                                "value": 12.3
-                            },
-                            "median_pt": {
-                                "values": {
-                                    "50.0": 17.2
-                                }
-                            },
-                            "min_pt": {
-                                "value": 2.2
-                            }
+                            "max_pt": {"value": 36.0},
+                            "mean_pt": {"value": 12.3},
+                            "median_pt": {"values": {"50.0": 17.2}},
+                            "min_pt": {"value": 2.2},
                         },
                         {
                             "key": "benchmark_ml_job_2",
                             "doc_count": 3333,
-                            "max_pt": {
-                                "value": 226.3
-                            },
-                            "mean_pt": {
-                                "value": 78.3
-                            },
-                            "median_pt": {
-                                "values": {
-                                    "50.0": 37.4
-                                }
-                            },
-                            "min_pt": {
-                                "value": 32.2
-                            }
-                        }
+                            "max_pt": {"value": 226.3},
+                            "mean_pt": {"value": 78.3},
+                            "median_pt": {"values": {"50.0": 37.4}},
+                            "min_pt": {"value": 32.2},
+                        },
                     ]
                 }
             }
@@ -3448,26 +3462,34 @@ class MlBucketProcessingTimeTests(TestCase):
         t = telemetry.Telemetry(cfg, devices=[device])
         t.on_benchmark_stop()
 
-        metrics_store_put_doc.assert_has_calls([
-            mock.call(doc={
-                "name": "ml_processing_time",
-                "job": "benchmark_ml_job_1",
-                "min": 2.2,
-                "mean": 12.3,
-                "median": 17.2,
-                "max": 36.0,
-                "unit": "ms"
-            }, level=metrics.MetaInfoScope.cluster),
-            mock.call(doc={
-                "name": "ml_processing_time",
-                "job": "benchmark_ml_job_2",
-                "min": 32.2,
-                "mean": 78.3,
-                "median": 37.4,
-                "max": 226.3,
-                "unit": "ms"
-            }, level=metrics.MetaInfoScope.cluster)
-        ])
+        metrics_store_put_doc.assert_has_calls(
+            [
+                mock.call(
+                    doc={
+                        "name": "ml_processing_time",
+                        "job": "benchmark_ml_job_1",
+                        "min": 2.2,
+                        "mean": 12.3,
+                        "median": 17.2,
+                        "max": 36.0,
+                        "unit": "ms",
+                    },
+                    level=metrics.MetaInfoScope.cluster,
+                ),
+                mock.call(
+                    doc={
+                        "name": "ml_processing_time",
+                        "job": "benchmark_ml_job_2",
+                        "min": 32.2,
+                        "mean": 78.3,
+                        "median": 37.4,
+                        "max": 226.3,
+                        "unit": "ms",
+                    },
+                    level=metrics.MetaInfoScope.cluster,
+                ),
+            ]
+        )
 
 
 class IndexSizeTests(TestCase):
@@ -3488,9 +3510,9 @@ class IndexSizeTests(TestCase):
         t.detach_from_node(node, running=False)
         t.store_system_metrics(node, metrics_store)
 
-        metrics_store_node_value.assert_has_calls([
-            mock.call("rally-node-0", "final_index_size_bytes", 18432, "byte")
-        ])
+        metrics_store_node_value.assert_has_calls(
+            [mock.call("rally-node-0", "final_index_size_bytes", 18432, "byte")],
+        )
 
     @mock.patch("esrally.utils.io.get_size")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")

--- a/tests/test_async_connection.py
+++ b/tests/test_async_connection.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -23,26 +23,23 @@ from esrally.async_connection import ResponseMatcher
 
 class ResponseMatcherTests(TestCase):
     def test_matches(self):
-        matcher = ResponseMatcher(responses=[
-            {
-                "path": "*/_bulk",
-                "body": {
-                    "response-type": "bulk",
-                }
-            },
-            {
-                "path": "/_cluster/health*",
-                "body": {
-                    "response-type": "cluster-health",
-                }
-            },
-            {
-                "path": "*",
-                "body": {
-                    "response-type": "default"
-                }
-            }
-        ])
+        matcher = ResponseMatcher(
+            responses=[
+                {
+                    "path": "*/_bulk",
+                    "body": {
+                        "response-type": "bulk",
+                    },
+                },
+                {
+                    "path": "/_cluster/health*",
+                    "body": {
+                        "response-type": "cluster-health",
+                    },
+                },
+                {"path": "*", "body": {"response-type": "default"}},
+            ]
+        )
 
         self.assert_response_type(matcher, "/_cluster/health", "cluster-health")
         self.assert_response_type(matcher, "/_cluster/health/geonames", "cluster-health")

--- a/tests/time_test.py
+++ b/tests/time_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tests/track/__init__.py
+++ b/tests/track/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -23,7 +23,7 @@ import unittest.mock as mock
 import urllib.error
 from unittest import TestCase
 
-from esrally import exceptions, config
+from esrally import config, exceptions
 from esrally.track import loader, track
 from esrally.utils import io
 
@@ -147,17 +147,21 @@ class TrackPreparationTests(TestCase):
         get_size.return_value = 2000
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
-        p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                            document_file="docs.json",
-                                                            document_archive="docs.json.bz2",
-                                                            number_of_documents=5,
-                                                            compressed_size_in_bytes=200,
-                                                            uncompressed_size_in_bytes=2000),
-                               data_root="/tmp")
+        p.prepare_document_set(
+            document_set=track.Documents(
+                source_format=track.Documents.SOURCE_FORMAT_BULK,
+                document_file="docs.json",
+                document_archive="docs.json.bz2",
+                number_of_documents=5,
+                compressed_size_in_bytes=200,
+                uncompressed_size_in_bytes=2000,
+            ),
+            data_root="/tmp",
+        )
 
         prepare_file_offset_table.assert_called_with("/tmp/docs.json")
 
@@ -169,17 +173,21 @@ class TrackPreparationTests(TestCase):
         get_size.return_value = 2000
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
-        p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                            document_file="docs.json",
-                                                            document_archive="docs.json.bz2",
-                                                            number_of_documents=5,
-                                                            compressed_size_in_bytes=200,
-                                                            uncompressed_size_in_bytes=2000),
-                               data_root="/tmp")
+        p.prepare_document_set(
+            document_set=track.Documents(
+                source_format=track.Documents.SOURCE_FORMAT_BULK,
+                document_file="docs.json",
+                document_archive="docs.json.bz2",
+                number_of_documents=5,
+                compressed_size_in_bytes=200,
+                uncompressed_size_in_bytes=2000,
+            ),
+            data_root="/tmp",
+        )
 
         prepare_file_offset_table.assert_called_with("/tmp/docs.json")
 
@@ -195,18 +203,22 @@ class TrackPreparationTests(TestCase):
         # uncompressed is corrupt, only 1 byte available
         get_size.side_effect = [200, 1]
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
         with self.assertRaises(exceptions.DataError) as ctx:
-            p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                document_file="docs.json",
-                                                                document_archive="docs.json.bz2",
-                                                                number_of_documents=5,
-                                                                compressed_size_in_bytes=200,
-                                                                uncompressed_size_in_bytes=2000),
-                                   data_root="/tmp")
+            p.prepare_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    document_file="docs.json",
+                    document_archive="docs.json.bz2",
+                    number_of_documents=5,
+                    compressed_size_in_bytes=200,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root="/tmp",
+            )
         self.assertEqual("[/tmp/docs.json] is corrupt. Extracted [1] bytes but [2000] bytes are expected.", ctx.exception.args[0])
 
         decompress.assert_called_with("/tmp/docs.json.bz2", "/tmp")
@@ -222,21 +234,28 @@ class TrackPreparationTests(TestCase):
         # compressed file size is 200
         get_size.return_value = 200
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
         with self.assertRaises(exceptions.DataError) as ctx:
-            p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
-                                                                document_file="docs.json",
-                                                                document_archive="docs.json.bz2",
-                                                                number_of_documents=5,
-                                                                compressed_size_in_bytes=200,
-                                                                uncompressed_size_in_bytes=2000),
-                                   data_root="/tmp")
-        self.assertEqual("Decompressing [/tmp/docs.json.bz2] did not create [/tmp/docs.json]. Please check with the track author if the "
-                         "compressed archive has been created correctly.", ctx.exception.args[0])
+            p.prepare_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
+                    document_file="docs.json",
+                    document_archive="docs.json.bz2",
+                    number_of_documents=5,
+                    compressed_size_in_bytes=200,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root="/tmp",
+            )
+        self.assertEqual(
+            "Decompressing [/tmp/docs.json.bz2] did not create [/tmp/docs.json]. Please check with the track author if the "
+            "compressed archive has been created correctly.",
+            ctx.exception.args[0],
+        )
 
         decompress.assert_called_with("/tmp/docs.json.bz2", "/tmp")
 
@@ -246,8 +265,9 @@ class TrackPreparationTests(TestCase):
     @mock.patch("esrally.utils.io.ensure_dir")
     @mock.patch("os.path.getsize")
     @mock.patch("os.path.isfile")
-    def test_download_document_archive_if_no_file_available(self, is_file, get_size, ensure_dir, download, decompress,
-                                                            prepare_file_offset_table):
+    def test_download_document_archive_if_no_file_available(
+        self, is_file, get_size, ensure_dir, download, decompress, prepare_file_offset_table
+    ):
         # uncompressed file does not exist
         # compressed file does not exist
         # after download compressed file exists
@@ -263,23 +283,28 @@ class TrackPreparationTests(TestCase):
 
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
-        p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                            base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
-                                                            document_file="docs.json",
-                                                            document_archive="docs.json.bz2",
-                                                            number_of_documents=5,
-                                                            compressed_size_in_bytes=200,
-                                                            uncompressed_size_in_bytes=2000),
-                               data_root="/tmp")
+        p.prepare_document_set(
+            document_set=track.Documents(
+                source_format=track.Documents.SOURCE_FORMAT_BULK,
+                base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
+                document_file="docs.json",
+                document_archive="docs.json.bz2",
+                number_of_documents=5,
+                compressed_size_in_bytes=200,
+                uncompressed_size_in_bytes=2000,
+            ),
+            data_root="/tmp",
+        )
 
         ensure_dir.assert_called_with("/tmp")
         decompress.assert_called_with("/tmp/docs.json.bz2", "/tmp")
-        download.assert_called_with("http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json.bz2",
-                                    "/tmp/docs.json.bz2", 200, progress_indicator=mock.ANY)
+        download.assert_called_with(
+            "http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json.bz2", "/tmp/docs.json.bz2", 200, progress_indicator=mock.ANY
+        )
         prepare_file_offset_table.assert_called_with("/tmp/docs.json")
 
     @mock.patch("esrally.utils.io.prepare_file_offset_table")
@@ -288,8 +313,9 @@ class TrackPreparationTests(TestCase):
     @mock.patch("esrally.utils.io.ensure_dir")
     @mock.patch("os.path.getsize")
     @mock.patch("os.path.isfile")
-    def test_download_document_with_trailing_baseurl_slash(self, is_file, get_size, ensure_dir, download, decompress,
-                                                           prepare_file_offset_table):
+    def test_download_document_with_trailing_baseurl_slash(
+        self, is_file, get_size, ensure_dir, download, decompress, prepare_file_offset_table
+    ):
         # uncompressed file does not exist
         # after download uncompressed file exists
         # after download uncompressed file exists (main loop)
@@ -300,23 +326,28 @@ class TrackPreparationTests(TestCase):
 
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
-        p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                            base_url=f"{scheme}://benchmarks.elasticsearch.org/corpora/unit-test/",
-                                                            document_file="docs.json",
-                                                            # --> We don't provide a document archive here <--
-                                                            document_archive=None,
-                                                            number_of_documents=5,
-                                                            compressed_size_in_bytes=200,
-                                                            uncompressed_size_in_bytes=2000),
-                               data_root="/tmp")
+        p.prepare_document_set(
+            document_set=track.Documents(
+                source_format=track.Documents.SOURCE_FORMAT_BULK,
+                base_url=f"{scheme}://benchmarks.elasticsearch.org/corpora/unit-test/",
+                document_file="docs.json",
+                # --> We don't provide a document archive here <--
+                document_archive=None,
+                number_of_documents=5,
+                compressed_size_in_bytes=200,
+                uncompressed_size_in_bytes=2000,
+            ),
+            data_root="/tmp",
+        )
 
         ensure_dir.assert_called_with("/tmp")
-        download.assert_called_with(f"{scheme}://benchmarks.elasticsearch.org/corpora/unit-test/docs.json",
-                                    "/tmp/docs.json", 2000, progress_indicator=mock.ANY)
+        download.assert_called_with(
+            f"{scheme}://benchmarks.elasticsearch.org/corpora/unit-test/docs.json", "/tmp/docs.json", 2000, progress_indicator=mock.ANY
+        )
         prepare_file_offset_table.assert_called_with("/tmp/docs.json")
 
     @mock.patch("esrally.utils.io.prepare_file_offset_table")
@@ -334,23 +365,28 @@ class TrackPreparationTests(TestCase):
 
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
-        p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                            base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
-                                                            document_file="docs.json",
-                                                            # --> We don't provide a document archive here <--
-                                                            document_archive=None,
-                                                            number_of_documents=5,
-                                                            compressed_size_in_bytes=200,
-                                                            uncompressed_size_in_bytes=2000),
-                               data_root="/tmp")
+        p.prepare_document_set(
+            document_set=track.Documents(
+                source_format=track.Documents.SOURCE_FORMAT_BULK,
+                base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
+                document_file="docs.json",
+                # --> We don't provide a document archive here <--
+                document_archive=None,
+                number_of_documents=5,
+                compressed_size_in_bytes=200,
+                uncompressed_size_in_bytes=2000,
+            ),
+            data_root="/tmp",
+        )
 
         ensure_dir.assert_called_with("/tmp")
-        download.assert_called_with("http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json",
-                                    "/tmp/docs.json", 2000, progress_indicator=mock.ANY)
+        download.assert_called_with(
+            "http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json", "/tmp/docs.json", 2000, progress_indicator=mock.ANY
+        )
         prepare_file_offset_table.assert_called_with("/tmp/docs.json")
 
     @mock.patch("esrally.utils.net.download")
@@ -360,17 +396,21 @@ class TrackPreparationTests(TestCase):
         # uncompressed file does not exist
         is_file.return_value = False
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=True, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=True, test_mode=False), decompressor=loader.Decompressor()
+        )
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
-            p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
-                                                                document_file="docs.json",
-                                                                number_of_documents=5,
-                                                                uncompressed_size_in_bytes=2000),
-                                   data_root="/tmp")
+            p.prepare_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
+                    document_file="docs.json",
+                    number_of_documents=5,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root="/tmp",
+            )
 
         self.assertEqual("Cannot find [/tmp/docs.json]. Please disable offline mode and retry.", ctx.exception.args[0])
 
@@ -384,18 +424,22 @@ class TrackPreparationTests(TestCase):
         # uncompressed file does not exist
         is_file.return_value = False
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
         with self.assertRaises(exceptions.DataError) as ctx:
-            p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                base_url=None,
-                                                                document_file="docs.json",
-                                                                document_archive=None,
-                                                                number_of_documents=5,
-                                                                uncompressed_size_in_bytes=2000),
-                                   data_root="/tmp")
+            p.prepare_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    base_url=None,
+                    document_file="docs.json",
+                    document_archive=None,
+                    number_of_documents=5,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root="/tmp",
+            )
 
         self.assertEqual("Cannot download data because no base URL is provided.", ctx.exception.args[0])
 
@@ -412,19 +456,26 @@ class TrackPreparationTests(TestCase):
         # but it's size is wrong
         get_size.return_value = 100
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
         with self.assertRaises(exceptions.DataError) as ctx:
-            p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                document_file="docs.json",
-                                                                number_of_documents=5,
-                                                                uncompressed_size_in_bytes=2000),
-                                   data_root="/tmp")
+            p.prepare_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    document_file="docs.json",
+                    number_of_documents=5,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root="/tmp",
+            )
 
-        self.assertEqual("[/tmp/docs.json] is present but does not have the expected size of [2000] bytes and it "
-                         "cannot be downloaded because no base URL is provided.", ctx.exception.args[0])
+        self.assertEqual(
+            "[/tmp/docs.json] is present but does not have the expected size of [2000] bytes and it "
+            "cannot be downloaded because no base URL is provided.",
+            ctx.exception.args[0],
+        )
 
         self.assertEqual(0, ensure_dir.call_count)
         self.assertEqual(0, download.call_count)
@@ -436,27 +487,35 @@ class TrackPreparationTests(TestCase):
         # uncompressed file does not exist
         is_file.return_value = False
 
-        download.side_effect = urllib.error.HTTPError("http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/unit-test/docs-1k.json",
-                                                      404, "", None, None)
+        download.side_effect = urllib.error.HTTPError(
+            "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/unit-test/docs-1k.json", 404, "", None, None
+        )
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=True),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=True), decompressor=loader.Decompressor()
+        )
 
         with self.assertRaises(exceptions.DataError) as ctx:
-            p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
-                                                                document_file="docs-1k.json",
-                                                                number_of_documents=5,
-                                                                uncompressed_size_in_bytes=None),
-                                   data_root="/tmp")
+            p.prepare_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
+                    document_file="docs-1k.json",
+                    number_of_documents=5,
+                    uncompressed_size_in_bytes=None,
+                ),
+                data_root="/tmp",
+            )
 
-        self.assertEqual("This track does not support test mode. Ask the track author to add it or disable "
-                         "test mode and retry.", ctx.exception.args[0])
+        self.assertEqual(
+            "This track does not support test mode. Ask the track author to add it or disable test mode and retry.",
+            ctx.exception.args[0],
+        )
 
         ensure_dir.assert_called_with("/tmp")
-        download.assert_called_with("http://benchmarks.elasticsearch.org/corpora/unit-test/docs-1k.json",
-                                    "/tmp/docs-1k.json", None, progress_indicator=mock.ANY)
+        download.assert_called_with(
+            "http://benchmarks.elasticsearch.org/corpora/unit-test/docs-1k.json", "/tmp/docs-1k.json", None, progress_indicator=mock.ANY
+        )
 
     @mock.patch("esrally.utils.net.download")
     @mock.patch("esrally.utils.io.ensure_dir")
@@ -465,27 +524,36 @@ class TrackPreparationTests(TestCase):
         # uncompressed file does not exist
         is_file.return_value = False
 
-        download.side_effect = urllib.error.HTTPError("http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json",
-                                                      500, "Internal Server Error", None, None)
+        download.side_effect = urllib.error.HTTPError(
+            "http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json", 500, "Internal Server Error", None, None
+        )
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
         with self.assertRaises(exceptions.DataError) as ctx:
-            p.prepare_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
-                                                                document_file="docs.json",
-                                                                number_of_documents=5,
-                                                                uncompressed_size_in_bytes=2000),
-                                   data_root="/tmp")
+            p.prepare_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    base_url="http://benchmarks.elasticsearch.org/corpora/unit-test",
+                    document_file="docs.json",
+                    number_of_documents=5,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root="/tmp",
+            )
 
-        self.assertEqual("Could not download [http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json] "
-                         "to [/tmp/docs.json] (HTTP status: 500, reason: Internal Server Error)", ctx.exception.args[0])
+        self.assertEqual(
+            "Could not download [http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json] "
+            "to [/tmp/docs.json] (HTTP status: 500, reason: Internal Server Error)",
+            ctx.exception.args[0],
+        )
 
         ensure_dir.assert_called_with("/tmp")
-        download.assert_called_with("http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json",
-                                    "/tmp/docs.json", 2000, progress_indicator=mock.ANY)
+        download.assert_called_with(
+            "http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json", "/tmp/docs.json", 2000, progress_indicator=mock.ANY
+        )
 
     @mock.patch("esrally.utils.io.prepare_file_offset_table")
     @mock.patch("esrally.utils.io.decompress")
@@ -497,17 +565,23 @@ class TrackPreparationTests(TestCase):
         get_size.side_effect = [2000]
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
-        self.assertTrue(p.prepare_bundled_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                                    document_file="docs.json",
-                                                                                    document_archive="docs.json.bz2",
-                                                                                    number_of_documents=5,
-                                                                                    compressed_size_in_bytes=200,
-                                                                                    uncompressed_size_in_bytes=2000),
-                                                       data_root="."))
+        self.assertTrue(
+            p.prepare_bundled_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    document_file="docs.json",
+                    document_archive="docs.json.bz2",
+                    number_of_documents=5,
+                    compressed_size_in_bytes=200,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root=".",
+            )
+        )
 
         prepare_file_offset_table.assert_called_with("./docs.json")
 
@@ -519,17 +593,23 @@ class TrackPreparationTests(TestCase):
         # no files present
         is_file.return_value = False
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
-        self.assertFalse(p.prepare_bundled_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                                     document_file="docs.json",
-                                                                                     document_archive="docs.json.bz2",
-                                                                                     number_of_documents=5,
-                                                                                     compressed_size_in_bytes=200,
-                                                                                     uncompressed_size_in_bytes=2000),
-                                                        data_root="."))
+        self.assertFalse(
+            p.prepare_bundled_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    document_file="docs.json",
+                    document_archive="docs.json.bz2",
+                    number_of_documents=5,
+                    compressed_size_in_bytes=200,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root=".",
+            )
+        )
 
         self.assertEqual(0, decompress.call_count)
         self.assertEqual(0, prepare_file_offset_table.call_count)
@@ -552,23 +632,23 @@ class TrackPreparationTests(TestCase):
                             "source-file": "documents-181998.unparsed.json.bz2",
                             "document-count": 2708746,
                             "compressed-bytes": 13064317,
-                            "uncompressed-bytes": 303920342
+                            "uncompressed-bytes": 303920342,
                         },
                         {
                             "target-index": "logs-191998",
                             "source-file": "documents-191998.unparsed.json.bz2",
                             "document-count": 9697882,
                             "compressed-bytes": 47211781,
-                            "uncompressed-bytes": 1088378738
+                            "uncompressed-bytes": 1088378738,
                         },
                         {
                             "target-index": "logs-201998",
                             "source-file": "documents-201998.unparsed.json.bz2",
                             "document-count": 13053463,
                             "compressed-bytes": 63174979,
-                            "uncompressed-bytes": 1456836090
-                        }
-                    ]
+                            "uncompressed-bytes": 1456836090,
+                        },
+                    ],
                 },
                 {
                     "name": "http_logs",
@@ -579,24 +659,24 @@ class TrackPreparationTests(TestCase):
                             "source-file": "documents-181998.json.bz2",
                             "document-count": 2708746,
                             "compressed-bytes": 13815456,
-                            "uncompressed-bytes": 363512754
+                            "uncompressed-bytes": 363512754,
                         },
                         {
                             "target-index": "logs-191998",
                             "source-file": "documents-191998.json.bz2",
                             "document-count": 9697882,
                             "compressed-bytes": 49439633,
-                            "uncompressed-bytes": 1301732149
+                            "uncompressed-bytes": 1301732149,
                         },
                         {
                             "target-index": "logs-201998",
                             "source-file": "documents-201998.json.bz2",
                             "document-count": 13053463,
                             "compressed-bytes": 65623436,
-                            "uncompressed-bytes": 1744012279
-                        }
-                    ]
-                }
+                            "uncompressed-bytes": 1744012279,
+                        },
+                    ],
+                },
             ],
             "operations": [
                 {
@@ -604,26 +684,23 @@ class TrackPreparationTests(TestCase):
                     "operation-type": "bulk",
                     "corpora": ["http_logs"],
                     "indices": ["logs-181998"],
-                    "bulk-size": 500
+                    "bulk-size": 500,
                 },
                 {
                     "name": "bulk-index-2",
                     "operation-type": "bulk",
                     "corpora": ["http_logs"],
                     "indices": ["logs-191998"],
-                    "bulk-size": 500
+                    "bulk-size": 500,
                 },
                 {
                     "name": "bulk-index-3",
                     "operation-type": "bulk",
                     "corpora": ["http_logs_unparsed"],
                     "indices": ["logs-201998"],
-                    "bulk-size": 500
+                    "bulk-size": 500,
                 },
-                {
-                    "name": "node-stats",
-                    "operation-type": "node-stats"
-                },
+                {"name": "node-stats", "operation-type": "node-stats"},
             ],
             "challenges": [
                 {
@@ -647,12 +724,10 @@ class TrackPreparationTests(TestCase):
                                 ]
                             }
                         },
-                        {
-                            "operation": "node-stats"
-                        }
-                    ]
+                        {"operation": "node-stats"},
+                    ],
                 }
-            ]
+            ],
         }
         reader = loader.TrackSpecificationReader(selected_challenge="default-challenge")
         full_track = reader("unittest", track_specification, "/mappings")
@@ -660,8 +735,9 @@ class TrackPreparationTests(TestCase):
         self.assertEqual(2, len(used_corpora))
         self.assertEqual("http_logs", used_corpora[0].name)
         # each bulk operation requires a different data file but they should have been merged properly.
-        self.assertEqual({"documents-181998.json.bz2", "documents-191998.json.bz2"},
-                         {d.document_archive for d in used_corpora[0].documents})
+        self.assertEqual(
+            {"documents-181998.json.bz2", "documents-191998.json.bz2"}, {d.document_archive for d in used_corpora[0].documents}
+        )
 
         self.assertEqual("http_logs_unparsed", used_corpora[1].name)
         self.assertEqual({"documents-201998.unparsed.json.bz2"}, {d.document_archive for d in used_corpora[1].documents})
@@ -682,17 +758,23 @@ class TrackPreparationTests(TestCase):
         get_size.side_effect = [200, 2000, 2000]
         prepare_file_offset_table.return_value = 5
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
-        self.assertTrue(p.prepare_bundled_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                                    document_file="docs.json",
-                                                                                    document_archive="docs.json.bz2",
-                                                                                    number_of_documents=5,
-                                                                                    compressed_size_in_bytes=200,
-                                                                                    uncompressed_size_in_bytes=2000),
-                                                       data_root="."))
+        self.assertTrue(
+            p.prepare_bundled_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    document_file="docs.json",
+                    document_archive="docs.json.bz2",
+                    number_of_documents=5,
+                    compressed_size_in_bytes=200,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root=".",
+            )
+        )
 
         prepare_file_offset_table.assert_called_with("./docs.json")
 
@@ -705,21 +787,24 @@ class TrackPreparationTests(TestCase):
         # compressed has wrong size
         get_size.side_effect = [150]
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
         with self.assertRaises(exceptions.DataError) as ctx:
-            p.prepare_bundled_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                        document_file="docs.json",
-                                                                        document_archive="docs.json.bz2",
-                                                                        number_of_documents=5,
-                                                                        compressed_size_in_bytes=200,
-                                                                        uncompressed_size_in_bytes=2000),
-                                           data_root=".")
+            p.prepare_bundled_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    document_file="docs.json",
+                    document_archive="docs.json.bz2",
+                    number_of_documents=5,
+                    compressed_size_in_bytes=200,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root=".",
+            )
 
-        self.assertEqual("[./docs.json.bz2] is present but does not have the expected size of [200] bytes.",
-                         ctx.exception.args[0])
+        self.assertEqual("[./docs.json.bz2] is present but does not have the expected size of [200] bytes.", ctx.exception.args[0])
 
     @mock.patch("esrally.utils.io.prepare_file_offset_table")
     @mock.patch("esrally.utils.io.decompress")
@@ -731,20 +816,23 @@ class TrackPreparationTests(TestCase):
         # uncompressed
         get_size.side_effect = [1500]
 
-        p = loader.DocumentSetPreparator(track_name="unit-test",
-                                         downloader=loader.Downloader(offline=False, test_mode=False),
-                                         decompressor=loader.Decompressor())
+        p = loader.DocumentSetPreparator(
+            track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
+        )
 
         with self.assertRaises(exceptions.DataError) as ctx:
-            p.prepare_bundled_document_set(document_set=track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                                        document_file="docs.json",
-                                                                        document_archive="docs.json.bz2",
-                                                                        number_of_documents=5,
-                                                                        compressed_size_in_bytes=200,
-                                                                        uncompressed_size_in_bytes=2000),
-                                           data_root=".")
-        self.assertEqual("[./docs.json] is present but does not have the expected size of [2000] bytes.",
-                         ctx.exception.args[0])
+            p.prepare_bundled_document_set(
+                document_set=track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    document_file="docs.json",
+                    document_archive="docs.json.bz2",
+                    number_of_documents=5,
+                    compressed_size_in_bytes=200,
+                    uncompressed_size_in_bytes=2000,
+                ),
+                data_root=".",
+            )
+        self.assertEqual("[./docs.json] is present but does not have the expected size of [2000] bytes.", ctx.exception.args[0])
 
         self.assertEqual(0, prepare_file_offset_table.call_count)
 
@@ -753,7 +841,8 @@ class TemplateSource(TestCase):
     @mock.patch("esrally.utils.io.dirname")
     @mock.patch.object(loader.TemplateSource, "read_glob_files")
     def test_entrypoint_of_replace_includes(self, patched_read_glob, patched_dirname):
-        track = textwrap.dedent("""
+        track = textwrap.dedent(
+            """
         {% import "rally.helpers" as rally with context %}
         {
           "version": 2,
@@ -786,10 +875,11 @@ class TemplateSource(TestCase):
             {{ rally.collect(parts="challenges/*.json") }}
           ]
         }
-        """)
+        """
+        )
 
         def dummy_read_glob(c):
-            return "{{\"replaced {}\": \"true\"}}".format(c)
+            return '{{"replaced {}": "true"}}'.format(c)
 
         patched_read_glob.side_effect = dummy_read_glob
 
@@ -797,7 +887,8 @@ class TemplateSource(TestCase):
         template_file_name = "track.json"
         tmpl_src = loader.TemplateSource(base_path, template_file_name)
         # pylint: disable=trailing-whitespace
-        expected_response = textwrap.dedent("""                                
+        expected_response = textwrap.dedent(
+            """                                
             {% import "rally.helpers" as rally with context %}
             {
               "version": 2,
@@ -830,12 +921,10 @@ class TemplateSource(TestCase):
                 {"replaced ~/.rally/benchmarks/tracks/default/geonames/challenges/*.json": "true"}
               ]
             }
-            """)
-
-        self.assertEqual(
-            expected_response,
-            tmpl_src.replace_includes(base_path, track)
+            """
         )
+
+        self.assertEqual(expected_response, tmpl_src.replace_includes(base_path, track))
 
     def test_read_glob_files(self):
         tmpl_obj = loader.TemplateSource(
@@ -843,8 +932,8 @@ class TemplateSource(TestCase):
             template_file_name="track.json",
             fileglobber=lambda pat: [
                 os.path.join(os.path.dirname(__file__), "resources", "track_fragment_1.json"),
-                os.path.join(os.path.dirname(__file__), "resources", "track_fragment_2.json")
-            ]
+                os.path.join(os.path.dirname(__file__), "resources", "track_fragment_2.json"),
+            ],
         )
         response = tmpl_obj.read_glob_files("*track_fragment_*.json")
         expected_response = '{\n  "item1": "value1"\n}\n,\n{\n  "item2": "value2"\n}\n'
@@ -881,8 +970,9 @@ class TemplateRenderTests(TestCase):
         }
         """
 
-        rendered = loader.render_template(template, template_vars={"greeting": "Hi"},
-                                          template_internal_vars=TemplateRenderTests.unittest_template_internal_vars)
+        rendered = loader.render_template(
+            template, template_vars={"greeting": "Hi"}, template_internal_vars=TemplateRenderTests.unittest_template_internal_vars
+        )
 
         expected = """
         {
@@ -912,24 +1002,20 @@ class TemplateRenderTests(TestCase):
         }
         """
 
-        source = io.DictStringFileSourceFactory({
-            "dynamic-key-1": [
-                textwrap.dedent('"dkey1": "value1"')
-            ],
-            "dynamic-key-2": [
-                textwrap.dedent('"dkey2": "value2"')
-            ],
-            "dynamic-key-3": [
-                textwrap.dedent('"dkey3": "value3"')
-            ]
-        })
+        source = io.DictStringFileSourceFactory(
+            {
+                "dynamic-key-1": [textwrap.dedent('"dkey1": "value1"')],
+                "dynamic-key-2": [textwrap.dedent('"dkey2": "value2"')],
+                "dynamic-key-3": [textwrap.dedent('"dkey3": "value3"')],
+            }
+        )
 
         template_source = loader.TemplateSource("", "track.json", source=source, fileglobber=key_globber)
         template_source.load_template_from_string(template)
 
         rendered = loader.render_template(
-            template_source.assembled_source,
-            template_internal_vars=TemplateRenderTests.unittest_template_internal_vars)
+            template_source.assembled_source, template_internal_vars=TemplateRenderTests.unittest_template_internal_vars
+        )
 
         expected = """
         {
@@ -954,9 +1040,8 @@ class TemplateRenderTests(TestCase):
         }
         """
         rendered = loader.render_template(
-            template,
-            template_vars={"clients": 8},
-            template_internal_vars=TemplateRenderTests.unittest_template_internal_vars)
+            template, template_vars={"clients": 8}, template_internal_vars=TemplateRenderTests.unittest_template_internal_vars
+        )
 
         expected = """
         {
@@ -972,72 +1057,63 @@ class TemplateRenderTests(TestCase):
 
 
 class CompleteTrackParamsTests(TestCase):
-    assembled_source = textwrap.dedent("""{% import "rally.helpers" as rally with context %}
+    assembled_source = textwrap.dedent(
+        """{% import "rally.helpers" as rally with context %}
         "key1": "value1",
         "key2": {{ value2 | default(3) }},
         "key3": {{ value3 | default("default_value3") }}
         "key4": {{ value2 | default(3) }}
-    """)
+    """
+    )
 
     def test_check_complete_track_params_contains_all_track_params(self):
         complete_track_params = loader.CompleteTrackParams()
         loader.register_all_params_in_track(CompleteTrackParamsTests.assembled_source, complete_track_params)
 
-        self.assertEqual(
-            ["value2", "value3"],
-            complete_track_params.sorted_track_defined_params
-        )
+        self.assertEqual(["value2", "value3"], complete_track_params.sorted_track_defined_params)
 
     def test_check_complete_track_params_does_not_fail_with_no_track_params(self):
         complete_track_params = loader.CompleteTrackParams()
-        loader.register_all_params_in_track('{}', complete_track_params)
+        loader.register_all_params_in_track("{}", complete_track_params)
 
-        self.assertEqual(
-            [],
-            complete_track_params.sorted_track_defined_params
-        )
+        self.assertEqual([], complete_track_params.sorted_track_defined_params)
 
     def test_unused_user_defined_track_params(self):
-        track_params = {
-            "number_of_repliacs": 1,  # deliberate typo
-            "enable_source": True,  # unknown parameter
-            "number_of_shards": 5
-        }
+        track_params = {"number_of_repliacs": 1, "enable_source": True, "number_of_shards": 5}  # deliberate typo  # unknown parameter
 
         complete_track_params = loader.CompleteTrackParams(user_specified_track_params=track_params)
-        complete_track_params.populate_track_defined_params(list_of_track_params=[
-            "bulk_indexing_clients",
-            "bulk_indexing_iterations",
-            "bulk_size",
-            "cluster_health",
-            "number_of_replicas",
-            "number_of_shards"]
+        complete_track_params.populate_track_defined_params(
+            list_of_track_params=[
+                "bulk_indexing_clients",
+                "bulk_indexing_iterations",
+                "bulk_size",
+                "cluster_health",
+                "number_of_replicas",
+                "number_of_shards",
+            ]
         )
 
-        self.assertEqual(
-            ["enable_source", "number_of_repliacs"],
-            sorted(complete_track_params.unused_user_defined_track_params())
-        )
+        self.assertEqual(["enable_source", "number_of_repliacs"], sorted(complete_track_params.unused_user_defined_track_params()))
 
     def test_unused_user_defined_track_params_doesnt_fail_with_detaults(self):
         complete_track_params = loader.CompleteTrackParams()
-        complete_track_params.populate_track_defined_params(list_of_track_params=[
-            "bulk_indexing_clients",
-            "bulk_indexing_iterations",
-            "bulk_size",
-            "cluster_health",
-            "number_of_replicas",
-            "number_of_shards"]
+        complete_track_params.populate_track_defined_params(
+            list_of_track_params=[
+                "bulk_indexing_clients",
+                "bulk_indexing_iterations",
+                "bulk_size",
+                "cluster_health",
+                "number_of_replicas",
+                "number_of_shards",
+            ]
         )
 
-        self.assertEqual(
-            [],
-            sorted(complete_track_params.unused_user_defined_track_params())
-        )
+        self.assertEqual([], sorted(complete_track_params.unused_user_defined_track_params()))
 
 
 class TrackPostProcessingTests(TestCase):
-    track_with_params_as_string = textwrap.dedent("""{
+    track_with_params_as_string = textwrap.dedent(
+        """{
         "indices": [
             {
                 "name": "test-index",
@@ -1111,7 +1187,8 @@ class TrackPostProcessingTests(TestCase):
                 ]
             }
         ]
-    }""")
+    }"""
+    )
 
     def test_post_processes_track_spec(self):
         track_specification = {
@@ -1119,8 +1196,10 @@ class TrackPostProcessingTests(TestCase):
                 {
                     "name": "test-index",
                     "body": "test-index-body.json",
-                    "types": ["test-type"]
-                }
+                    "types": [
+                        "test-type",
+                    ],
+                },
             ],
             "corpora": [
                 {
@@ -1130,21 +1209,21 @@ class TrackPostProcessingTests(TestCase):
                             "source-file": "documents.json.bz2",
                             "document-count": 10,
                             "compressed-bytes": 100,
-                            "uncompressed-bytes": 10000
+                            "uncompressed-bytes": 10000,
                         }
-                    ]
+                    ],
                 }
             ],
             "operations": [
                 {
                     "name": "index-append",
                     "operation-type": "bulk",
-                    "bulk-size": 5000
+                    "bulk-size": 5000,
                 },
                 {
                     "name": "search",
-                    "operation-type": "search"
-                }
+                    "operation-type": "search",
+                },
             ],
             "challenges": [
                 {
@@ -1166,7 +1245,7 @@ class TrackPostProcessingTests(TestCase):
                                         "operation": "search",
                                         "warmup-iterations": 1000,
                                         "iterations": 2000,
-                                        "target-interval": 30
+                                        "target-interval": 30,
                                     },
                                     {
                                         "name": "search #2",
@@ -1174,20 +1253,20 @@ class TrackPostProcessingTests(TestCase):
                                         "operation": "search",
                                         "warmup-iterations": 1000,
                                         "iterations": 2000,
-                                        "target-throughput": 200
+                                        "target-throughput": 200,
                                     },
                                     {
                                         "name": "search #3",
                                         "clients": 1,
                                         "operation": "search",
-                                        "iterations": 1
-                                    }
+                                        "iterations": 1,
+                                    },
                                 ]
                             }
-                        }
-                    ]
+                        },
+                    ],
                 }
-            ]
+            ],
         }
 
         expected_post_processed = {
@@ -1195,30 +1274,27 @@ class TrackPostProcessingTests(TestCase):
                 {
                     "name": "test-index",
                     "body": "test-index-body.json",
-                    "types": ["test-type"]
-                }
+                    "types": ["test-type"],
+                },
             ],
             "corpora": [
                 {
                     "name": "unittest",
                     "documents": [
-                        {
-                            "source-file": "documents-1k.json.bz2",
-                            "document-count": 1000
-                        }
-                    ]
-                }
+                        {"source-file": "documents-1k.json.bz2", "document-count": 1000},
+                    ],
+                },
             ],
             "operations": [
                 {
                     "name": "index-append",
                     "operation-type": "bulk",
-                    "bulk-size": 5000
+                    "bulk-size": 5000,
                 },
                 {
                     "name": "search",
-                    "operation-type": "search"
-                }
+                    "operation-type": "search",
+                },
             ],
             "challenges": [
                 {
@@ -1239,55 +1315,60 @@ class TrackPostProcessingTests(TestCase):
                                         "clients": 4,
                                         "operation": "search",
                                         "warmup-iterations": 4,
-                                        "iterations": 4
+                                        "iterations": 4,
                                     },
                                     {
                                         "name": "search #2",
                                         "clients": 1,
                                         "operation": "search",
                                         "warmup-iterations": 1,
-                                        "iterations": 1
+                                        "iterations": 1,
                                     },
                                     {
                                         "name": "search #3",
                                         "clients": 1,
                                         "operation": "search",
-                                        "iterations": 1
-                                    }
+                                        "iterations": 1,
+                                    },
                                 ]
                             }
-                        }
-                    ]
+                        },
+                    ],
                 }
-            ]
+            ],
         }
 
         complete_track_params = loader.CompleteTrackParams()
-        index_body = '{"settings": {"index.number_of_shards": {{ number_of_shards | default(5) }}, '\
-                     '"index.number_of_replicas": {{ number_of_replicas | default(0)}} }}'
+        index_body = (
+            '{"settings": {"index.number_of_shards": {{ number_of_shards | default(5) }}, '
+            '"index.number_of_replicas": {{ number_of_replicas | default(0)}} }}'
+        )
 
         cfg = config.Config()
         cfg.add(config.Scope.application, "track", "test.mode.enabled", True)
 
         self.assertEqual(
-            self.as_track(expected_post_processed, complete_track_params=complete_track_params, index_body=index_body),
+            self.as_track(
+                expected_post_processed,
+                complete_track_params=complete_track_params,
+                index_body=index_body,
+            ),
             loader.TestModeTrackProcessor(cfg).on_after_load_track(
-                self.as_track(track_specification, complete_track_params=complete_track_params, index_body=index_body)
-            )
+                self.as_track(
+                    track_specification,
+                    complete_track_params=complete_track_params,
+                    index_body=index_body,
+                )
+            ),
         )
 
-        self.assertEqual(
-            ["number_of_replicas", "number_of_shards"],
-            complete_track_params.sorted_track_defined_params
-        )
+        self.assertEqual(["number_of_replicas", "number_of_shards"], complete_track_params.sorted_track_defined_params)
 
     def as_track(self, track_specification, track_params=None, complete_track_params=None, index_body=None):
         reader = loader.TrackSpecificationReader(
             track_params=track_params,
             complete_track_params=complete_track_params,
-            source=io.DictStringFileSourceFactory({
-                "/mappings/test-index-body.json": [index_body]
-            })
+            source=io.DictStringFileSourceFactory({"/mappings/test-index-body.json": [index_body]}),
         )
         return reader("unittest", track_specification, "/mappings")
 
@@ -1300,19 +1381,29 @@ class TrackPathTests(TestCase):
         cfg = config.Config()
         cfg.add(config.Scope.application, "benchmarks", "local.dataset.cache", "/data")
 
-        default_challenge = track.Challenge("default", default=True, schedule=[
-            track.Task(name="index", operation=track.Operation("index", operation_type=track.OperationType.Bulk), clients=4)
-        ])
+        default_challenge = track.Challenge(
+            "default",
+            default=True,
+            schedule=[track.Task(name="index", operation=track.Operation("index", operation_type=track.OperationType.Bulk), clients=4)],
+        )
         another_challenge = track.Challenge("other", default=False)
-        t = track.Track(name="u", challenges=[another_challenge, default_challenge],
-                        corpora=[
-                            track.DocumentCorpus("unittest", documents=[
-                                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                                document_file="docs/documents.json",
-                                                document_archive="docs/documents.json.bz2")
-                            ])
-                        ],
-                        indices=[track.Index(name="test", types=["docs"])])
+        t = track.Track(
+            name="u",
+            challenges=[another_challenge, default_challenge],
+            corpora=[
+                track.DocumentCorpus(
+                    "unittest",
+                    documents=[
+                        track.Documents(
+                            source_format=track.Documents.SOURCE_FORMAT_BULK,
+                            document_file="docs/documents.json",
+                            document_archive="docs/documents.json.bz2",
+                        )
+                    ],
+                )
+            ],
+            indices=[track.Index(name="test", types=["docs"])],
+        )
 
         loader.set_absolute_data_path(cfg, t)
 
@@ -1337,8 +1428,7 @@ class TrackFilterTests(TestCase):
     def test_rejects_unknown_filter_type(self):
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             self.filter(track_specification=None, include_tasks=["valid", "op-type:index"])
-        self.assertEqual("Invalid format for filtered tasks: [op-type:index]. Expected [type] but got [op-type].",
-                         ctx.exception.args[0])
+        self.assertEqual("Invalid format for filtered tasks: [op-type:index]. Expected [type] but got [op-type].", ctx.exception.args[0])
 
     def test_filters_tasks(self):
         track_specification = {
@@ -1347,28 +1437,28 @@ class TrackFilterTests(TestCase):
             "operations": [
                 {
                     "name": "create-index",
-                    "operation-type": "create-index"
+                    "operation-type": "create-index",
                 },
                 {
                     "name": "bulk-index",
-                    "operation-type": "bulk"
+                    "operation-type": "bulk",
                 },
                 {
                     "name": "node-stats",
-                    "operation-type": "node-stats"
+                    "operation-type": "node-stats",
                 },
                 {
                     "name": "cluster-stats",
-                    "operation-type": "custom-operation-type"
+                    "operation-type": "custom-operation-type",
                 },
                 {
                     "name": "match-all",
                     "operation-type": "search",
                     "body": {
                         "query": {
-                            "match_all": {}
-                        }
-                    }
+                            "match_all": {},
+                        },
+                    },
                 },
             ],
             "challenges": [
@@ -1376,7 +1466,7 @@ class TrackFilterTests(TestCase):
                     "name": "default-challenge",
                     "schedule": [
                         {
-                            "operation": "create-index"
+                            "operation": "create-index",
                         },
                         {
                             "parallel": {
@@ -1401,14 +1491,14 @@ class TrackFilterTests(TestCase):
                             }
                         },
                         {
-                            "operation": "node-stats"
+                            "operation": "node-stats",
                         },
                         {
                             "name": "match-all-serial",
-                            "operation": "match-all"
+                            "operation": "match-all",
                         },
                         {
-                            "operation": "cluster-stats"
+                            "operation": "cluster-stats",
                         },
                         {
                             "parallel": {
@@ -1426,28 +1516,33 @@ class TrackFilterTests(TestCase):
                                     {
                                         "name": "index-5",
                                         "operation": "bulk-index",
-                                    }
+                                    },
                                 ]
                             }
                         },
                         {
                             "name": "final-cluster-stats",
                             "operation": "cluster-stats",
-                            "tags": "include-me"
-                        }
-                    ]
+                            "tags": "include-me",
+                        },
+                    ],
                 }
-            ]
+            ],
         }
         reader = loader.TrackSpecificationReader()
         full_track = reader("unittest", track_specification, "/mappings")
         self.assertEqual(7, len(full_track.challenges[0].schedule))
 
-        filtered = self.filter(full_track, include_tasks=["index-3",
-                                                          "type:search",
-                                                          # Filtering should also work for non-core operation types.
-                                                          "type:custom-operation-type",
-                                                          "tag:include-me"])
+        filtered = self.filter(
+            full_track,
+            include_tasks=[
+                "index-3",
+                "type:search",
+                # Filtering should also work for non-core operation types.
+                "type:custom-operation-type",
+                "tag:include-me",
+            ],
+        )
 
         schedule = filtered.challenges[0].schedule
         self.assertEqual(5, len(schedule))
@@ -1460,32 +1555,37 @@ class TrackFilterTests(TestCase):
     def test_filters_exclude_tasks(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index", "auto-managed": False}],
+            "indices": [
+                {
+                    "name": "test-index",
+                    "auto-managed": False,
+                },
+            ],
             "operations": [
                 {
                     "name": "create-index",
-                    "operation-type": "create-index"
+                    "operation-type": "create-index",
                 },
                 {
                     "name": "bulk-index",
-                    "operation-type": "bulk"
+                    "operation-type": "bulk",
                 },
                 {
                     "name": "node-stats",
-                    "operation-type": "node-stats"
+                    "operation-type": "node-stats",
                 },
                 {
                     "name": "cluster-stats",
-                    "operation-type": "custom-operation-type"
+                    "operation-type": "custom-operation-type",
                 },
                 {
                     "name": "match-all",
                     "operation-type": "search",
                     "body": {
                         "query": {
-                            "match_all": {}
-                        }
-                    }
+                            "match_all": {},
+                        },
+                    },
                 },
             ],
             "challenges": [
@@ -1493,7 +1593,7 @@ class TrackFilterTests(TestCase):
                     "name": "default-challenge",
                     "schedule": [
                         {
-                            "operation": "create-index"
+                            "operation": "create-index",
                         },
                         {
                             "parallel": {
@@ -1518,18 +1618,18 @@ class TrackFilterTests(TestCase):
                             }
                         },
                         {
-                            "operation": "node-stats"
+                            "operation": "node-stats",
                         },
                         {
                             "name": "match-all-serial",
-                            "operation": "match-all"
+                            "operation": "match-all",
                         },
                         {
-                            "operation": "cluster-stats"
-                        }
-                    ]
+                            "operation": "cluster-stats",
+                        },
+                    ],
                 }
-            ]
+            ],
         }
         reader = loader.TrackSpecificationReader()
         full_track = reader("unittest", track_specification, "/mappings")
@@ -1546,32 +1646,37 @@ class TrackFilterTests(TestCase):
     def test_unmatched_exclude_runs_everything(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index", "auto-managed": False}],
+            "indices": [
+                {
+                    "name": "test-index",
+                    "auto-managed": False,
+                },
+            ],
             "operations": [
                 {
                     "name": "create-index",
-                    "operation-type": "create-index"
+                    "operation-type": "create-index",
                 },
                 {
                     "name": "bulk-index",
-                    "operation-type": "bulk"
+                    "operation-type": "bulk",
                 },
                 {
                     "name": "node-stats",
-                    "operation-type": "node-stats"
+                    "operation-type": "node-stats",
                 },
                 {
                     "name": "cluster-stats",
-                    "operation-type": "custom-operation-type"
+                    "operation-type": "custom-operation-type",
                 },
                 {
                     "name": "match-all",
                     "operation-type": "search",
                     "body": {
                         "query": {
-                            "match_all": {}
-                        }
-                    }
+                            "match_all": {},
+                        },
+                    },
                 },
             ],
             "challenges": [
@@ -1579,24 +1684,24 @@ class TrackFilterTests(TestCase):
                     "name": "default-challenge",
                     "schedule": [
                         {
-                            "operation": "create-index"
+                            "operation": "create-index",
                         },
                         {
-                            "operation": "bulk-index"
+                            "operation": "bulk-index",
                         },
                         {
-                            "operation": "node-stats"
+                            "operation": "node-stats",
                         },
                         {
                             "name": "match-all-serial",
-                            "operation": "match-all"
+                            "operation": "match-all",
                         },
                         {
-                            "operation": "cluster-stats"
-                        }
-                    ]
+                            "operation": "cluster-stats",
+                        },
+                    ],
                 }
-            ]
+            ],
         }
 
         reader = loader.TrackSpecificationReader()
@@ -1612,32 +1717,37 @@ class TrackFilterTests(TestCase):
     def test_unmatched_include_runs_nothing(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index", "auto-managed": False}],
+            "indices": [
+                {
+                    "name": "test-index",
+                    "auto-managed": False,
+                },
+            ],
             "operations": [
                 {
                     "name": "create-index",
-                    "operation-type": "create-index"
+                    "operation-type": "create-index",
                 },
                 {
                     "name": "bulk-index",
-                    "operation-type": "bulk"
+                    "operation-type": "bulk",
                 },
                 {
                     "name": "node-stats",
-                    "operation-type": "node-stats"
+                    "operation-type": "node-stats",
                 },
                 {
                     "name": "cluster-stats",
-                    "operation-type": "custom-operation-type"
+                    "operation-type": "custom-operation-type",
                 },
                 {
                     "name": "match-all",
                     "operation-type": "search",
                     "body": {
                         "query": {
-                            "match_all": {}
-                        }
-                    }
+                            "match_all": {},
+                        },
+                    },
                 },
             ],
             "challenges": [
@@ -1645,24 +1755,24 @@ class TrackFilterTests(TestCase):
                     "name": "default-challenge",
                     "schedule": [
                         {
-                            "operation": "create-index"
+                            "operation": "create-index",
                         },
                         {
-                            "operation": "bulk-index"
+                            "operation": "bulk-index",
                         },
                         {
-                            "operation": "node-stats"
+                            "operation": "node-stats",
                         },
                         {
                             "name": "match-all-serial",
-                            "operation": "match-all"
+                            "operation": "match-all",
                         },
                         {
-                            "operation": "cluster-stats"
-                        }
-                    ]
+                            "operation": "cluster-stats",
+                        },
+                    ],
                 }
-            ]
+            ],
         }
 
         reader = loader.TrackSpecificationReader()
@@ -1692,11 +1802,16 @@ class TrackSpecificationReaderTests(TestCase):
     def test_can_read_track_info(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index", "types": ["test-type"]}],
+            "indices": [
+                {
+                    "name": "test-index",
+                    "types": ["test-type"],
+                },
+            ],
             "data-streams": [],
             "corpora": [],
             "operations": [],
-            "challenges": []
+            "challenges": [],
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -1706,15 +1821,22 @@ class TrackSpecificationReaderTests(TestCase):
     def test_document_count_mandatory_if_file_present(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index", "types": ["docs"]}],
+            "indices": [
+                {
+                    "name": "test-index",
+                    "types": ["docs"],
+                },
+            ],
             "corpora": [
                 {
                     "name": "test",
                     "base-url": "https://localhost/data",
-                    "documents": [{"source-file": "documents-main.json.bz2"}]
-                }
+                    "documents": [
+                        {"source-file": "documents-main.json.bz2"},
+                    ],
+                },
             ],
-            "challenges": []
+            "challenges": [],
         }
         reader = loader.TrackSpecificationReader()
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
@@ -1728,7 +1850,7 @@ class TrackSpecificationReaderTests(TestCase):
                 {
                     "name": "test-index",
                     "body": "index.json",
-                    "types": ["docs"]
+                    "types": ["docs"],
                 }
             ],
             "corpora": [
@@ -1739,9 +1861,9 @@ class TrackSpecificationReaderTests(TestCase):
                             "source-file": "documents-main.json.bz2",
                             "document-count": 10,
                             "compressed-bytes": 100,
-                            "uncompressed-bytes": 10000
+                            "uncompressed-bytes": 10000,
                         }
-                    ]
+                    ],
                 }
             ],
             "operations": [
@@ -1759,33 +1881,32 @@ class TrackSpecificationReaderTests(TestCase):
                             "clients": 8,
                             "operation": "index-append",
                             "warmup-iterations": 3,
-                            "time-period": 60
-                        }
-                    ]
+                            "time-period": 60,
+                        },
+                    ],
                 }
-
-            ]
+            ],
         }
 
-        reader = loader.TrackSpecificationReader(source=io.DictStringFileSourceFactory({
-            "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
-        }))
+        reader = loader.TrackSpecificationReader(
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
+                }
+            )
+        )
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' defines 3 warmup "
-                         "iterations and a time period of 60 seconds but mixing time periods and iterations is not allowed.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' defines 3 warmup "
+            "iterations and a time period of 60 seconds but mixing time periods and iterations is not allowed.",
+            ctx.exception.args[0],
+        )
 
     def test_parse_with_mixed_iterations_and_ramp_up(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [
-                {
-                    "name": "test-index",
-                    "body": "index.json",
-                    "types": ["docs"]
-                }
-            ],
+            "indices": [{"name": "test-index", "body": "index.json", "types": ["docs"]}],
             "corpora": [
                 {
                     "name": "test",
@@ -1794,9 +1915,9 @@ class TrackSpecificationReaderTests(TestCase):
                             "source-file": "documents-main.json.bz2",
                             "document-count": 10,
                             "compressed-bytes": 100,
-                            "uncompressed-bytes": 10000
+                            "uncompressed-bytes": 10000,
                         }
-                    ]
+                    ],
                 }
             ],
             "operations": [
@@ -1815,23 +1936,28 @@ class TrackSpecificationReaderTests(TestCase):
                             "operation": "index-append",
                             "ramp-up-time-period": 120,
                             "warmup-iterations": 3,
-                            "iterations": 5
+                            "iterations": 5,
                         }
-                    ]
+                    ],
                 }
-
-            ]
+            ],
         }
 
-        reader = loader.TrackSpecificationReader(source=io.DictStringFileSourceFactory({
-            "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
-        }))
+        reader = loader.TrackSpecificationReader(
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
+                }
+            )
+        )
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' "
-                         "defines a ramp-up time period of 120 seconds as well as 3 warmup iterations and 5 iterations "
-                         "but mixing time periods and iterations is not allowed.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' "
+            "defines a ramp-up time period of 120 seconds as well as 3 warmup iterations and 5 iterations "
+            "but mixing time periods and iterations is not allowed.",
+            ctx.exception.args[0],
+        )
 
     def test_parse_missing_challenge_or_challenges(self):
         track_specification = {
@@ -1840,8 +1966,8 @@ class TrackSpecificationReaderTests(TestCase):
                 {
                     "name": "test-index",
                     "body": "index.json",
-                    "types": ["docs"]
-                }
+                    "types": ["docs"],
+                },
             ],
             "corpora": [
                 {
@@ -1851,31 +1977,31 @@ class TrackSpecificationReaderTests(TestCase):
                             "source-file": "documents-main.json.bz2",
                             "document-count": 10,
                             "compressed-bytes": 100,
-                            "uncompressed-bytes": 10000
+                            "uncompressed-bytes": 10000,
                         }
-                    ]
+                    ],
                 }
             ],
             # no challenge or challenges element
         }
-        reader = loader.TrackSpecificationReader(source=io.DictStringFileSourceFactory({
-            "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
-        }))
+        reader = loader.TrackSpecificationReader(
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
+                }
+            )
+        )
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. You must define 'challenge', 'challenges' or 'schedule' but none is specified.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. You must define 'challenge', 'challenges' or 'schedule' but none is specified.",
+            ctx.exception.args[0],
+        )
 
     def test_parse_challenge_and_challenges_are_defined(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [
-                {
-                    "name": "test-index",
-                    "body": "index.json",
-                    "types": ["docs"]
-                }
-            ],
+            "indices": [{"name": "test-index", "body": "index.json", "types": ["docs"]}],
             "corpora": [
                 {
                     "name": "test",
@@ -1884,22 +2010,29 @@ class TrackSpecificationReaderTests(TestCase):
                             "source-file": "documents-main.json.bz2",
                             "document-count": 10,
                             "compressed-bytes": 100,
-                            "uncompressed-bytes": 10000
+                            "uncompressed-bytes": 10000,
                         }
-                    ]
+                    ],
                 }
             ],
             # We define both. Note that challenges without any properties would not pass JSON schema validation but we don't test this here.
             "challenge": {},
-            "challenges": []
+            "challenges": [],
         }
-        reader = loader.TrackSpecificationReader(source=io.DictStringFileSourceFactory({
-            "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
-        }))
+        reader = loader.TrackSpecificationReader(
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
+                }
+            )
+        )
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Multiple out of 'challenge', 'challenges' or 'schedule' are defined but only "
-                         "one of them is allowed.", ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. Multiple out of 'challenge', 'challenges' or 'schedule' are defined but only "
+            "one of them is allowed.",
+            ctx.exception.args[0],
+        )
 
     def test_parse_with_mixed_warmup_time_period_and_iterations(self):
         track_specification = {
@@ -1908,8 +2041,8 @@ class TrackSpecificationReaderTests(TestCase):
                 {
                     "name": "test-index",
                     "body": "index.json",
-                    "types": ["docs"]
-                }
+                    "types": ["docs"],
+                },
             ],
             "corpora": [
                 {
@@ -1919,9 +2052,9 @@ class TrackSpecificationReaderTests(TestCase):
                             "source-file": "documents-main.json.bz2",
                             "document-count": 10,
                             "compressed-bytes": 100,
-                            "uncompressed-bytes": 10000
+                            "uncompressed-bytes": 10000,
                         }
-                    ]
+                    ],
                 }
             ],
             "operations": [
@@ -1939,22 +2072,27 @@ class TrackSpecificationReaderTests(TestCase):
                             "clients": 8,
                             "operation": "index-append",
                             "warmup-time-period": 20,
-                            "iterations": 1000
-                        }
-                    ]
+                            "iterations": 1000,
+                        },
+                    ],
                 }
-
-            ]
+            ],
         }
 
-        reader = loader.TrackSpecificationReader(source=io.DictStringFileSourceFactory({
-            "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
-        }))
+        reader = loader.TrackSpecificationReader(
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/index.json": ['{"mappings": {"docs": "empty-for-test"}}'],
+                }
+            )
+        )
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' defines a warmup time "
-                         "period of 20 seconds and 1000 iterations but mixing time periods and iterations is not allowed.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' defines a warmup time "
+            "period of 20 seconds and 1000 iterations but mixing time periods and iterations is not allowed.",
+            ctx.exception.args[0],
+        )
 
     def test_parse_duplicate_implicit_task_names(self):
         track_specification = {
@@ -1963,29 +2101,31 @@ class TrackSpecificationReaderTests(TestCase):
                 {
                     "name": "search",
                     "operation-type": "search",
-                    "index": "_all"
-                }
+                    "index": "_all",
+                },
             ],
             "challenge": {
                 "name": "default-challenge",
                 "schedule": [
                     {
                         "operation": "search",
-                        "clients": 1
+                        "clients": 1,
                     },
                     {
                         "operation": "search",
-                        "clients": 2
-                    }
-                ]
-            }
+                        "clients": 2,
+                    },
+                ],
+            },
         }
         reader = loader.TrackSpecificationReader()
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Challenge 'default-challenge' contains multiple tasks with the name 'search'. Please"
-                         " use the task's name property to assign a unique name for each task.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. Challenge 'default-challenge' contains multiple tasks with the name 'search'. Please"
+            " use the task's name property to assign a unique name for each task.",
+            ctx.exception.args[0],
+        )
 
     def test_parse_duplicate_explicit_task_names(self):
         track_specification = {
@@ -1994,8 +2134,8 @@ class TrackSpecificationReaderTests(TestCase):
                 {
                     "name": "search",
                     "operation-type": "search",
-                    "index": "_all"
-                }
+                    "index": "_all",
+                },
             ],
             "challenge": {
                 "name": "default-challenge",
@@ -2003,22 +2143,24 @@ class TrackSpecificationReaderTests(TestCase):
                     {
                         "name": "duplicate-task-name",
                         "operation": "search",
-                        "clients": 1
+                        "clients": 1,
                     },
                     {
                         "name": "duplicate-task-name",
                         "operation": "search",
-                        "clients": 2
-                    }
-                ]
-            }
+                        "clients": 2,
+                    },
+                ],
+            },
         }
         reader = loader.TrackSpecificationReader()
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Challenge 'default-challenge' contains multiple tasks with the name "
-                         "'duplicate-task-name'. Please use the task's name property to assign a unique name for each task.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. Challenge 'default-challenge' contains multiple tasks with the name "
+            "'duplicate-task-name'. Please use the task's name property to assign a unique name for each task.",
+            ctx.exception.args[0],
+        )
 
     def test_load_invalid_index_body(self):
         track_specification = {
@@ -2027,8 +2169,8 @@ class TrackSpecificationReaderTests(TestCase):
                 {
                     "name": "index-historical",
                     "body": "body.json",
-                    "types": ["_doc"]
-                }
+                    "types": ["_doc"],
+                },
             ],
             "corpora": [
                 {
@@ -2038,9 +2180,9 @@ class TrackSpecificationReaderTests(TestCase):
                             "source-file": "documents-main.json.bz2",
                             "document-count": 10,
                             "compressed-bytes": 100,
-                            "uncompressed-bytes": 10000
+                            "uncompressed-bytes": 10000,
                         }
-                    ]
+                    ],
                 }
             ],
             "schedule": [
@@ -2049,15 +2191,17 @@ class TrackSpecificationReaderTests(TestCase):
                     "operation": {
                         "name": "index-append",
                         "operation-type": "index",
-                        "bulk-size": 5000
-                    }
-                }
-            ]
+                        "bulk-size": 5000,
+                    },
+                },
+            ],
         }
         reader = loader.TrackSpecificationReader(
             track_params={"number_of_shards": 3},
-            source=io.DictStringFileSourceFactory({
-                "/mappings/body.json": ["""
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/body.json": [
+                        """
             {
                 "settings": {
                     "number_of_shards": {{ number_of_shards }}
@@ -2066,8 +2210,11 @@ class TrackSpecificationReaderTests(TestCase):
                     "_doc": "no closing quotation mark!!,
                 }
             }
-            """]
-            }))
+            """
+                    ]
+                }
+            ),
+        )
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
         self.assertEqual("Could not load file template for 'definition for index index-historical in body.json'", ctx.exception.args[0])
@@ -2079,8 +2226,8 @@ class TrackSpecificationReaderTests(TestCase):
                 {
                     "name": "search",
                     "operation-type": "search",
-                    "index": "_all"
-                }
+                    "index": "_all",
+                },
             ],
             "challenge": {
                 "name": "default-challenge",
@@ -2088,15 +2235,15 @@ class TrackSpecificationReaderTests(TestCase):
                     {
                         "name": "search-one-client",
                         "operation": "search",
-                        "clients": 1
+                        "clients": 1,
                     },
                     {
                         "name": "search-two-clients",
                         "operation": "search",
-                        "clients": 2
-                    }
-                ]
-            }
+                        "clients": 2,
+                    },
+                ],
+            },
         }
         reader = loader.TrackSpecificationReader(selected_challenge="default-challenge")
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -2117,16 +2264,14 @@ class TrackSpecificationReaderTests(TestCase):
                 {
                     "name": "index-historical",
                     "body": "body.json",
-                    "types": ["main", "secondary"]
-                }
+                    "types": ["main", "secondary"],
+                },
             ],
             "corpora": [
                 {
                     "name": "test",
                     "base-url": "https://localhost/data",
-                    "meta": {
-                        "test-corpus": True
-                    },
+                    "meta": {"test-corpus": True},
                     "documents": [
                         {
                             "source-file": "documents-main.json.bz2",
@@ -2135,10 +2280,7 @@ class TrackSpecificationReaderTests(TestCase):
                             "uncompressed-bytes": 10000,
                             "target-index": "index-historical",
                             "target-type": "main",
-                            "meta": {
-                                "test-docs": True,
-                                "role": "main"
-                            }
+                            "meta": {"test-docs": True, "role": "main"},
                         },
                         {
                             "source-file": "documents-secondary.json.bz2",
@@ -2146,13 +2288,9 @@ class TrackSpecificationReaderTests(TestCase):
                             "document-count": 20,
                             "compressed-bytes": 200,
                             "uncompressed-bytes": 20000,
-                            "meta": {
-                                "test-docs": True,
-                                "role": "secondary"
-                            }
-
-                        }
-                    ]
+                            "meta": {"test-docs": True, "role": "secondary"},
+                        },
+                    ],
                 }
             ],
             "operations": [
@@ -2160,46 +2298,41 @@ class TrackSpecificationReaderTests(TestCase):
                     "name": "index-append",
                     "operation-type": "index",
                     "bulk-size": 5000,
-                    "meta": {
-                        "append": True
-                    }
+                    "meta": {"append": True},
                 },
                 {
                     "name": "search",
                     "operation-type": "search",
-                    "index": "index-historical"
-                }
+                    "index": "index-historical",
+                },
             ],
             "challenges": [
                 {
                     "name": "default-challenge",
                     "description": "Default challenge",
-                    "meta": {
-                        "mixed": True,
-                        "max-clients": 8
-                    },
+                    "meta": {"mixed": True, "max-clients": 8},
                     "schedule": [
                         {
                             "clients": 8,
                             "operation": "index-append",
-                            "meta": {
-                                "operation-index": 0
-                            }
+                            "meta": {"operation-index": 0},
                         },
                         {
                             "clients": 1,
-                            "operation": "search"
-                        }
-                    ]
+                            "operation": "search",
+                        },
+                    ],
                 }
-            ]
+            ],
         }
         complete_track_params = loader.CompleteTrackParams()
         reader = loader.TrackSpecificationReader(
             track_params={"number_of_shards": 3},
             complete_track_params=complete_track_params,
-            source=io.DictStringFileSourceFactory({
-                "/mappings/body.json": ["""
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/body.json": [
+                        """
             {
                 "settings": {
                     "number_of_shards": {{ number_of_shards }}
@@ -2209,29 +2342,31 @@ class TrackSpecificationReaderTests(TestCase):
                     "secondary": "empty-for-test"
                 }
             }
-            """]
-            }))
+            """
+                    ]
+                }
+            ),
+        )
         resulting_track = reader("unittest", track_specification, "/mappings")
         # j2 variables defined in the track -- used for checking mismatching user track params
-        self.assertEqual(
-            ["number_of_shards"],
-            complete_track_params.sorted_track_defined_params
-        )
+        self.assertEqual(["number_of_shards"], complete_track_params.sorted_track_defined_params)
         self.assertEqual("unittest", resulting_track.name)
         self.assertEqual("description for unit test", resulting_track.description)
         # indices
         self.assertEqual(1, len(resulting_track.indices))
         self.assertEqual("index-historical", resulting_track.indices[0].name)
-        self.assertDictEqual({
-            "settings": {
-                "number_of_shards": 3
-            },
-            "mappings":
-                {
+        self.assertDictEqual(
+            {
+                "settings": {
+                    "number_of_shards": 3,
+                },
+                "mappings": {
                     "main": "empty-for-test",
-                    "secondary": "empty-for-test"
-                }
-        }, resulting_track.indices[0].body)
+                    "secondary": "empty-for-test",
+                },
+            },
+            resulting_track.indices[0].body,
+        )
         self.assertEqual(2, len(resulting_track.indices[0].types))
         self.assertEqual("main", resulting_track.indices[0].types[0])
         self.assertEqual("secondary", resulting_track.indices[0].types[1])
@@ -2252,10 +2387,7 @@ class TrackSpecificationReaderTests(TestCase):
         self.assertEqual(10000, docs_primary.uncompressed_size_in_bytes)
         self.assertEqual("index-historical", docs_primary.target_index)
         self.assertEqual("main", docs_primary.target_type)
-        self.assertDictEqual({
-            "test-docs": True,
-            "role": "main"
-        }, docs_primary.meta_data)
+        self.assertDictEqual({"test-docs": True, "role": "main"}, docs_primary.meta_data)
 
         docs_secondary = resulting_track.corpora[0].documents[1]
         self.assertEqual(track.Documents.SOURCE_FORMAT_BULK, docs_secondary.source_format)
@@ -2269,10 +2401,7 @@ class TrackSpecificationReaderTests(TestCase):
         # This is defined by the action-and-meta-data line!
         self.assertIsNone(docs_secondary.target_index)
         self.assertIsNone(docs_secondary.target_type)
-        self.assertDictEqual({
-            "test-docs": True,
-            "role": "secondary"
-        }, docs_secondary.meta_data)
+        self.assertDictEqual({"test-docs": True, "role": "secondary"}, docs_secondary.meta_data)
 
         # challenges
         self.assertEqual(1, len(resulting_track.challenges))
@@ -2285,11 +2414,7 @@ class TrackSpecificationReaderTests(TestCase):
     def test_parse_data_streams_valid_track_specification(self):
         track_specification = {
             "description": "description for unit test",
-            "data-streams": [
-                {
-                    "name": "data-stream-historical"
-                }
-            ],
+            "data-streams": [{"name": "data-stream-historical"}],
             "corpora": [
                 {
                     "name": "test",
@@ -2300,23 +2425,23 @@ class TrackSpecificationReaderTests(TestCase):
                             "document-count": 10,
                             "compressed-bytes": 100,
                             "uncompressed-bytes": 10000,
-                            "target-data-stream": "data-stream-historical"
+                            "target-data-stream": "data-stream-historical",
                         },
                         {
                             "source-file": "documents-secondary.json.bz2",
                             "includes-action-and-meta-data": True,
                             "document-count": 20,
                             "compressed-bytes": 200,
-                            "uncompressed-bytes": 20000
+                            "uncompressed-bytes": 20000,
                         },
                         {
                             "source-file": "documents-main.json.bz2",
                             "document-count": 10,
                             "compressed-bytes": 100,
                             "uncompressed-bytes": 10000,
-                            "target-data-stream": "data-stream-historical"
-                        }
-                    ]
+                            "target-data-stream": "data-stream-historical",
+                        },
+                    ],
                 }
             ],
             "operations": [
@@ -2324,15 +2449,13 @@ class TrackSpecificationReaderTests(TestCase):
                     "name": "index-append",
                     "operation-type": "index",
                     "bulk-size": 5000,
-                    "meta": {
-                        "append": True
-                    }
+                    "meta": {"append": True},
                 },
                 {
                     "name": "search",
                     "operation-type": "search",
-                    "data-stream": "data-stream-historical"
-                }
+                    "data-stream": "data-stream-historical",
+                },
             ],
             "challenges": [
                 {
@@ -2340,27 +2463,24 @@ class TrackSpecificationReaderTests(TestCase):
                     "description": "Default challenge",
                     "meta": {
                         "mixed": True,
-                        "max-clients": 8
+                        "max-clients": 8,
                     },
                     "schedule": [
                         {
                             "clients": 8,
                             "operation": "index-append",
-                            "meta": {
-                                "operation-index": 0
-                            }
+                            "meta": {"operation-index": 0},
                         },
                         {
                             "clients": 1,
-                            "operation": "search"
-                        }
-                    ]
+                            "operation": "search",
+                        },
+                    ],
                 }
-            ]
+            ],
         }
         complete_track_params = loader.CompleteTrackParams()
-        reader = loader.TrackSpecificationReader(
-            complete_track_params=complete_track_params)
+        reader = loader.TrackSpecificationReader(complete_track_params=complete_track_params)
         resulting_track = reader("unittest", track_specification, "/mappings")
         # j2 variables defined in the track -- used for checking mismatching user track params
         self.assertEqual("unittest", resulting_track.name)
@@ -2441,7 +2561,7 @@ class TrackSpecificationReaderTests(TestCase):
                             "compressed-bytes": 100,
                             "uncompressed-bytes": 10000,
                         },
-                    ]
+                    ],
                 }
             ],
             "schedule": [
@@ -2450,33 +2570,41 @@ class TrackSpecificationReaderTests(TestCase):
                     "operation": {
                         "name": "index-append",
                         "operation-type": "bulk",
-                        "bulk-size": 5000
-                    }
-                }
-            ]
+                        "bulk-size": 5000,
+                    },
+                },
+            ],
         }
         reader = loader.TrackSpecificationReader(
             track_params={"number_of_shards": 3},
-            source=io.DictStringFileSourceFactory({
-                "/mappings/body.json": ["""
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/body.json": [
+                        """
             {
                 "settings": {
                     "number_of_shards": {{ number_of_shards }}
                 }
             }
-            """]
-            }))
+            """
+                    ]
+                }
+            ),
+        )
         resulting_track = reader("unittest", track_specification, "/mappings")
         self.assertEqual("unittest", resulting_track.name)
         self.assertEqual("description for unit test", resulting_track.description)
         # indices
         self.assertEqual(1, len(resulting_track.indices))
         self.assertEqual("index-historical", resulting_track.indices[0].name)
-        self.assertDictEqual({
-            "settings": {
-                "number_of_shards": 3
-            }
-        }, resulting_track.indices[0].body)
+        self.assertDictEqual(
+            {
+                "settings": {
+                    "number_of_shards": 3,
+                },
+            },
+            resulting_track.indices[0].body,
+        )
         self.assertEqual(0, len(resulting_track.indices[0].types))
         # corpora
         self.assertEqual(1, len(resulting_track.corpora))
@@ -2510,8 +2638,8 @@ class TrackSpecificationReaderTests(TestCase):
             ],
             "data-streams": [
                 {
-                    "name": "historical-data-stream"
-                }
+                    "name": "historical-data-stream",
+                },
             ],
             "corpora": [
                 {
@@ -2524,7 +2652,7 @@ class TrackSpecificationReaderTests(TestCase):
                             "compressed-bytes": 100,
                             "uncompressed-bytes": 10000,
                         },
-                    ]
+                    ],
                 }
             ],
             "schedule": [
@@ -2533,14 +2661,13 @@ class TrackSpecificationReaderTests(TestCase):
                     "operation": {
                         "name": "index-append",
                         "operation-type": "bulk",
-                        "bulk-size": 5000
-                    }
+                        "bulk-size": 5000,
+                    },
                 }
-            ]
+            ],
         }
         complete_track_params = loader.CompleteTrackParams()
-        reader = loader.TrackSpecificationReader(
-            complete_track_params=complete_track_params)
+        reader = loader.TrackSpecificationReader(complete_track_params=complete_track_params)
         with self.assertRaises(loader.TrackSyntaxError):
             reader("unittest", track_specification, "/mapping")
 
@@ -2549,8 +2676,8 @@ class TrackSpecificationReaderTests(TestCase):
             "description": "description for unit test",
             "data-streams": [
                 {
-                    "name": "historical-data-stream"
-                }
+                    "name": "historical-data-stream",
+                },
             ],
             "corpora": [
                 {
@@ -2564,7 +2691,7 @@ class TrackSpecificationReaderTests(TestCase):
                             "uncompressed-bytes": 10000,
                             "target-index": "historical-index",
                         },
-                    ]
+                    ],
                 }
             ],
             "schedule": [
@@ -2573,25 +2700,20 @@ class TrackSpecificationReaderTests(TestCase):
                     "operation": {
                         "name": "index-append",
                         "operation-type": "bulk",
-                        "bulk-size": 5000
-                    }
-                }
-            ]
+                        "bulk-size": 5000,
+                    },
+                },
+            ],
         }
         complete_track_params = loader.CompleteTrackParams()
-        reader = loader.TrackSpecificationReader(
-            complete_track_params=complete_track_params)
+        reader = loader.TrackSpecificationReader(complete_track_params=complete_track_params)
         with self.assertRaises(loader.TrackSyntaxError):
             reader("unittest", track_specification, "/mapping")
 
     def test_parse_invalid_data_streams_with_target_type(self):
         track_specification = {
             "description": "description for unit test",
-            "data-streams": [
-                {
-                    "name": "historical-data-stream"
-                }
-            ],
+            "data-streams": [{"name": "historical-data-stream"}],
             "corpora": [
                 {
                     "name": "test",
@@ -2604,7 +2726,7 @@ class TrackSpecificationReaderTests(TestCase):
                             "uncompressed-bytes": 10000,
                             "target-type": "_doc",
                         },
-                    ]
+                    ],
                 }
             ],
             "schedule": [
@@ -2613,14 +2735,13 @@ class TrackSpecificationReaderTests(TestCase):
                     "operation": {
                         "name": "index-append",
                         "operation-type": "bulk",
-                        "bulk-size": 5000
-                    }
-                }
-            ]
+                        "bulk-size": 5000,
+                    },
+                },
+            ],
         }
         complete_track_params = loader.CompleteTrackParams()
-        reader = loader.TrackSpecificationReader(
-            complete_track_params=complete_track_params)
+        reader = loader.TrackSpecificationReader(complete_track_params=complete_track_params)
         with self.assertRaises(loader.TrackSyntaxError):
             reader("unittest", track_specification, "/mapping")
 
@@ -2629,50 +2750,11 @@ class TrackSpecificationReaderTests(TestCase):
             "description": "description for unit test",
             "data-streams": [
                 {
-                    "name": "historical-data-stream"
+                    "name": "historical-data-stream",
                 },
                 {
-                    "name": "historical-data-stream-2"
-                }
-            ],
-            "corpora": [
-                {
-                    "name": "test",
-                    "base-url": "https://localhost/data",
-                    "documents": [
-                        {
-                            "source-file": "documents-main.json.bz2",
-                            "document-count": 10,
-                            "compressed-bytes": 100,
-                            "uncompressed-bytes": 10000
-                        }
-                    ]
-                }
-            ],
-            "schedule": [
-                {
-                    "clients": 8,
-                    "operation": {
-                        "name": "index-append",
-                        "operation-type": "bulk",
-                        "bulk-size": 5000
-                    }
-                }
-            ]
-        }
-        complete_track_params = loader.CompleteTrackParams()
-        reader = loader.TrackSpecificationReader(
-            complete_track_params=complete_track_params)
-        with self.assertRaises(loader.TrackSyntaxError):
-            reader("unittest", track_specification, "/mapping")
-
-    def test_parse_valid_without_indices(self):
-        track_specification = {
-            "description": "description for unit test",
-            "data-streams": [
-                {
-                    "name": "historical-data-stream"
-                }
+                    "name": "historical-data-stream-2",
+                },
             ],
             "corpora": [
                 {
@@ -2684,8 +2766,8 @@ class TrackSpecificationReaderTests(TestCase):
                             "document-count": 10,
                             "compressed-bytes": 100,
                             "uncompressed-bytes": 10000,
-                        },
-                    ]
+                        }
+                    ],
                 }
             ],
             "schedule": [
@@ -2694,22 +2776,61 @@ class TrackSpecificationReaderTests(TestCase):
                     "operation": {
                         "name": "index-append",
                         "operation-type": "bulk",
-                        "bulk-size": 5000
-                    }
+                        "bulk-size": 5000,
+                    },
+                },
+            ],
+        }
+        complete_track_params = loader.CompleteTrackParams()
+        reader = loader.TrackSpecificationReader(complete_track_params=complete_track_params)
+        with self.assertRaises(loader.TrackSyntaxError):
+            reader("unittest", track_specification, "/mapping")
+
+    def test_parse_valid_without_indices(self):
+        track_specification = {
+            "description": "description for unit test",
+            "data-streams": [{"name": "historical-data-stream"}],
+            "corpora": [
+                {
+                    "name": "test",
+                    "base-url": "https://localhost/data",
+                    "documents": [
+                        {
+                            "source-file": "documents-main.json.bz2",
+                            "document-count": 10,
+                            "compressed-bytes": 100,
+                            "uncompressed-bytes": 10000,
+                        },
+                    ],
                 }
-            ]
+            ],
+            "schedule": [
+                {
+                    "clients": 8,
+                    "operation": {
+                        "name": "index-append",
+                        "operation-type": "bulk",
+                        "bulk-size": 5000,
+                    },
+                },
+            ],
         }
         reader = loader.TrackSpecificationReader(
             track_params={"number_of_shards": 3},
-            source=io.DictStringFileSourceFactory({
-                "/mappings/body.json": ["""
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/body.json": [
+                        """
                 {
                     "settings": {
                         "number_of_shards": {{ number_of_shards }}
                     }
                 }
-                """]
-            }))
+                """
+                    ]
+                }
+            ),
+        )
         resulting_track = reader("unittest", track_specification, "/mappings")
         self.assertEqual("unittest", resulting_track.name)
         self.assertEqual("description for unit test", resulting_track.description)
@@ -2746,31 +2867,33 @@ class TrackSpecificationReaderTests(TestCase):
                 {
                     "name": "my-index-template",
                     "index-pattern": "*",
-                    "template": "default-template.json"
-                }
+                    "template": "default-template.json",
+                },
             ],
             "operations": [],
-            "challenges": []
+            "challenges": [],
         }
         complete_track_params = loader.CompleteTrackParams()
         reader = loader.TrackSpecificationReader(
             track_params={"index_pattern": "*"},
             complete_track_params=complete_track_params,
-            source=io.DictStringFileSourceFactory({
-                "/mappings/default-template.json": ["""
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/default-template.json": [
+                        """
                 {
                     "index_patterns": [ "{{index_pattern}}"],
                     "settings": {
                         "number_of_shards": {{ number_of_shards | default(1) }}
                     }
                 }
-                """],
-        }))
-        resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
-            ["index_pattern", "number_of_shards"],
-            complete_track_params.sorted_track_defined_params
+                """
+                    ],
+                }
+            ),
         )
+        resulting_track = reader("unittest", track_specification, "/mappings")
+        self.assertEqual(["index_pattern", "number_of_shards"], complete_track_params.sorted_track_defined_params)
         self.assertEqual("unittest", resulting_track.name)
         self.assertEqual("description for unit test", resulting_track.description)
         self.assertEqual(0, len(resulting_track.indices))
@@ -2781,9 +2904,11 @@ class TrackSpecificationReaderTests(TestCase):
             {
                 "index_patterns": ["*"],
                 "settings": {
-                    "number_of_shards": 1
-                }
-            }, resulting_track.templates[0].content)
+                    "number_of_shards": 1,
+                },
+            },
+            resulting_track.templates[0].content,
+        )
         self.assertEqual(0, len(resulting_track.challenges))
 
     def test_parse_valid_track_specification_with_composable_template(self):
@@ -2793,28 +2918,30 @@ class TrackSpecificationReaderTests(TestCase):
                 {
                     "name": "my-index-template",
                     "index-pattern": "*",
-                    "template": "default-template.json"
-                }
+                    "template": "default-template.json",
+                },
             ],
             "component-templates": [
                 {
                     "name": "my-component-template-1",
-                    "template": "component-template-1.json"
+                    "template": "component-template-1.json",
                 },
                 {
                     "name": "my-component-template-2",
-                    "template": "component-template-2.json"
-                }
+                    "template": "component-template-2.json",
+                },
             ],
             "operations": [],
-            "challenges": []
+            "challenges": [],
         }
         complete_track_params = loader.CompleteTrackParams()
         reader = loader.TrackSpecificationReader(
             track_params={"index_pattern": "logs-*", "number_of_replicas": 1},
             complete_track_params=complete_track_params,
-            source=io.DictStringFileSourceFactory({
-                "/mappings/default-template.json": ["""
+            source=io.DictStringFileSourceFactory(
+                {
+                    "/mappings/default-template.json": [
+                        """
                         {
                             "index_patterns": [ "{{index_pattern}}"],
                             "template": {
@@ -2824,8 +2951,10 @@ class TrackSpecificationReaderTests(TestCase):
                             },
                             "composed_of": ["my-component-template-1", "my-component-template-2"]
                         }
-                        """],
-                "/mappings/component-template-1.json": ["""
+                        """
+                    ],
+                    "/mappings/component-template-1.json": [
+                        """
                         {
                             "template": {
                                 "settings": {
@@ -2833,8 +2962,10 @@ class TrackSpecificationReaderTests(TestCase):
                                 }
                             }
                         }
-                        """],
-                "/mappings/component-template-2.json": ["""
+                        """
+                    ],
+                    "/mappings/component-template-2.json": [
+                        """
                         {
                             "template": {
                                 "settings": {
@@ -2849,13 +2980,13 @@ class TrackSpecificationReaderTests(TestCase):
                                 }
                               }
                         }
-                        """]
-            }))
-        resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
-            ["index_pattern", "number_of_replicas", "number_of_shards"],
-            complete_track_params.sorted_track_defined_params
+                        """
+                    ],
+                }
+            ),
         )
+        resulting_track = reader("unittest", track_specification, "/mappings")
+        self.assertEqual(["index_pattern", "number_of_replicas", "number_of_shards"], complete_track_params.sorted_track_defined_params)
         self.assertEqual("unittest", resulting_track.name)
         self.assertEqual("description for unit test", resulting_track.description)
         self.assertEqual(0, len(resulting_track.indices))
@@ -2870,34 +3001,39 @@ class TrackSpecificationReaderTests(TestCase):
                 "index_patterns": ["logs-*"],
                 "template": {
                     "settings": {
-                        "number_of_shards": 1
-                    }
-                },
-                "composed_of": ["my-component-template-1", "my-component-template-2"]
-            }, resulting_track.composable_templates[0].content)
-        self.assertDictEqual(
-            {
-                "template": {
-                    "settings": {
-                        "index.number_of_shards": 2
-                    }
-                }
-            }, resulting_track.component_templates[0].content)
-        self.assertDictEqual(
-            {
-                "template": {
-                    "settings": {
-                        "index.number_of_replicas": 1
+                        "number_of_shards": 1,
                     },
+                },
+                "composed_of": [
+                    "my-component-template-1",
+                    "my-component-template-2",
+                ],
+            },
+            resulting_track.composable_templates[0].content,
+        )
+        self.assertDictEqual(
+            {
+                "template": {
+                    "settings": {
+                        "index.number_of_shards": 2,
+                    },
+                },
+            },
+            resulting_track.component_templates[0].content,
+        )
+        self.assertDictEqual(
+            {
+                "template": {
+                    "settings": {"index.number_of_replicas": 1},
                     "mappings": {
                         "properties": {
-                            "@timestamp": {
-                                "type": "date"
-                            }
-                        }
-                    }
-                }
-            }, resulting_track.component_templates[1].content)
+                            "@timestamp": {"type": "date"},
+                        },
+                    },
+                },
+            },
+            resulting_track.component_templates[1].content,
+        )
         self.assertEqual(0, len(resulting_track.challenges))
 
     def test_parse_invalid_track_specification_with_composable_template(self):
@@ -2905,20 +3041,19 @@ class TrackSpecificationReaderTests(TestCase):
             "description": "description for unit test",
             "component-templates": [
                 {
-                    "name": "my-component-template-2"
-                }
+                    "name": "my-component-template-2",
+                },
             ],
             "operations": [],
-            "challenges": []
+            "challenges": [],
         }
         complete_track_params = loader.CompleteTrackParams()
         reader = loader.TrackSpecificationReader(
-            track_params={"index_pattern": "logs-*", "number_of_replicas": 1},
-            complete_track_params=complete_track_params)
+            track_params={"index_pattern": "logs-*", "number_of_replicas": 1}, complete_track_params=complete_track_params
+        )
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Mandatory element 'template' is missing.",
-                         ctx.exception.args[0])
+        self.assertEqual("Track 'unittest' is invalid. Mandatory element 'template' is missing.", ctx.exception.args[0])
 
     def test_unique_challenge_names(self):
         track_specification = {
@@ -2927,31 +3062,22 @@ class TrackSpecificationReaderTests(TestCase):
             "operations": [
                 {
                     "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
                     "name": "test-challenge",
                     "description": "Some challenge",
                     "default": True,
-                    "schedule": [
-                        {
-                            "operation": "index-append"
-                        }
-                    ]
+                    "schedule": [{"operation": "index-append"}],
                 },
                 {
                     "name": "test-challenge",
                     "description": "Another challenge with the same name",
-                    "schedule": [
-                        {
-                            "operation": "index-append"
-                        }
-                    ]
-                }
-
-            ]
+                    "schedule": [{"operation": "index-append"}],
+                },
+            ],
         }
         reader = loader.TrackSpecificationReader()
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
@@ -2961,109 +3087,108 @@ class TrackSpecificationReaderTests(TestCase):
     def test_not_more_than_one_default_challenge_possible(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
                     "name": "default-challenge",
                     "description": "Default challenge",
                     "default": True,
-                    "schedule": [
-                        {
-                            "operation": "index-append"
-                        }
-                    ]
+                    "schedule": [{"operation": "index-append"}],
                 },
                 {
                     "name": "another-challenge",
                     "description": "See if we can sneek it in as another default",
                     "default": True,
-                    "schedule": [
-                        {
-                            "operation": "index-append"
-                        }
-                    ]
-                }
-
-            ]
+                    "schedule": [{"operation": "index-append"}],
+                },
+            ],
         }
         reader = loader.TrackSpecificationReader()
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Both 'default-challenge' and 'another-challenge' are defined as default challenges. "
-                         "Please define only one of them as default.", ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. Both 'default-challenge' and 'another-challenge' are defined as default challenges. "
+            "Please define only one of them as default.",
+            ctx.exception.args[0],
+        )
 
     def test_at_least_one_default_challenge(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
                     "name": "challenge",
                     "schedule": [
-                        {
-                            "operation": "index-append"
-                        }
-                    ]
+                        {"operation": "index-append"},
+                    ],
                 },
                 {
                     "name": "another-challenge",
                     "schedule": [
-                        {
-                            "operation": "index-append"
-                        }
-                    ]
-                }
-
-            ]
+                        {"operation": "index-append"},
+                    ],
+                },
+            ],
         }
         reader = loader.TrackSpecificationReader()
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. No default challenge specified. Please edit the track and add \"default\": true "
-                         "to one of the challenges challenge, another-challenge.", ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. No default challenge specified. Please edit the track and add \"default\": true "
+            "to one of the challenges challenge, another-challenge.",
+            ctx.exception.args[0],
+        )
 
     def test_exactly_one_default_challenge(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
                     "name": "challenge",
                     "default": True,
                     "schedule": [
-                        {
-                            "operation": "index-append"
-                        }
-                    ]
+                        {"operation": "index-append"},
+                    ],
                 },
                 {
                     "name": "another-challenge",
                     "schedule": [
-                        {
-                            "operation": "index-append"
-                        }
-                    ]
-                }
-
-            ]
+                        {"operation": "index-append"},
+                    ],
+                },
+            ],
         }
         reader = loader.TrackSpecificationReader(selected_challenge="another-challenge")
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -3076,21 +3201,21 @@ class TrackSpecificationReaderTests(TestCase):
     def test_selects_sole_challenge_implicitly_as_default(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {"name": "test-index"},
+            ],
             "operations": [
                 {
                     "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenge": {
                 "name": "challenge",
                 "schedule": [
-                    {
-                        "operation": "index-append"
-                    }
-                ]
-            }
+                    {"operation": "index-append"},
+                ],
+            },
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -3102,18 +3227,20 @@ class TrackSpecificationReaderTests(TestCase):
     def test_auto_generates_challenge_from_schedule(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "schedule": [
-                {
-                    "operation": "index-append"
-                }
-            ]
+                {"operation": "index-append"},
+            ],
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -3125,23 +3252,24 @@ class TrackSpecificationReaderTests(TestCase):
     def test_inline_operations(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "challenge": {
                 "name": "challenge",
                 "schedule": [
                     # an operation with parameters still needs to define a type
                     {
-                        "operation": {
-                            "operation-type": "bulk",
-                            "bulk-size": 5000
-                        }
+                        "operation": {"operation-type": "bulk", "bulk-size": 5000},
                     },
                     # a parameterless operation can just use the operation type as implicit reference to the operation
                     {
-                        "operation": "force-merge"
-                    }
-                ]
-            }
+                        "operation": "force-merge",
+                    },
+                ],
+            },
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -3154,12 +3282,16 @@ class TrackSpecificationReaderTests(TestCase):
     def test_supports_target_throughput(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenge": {
                 "name": "default-challenge",
@@ -3168,10 +3300,10 @@ class TrackSpecificationReaderTests(TestCase):
                         "operation": "index-append",
                         "target-throughput": 10,
                         "warmup-time-period": 120,
-                        "ramp-up-time-period": 60
-                    }
-                ]
-            }
+                        "ramp-up-time-period": 60,
+                    },
+                ],
+            },
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -3184,12 +3316,16 @@ class TrackSpecificationReaderTests(TestCase):
     def test_supports_target_interval(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
@@ -3199,9 +3335,9 @@ class TrackSpecificationReaderTests(TestCase):
                             "operation": "index-append",
                             "target-interval": 5,
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -3210,41 +3346,16 @@ class TrackSpecificationReaderTests(TestCase):
     def test_ramp_up_but_no_warmup(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
-            "operations": [
+            "indices": [
                 {
-                    "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "name": "test-index",
+                },
             ],
-            "challenge": {
-                "name": "default-challenge",
-                "schedule": [
-                    {
-                        "operation": "index-append",
-                        "target-throughput": 10,
-                        "ramp-up-time-period": 60
-                    }
-                ]
-            }
-        }
-
-        reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
-            reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' "
-                         "defines a ramp-up time period of 60 seconds but no warmup-time-period.",
-                         ctx.exception.args[0])
-
-    def test_warmup_shorter_than_ramp_up(self):
-        track_specification = {
-            "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
             "operations": [
                 {
                     "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenge": {
                 "name": "default-challenge",
@@ -3253,38 +3364,65 @@ class TrackSpecificationReaderTests(TestCase):
                         "operation": "index-append",
                         "target-throughput": 10,
                         "ramp-up-time-period": 60,
-                        "warmup-time-period": 59
-                    }
-                ]
-            }
+                    },
+                ],
+            },
         }
 
         reader = loader.TrackSpecificationReader()
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. The warmup-time-period of operation 'index-append' in "
-                         "challenge 'default-challenge' is 59 seconds but must be greater than or equal to the "
-                         "ramp-up-time-period of 60 seconds.", ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' "
+            "defines a ramp-up time period of 60 seconds but no warmup-time-period.",
+            ctx.exception.args[0],
+        )
 
+    def test_warmup_shorter_than_ramp_up(self):
+        track_specification = {
+            "description": "description for unit test",
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
+            "operations": [
+                {
+                    "name": "index-append",
+                    "operation-type": "bulk",
+                },
+            ],
+            "challenge": {
+                "name": "default-challenge",
+                "schedule": [
+                    {
+                        "operation": "index-append",
+                        "target-throughput": 10,
+                        "ramp-up-time-period": 60,
+                        "warmup-time-period": 59,
+                    },
+                ],
+            },
+        }
 
+        reader = loader.TrackSpecificationReader()
+        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+            reader("unittest", track_specification, "/mappings")
+        self.assertEqual(
+            "Track 'unittest' is invalid. The warmup-time-period of operation 'index-append' in "
+            "challenge 'default-challenge' is 59 seconds but must be greater than or equal to the "
+            "ramp-up-time-period of 60 seconds.",
+            ctx.exception.args[0],
+        )
 
     def test_parallel_tasks_with_default_values(self):
         track_specification = {
             "description": "description for unit test",
             "indices": [{"name": "test-index"}],
             "operations": [
-                {
-                    "name": "index-1",
-                    "operation-type": "bulk"
-                },
-                {
-                    "name": "index-2",
-                    "operation-type": "bulk"
-                },
-                {
-                    "name": "index-3",
-                    "operation-type": "bulk"
-                },
+                {"name": "index-1", "operation-type": "bulk"},
+                {"name": "index-2", "operation-type": "bulk"},
+                {"name": "index-3", "operation-type": "bulk"},
             ],
             "challenges": [
                 {
@@ -3299,24 +3437,24 @@ class TrackSpecificationReaderTests(TestCase):
                                     {
                                         "operation": "index-1",
                                         "warmup-time-period": 300,
-                                        "clients": 2
+                                        "clients": 2,
                                     },
                                     {
                                         "operation": "index-2",
                                         "time-period": 3600,
-                                        "clients": 4
+                                        "clients": 4,
                                     },
                                     {
                                         "operation": "index-3",
                                         "target-throughput": 10,
-                                        "clients": 16
+                                        "clients": 16,
                                     },
-                                ]
+                                ],
                             }
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -3350,12 +3488,16 @@ class TrackSpecificationReaderTests(TestCase):
     def test_parallel_tasks_with_default_clients_does_not_propagate(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-1",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
@@ -3369,26 +3511,26 @@ class TrackSpecificationReaderTests(TestCase):
                                 "tasks": [
                                     {
                                         "name": "index-1-1",
-                                        "operation": "index-1"
+                                        "operation": "index-1",
                                     },
                                     {
                                         "name": "index-1-2",
-                                        "operation": "index-1"
+                                        "operation": "index-1",
                                     },
                                     {
                                         "name": "index-1-3",
-                                        "operation": "index-1"
+                                        "operation": "index-1",
                                     },
                                     {
                                         "name": "index-1-4",
-                                        "operation": "index-1"
-                                    }
-                                ]
+                                        "operation": "index-1",
+                                    },
+                                ],
                             }
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -3404,16 +3546,20 @@ class TrackSpecificationReaderTests(TestCase):
     def test_parallel_tasks_with_completed_by_set(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-1",
-                    "operation-type": "bulk"
+                    "operation-type": "bulk",
                 },
                 {
                     "name": "index-2",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
@@ -3425,18 +3571,14 @@ class TrackSpecificationReaderTests(TestCase):
                                 "time-period": 36000,
                                 "completed-by": "index-2",
                                 "tasks": [
-                                    {
-                                        "operation": "index-1"
-                                    },
-                                    {
-                                        "operation": "index-2"
-                                    }
-                                ]
+                                    {"operation": "index-1"},
+                                    {"operation": "index-2"},
+                                ],
                             }
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -3456,16 +3598,20 @@ class TrackSpecificationReaderTests(TestCase):
     def test_parallel_tasks_with_named_task_completed_by_set(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-1",
-                    "operation-type": "bulk"
+                    "operation-type": "bulk",
                 },
                 {
                     "name": "index-2",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
@@ -3479,18 +3625,18 @@ class TrackSpecificationReaderTests(TestCase):
                                 "tasks": [
                                     {
                                         "name": "name-index-1",
-                                        "operation": "index-1"
+                                        "operation": "index-1",
                                     },
                                     {
                                         "name": "name-index-2",
-                                        "operation": "index-2"
-                                    }
-                                ]
+                                        "operation": "index-2",
+                                    },
+                                ],
                             }
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
@@ -3510,16 +3656,20 @@ class TrackSpecificationReaderTests(TestCase):
     def test_parallel_tasks_with_completed_by_set_no_task_matches(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-1",
-                    "operation-type": "bulk"
+                    "operation-type": "bulk",
                 },
                 {
                     "name": "index-2",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
@@ -3529,35 +3679,38 @@ class TrackSpecificationReaderTests(TestCase):
                             "parallel": {
                                 "completed-by": "non-existing-task",
                                 "tasks": [
-                                    {
-                                        "operation": "index-1"
-                                    },
-                                    {
-                                        "operation": "index-2"
-                                    }
-                                ]
-                            }
+                                    {"operation": "index-1"},
+                                    {"operation": "index-2"},
+                                ],
+                            },
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         }
         reader = loader.TrackSpecificationReader()
 
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. 'parallel' element for challenge 'default-challenge' is marked with 'completed-by' "
-                         "with task name 'non-existing-task' but no task with this name exists.", ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. 'parallel' element for challenge 'default-challenge' is marked with 'completed-by' "
+            "with task name 'non-existing-task' but no task with this name exists.",
+            ctx.exception.args[0],
+        )
 
     def test_parallel_tasks_with_completed_by_set_multiple_tasks_match(self):
         track_specification = {
             "description": "description for unit test",
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-1",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
@@ -3567,40 +3720,32 @@ class TrackSpecificationReaderTests(TestCase):
                             "parallel": {
                                 "completed-by": "index-1",
                                 "tasks": [
-                                    {
-                                        "operation": "index-1"
-                                    },
-                                    {
-                                        "operation": "index-1"
-                                    }
-                                ]
-                            }
-                        }
-                    ]
+                                    {"operation": "index-1"},
+                                    {"operation": "index-1"},
+                                ],
+                            },
+                        },
+                    ],
                 }
-            ]
+            ],
         }
         reader = loader.TrackSpecificationReader()
 
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. 'parallel' element for challenge 'default-challenge' contains multiple tasks with "
-                         "the name 'index-1' marked with 'completed-by' but only task is allowed to match.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. 'parallel' element for challenge 'default-challenge' contains multiple tasks with "
+            "the name 'index-1' marked with 'completed-by' but only task is allowed to match.",
+            ctx.exception.args[0],
+        )
 
     def test_parallel_tasks_ramp_up_cannot_be_overridden(self):
         track_specification = {
             "description": "description for unit test",
             "indices": [{"name": "test-index"}],
             "operations": [
-                {
-                    "name": "index-1",
-                    "operation-type": "bulk"
-                },
-                {
-                    "name": "index-2",
-                    "operation-type": "bulk"
-                }
+                {"name": "index-1", "operation-type": "bulk"},
+                {"name": "index-2", "operation-type": "bulk"},
             ],
             "challenges": [
                 {
@@ -3619,37 +3764,30 @@ class TrackSpecificationReaderTests(TestCase):
                                     },
                                     {
                                         "name": "name-index-2",
-                                        "operation": "index-2"
-                                    }
-                                ]
+                                        "operation": "index-2",
+                                    },
+                                ],
                             }
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         }
 
         reader = loader.TrackSpecificationReader()
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. task 'name-index-1' specifies a different ramp-up-time-period "
-                         "than its enclosing 'parallel' element in challenge 'default-challenge'.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. task 'name-index-1' specifies a different ramp-up-time-period "
+            "than its enclosing 'parallel' element in challenge 'default-challenge'.",
+            ctx.exception.args[0],
+        )
 
     def test_parallel_tasks_ramp_up_only_on_parallel(self):
         track_specification = {
             "description": "description for unit test",
             "indices": [{"name": "test-index"}],
-            "operations": [
-                {
-                    "name": "index-1",
-                    "operation-type": "bulk"
-                },
-                {
-                    "name": "index-2",
-                    "operation-type": "bulk"
-                }
-            ],
+            "operations": [{"name": "index-1", "operation-type": "bulk"}, {"name": "index-2", "operation-type": "bulk"}],
             "challenges": [
                 {
                     "name": "default-challenge",
@@ -3664,39 +3802,42 @@ class TrackSpecificationReaderTests(TestCase):
                                         "operation": "index-1",
                                         "ramp-up-time-period": 500,
                                     },
-                                    {
-                                        "name": "name-index-2",
-                                        "operation": "index-2"
-                                    }
-                                ]
+                                    {"name": "name-index-2", "operation": "index-2"},
+                                ],
                             }
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         }
 
         reader = loader.TrackSpecificationReader()
         with self.assertRaises(loader.TrackSyntaxError) as ctx:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. task 'name-index-1' in 'parallel' element of challenge "
-                         "'default-challenge' specifies a ramp-up-time-period but it is only allowed on the 'parallel' "
-                         "element.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Track 'unittest' is invalid. task 'name-index-1' in 'parallel' element of challenge "
+            "'default-challenge' specifies a ramp-up-time-period but it is only allowed on the 'parallel' "
+            "element.",
+            ctx.exception.args[0],
+        )
 
     def test_propagate_parameters_to_challenge_level(self):
         track_specification = {
             "description": "description for unit test",
             "parameters": {
                 "level": "track",
-                "value": 7
+                "value": 7,
             },
-            "indices": [{"name": "test-index"}],
+            "indices": [
+                {
+                    "name": "test-index",
+                },
+            ],
             "operations": [
                 {
                     "name": "index-append",
-                    "operation-type": "bulk"
-                }
+                    "operation-type": "bulk",
+                },
             ],
             "challenges": [
                 {
@@ -3704,42 +3845,47 @@ class TrackSpecificationReaderTests(TestCase):
                     "default": True,
                     "parameters": {
                         "level": "challenge",
-                        "another-value": 17
+                        "another-value": 17,
                     },
                     "schedule": [
                         {
-                            "operation": "index-append"
-                        }
-                    ]
+                            "operation": "index-append",
+                        },
+                    ],
                 },
                 {
                     "name": "another-challenge",
                     "schedule": [
                         {
-                            "operation": "index-append"
-                        }
-                    ]
-                }
-
-            ]
+                            "operation": "index-append",
+                        },
+                    ],
+                },
+            ],
         }
         reader = loader.TrackSpecificationReader(selected_challenge="another-challenge")
         resulting_track = reader("unittest", track_specification, "/mappings")
         self.assertEqual(2, len(resulting_track.challenges))
         self.assertEqual("challenge", resulting_track.challenges[0].name)
         self.assertTrue(resulting_track.challenges[0].default)
-        self.assertDictEqual({
-            "level": "challenge",
-            "value": 7,
-            "another-value": 17
-        }, resulting_track.challenges[0].parameters)
+        self.assertDictEqual(
+            {
+                "level": "challenge",
+                "value": 7,
+                "another-value": 17,
+            },
+            resulting_track.challenges[0].parameters,
+        )
 
         self.assertFalse(resulting_track.challenges[1].default)
         self.assertTrue(resulting_track.challenges[1].selected)
-        self.assertDictEqual({
-            "level": "track",
-            "value": 7
-        }, resulting_track.challenges[1].parameters)
+        self.assertDictEqual(
+            {
+                "level": "track",
+                "value": 7,
+            },
+            resulting_track.challenges[1].parameters,
+        )
 
 
 class MyMockTrackProcessor(loader.TrackProcessor):
@@ -3751,11 +3897,7 @@ class TrackProcessorRegistryTests(TestCase):
         cfg = config.Config()
         cfg.add(config.Scope.application, "system", "offline.mode", False)
         tpr = loader.TrackProcessorRegistry(cfg)
-        expected_defaults = [
-            loader.TaskFilterTrackProcessor,
-            loader.TestModeTrackProcessor,
-            loader.DefaultTrackPreparator
-        ]
+        expected_defaults = [loader.TaskFilterTrackProcessor, loader.TestModeTrackProcessor, loader.DefaultTrackPreparator]
         actual_defaults = [proc.__class__ for proc in tpr.processors]
         self.assertCountEqual(expected_defaults, actual_defaults)
 
@@ -3764,13 +3906,9 @@ class TrackProcessorRegistryTests(TestCase):
         cfg.add(config.Scope.application, "system", "offline.mode", False)
         tpr = loader.TrackProcessorRegistry(cfg)
         # call this once beforehand to make sure we don't "harden" the default in case calls are made out of order
-        tpr.processors # pylint: disable=pointless-statement
+        tpr.processors  # pylint: disable=pointless-statement
         tpr.register_track_processor(MyMockTrackProcessor())
-        expected_processors = [
-            loader.TaskFilterTrackProcessor,
-            loader.TestModeTrackProcessor,
-            MyMockTrackProcessor
-        ]
+        expected_processors = [loader.TaskFilterTrackProcessor, loader.TestModeTrackProcessor, MyMockTrackProcessor]
         actual_processors = [proc.__class__ for proc in tpr.processors]
         self.assertCountEqual(expected_processors, actual_processors)
 
@@ -3780,13 +3918,13 @@ class TrackProcessorRegistryTests(TestCase):
         tpr = loader.TrackProcessorRegistry(cfg)
         tpr.register_track_processor(MyMockTrackProcessor())
         # should be idempotent now that we have a custom config
-        tpr.processors # pylint: disable=pointless-statement
+        tpr.processors  # pylint: disable=pointless-statement
         tpr.register_track_processor(loader.DefaultTrackPreparator())
         expected_processors = [
             loader.TaskFilterTrackProcessor,
             loader.TestModeTrackProcessor,
             MyMockTrackProcessor,
-            loader.DefaultTrackPreparator
+            loader.DefaultTrackPreparator,
         ]
         actual_processors = [proc.__class__ for proc in tpr.processors]
         self.assertCountEqual(expected_processors, actual_processors)

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -59,7 +59,7 @@ class SliceTests(TestCase):
             '{"key": "value7"}',
             '{"key": "value8"}',
             '{"key": "value9"}',
-            '{"key": "value10"}'
+            '{"key": "value10"}',
         ]
 
         source.open(data, "r", 5)
@@ -89,74 +89,73 @@ class ConflictingIdsBuilderTests(TestCase):
     def test_sequential_conflicts(self):
         self.assertEqual(
             [
-                '0000000000',
-                '0000000001',
-                '0000000002',
-                '0000000003',
-                '0000000004',
-                '0000000005',
-                '0000000006',
-                '0000000007',
-                '0000000008',
-                '0000000009',
-                '0000000010'
+                "0000000000",
+                "0000000001",
+                "0000000002",
+                "0000000003",
+                "0000000004",
+                "0000000005",
+                "0000000006",
+                "0000000007",
+                "0000000008",
+                "0000000009",
+                "0000000010",
             ],
-            params.build_conflicting_ids(params.IndexIdConflict.SequentialConflicts, 11, 0)
+            params.build_conflicting_ids(params.IndexIdConflict.SequentialConflicts, 11, 0),
         )
 
         self.assertEqual(
             [
-                '0000000005',
-                '0000000006',
-                '0000000007',
-                '0000000008',
-                '0000000009',
-                '0000000010',
-                '0000000011',
-                '0000000012',
-                '0000000013',
-                '0000000014',
-                '0000000015'
+                "0000000005",
+                "0000000006",
+                "0000000007",
+                "0000000008",
+                "0000000009",
+                "0000000010",
+                "0000000011",
+                "0000000012",
+                "0000000013",
+                "0000000014",
+                "0000000015",
             ],
-            params.build_conflicting_ids(params.IndexIdConflict.SequentialConflicts, 11, 5)
+            params.build_conflicting_ids(params.IndexIdConflict.SequentialConflicts, 11, 5),
         )
 
     def test_random_conflicts(self):
         predictable_shuffle = list.reverse
 
         self.assertEqual(
-            [
-                '0000000002', '0000000001', '0000000000'
-            ],
-            params.build_conflicting_ids(params.IndexIdConflict.RandomConflicts, 3, 0, shuffle=predictable_shuffle)
+            ["0000000002", "0000000001", "0000000000"],
+            params.build_conflicting_ids(params.IndexIdConflict.RandomConflicts, 3, 0, shuffle=predictable_shuffle),
         )
 
         self.assertEqual(
-            [
-                '0000000007', '0000000006', '0000000005'
-            ],
-            params.build_conflicting_ids(params.IndexIdConflict.RandomConflicts, 3, 5, shuffle=predictable_shuffle)
+            ["0000000007", "0000000006", "0000000005"],
+            params.build_conflicting_ids(params.IndexIdConflict.RandomConflicts, 3, 5, shuffle=predictable_shuffle),
         )
 
 
 class ActionMetaDataTests(TestCase):
     def test_generate_action_meta_data_without_id_conflicts(self):
-        self.assertEqual(("index", '{"index": {"_index": "test_index", "_type": "test_type"}}\n'),
-                         next(params.GenerateActionMetaData("test_index", "test_type")))
+        self.assertEqual(
+            ("index", '{"index": {"_index": "test_index", "_type": "test_type"}}\n'),
+            next(params.GenerateActionMetaData("test_index", "test_type")),
+        )
 
     def test_generate_action_meta_data_create(self):
-        self.assertEqual(("create", '{"create": {"_index": "test_index"}}\n'),
-                         next(params.GenerateActionMetaData("test_index", None, use_create=True)))
+        self.assertEqual(
+            ("create", '{"create": {"_index": "test_index"}}\n'), next(params.GenerateActionMetaData("test_index", None, use_create=True))
+        )
 
     def test_generate_action_meta_data_create_with_conflicts(self):
         with self.assertRaises(exceptions.RallyError) as ctx:
             params.GenerateActionMetaData("test_index", None, conflicting_ids=[100, 200, 300, 400], use_create=True)
-        self.assertEqual("Index mode '_create' cannot be used with conflicting ids",
-                         ctx.exception.args[0])
+        self.assertEqual("Index mode '_create' cannot be used with conflicting ids", ctx.exception.args[0])
 
     def test_generate_action_meta_data_typeless(self):
-        self.assertEqual(("index", '{"index": {"_index": "test_index"}}\n'),
-                         next(params.GenerateActionMetaData("test_index", type_name=None)))
+        self.assertEqual(
+            ("index", '{"index": {"_index": "test_index"}}\n'), next(params.GenerateActionMetaData("test_index", type_name=None))
+        )
 
     def test_generate_action_meta_data_with_id_conflicts(self):
         def idx(id):
@@ -165,32 +164,40 @@ class ActionMetaDataTests(TestCase):
         def conflict(action, id):
             return action, '{"%s": {"_index": "test_index", "_type": "test_type", "_id": "%s"}}\n' % (action, id)
 
-        pseudo_random_conflicts = iter([
-            # if this value is <= our chosen threshold of 0.25 (see conflict_probability) we produce a conflict.
-            0.2,
-            0.25,
-            0.2,
-            # no conflict
-            0.3,
-            # conflict again
-            0.0
-        ])
+        pseudo_random_conflicts = iter(
+            [
+                # if this value is <= our chosen threshold of 0.25 (see conflict_probability) we produce a conflict.
+                0.2,
+                0.25,
+                0.2,
+                # no conflict
+                0.3,
+                # conflict again
+                0.0,
+            ]
+        )
 
-        chosen_index_of_conflicting_ids = iter([
-            # the "random" index of the id in the array `conflicting_ids` that will produce a conflict
-            1,
-            3,
-            2,
-            0])
+        chosen_index_of_conflicting_ids = iter(
+            [
+                # the "random" index of the id in the array `conflicting_ids` that will produce a conflict
+                1,
+                3,
+                2,
+                0,
+            ]
+        )
 
         conflict_action = random.choice(["index", "update"])
 
-        generator = params.GenerateActionMetaData("test_index", "test_type",
-                                                  conflicting_ids=[100, 200, 300, 400],
-                                                  conflict_probability=25,
-                                                  on_conflict=conflict_action,
-                                                  rand=lambda: next(pseudo_random_conflicts),
-                                                  randint=lambda x, y: next(chosen_index_of_conflicting_ids))
+        generator = params.GenerateActionMetaData(
+            "test_index",
+            "test_type",
+            conflicting_ids=[100, 200, 300, 400],
+            conflict_probability=25,
+            on_conflict=conflict_action,
+            rand=lambda: next(pseudo_random_conflicts),
+            randint=lambda x, y: next(chosen_index_of_conflicting_ids),
+        )
 
         # first one is always *not* drawn from a random index
         self.assertEqual(idx("100"), next(generator))
@@ -216,52 +223,58 @@ class ActionMetaDataTests(TestCase):
             else:
                 return action, '{"%s": {"_index": "test_index", "_id": "%s"}}\n' % (action, id)
 
-        pseudo_random_conflicts = iter([
-            # if this value is <= our chosen threshold of 0.25 (see conflict_probability) we produce a conflict.
-            0.2,
-            0.25,
-            0.2,
-            # no conflict
-            0.3,
-            0.4,
-            0.35,
-            # conflict again
-            0.0,
-            0.2,
-            0.15
-        ])
+        pseudo_random_conflicts = iter(
+            [
+                # if this value is <= our chosen threshold of 0.25 (see conflict_probability) we produce a conflict.
+                0.2,
+                0.25,
+                0.2,
+                # no conflict
+                0.3,
+                0.4,
+                0.35,
+                # conflict again
+                0.0,
+                0.2,
+                0.15,
+            ]
+        )
 
         # we use this value as `idx_range` in the calculation: idx = round((self.id_up_to - 1) * (1 - idx_range))
-        pseudo_exponential_distribution = iter([
-            # id_up_to = 1 -> idx = 0
-            0.013375248172714948,
-            # id_up_to = 1 -> idx = 0
-            0.042495604491024914,
-            # id_up_to = 1 -> idx = 0
-            0.005491072642023834,
-            # no conflict: id_up_to = 2
-            # no conflict: id_up_to = 3
-            # no conflict: id_up_to = 4
-            # id_up_to = 4 -> idx = round((4 - 1) * (1 - 0.028557879547255083)) = 3
-            0.028557879547255083,
-            # id_up_to = 4 -> idx = round((4 - 1) * (1 - 0.209771474243926352)) = 2
-            0.209771474243926352
-        ])
+        pseudo_exponential_distribution = iter(
+            [
+                # id_up_to = 1 -> idx = 0
+                0.013375248172714948,
+                # id_up_to = 1 -> idx = 0
+                0.042495604491024914,
+                # id_up_to = 1 -> idx = 0
+                0.005491072642023834,
+                # no conflict: id_up_to = 2
+                # no conflict: id_up_to = 3
+                # no conflict: id_up_to = 4
+                # id_up_to = 4 -> idx = round((4 - 1) * (1 - 0.028557879547255083)) = 3
+                0.028557879547255083,
+                # id_up_to = 4 -> idx = round((4 - 1) * (1 - 0.209771474243926352)) = 2
+                0.209771474243926352,
+            ]
+        )
 
         conflict_action = random.choice(["index", "update"])
         type_name = random.choice([None, "test_type"])
 
-        generator = params.GenerateActionMetaData("test_index", type_name=type_name,
-                                                  conflicting_ids=[100, 200, 300, 400, 500, 600],
-                                                  conflict_probability=25,
-                                                  # heavily biased towards recent ids
-                                                  recency=1.0,
-                                                  on_conflict=conflict_action,
-                                                  rand=lambda: next(pseudo_random_conflicts),
-                                                  # we don't use this one here because recency is > 0.
-                                                  # randint=lambda x, y: next(chosen_index_of_conflicting_ids),
-                                                  randexp=lambda lmbda: next(pseudo_exponential_distribution)
-                                                  )
+        generator = params.GenerateActionMetaData(
+            "test_index",
+            type_name=type_name,
+            conflicting_ids=[100, 200, 300, 400, 500, 600],
+            conflict_probability=25,
+            # heavily biased towards recent ids
+            recency=1.0,
+            on_conflict=conflict_action,
+            rand=lambda: next(pseudo_random_conflicts),
+            # we don't use this one here because recency is > 0.
+            # randint=lambda x, y: next(chosen_index_of_conflicting_ids),
+            randexp=lambda lmbda: next(pseudo_exponential_distribution),
+        )
 
         # first one is always *not* drawn from a random index
         self.assertEqual(idx(type_name, "100"), next(generator))
@@ -283,34 +296,28 @@ class ActionMetaDataTests(TestCase):
 
         test_ids = [100, 200, 300, 400]
 
-        generator = params.GenerateActionMetaData("test_index", "test_type",
-                                                  conflicting_ids=test_ids,
-                                                  conflict_probability=0)
+        generator = params.GenerateActionMetaData("test_index", "test_type", conflicting_ids=test_ids, conflict_probability=0)
 
         self.assertListEqual([idx(id) for id in test_ids], list(generator))
 
 
 class IndexDataReaderTests(TestCase):
     def test_read_bulk_larger_than_number_of_docs(self):
-        data = [
-            b'{"key": "value1"}\n',
-            b'{"key": "value2"}\n',
-            b'{"key": "value3"}\n',
-            b'{"key": "value4"}\n',
-            b'{"key": "value5"}\n'
-        ]
+        data = [b'{"key": "value1"}\n', b'{"key": "value2"}\n', b'{"key": "value3"}\n', b'{"key": "value4"}\n', b'{"key": "value5"}\n']
         bulk_size = 50
 
         source = params.Slice(io.StringAsFileSource, 0, len(data))
         am_handler = params.GenerateActionMetaData("test_index", "test_type")
 
-        reader = params.MetadataIndexDataReader(data,
-                                                batch_size=bulk_size,
-                                                bulk_size=bulk_size,
-                                                file_source=source,
-                                                action_metadata=am_handler,
-                                                index_name="test_index",
-                                                type_name="test_type")
+        reader = params.MetadataIndexDataReader(
+            data,
+            batch_size=bulk_size,
+            bulk_size=bulk_size,
+            file_source=source,
+            action_metadata=am_handler,
+            index_name="test_index",
+            type_name="test_type",
+        )
 
         expected_bulk_sizes = [len(data)]
         # lines should include meta-data
@@ -318,25 +325,21 @@ class IndexDataReaderTests(TestCase):
         self.assert_bulks_sized(reader, expected_bulk_sizes, expected_line_sizes)
 
     def test_read_bulk_with_offset(self):
-        data = [
-            b'{"key": "value1"}\n',
-            b'{"key": "value2"}\n',
-            b'{"key": "value3"}\n',
-            b'{"key": "value4"}\n',
-            b'{"key": "value5"}\n'
-        ]
+        data = [b'{"key": "value1"}\n', b'{"key": "value2"}\n', b'{"key": "value3"}\n', b'{"key": "value4"}\n', b'{"key": "value5"}\n']
         bulk_size = 50
 
         source = params.Slice(io.StringAsFileSource, 3, len(data))
         am_handler = params.GenerateActionMetaData("test_index", "test_type")
 
-        reader = params.MetadataIndexDataReader(data,
-                                                batch_size=bulk_size,
-                                                bulk_size=bulk_size,
-                                                file_source=source,
-                                                action_metadata=am_handler,
-                                                index_name="test_index",
-                                                type_name="test_type")
+        reader = params.MetadataIndexDataReader(
+            data,
+            batch_size=bulk_size,
+            bulk_size=bulk_size,
+            file_source=source,
+            action_metadata=am_handler,
+            index_name="test_index",
+            type_name="test_type",
+        )
 
         expected_bulk_sizes = [(len(data) - 3)]
         # lines should include meta-data
@@ -358,13 +361,15 @@ class IndexDataReaderTests(TestCase):
         source = params.Slice(io.StringAsFileSource, 0, len(data))
         am_handler = params.GenerateActionMetaData("test_index", "test_type")
 
-        reader = params.MetadataIndexDataReader(data,
-                                                batch_size=bulk_size,
-                                                bulk_size=bulk_size,
-                                                file_source=source,
-                                                action_metadata=am_handler,
-                                                index_name="test_index",
-                                                type_name="test_type")
+        reader = params.MetadataIndexDataReader(
+            data,
+            batch_size=bulk_size,
+            bulk_size=bulk_size,
+            file_source=source,
+            action_metadata=am_handler,
+            index_name="test_index",
+            type_name="test_type",
+        )
 
         expected_bulk_sizes = [3, 3, 1]
         # lines should include meta-data
@@ -387,13 +392,15 @@ class IndexDataReaderTests(TestCase):
         source = params.Slice(io.StringAsFileSource, 0, 5)
         am_handler = params.GenerateActionMetaData("test_index", "test_type")
 
-        reader = params.MetadataIndexDataReader(data,
-                                                batch_size=bulk_size,
-                                                bulk_size=bulk_size,
-                                                file_source=source,
-                                                action_metadata=am_handler,
-                                                index_name="test_index",
-                                                type_name="test_type")
+        reader = params.MetadataIndexDataReader(
+            data,
+            batch_size=bulk_size,
+            bulk_size=bulk_size,
+            file_source=source,
+            action_metadata=am_handler,
+            index_name="test_index",
+            type_name="test_type",
+        )
 
         expected_bulk_sizes = [3, 2]
         # lines should include meta-data
@@ -415,18 +422,15 @@ class IndexDataReaderTests(TestCase):
             b'{"index": {"_index": "test_index", "_type": "test_type"}\n',
             b'{"key": "value6"}\n',
             b'{"index": {"_index": "test_index", "_type": "test_type"}\n',
-            b'{"key": "value7"}\n'
+            b'{"key": "value7"}\n',
         ]
         bulk_size = 3
 
         source = params.Slice(io.StringAsFileSource, 0, len(data))
 
-        reader = params.SourceOnlyIndexDataReader(data,
-                                                  batch_size=bulk_size,
-                                                  bulk_size=bulk_size,
-                                                  file_source=source,
-                                                  index_name="test_index",
-                                                  type_name="test_type")
+        reader = params.SourceOnlyIndexDataReader(
+            data, batch_size=bulk_size, bulk_size=bulk_size, file_source=source, index_name="test_index", type_name="test_type"
+        )
 
         expected_bulk_sizes = [3, 3, 1]
         # lines should include meta-data
@@ -434,45 +438,49 @@ class IndexDataReaderTests(TestCase):
         self.assert_bulks_sized(reader, expected_bulk_sizes, expected_line_sizes)
 
     def test_read_bulk_with_id_conflicts(self):
-        pseudo_random_conflicts = iter([
-            # if this value is <= our chosen threshold of 0.25 (see conflict_probability) we produce a conflict.
-            0.2,
-            0.25,
-            0.2,
-            # no conflict
-            0.3
-        ])
+        pseudo_random_conflicts = iter(
+            [
+                # if this value is <= our chosen threshold of 0.25 (see conflict_probability) we produce a conflict.
+                0.2,
+                0.25,
+                0.2,
+                # no conflict
+                0.3,
+            ]
+        )
 
-        chosen_index_of_conflicting_ids = iter([
-            # the "random" index of the id in the array `conflicting_ids` that will produce a conflict
-            1,
-            3,
-            2])
+        chosen_index_of_conflicting_ids = iter(
+            [
+                # the "random" index of the id in the array `conflicting_ids` that will produce a conflict
+                1,
+                3,
+                2,
+            ]
+        )
 
-        data = [
-            b'{"key": "value1"}\n',
-            b'{"key": "value2"}\n',
-            b'{"key": "value3"}\n',
-            b'{"key": "value4"}\n',
-            b'{"key": "value5"}\n'
-        ]
+        data = [b'{"key": "value1"}\n', b'{"key": "value2"}\n', b'{"key": "value3"}\n', b'{"key": "value4"}\n', b'{"key": "value5"}\n']
         bulk_size = 2
 
         source = params.Slice(io.StringAsFileSource, 0, len(data))
-        am_handler = params.GenerateActionMetaData("test_index", "test_type",
-                                                   conflicting_ids=[100, 200, 300, 400],
-                                                   conflict_probability=25,
-                                                   on_conflict="update",
-                                                   rand=lambda: next(pseudo_random_conflicts),
-                                                   randint=lambda x, y: next(chosen_index_of_conflicting_ids))
+        am_handler = params.GenerateActionMetaData(
+            "test_index",
+            "test_type",
+            conflicting_ids=[100, 200, 300, 400],
+            conflict_probability=25,
+            on_conflict="update",
+            rand=lambda: next(pseudo_random_conflicts),
+            randint=lambda x, y: next(chosen_index_of_conflicting_ids),
+        )
 
-        reader = params.MetadataIndexDataReader(data,
-                                                batch_size=bulk_size,
-                                                bulk_size=bulk_size,
-                                                file_source=source,
-                                                action_metadata=am_handler,
-                                                index_name="test_index",
-                                                type_name="test_type")
+        reader = params.MetadataIndexDataReader(
+            data,
+            batch_size=bulk_size,
+            bulk_size=bulk_size,
+            file_source=source,
+            action_metadata=am_handler,
+            index_name="test_index",
+            type_name="test_type",
+        )
 
         # consume all bulks
         bulks = []
@@ -481,40 +489,37 @@ class IndexDataReaderTests(TestCase):
                 for bulk_size, bulk in batch:
                     bulks.append(bulk)
 
-        self.assertEqual([
-            b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "100"}}\n' +
-            b'{"key": "value1"}\n' +
-            b'{"update": {"_index": "test_index", "_type": "test_type", "_id": "200"}}\n' +
-            b'{"doc":{"key": "value2"}}\n',
-            b'{"update": {"_index": "test_index", "_type": "test_type", "_id": "400"}}\n' +
-            b'{"doc":{"key": "value3"}}\n' +
-            b'{"update": {"_index": "test_index", "_type": "test_type", "_id": "300"}}\n' +
-            b'{"doc":{"key": "value4"}}\n',
-            b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "200"}}\n' +
-            b'{"key": "value5"}\n'
-        ], bulks)
+        self.assertEqual(
+            [
+                b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "100"}}\n'
+                + b'{"key": "value1"}\n'
+                + b'{"update": {"_index": "test_index", "_type": "test_type", "_id": "200"}}\n'
+                + b'{"doc":{"key": "value2"}}\n',
+                b'{"update": {"_index": "test_index", "_type": "test_type", "_id": "400"}}\n'
+                + b'{"doc":{"key": "value3"}}\n'
+                + b'{"update": {"_index": "test_index", "_type": "test_type", "_id": "300"}}\n'
+                + b'{"doc":{"key": "value4"}}\n',
+                b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "200"}}\n' + b'{"key": "value5"}\n',
+            ],
+            bulks,
+        )
 
     def test_read_bulk_with_external_id_and_zero_conflict_probability(self):
-        data = [
-            b'{"key": "value1"}\n',
-            b'{"key": "value2"}\n',
-            b'{"key": "value3"}\n',
-            b'{"key": "value4"}\n'
-        ]
+        data = [b'{"key": "value1"}\n', b'{"key": "value2"}\n', b'{"key": "value3"}\n', b'{"key": "value4"}\n']
         bulk_size = 2
 
         source = params.Slice(io.StringAsFileSource, 0, len(data))
-        am_handler = params.GenerateActionMetaData("test_index", "test_type",
-                                                   conflicting_ids=[100, 200, 300, 400],
-                                                   conflict_probability=0)
+        am_handler = params.GenerateActionMetaData("test_index", "test_type", conflicting_ids=[100, 200, 300, 400], conflict_probability=0)
 
-        reader = params.MetadataIndexDataReader(data,
-                                                batch_size=bulk_size,
-                                                bulk_size=bulk_size,
-                                                file_source=source,
-                                                action_metadata=am_handler,
-                                                index_name="test_index",
-                                                type_name="test_type")
+        reader = params.MetadataIndexDataReader(
+            data,
+            batch_size=bulk_size,
+            bulk_size=bulk_size,
+            file_source=source,
+            action_metadata=am_handler,
+            index_name="test_index",
+            type_name="test_type",
+        )
 
         # consume all bulks
         bulks = []
@@ -523,17 +528,19 @@ class IndexDataReaderTests(TestCase):
                 for bulk_size, bulk in batch:
                     bulks.append(bulk)
 
-        self.assertEqual([
-            b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "100"}}\n' +
-            b'{"key": "value1"}\n' +
-            b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "200"}}\n' +
-            b'{"key": "value2"}\n',
-
-            b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "300"}}\n' +
-            b'{"key": "value3"}\n' +
-            b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "400"}}\n' +
-            b'{"key": "value4"}\n'
-        ], bulks)
+        self.assertEqual(
+            [
+                b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "100"}}\n'
+                + b'{"key": "value1"}\n'
+                + b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "200"}}\n'
+                + b'{"key": "value2"}\n',
+                b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "300"}}\n'
+                + b'{"key": "value3"}\n'
+                + b'{"index": {"_index": "test_index", "_type": "test_type", "_id": "400"}}\n'
+                + b'{"key": "value4"}\n',
+            ],
+            bulks,
+        )
 
     def assert_bulks_sized(self, reader, expected_bulk_sizes, expected_line_sizes):
         self.assertEqual(len(expected_bulk_sizes), len(expected_line_sizes), "Bulk sizes and line sizes must be equal")
@@ -667,18 +674,46 @@ class InvocationGeneratorTests(TestCase):
 
         self.assertEqual(1, self.number_of_bulks([self.corpus("a", [docs1])], 0, 0, 1, 1))
         self.assertEqual(1, self.number_of_bulks([self.corpus("a", [docs1])], 0, 0, 1, 2))
-        self.assertEqual(20, self.number_of_bulks(
-            [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]),
-             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 0, 1, 1))
-        self.assertEqual(11, self.number_of_bulks(
-            [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]),
-             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 0, 1, 2))
-        self.assertEqual(11, self.number_of_bulks(
-            [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]),
-             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 0, 1, 3))
-        self.assertEqual(11, self.number_of_bulks(
-            [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]),
-             self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])], 0, 0, 1, 100))
+        self.assertEqual(
+            20,
+            self.number_of_bulks(
+                [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]), self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])],
+                0,
+                0,
+                1,
+                1,
+            ),
+        )
+        self.assertEqual(
+            11,
+            self.number_of_bulks(
+                [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]), self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])],
+                0,
+                0,
+                1,
+                2,
+            ),
+        )
+        self.assertEqual(
+            11,
+            self.number_of_bulks(
+                [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]), self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])],
+                0,
+                0,
+                1,
+                3,
+            ),
+        )
+        self.assertEqual(
+            11,
+            self.number_of_bulks(
+                [self.corpus("a", [docs2, docs2, docs2, docs2, docs1]), self.corpus("b", [docs2, docs2, docs2, docs2, docs2, docs1])],
+                0,
+                0,
+                1,
+                100,
+            ),
+        )
 
         self.assertEqual(2, self.number_of_bulks([self.corpus("a", [self.docs(800)])], 0, 0, 3, 250))
         self.assertEqual(1, self.number_of_bulks([self.corpus("a", [self.docs(800)])], 0, 0, 3, 267))
@@ -701,8 +736,9 @@ class InvocationGeneratorTests(TestCase):
 
     def test_build_conflicting_ids(self):
         self.assertIsNone(params.build_conflicting_ids(params.IndexIdConflict.NoConflicts, 3, 0))
-        self.assertEqual(["0000000000", "0000000001", "0000000002"],
-                         params.build_conflicting_ids(params.IndexIdConflict.SequentialConflicts, 3, 0))
+        self.assertEqual(
+            ["0000000000", "0000000001", "0000000002"], params.build_conflicting_ids(params.IndexIdConflict.SequentialConflicts, 3, 0)
+        )
         # we cannot tell anything specific about the contents...
         self.assertEqual(3, len(params.build_conflicting_ids(params.IndexIdConflict.RandomConflicts, 3, 0)))
 
@@ -710,210 +746,318 @@ class InvocationGeneratorTests(TestCase):
 # pylint: disable=too-many-public-methods
 class BulkIndexParamSourceTests(TestCase):
     def test_create_without_params(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test", corpora=[corpus]), params={})
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test", corpora=[corpus]),
+                params={},
+            )
 
         self.assertEqual("Mandatory parameter 'bulk-size' is missing", ctx.exception.args[0])
 
     def test_create_without_corpora_definition(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test"), params={})
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test"),
+                params={},
+            )
 
-        self.assertEqual("There is no document corpus definition for track unit-test. "
-                         "You must add at least one before making bulk requests to Elasticsearch.", ctx.exception.args[0])
+        self.assertEqual(
+            "There is no document corpus definition for track unit-test. "
+            "You must add at least one before making bulk requests to Elasticsearch.",
+            ctx.exception.args[0],
+        )
 
     def test_create_with_non_numeric_bulk_size(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test", corpora=[corpus]), params={
-                "bulk-size": "Three"
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test", corpora=[corpus]),
+                params={
+                    "bulk-size": "Three",
+                },
+            )
 
         self.assertEqual("'bulk-size' must be numeric", ctx.exception.args[0])
 
     def test_create_with_negative_bulk_size(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test", corpora=[corpus]), params={
-                "bulk-size": -5
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test", corpora=[corpus]),
+                params={
+                    "bulk-size": -5,
+                },
+            )
 
         self.assertEqual("'bulk-size' must be positive but was -5", ctx.exception.args[0])
 
     def test_create_with_fraction_smaller_batch_size(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test", corpora=[corpus]), params={
-                "bulk-size": 5,
-                "batch-size": 3
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test", corpora=[corpus]),
+                params={
+                    "bulk-size": 5,
+                    "batch-size": 3,
+                },
+            )
 
         self.assertEqual("'batch-size' must be greater than or equal to 'bulk-size'", ctx.exception.args[0])
 
     def test_create_with_fraction_larger_batch_size(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test", corpora=[corpus]), params={
-                "bulk-size": 5,
-                "batch-size": 8
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test", corpora=[corpus]),
+                params={
+                    "bulk-size": 5,
+                    "batch-size": 8,
+                },
+            )
 
         self.assertEqual("'batch-size' must be a multiple of 'bulk-size'", ctx.exception.args[0])
 
     def test_create_with_metadata_in_source_file_but_conflicts(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            document_archive="docs.json.bz2",
-                            document_file="docs.json",
-                            number_of_documents=10,
-                            includes_action_and_meta_data=True)
-        ])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    document_archive="docs.json.bz2",
+                    document_file="docs.json",
+                    number_of_documents=10,
+                    includes_action_and_meta_data=True,
+                )
+            ],
+        )
 
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test", corpora=[corpus]), params={
-                "conflicts": "random"
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test", corpora=[corpus]),
+                params={
+                    "conflicts": "random",
+                },
+            )
 
-        self.assertEqual("Cannot generate id conflicts [random] as [docs.json.bz2] in document corpus [default] already contains "
-                         "an action and meta-data line.", ctx.exception.args[0])
+        self.assertEqual(
+            "Cannot generate id conflicts [random] as [docs.json.bz2] in document corpus [default] already contains "
+            "an action and meta-data line.",
+            ctx.exception.args[0],
+        )
 
     def test_create_with_unknown_id_conflicts(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test"), params={
-                "conflicts": "crazy"
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test"),
+                params={
+                    "conflicts": "crazy",
+                },
+            )
 
         self.assertEqual("Unknown 'conflicts' setting [crazy]", ctx.exception.args[0])
 
     def test_create_with_unknown_on_conflict_setting(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test"), params={
-                "conflicts": "sequential",
-                "on-conflict": "delete"
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test"),
+                params={
+                    "conflicts": "sequential",
+                    "on-conflict": "delete",
+                },
+            )
 
         self.assertEqual("Unknown 'on-conflict' setting [delete]", ctx.exception.args[0])
 
     def test_create_with_conflicts_and_data_streams(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test"), params={
-                "data-streams": ["test-data-stream-1", "test-data-stream-2"],
-                "conflicts": "sequential"
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test"),
+                params={
+                    "data-streams": ["test-data-stream-1", "test-data-stream-2"],
+                    "conflicts": "sequential",
+                },
+            )
 
         self.assertEqual("'conflicts' cannot be used with 'data-streams'", ctx.exception.args[0])
 
     def test_create_with_ingest_percentage_too_low(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test", corpora=[corpus]), params={
-                "bulk-size": 5000,
-                "ingest-percentage": 0.0
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test", corpora=[corpus]),
+                params={
+                    "bulk-size": 5000,
+                    "ingest-percentage": 0.0,
+                },
+            )
 
         self.assertEqual("'ingest-percentage' must be in the range (0.0, 100.0] but was 0.0", ctx.exception.args[0])
 
     def test_create_with_ingest_percentage_too_high(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test", corpora=[corpus]), params={
-                "bulk-size": 5000,
-                "ingest-percentage": 100.1
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test", corpora=[corpus]),
+                params={
+                    "bulk-size": 5000,
+                    "ingest-percentage": 100.1,
+                },
+            )
 
         self.assertEqual("'ingest-percentage' must be in the range (0.0, 100.0] but was 100.1", ctx.exception.args[0])
 
     def test_create_with_ingest_percentage_not_numeric(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test", corpora=[corpus]), params={
-                "bulk-size": 5000,
-                "ingest-percentage": "100 percent"
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test", corpora=[corpus]),
+                params={
+                    "bulk-size": 5000,
+                    "ingest-percentage": "100 percent",
+                },
+            )
 
         self.assertEqual("'ingest-percentage' must be numeric", ctx.exception.args[0])
 
     def test_create_valid_param_source(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
-        self.assertIsNotNone(params.BulkIndexParamSource(track.Track(name="unit-test", corpora=[corpus]), params={
-            "conflicts": "random",
-            "bulk-size": 5000,
-            "batch-size": 20000,
-            "ingest-percentage": 20.5,
-            "pipeline": "test-pipeline"
-        }))
+        self.assertIsNotNone(
+            params.BulkIndexParamSource(
+                track.Track(name="unit-test", corpora=[corpus]),
+                params={
+                    "conflicts": "random",
+                    "bulk-size": 5000,
+                    "batch-size": 20000,
+                    "ingest-percentage": 20.5,
+                    "pipeline": "test-pipeline",
+                },
+            )
+        )
 
     def test_passes_all_corpora_by_default(self):
         corpora = [
-            track.DocumentCorpus(name="default", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=10,
-                                target_index="test-idx",
-                                target_type="test-type"
-                                )
-            ]),
-            track.DocumentCorpus(name="special", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=100,
-                                target_index="test-idx2",
-                                target_type="type"
-                                )
-            ]),
+            track.DocumentCorpus(
+                name="default",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=10,
+                        target_index="test-idx",
+                        target_type="test-type",
+                    )
+                ],
+            ),
+            track.DocumentCorpus(
+                name="special",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=100,
+                        target_index="test-idx2",
+                        target_type="type",
+                    )
+                ],
+            ),
         ]
 
         source = params.BulkIndexParamSource(
@@ -922,28 +1066,37 @@ class BulkIndexParamSourceTests(TestCase):
                 "conflicts": "random",
                 "bulk-size": 5000,
                 "batch-size": 20000,
-                "pipeline": "test-pipeline"
-            })
+                "pipeline": "test-pipeline",
+            },
+        )
 
         partition = source.partition(0, 1)
         self.assertEqual(partition.corpora, corpora)
 
     def test_filters_corpora(self):
         corpora = [
-            track.DocumentCorpus(name="default", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=10,
-                                target_index="test-idx",
-                                target_type="test-type"
-                                )
-            ]),
-            track.DocumentCorpus(name="special", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=100,
-                                target_index="test-idx2",
-                                target_type="type"
-                                )
-            ]),
+            track.DocumentCorpus(
+                name="default",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=10,
+                        target_index="test-idx",
+                        target_type="test-type",
+                    )
+                ],
+            ),
+            track.DocumentCorpus(
+                name="special",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=100,
+                        target_index="test-idx2",
+                        target_type="type",
+                    )
+                ],
+            ),
         ]
 
         source = params.BulkIndexParamSource(
@@ -953,33 +1106,42 @@ class BulkIndexParamSourceTests(TestCase):
                 "conflicts": "random",
                 "bulk-size": 5000,
                 "batch-size": 20000,
-                "pipeline": "test-pipeline"
-            })
+                "pipeline": "test-pipeline",
+            },
+        )
 
         partition = source.partition(0, 1)
         self.assertEqual(partition.corpora, [corpora[1]])
 
     def test_filters_corpora_by_data_stream(self):
         corpora = [
-            track.DocumentCorpus(name="default", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=10,
-                                target_data_stream="test-data-stream-1"
-                                )
-            ]),
-            track.DocumentCorpus(name="special", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=100,
-                                target_index="test-idx2",
-                                target_type="type"
-                                )
-            ]),
-            track.DocumentCorpus(name="special-2", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=10,
-                                target_data_stream="test-data-stream-2"
-                                )
-            ])
+            track.DocumentCorpus(
+                name="default",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=10, target_data_stream="test-data-stream-1"
+                    )
+                ],
+            ),
+            track.DocumentCorpus(
+                name="special",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=100,
+                        target_index="test-idx2",
+                        target_type="type",
+                    )
+                ],
+            ),
+            track.DocumentCorpus(
+                name="special-2",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=10, target_data_stream="test-data-stream-2"
+                    )
+                ],
+            ),
         ]
 
         source = params.BulkIndexParamSource(
@@ -988,19 +1150,25 @@ class BulkIndexParamSourceTests(TestCase):
                 "data-streams": ["test-data-stream-1", "test-data-stream-2"],
                 "bulk-size": 5000,
                 "batch-size": 20000,
-                "pipeline": "test-pipeline"
-            })
+                "pipeline": "test-pipeline",
+            },
+        )
 
         partition = source.partition(0, 1)
         self.assertEqual(partition.corpora, [corpora[0], corpora[2]])
 
     def test_raises_exception_if_no_corpus_matches(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
         with self.assertRaises(exceptions.RallyAssertionError) as ctx:
             params.BulkIndexParamSource(
@@ -1010,34 +1178,44 @@ class BulkIndexParamSourceTests(TestCase):
                     "conflicts": "random",
                     "bulk-size": 5000,
                     "batch-size": 20000,
-                    "pipeline": "test-pipeline"
-                })
+                    "pipeline": "test-pipeline",
+                },
+            )
 
         self.assertEqual("The provided corpus ['does_not_exist'] does not match any of the corpora ['default'].", ctx.exception.args[0])
 
     def test_ingests_all_documents_by_default(self):
         corpora = [
-            track.DocumentCorpus(name="default", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=300000,
-                                target_index="test-idx",
-                                target_type="test-type"
-                                )
-            ]),
-            track.DocumentCorpus(name="special", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=700000,
-                                target_index="test-idx2",
-                                target_type="type"
-                                )
-            ]),
+            track.DocumentCorpus(
+                name="default",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=300000,
+                        target_index="test-idx",
+                        target_type="test-type",
+                    )
+                ],
+            ),
+            track.DocumentCorpus(
+                name="special",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=700000,
+                        target_index="test-idx2",
+                        target_type="type",
+                    )
+                ],
+            ),
         ]
 
         source = params.BulkIndexParamSource(
             track=track.Track(name="unit-test", corpora=corpora),
             params={
-                "bulk-size": 10000
-            })
+                "bulk-size": 10000,
+            },
+        )
 
         partition = source.partition(0, 1)
         partition._init_internal_params()
@@ -1046,18 +1224,22 @@ class BulkIndexParamSourceTests(TestCase):
 
     def test_restricts_number_of_bulks_if_required(self):
         def create_unit_test_reader(*args):
-            return StaticBulkReader("idx", "doc", bulks=[
-                ['{"location" : [-0.1485188, 51.5250666]}'],
-                ['{"location" : [-0.1479949, 51.5252071]}'],
-                ['{"location" : [-0.1458559, 51.5289059]}'],
-                ['{"location" : [-0.1498551, 51.5282564]}'],
-                ['{"location" : [-0.1487043, 51.5254843]}'],
-                ['{"location" : [-0.1533367, 51.5261779]}'],
-                ['{"location" : [-0.1543018, 51.5262398]}'],
-                ['{"location" : [-0.1522118, 51.5266564]}'],
-                ['{"location" : [-0.1529092, 51.5263360]}'],
-                ['{"location" : [-0.1537008, 51.5265365]}'],
-            ])
+            return StaticBulkReader(
+                "idx",
+                "doc",
+                bulks=[
+                    ['{"location" : [-0.1485188, 51.5250666]}'],
+                    ['{"location" : [-0.1479949, 51.5252071]}'],
+                    ['{"location" : [-0.1458559, 51.5289059]}'],
+                    ['{"location" : [-0.1498551, 51.5282564]}'],
+                    ['{"location" : [-0.1487043, 51.5254843]}'],
+                    ['{"location" : [-0.1533367, 51.5261779]}'],
+                    ['{"location" : [-0.1543018, 51.5262398]}'],
+                    ['{"location" : [-0.1522118, 51.5266564]}'],
+                    ['{"location" : [-0.1529092, 51.5263360]}'],
+                    ['{"location" : [-0.1537008, 51.5265365]}'],
+                ],
+            )
 
         def schedule(param_source):
             while True:
@@ -1067,20 +1249,28 @@ class BulkIndexParamSourceTests(TestCase):
                     return
 
         corpora = [
-            track.DocumentCorpus(name="default", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=300000,
-                                target_index="test-idx",
-                                target_type="test-type"
-                                )
-            ]),
-            track.DocumentCorpus(name="special", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=700000,
-                                target_index="test-idx2",
-                                target_type="type"
-                                )
-            ]),
+            track.DocumentCorpus(
+                name="default",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=300000,
+                        target_index="test-idx",
+                        target_type="test-type",
+                    )
+                ],
+            ),
+            track.DocumentCorpus(
+                name="special",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=700000,
+                        target_index="test-idx2",
+                        target_type="type",
+                    )
+                ],
+            ),
         ]
 
         source = params.BulkIndexParamSource(
@@ -1088,8 +1278,9 @@ class BulkIndexParamSourceTests(TestCase):
             params={
                 "bulk-size": 10000,
                 "ingest-percentage": 2.5,
-                "__create_reader": create_unit_test_reader
-            })
+                "__create_reader": create_unit_test_reader,
+            },
+        )
 
         partition = source.partition(0, 1)
         partition._init_internal_params()
@@ -1098,52 +1289,50 @@ class BulkIndexParamSourceTests(TestCase):
         self.assertEqual(3, len(list(schedule(partition))))
 
     def test_create_with_conflict_probability_zero(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
-        params.BulkIndexParamSource(track=track.Track(name="unit-test", corpora=[corpus]), params={
-            "bulk-size": 5000,
-            "conflicts": "sequential",
-            "conflict-probability": 0
-        })
+        params.BulkIndexParamSource(
+            track=track.Track(name="unit-test", corpora=[corpus]),
+            params={"bulk-size": 5000, "conflicts": "sequential", "conflict-probability": 0},
+        )
 
     def test_create_with_conflict_probability_too_low(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test"), params={
-                "bulk-size": 5000,
-                "conflicts": "sequential",
-                "conflict-probability": -0.1
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test"), params={"bulk-size": 5000, "conflicts": "sequential", "conflict-probability": -0.1}
+            )
 
         self.assertEqual("'conflict-probability' must be in the range [0.0, 100.0] but was -0.1", ctx.exception.args[0])
 
     def test_create_with_conflict_probability_too_high(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test"), params={
-                "bulk-size": 5000,
-                "conflicts": "sequential",
-                "conflict-probability": 100.1
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test"), params={"bulk-size": 5000, "conflicts": "sequential", "conflict-probability": 100.1}
+            )
 
         self.assertEqual("'conflict-probability' must be in the range [0.0, 100.0] but was 100.1", ctx.exception.args[0])
 
     def test_create_with_conflict_probability_not_numeric(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.BulkIndexParamSource(track=track.Track(name="unit-test"), params={
-                "bulk-size": 5000,
-                "conflicts": "sequential",
-                "conflict-probability": "100 percent"
-            })
+            params.BulkIndexParamSource(
+                track=track.Track(name="unit-test"),
+                params={"bulk-size": 5000, "conflicts": "sequential", "conflict-probability": "100 percent"},
+            )
 
         self.assertEqual("'conflict-probability' must be numeric", ctx.exception.args[0])
 
 
 class BulkDataGeneratorTests(TestCase):
-
     @classmethod
     def create_test_reader(cls, batches):
         def inner_create_test_reader(docs, *args):
@@ -1152,160 +1341,207 @@ class BulkDataGeneratorTests(TestCase):
         return inner_create_test_reader
 
     def test_generate_two_bulks(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=10,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )
-        ])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=10,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
-        bulks = params.bulk_data_based(num_clients=1, start_client_index=0, end_client_index=0, corpora=[corpus],
-                                       batch_size=5, bulk_size=5,
-                                       id_conflicts=params.IndexIdConflict.NoConflicts, conflict_probability=None, on_conflict=None,
-                                       recency=None, pipeline=None,
-                                       original_params={
-                                           "my-custom-parameter": "foo",
-                                           "my-custom-parameter-2": True
-                                       }, create_reader=BulkDataGeneratorTests.
-                                       create_test_reader([["1", "2", "3", "4", "5"], ["6", "7", "8"]]))
+        bulks = params.bulk_data_based(
+            num_clients=1,
+            start_client_index=0,
+            end_client_index=0,
+            corpora=[corpus],
+            batch_size=5,
+            bulk_size=5,
+            id_conflicts=params.IndexIdConflict.NoConflicts,
+            conflict_probability=None,
+            on_conflict=None,
+            recency=None,
+            pipeline=None,
+            original_params={"my-custom-parameter": "foo", "my-custom-parameter-2": True},
+            create_reader=BulkDataGeneratorTests.create_test_reader([["1", "2", "3", "4", "5"], ["6", "7", "8"]]),
+        )
         all_bulks = list(bulks)
         self.assertEqual(2, len(all_bulks))
-        self.assertEqual({
-            "action-metadata-present": True,
-            "body": ["1", "2", "3", "4", "5"],
-            "bulk-size": 5,
-            "unit": "docs",
-            "index": "test-idx",
-            "type": "test-type",
-            "my-custom-parameter": "foo",
-            "my-custom-parameter-2": True
-        }, all_bulks[0])
+        self.assertEqual(
+            {
+                "action-metadata-present": True,
+                "body": ["1", "2", "3", "4", "5"],
+                "bulk-size": 5,
+                "unit": "docs",
+                "index": "test-idx",
+                "type": "test-type",
+                "my-custom-parameter": "foo",
+                "my-custom-parameter-2": True,
+            },
+            all_bulks[0],
+        )
 
-        self.assertEqual({
-            "action-metadata-present": True,
-            "body": ["6", "7", "8"],
-            "bulk-size": 3,
-            "unit": "docs",
-            "index": "test-idx",
-            "type": "test-type",
-            "my-custom-parameter": "foo",
-            "my-custom-parameter-2": True
-        }, all_bulks[1])
+        self.assertEqual(
+            {
+                "action-metadata-present": True,
+                "body": ["6", "7", "8"],
+                "bulk-size": 3,
+                "unit": "docs",
+                "index": "test-idx",
+                "type": "test-type",
+                "my-custom-parameter": "foo",
+                "my-custom-parameter-2": True,
+            },
+            all_bulks[1],
+        )
 
     def test_generate_bulks_from_multiple_corpora(self):
         corpora = [
-            track.DocumentCorpus(name="default", documents=[
-                        track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                        number_of_documents=5,
-                                        target_index="logs-2018-01",
-                                        target_type="docs"
-                                        ),
-                        track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                        number_of_documents=5,
-                                        target_index="logs-2018-02",
-                                        target_type="docs"
-                                        ),
+            track.DocumentCorpus(
+                name="default",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=5,
+                        target_index="logs-2018-01",
+                        target_type="docs",
+                    ),
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=5,
+                        target_index="logs-2018-02",
+                        target_type="docs",
+                    ),
+                ],
+            ),
+            track.DocumentCorpus(
+                name="special",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=5,
+                        target_index="logs-2017-01",
+                        target_type="docs",
+                    )
+                ],
+            ),
+        ]
 
-                    ]),
-            track.DocumentCorpus(name="special", documents=[
-                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                                number_of_documents=5,
-                                target_index="logs-2017-01",
-                                target_type="docs"
-                                )
-            ])
-
-            ]
-
-        bulks = params.bulk_data_based(num_clients=1, start_client_index=0, end_client_index=0, corpora=corpora,
-                                       batch_size=5, bulk_size=5,
-                                       id_conflicts=params.IndexIdConflict.NoConflicts, conflict_probability=None, on_conflict=None,
-                                       recency=None, pipeline=None,
-                                       original_params={
-                                           "my-custom-parameter": "foo",
-                                           "my-custom-parameter-2": True
-                                       }, create_reader=BulkDataGeneratorTests.
-                                       create_test_reader([["1", "2", "3", "4", "5"]]))
+        bulks = params.bulk_data_based(
+            num_clients=1,
+            start_client_index=0,
+            end_client_index=0,
+            corpora=corpora,
+            batch_size=5,
+            bulk_size=5,
+            id_conflicts=params.IndexIdConflict.NoConflicts,
+            conflict_probability=None,
+            on_conflict=None,
+            recency=None,
+            pipeline=None,
+            original_params={"my-custom-parameter": "foo", "my-custom-parameter-2": True},
+            create_reader=BulkDataGeneratorTests.create_test_reader([["1", "2", "3", "4", "5"]]),
+        )
         all_bulks = list(bulks)
         self.assertEqual(3, len(all_bulks))
-        self.assertEqual({
-            "action-metadata-present": True,
-            "body": ["1", "2", "3", "4", "5"],
-            "bulk-size": 5,
-            "unit": "docs",
-            "index": "logs-2018-01",
-            "type": "docs",
-            "my-custom-parameter": "foo",
-            "my-custom-parameter-2": True
-        }, all_bulks[0])
+        self.assertEqual(
+            {
+                "action-metadata-present": True,
+                "body": ["1", "2", "3", "4", "5"],
+                "bulk-size": 5,
+                "unit": "docs",
+                "index": "logs-2018-01",
+                "type": "docs",
+                "my-custom-parameter": "foo",
+                "my-custom-parameter-2": True,
+            },
+            all_bulks[0],
+        )
 
-        self.assertEqual({
-            "action-metadata-present": True,
-            "body": ["1", "2", "3", "4", "5"],
-            "bulk-size": 5,
-            "unit": "docs",
-            "index": "logs-2018-02",
-            "type": "docs",
-            "my-custom-parameter": "foo",
-            "my-custom-parameter-2": True
-        }, all_bulks[1])
+        self.assertEqual(
+            {
+                "action-metadata-present": True,
+                "body": ["1", "2", "3", "4", "5"],
+                "bulk-size": 5,
+                "unit": "docs",
+                "index": "logs-2018-02",
+                "type": "docs",
+                "my-custom-parameter": "foo",
+                "my-custom-parameter-2": True,
+            },
+            all_bulks[1],
+        )
 
-        self.assertEqual({
-            "action-metadata-present": True,
-            "body": ["1", "2", "3", "4", "5"],
-            "bulk-size": 5,
-            "unit": "docs",
-            "index": "logs-2017-01",
-            "type": "docs",
-            "my-custom-parameter": "foo",
-            "my-custom-parameter-2": True
-        }, all_bulks[2])
+        self.assertEqual(
+            {
+                "action-metadata-present": True,
+                "body": ["1", "2", "3", "4", "5"],
+                "bulk-size": 5,
+                "unit": "docs",
+                "index": "logs-2017-01",
+                "type": "docs",
+                "my-custom-parameter": "foo",
+                "my-custom-parameter-2": True,
+            },
+            all_bulks[2],
+        )
 
     def test_internal_params_take_precedence(self):
-        corpus = track.DocumentCorpus(name="default", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK,
-                            number_of_documents=3,
-                            target_index="test-idx",
-                            target_type="test-type"
-                            )
-        ])
+        corpus = track.DocumentCorpus(
+            name="default",
+            documents=[
+                track.Documents(
+                    source_format=track.Documents.SOURCE_FORMAT_BULK,
+                    number_of_documents=3,
+                    target_index="test-idx",
+                    target_type="test-type",
+                )
+            ],
+        )
 
-        bulks = params.bulk_data_based(num_clients=1, start_client_index=0, end_client_index=0, corpora=[corpus],
-                                       batch_size=3, bulk_size=3, id_conflicts=params.IndexIdConflict.NoConflicts,
-                                       conflict_probability=None, on_conflict=None,
-                                       recency=None, pipeline=None,
-                                       original_params={
-                                           "body": "foo",
-                                           "custom-param": "bar"
-                                       }, create_reader=BulkDataGeneratorTests.
-                                       create_test_reader([["1", "2", "3"]]))
+        bulks = params.bulk_data_based(
+            num_clients=1,
+            start_client_index=0,
+            end_client_index=0,
+            corpora=[corpus],
+            batch_size=3,
+            bulk_size=3,
+            id_conflicts=params.IndexIdConflict.NoConflicts,
+            conflict_probability=None,
+            on_conflict=None,
+            recency=None,
+            pipeline=None,
+            original_params={"body": "foo", "custom-param": "bar"},
+            create_reader=BulkDataGeneratorTests.create_test_reader([["1", "2", "3"]]),
+        )
         all_bulks = list(bulks)
         self.assertEqual(1, len(all_bulks))
         # body must not contain 'foo'!
-        self.assertEqual({
-            "action-metadata-present": True,
-            "body": ["1", "2", "3"],
-            "bulk-size": 3,
-            "unit": "docs",
-            "index": "test-idx",
-            "type": "test-type",
-            "custom-param": "bar"
-        }, all_bulks[0])
+        self.assertEqual(
+            {
+                "action-metadata-present": True,
+                "body": ["1", "2", "3"],
+                "bulk-size": 3,
+                "unit": "docs",
+                "index": "test-idx",
+                "type": "test-type",
+                "custom-param": "bar",
+            },
+            all_bulks[0],
+        )
 
 
 class ParamsRegistrationTests(TestCase):
     @staticmethod
     def param_source_legacy_function(indices, params):
-        return {
-            "key": params["parameter"]
-        }
+        return {"key": params["parameter"]}
 
     @staticmethod
     def param_source_function(track, params, **kwargs):
-        return {
-            "key": params["parameter"]
-        }
+        return {"key": params["parameter"]}
 
     class ParamSourceLegacyClass:
         def __init__(self, indices=None, params=None):
@@ -1319,9 +1555,7 @@ class ParamsRegistrationTests(TestCase):
             return 1
 
         def params(self):
-            return {
-                "class-key": self._params["parameter"]
-            }
+            return {"class-key": self._params["parameter"]}
 
     class ParamSourceClass:
         def __init__(self, track=None, params=None, **kwargs):
@@ -1335,9 +1569,7 @@ class ParamsRegistrationTests(TestCase):
             return 1
 
         def params(self):
-            return {
-                "class-key": self._params["parameter"]
-            }
+            return {"class-key": self._params["parameter"]}
 
         def __str__(self):
             return "test param source"
@@ -1381,8 +1613,9 @@ class ParamsRegistrationTests(TestCase):
     def test_cannot_register_an_instance_as_param_source(self):
         source_name = "params-test-class-param-source"
         # we create an instance, instead of passing the class
-        with self.assertRaisesRegex(exceptions.RallyAssertionError,
-                                    "Parameter source \\[test param source\\] must be either a function or a class\\."):
+        with self.assertRaisesRegex(
+            exceptions.RallyAssertionError, "Parameter source \\[test param source\\] must be either a function or a class\\."
+        ):
             params.register_param_source_for_name(source_name, ParamsRegistrationTests.ParamSourceClass())
 
 
@@ -1392,13 +1625,11 @@ class SleepParamSourceTests(TestCase):
             params.SleepParamSource(track.Track(name="unit-test"), params={})
 
     def test_duration_parameter_wrong_type(self):
-        with self.assertRaisesRegex(exceptions.InvalidSyntax,
-                                    "parameter 'duration' for sleep operation must be a number"):
+        with self.assertRaisesRegex(exceptions.InvalidSyntax, "parameter 'duration' for sleep operation must be a number"):
             params.SleepParamSource(track.Track(name="unit-test"), params={"duration": "this is a string"})
 
     def test_duration_parameter_negative_number(self):
-        with self.assertRaisesRegex(exceptions.InvalidSyntax,
-                                    "parameter 'duration' must be non-negative but was -1.0"):
+        with self.assertRaisesRegex(exceptions.InvalidSyntax, "parameter 'duration' must be non-negative but was -1.0"):
             params.SleepParamSource(track.Track(name="unit-test"), params={"duration": -1.0})
 
     def test_param_source_passes_all_parameters(self):
@@ -1408,23 +1639,26 @@ class SleepParamSourceTests(TestCase):
 
 class CreateIndexParamSourceTests(TestCase):
     def test_create_index_inline_with_body(self):
-        source = params.CreateIndexParamSource(track.Track(name="unit-test"), params={
-            "index": "test",
-            "body": {
-                "settings": {
-                    "index.number_of_replicas": 0
-                },
-                "mappings": {
-                    "doc": {
-                        "properties": {
-                            "name": {
-                                "type": "keyword",
+        source = params.CreateIndexParamSource(
+            track.Track(name="unit-test"),
+            params={
+                "index": "test",
+                "body": {
+                    "settings": {
+                        "index.number_of_replicas": 0,
+                    },
+                    "mappings": {
+                        "doc": {
+                            "properties": {
+                                "name": {
+                                    "type": "keyword",
+                                }
                             }
                         }
-                    }
-                }
-            }
-        })
+                    },
+                },
+            },
+        )
 
         p = source.params()
         self.assertEqual(1, len(p["indices"]))
@@ -1434,45 +1668,48 @@ class CreateIndexParamSourceTests(TestCase):
         self.assertEqual({}, p["request-params"])
 
     def test_create_index_inline_without_body(self):
-        source = params.CreateIndexParamSource(track.Track(name="unit-test"), params={
-            "index": "test",
-            "request-params": {
-                "wait_for_active_shards": True
-            }
-        })
+        source = params.CreateIndexParamSource(
+            track.Track(name="unit-test"),
+            params={"index": "test", "request-params": {"wait_for_active_shards": True}},
+        )
 
         p = source.params()
         self.assertEqual(1, len(p["indices"]))
         index, body = p["indices"][0]
         self.assertEqual("test", index)
         self.assertIsNone(body)
-        self.assertDictEqual({
-            "wait_for_active_shards": True
-        }, p["request-params"])
+        self.assertDictEqual({"wait_for_active_shards": True}, p["request-params"])
 
     def test_create_index_from_track_with_settings(self):
         index1 = track.Index(name="index1", types=["type1"])
-        index2 = track.Index(name="index2", types=["type1"], body={
-            "settings": {
-                "index.number_of_replicas": 0,
-                "index.number_of_shards": 3
-            },
-            "mappings": {
-                "type1": {
-                    "properties": {
-                        "name": {
-                            "type": "keyword",
+        index2 = track.Index(
+            name="index2",
+            types=["type1"],
+            body={
+                "settings": {
+                    "index.number_of_replicas": 0,
+                    "index.number_of_shards": 3,
+                },
+                "mappings": {
+                    "type1": {
+                        "properties": {
+                            "name": {
+                                "type": "keyword",
+                            }
                         }
                     }
-                }
-            }
-        })
+                },
+            },
+        )
 
-        source = params.CreateIndexParamSource(track.Track(name="unit-test", indices=[index1, index2]), params={
-            "settings": {
-                "index.number_of_replicas": 1
-            }
-        })
+        source = params.CreateIndexParamSource(
+            track.Track(name="unit-test", indices=[index1, index2]),
+            params={
+                "settings": {
+                    "index.number_of_replicas": 1,
+                },
+            },
+        )
 
         p = source.params()
         self.assertEqual(2, len(p["indices"]))
@@ -1480,52 +1717,58 @@ class CreateIndexParamSourceTests(TestCase):
         index, body = p["indices"][0]
         self.assertEqual("index1", index)
         # index did not specify any body
-        self.assertDictEqual({
-            "settings": {
-                "index.number_of_replicas": 1
-            }
-        }, body)
+        self.assertDictEqual({"settings": {"index.number_of_replicas": 1}}, body)
 
         index, body = p["indices"][1]
         self.assertEqual("index2", index)
         # index specified a body + we need to merge settings
-        self.assertDictEqual({
-            "settings": {
-                # we have properly merged (overridden) an existing setting
-                "index.number_of_replicas": 1,
-                # and we have preserved one that was specified in the original index body
-                "index.number_of_shards": 3
-            },
-            "mappings": {
-                "type1": {
-                    "properties": {
-                        "name": {
-                            "type": "keyword",
+        self.assertDictEqual(
+            {
+                "settings": {
+                    # we have properly merged (overridden) an existing setting
+                    "index.number_of_replicas": 1,
+                    # and we have preserved one that was specified in the original index body
+                    "index.number_of_shards": 3,
+                },
+                "mappings": {
+                    "type1": {
+                        "properties": {
+                            "name": {
+                                "type": "keyword",
+                            }
                         }
                     }
-                }
-            }
-        }, body)
+                },
+            },
+            body,
+        )
 
     def test_create_index_from_track_without_settings(self):
         index1 = track.Index(name="index1", types=["type1"])
-        index2 = track.Index(name="index2", types=["type1"], body={
-            "settings": {
-                "index.number_of_replicas": 0,
-                "index.number_of_shards": 3
-            },
-            "mappings": {
-                "type1": {
-                    "properties": {
-                        "name": {
-                            "type": "keyword",
+        index2 = track.Index(
+            name="index2",
+            types=["type1"],
+            body={
+                "settings": {
+                    "index.number_of_replicas": 0,
+                    "index.number_of_shards": 3,
+                },
+                "mappings": {
+                    "type1": {
+                        "properties": {
+                            "name": {
+                                "type": "keyword",
+                            }
                         }
                     }
-                }
-            }
-        })
+                },
+            },
+        )
 
-        source = params.CreateIndexParamSource(track.Track(name="unit-test", indices=[index1, index2]), params={})
+        source = params.CreateIndexParamSource(
+            track.Track(name="unit-test", indices=[index1, index2]),
+            params={},
+        )
 
         p = source.params()
         self.assertEqual(2, len(p["indices"]))
@@ -1538,30 +1781,34 @@ class CreateIndexParamSourceTests(TestCase):
         index, body = p["indices"][1]
         self.assertEqual("index2", index)
         # index specified a body
-        self.assertDictEqual({
-            "settings": {
-                "index.number_of_replicas": 0,
-                "index.number_of_shards": 3
-            },
-            "mappings": {
-                "type1": {
-                    "properties": {
-                        "name": {
-                            "type": "keyword",
+        self.assertDictEqual(
+            {
+                "settings": {
+                    "index.number_of_replicas": 0,
+                    "index.number_of_shards": 3,
+                },
+                "mappings": {
+                    "type1": {
+                        "properties": {
+                            "name": {
+                                "type": "keyword",
+                            }
                         }
                     }
-                }
-            }
-        }, body)
+                },
+            },
+            body,
+        )
 
     def test_filter_index(self):
         index1 = track.Index(name="index1", types=["type1"])
         index2 = track.Index(name="index2", types=["type1"])
         index3 = track.Index(name="index3", types=["type1"])
 
-        source = params.CreateIndexParamSource(track.Track(name="unit-test", indices=[index1, index2, index3]), params={
-            "index": "index2"
-        })
+        source = params.CreateIndexParamSource(
+            track.Track(name="unit-test", indices=[index1, index2, index3]),
+            params={"index": "index2"},
+        )
 
         p = source.params()
         self.assertEqual(1, len(p["indices"]))
@@ -1572,9 +1819,10 @@ class CreateIndexParamSourceTests(TestCase):
 
 class CreateDataStreamParamSourceTests(TestCase):
     def test_create_data_stream(self):
-        source = params.CreateDataStreamParamSource(track.Track(name="unit-test"), params={
-            "data-stream": "test-data-stream"
-        })
+        source = params.CreateDataStreamParamSource(
+            track.Track(name="unit-test"),
+            params={"data-stream": "test-data-stream"},
+        )
         p = source.params()
         self.assertEqual(1, len(p["data-streams"]))
         ds = p["data-streams"][0]
@@ -1582,27 +1830,32 @@ class CreateDataStreamParamSourceTests(TestCase):
         self.assertEqual({}, p["request-params"])
 
     def test_create_data_stream_inline_without_body(self):
-        source = params.CreateDataStreamParamSource(track.Track(name="unit-test"), params={
-            "data-stream": "test-data-stream",
-            "request-params": {
-                "wait_for_active_shards": True
-            }
-        })
+        source = params.CreateDataStreamParamSource(
+            track.Track(name="unit-test"),
+            params={
+                "data-stream": "test-data-stream",
+                "request-params": {"wait_for_active_shards": True},
+            },
+        )
 
         p = source.params()
         self.assertEqual(1, len(p["data-streams"]))
         ds = p["data-streams"][0]
         self.assertEqual("test-data-stream", ds)
-        self.assertDictEqual({
-            "wait_for_active_shards": True
-        }, p["request-params"])
+        self.assertDictEqual({"wait_for_active_shards": True}, p["request-params"])
 
     def test_filter_data_stream(self):
         source = params.CreateDataStreamParamSource(
-            track.Track(name="unit-test", data_streams=[track.DataStream(name="data-stream-1"),
-                                                        track.DataStream(name="data-stream-2"),
-                                                        track.DataStream(name="data-stream-3")]),
-            params={"data-stream": "data-stream-2"})
+            track.Track(
+                name="unit-test",
+                data_streams=[
+                    track.DataStream(name="data-stream-1"),
+                    track.DataStream(name="data-stream-2"),
+                    track.DataStream(name="data-stream-3"),
+                ],
+            ),
+            params={"data-stream": "data-stream-2"},
+        )
 
         p = source.params()
         self.assertEqual(1, len(p["data-streams"]))
@@ -1613,11 +1866,17 @@ class CreateDataStreamParamSourceTests(TestCase):
 
 class DeleteIndexParamSourceTests(TestCase):
     def test_delete_index_from_track(self):
-        source = params.DeleteIndexParamSource(track.Track(name="unit-test", indices=[
-            track.Index(name="index1"),
-            track.Index(name="index2"),
-            track.Index(name="index3")
-        ]), params={})
+        source = params.DeleteIndexParamSource(
+            track.Track(
+                name="unit-test",
+                indices=[
+                    track.Index(name="index1"),
+                    track.Index(name="index2"),
+                    track.Index(name="index3"),
+                ],
+            ),
+            params={},
+        )
 
         p = source.params()
 
@@ -1626,11 +1885,21 @@ class DeleteIndexParamSourceTests(TestCase):
         self.assertTrue(p["only-if-exists"])
 
     def test_filter_index_from_track(self):
-        source = params.DeleteIndexParamSource(track.Track(name="unit-test", indices=[
-            track.Index(name="index1"),
-            track.Index(name="index2"),
-            track.Index(name="index3")
-        ]), params={"index": "index2", "only-if-exists": False, "request-params": {"allow_no_indices": True}})
+        source = params.DeleteIndexParamSource(
+            track.Track(
+                name="unit-test",
+                indices=[
+                    track.Index(name="index1"),
+                    track.Index(name="index2"),
+                    track.Index(name="index3"),
+                ],
+            ),
+            params={
+                "index": "index2",
+                "only-if-exists": False,
+                "request-params": {"allow_no_indices": True},
+            },
+        )
 
         p = source.params()
 
@@ -1653,11 +1922,17 @@ class DeleteIndexParamSourceTests(TestCase):
 
 class DeleteDataStreamParamSourceTests(TestCase):
     def test_delete_data_stream_from_track(self):
-        source = params.DeleteDataStreamParamSource(track.Track(name="unit-test", data_streams=[
-            track.DataStream(name="data-stream-1"),
-            track.DataStream(name="data-stream-2"),
-            track.DataStream(name="data-stream-3")
-        ]), params={})
+        source = params.DeleteDataStreamParamSource(
+            track.Track(
+                name="unit-test",
+                data_streams=[
+                    track.DataStream(name="data-stream-1"),
+                    track.DataStream(name="data-stream-2"),
+                    track.DataStream(name="data-stream-3"),
+                ],
+            ),
+            params={},
+        )
 
         p = source.params()
 
@@ -1666,12 +1941,21 @@ class DeleteDataStreamParamSourceTests(TestCase):
         self.assertTrue(p["only-if-exists"])
 
     def test_filter_data_stream_from_track(self):
-        source = params.DeleteDataStreamParamSource(track.Track(name="unit-test", data_streams=[
-            track.DataStream(name="data-stream-1"),
-            track.DataStream(name="data-stream-2"),
-            track.DataStream(name="data-stream-3")
-        ]), params={"data-stream": "data-stream-2", "only-if-exists": False,
-                    "request-params": {"allow_no_indices": True}})
+        source = params.DeleteDataStreamParamSource(
+            track.Track(
+                name="unit-test",
+                data_streams=[
+                    track.DataStream(name="data-stream-1"),
+                    track.DataStream(name="data-stream-2"),
+                    track.DataStream(name="data-stream-3"),
+                ],
+            ),
+            params={
+                "data-stream": "data-stream-2",
+                "only-if-exists": False,
+                "request-params": {"allow_no_indices": True},
+            },
+        )
 
         p = source.params()
 
@@ -1680,8 +1964,7 @@ class DeleteDataStreamParamSourceTests(TestCase):
         self.assertFalse(p["only-if-exists"])
 
     def test_delete_data_stream_by_name(self):
-        source = params.DeleteDataStreamParamSource(track.Track(name="unit-test"),
-                                                    params={"data-stream": "data-stream-2"})
+        source = params.DeleteDataStreamParamSource(track.Track(name="unit-test"), params={"data-stream": "data-stream-2"})
 
         p = source.params()
 
@@ -1695,22 +1978,17 @@ class DeleteDataStreamParamSourceTests(TestCase):
 
 class CreateIndexTemplateParamSourceTests(TestCase):
     def test_create_index_template_inline(self):
-        source = params.CreateIndexTemplateParamSource(track=track.Track(name="unit-test"), params={
-            "template": "test",
-            "body": {
-                "index_patterns": ["*"],
-                "settings": {
-                    "index.number_of_shards": 3
+        source = params.CreateIndexTemplateParamSource(
+            track=track.Track(name="unit-test"),
+            params={
+                "template": "test",
+                "body": {
+                    "index_patterns": ["*"],
+                    "settings": {"index.number_of_shards": 3},
+                    "mappings": {"docs": {"_source": {"enabled": False}}},
                 },
-                "mappings": {
-                    "docs": {
-                        "_source": {
-                            "enabled": False
-                        }
-                    }
-                }
-            }
-        })
+            },
+        )
 
         p = source.params()
 
@@ -1718,40 +1996,42 @@ class CreateIndexTemplateParamSourceTests(TestCase):
         self.assertDictEqual({}, p["request-params"])
         template, body = p["templates"][0]
         self.assertEqual("test", template)
-        self.assertDictEqual({
-            "index_patterns": ["*"],
-            "settings": {
-                "index.number_of_shards": 3
+        self.assertDictEqual(
+            {
+                "index_patterns": ["*"],
+                "settings": {"index.number_of_shards": 3},
+                "mappings": {
+                    "docs": {
+                        "_source": {"enabled": False},
+                    },
+                },
             },
-            "mappings": {
-                "docs": {
-                    "_source": {
-                        "enabled": False
-                    }
-                }
-            }
-        }, body)
+            body,
+        )
 
     def test_create_index_template_from_track(self):
-        tpl = track.IndexTemplate(name="default", pattern="*", content={
-            "index_patterns": ["*"],
-            "settings": {
-                "index.number_of_shards": 3
+        tpl = track.IndexTemplate(
+            name="default",
+            pattern="*",
+            content={
+                "index_patterns": ["*"],
+                "settings": {"index.number_of_shards": 3},
+                "mappings": {
+                    "docs": {
+                        "_source": {"enabled": False},
+                    },
+                },
             },
-            "mappings": {
-                "docs": {
-                    "_source": {
-                        "enabled": False
-                    }
-                }
-            }
-        })
+        )
 
-        source = params.CreateIndexTemplateParamSource(track=track.Track(name="unit-test", templates=[tpl]), params={
-            "settings": {
-                "index.number_of_replicas": 1
-            }
-        })
+        source = params.CreateIndexTemplateParamSource(
+            track=track.Track(name="unit-test", templates=[tpl]),
+            params={
+                "settings": {
+                    "index.number_of_replicas": 1,
+                }
+            },
+        )
 
         p = source.params()
 
@@ -1759,20 +2039,14 @@ class CreateIndexTemplateParamSourceTests(TestCase):
         self.assertDictEqual({}, p["request-params"])
         template, body = p["templates"][0]
         self.assertEqual("default", template)
-        self.assertDictEqual({
-            "index_patterns": ["*"],
-            "settings": {
-                "index.number_of_shards": 3,
-                "index.number_of_replicas": 1
+        self.assertDictEqual(
+            {
+                "index_patterns": ["*"],
+                "settings": {"index.number_of_shards": 3, "index.number_of_replicas": 1},
+                "mappings": {"docs": {"_source": {"enabled": False}}},
             },
-            "mappings": {
-                "docs": {
-                    "_source": {
-                        "enabled": False
-                    }
-                }
-            }
-        }, body)
+            body,
+        )
 
 
 class DeleteIndexTemplateParamSourceTests(TestCase):
@@ -1787,12 +2061,14 @@ class DeleteIndexTemplateParamSourceTests(TestCase):
         self.assertDictEqual({}, p["request-params"])
 
     def test_delete_index_template_by_name_and_matching_indices(self):
-        source = params.DeleteIndexTemplateParamSource(track.Track(name="unit-test"),
-                                                       params={
-                                                           "template": "default",
-                                                           "delete-matching-indices": True,
-                                                           "index-pattern": "logs-*"
-                                                       })
+        source = params.DeleteIndexTemplateParamSource(
+            track.Track(name="unit-test"),
+            params={
+                "template": "default",
+                "delete-matching-indices": True,
+                "index-pattern": "logs-*",
+            },
+        )
 
         p = source.params()
 
@@ -1803,32 +2079,40 @@ class DeleteIndexTemplateParamSourceTests(TestCase):
 
     def test_delete_index_template_by_name_and_matching_indices_missing_index_pattern(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.DeleteIndexTemplateParamSource(track.Track(name="unit-test"),
-                                                  params={
-                                                      "template": "default",
-                                                      "delete-matching-indices": True
-                                                  })
-        self.assertEqual("The property 'index-pattern' is required for delete-index-template if 'delete-matching-indices' is true.",
-                         ctx.exception.args[0])
+            params.DeleteIndexTemplateParamSource(
+                track.Track(name="unit-test"), params={"template": "default", "delete-matching-indices": True}
+            )
+        self.assertEqual(
+            "The property 'index-pattern' is required for delete-index-template if 'delete-matching-indices' is true.",
+            ctx.exception.args[0],
+        )
 
     def test_delete_index_template_from_track(self):
-        tpl1 = track.IndexTemplate(name="metrics", pattern="metrics-*", delete_matching_indices=True, content={
-            "index_patterns": ["metrics-*"],
-            "settings": {},
-            "mappings": {}
-        })
-        tpl2 = track.IndexTemplate(name="logs", pattern="logs-*", delete_matching_indices=False, content={
-            "index_patterns": ["logs-*"],
-            "settings": {},
-            "mappings": {}
-        })
-
-        source = params.DeleteIndexTemplateParamSource(track.Track(name="unit-test", templates=[tpl1, tpl2]), params={
-            "request-params": {
-                "master_timeout": 20
+        tpl1 = track.IndexTemplate(
+            name="metrics",
+            pattern="metrics-*",
+            delete_matching_indices=True,
+            content={
+                "index_patterns": ["metrics-*"],
+                "settings": {},
+                "mappings": {},
             },
-            "only-if-exists": False
-        })
+        )
+        tpl2 = track.IndexTemplate(
+            name="logs",
+            pattern="logs-*",
+            delete_matching_indices=False,
+            content={
+                "index_patterns": ["logs-*"],
+                "settings": {},
+                "mappings": {},
+            },
+        )
+
+        source = params.DeleteIndexTemplateParamSource(
+            track.Track(name="unit-test", templates=[tpl1, tpl2]),
+            params={"request-params": {"master_timeout": 20}, "only-if-exists": False},
+        )
 
         p = source.params()
 
@@ -1841,18 +2125,17 @@ class DeleteIndexTemplateParamSourceTests(TestCase):
 
 class CreateComposableTemplateParamSourceTests(TestCase):
     def test_create_index_template_inline(self):
-        source = params.CreateComposableTemplateParamSource(track=track.Track(name="unit-test"), params={
-            "template": "test",
-            "body": {
-              "index_patterns": ["my*"],
-              "template": {
-                "settings" : {
-                    "index.number_of_shards" : 3
-                }
-              },
-              "composed_of": ["ct1", "ct2"]
-            }
-        })
+        source = params.CreateComposableTemplateParamSource(
+            track=track.Track(name="unit-test"),
+            params={
+                "template": "test",
+                "body": {
+                    "index_patterns": ["my*"],
+                    "template": {"settings": {"index.number_of_shards": 3}},
+                    "composed_of": ["ct1", "ct2"],
+                },
+            },
+        )
 
         p = source.params()
 
@@ -1860,32 +2143,32 @@ class CreateComposableTemplateParamSourceTests(TestCase):
         self.assertDictEqual({}, p["request-params"])
         template, body = p["templates"][0]
         self.assertEqual("test", template)
-        self.assertDictEqual({
-              "index_patterns": ["my*"],
-              "template": {
-                "settings" : {
-                    "index.number_of_shards" : 3
-                }
-              },
-              "composed_of": ["ct1", "ct2"]
-            }, body)
+        self.assertDictEqual(
+            {
+                "index_patterns": ["my*"],
+                "template": {"settings": {"index.number_of_shards": 3}},
+                "composed_of": ["ct1", "ct2"],
+            },
+            body,
+        )
 
     def test_create_composable_index_template_from_track(self):
-        tpl = track.IndexTemplate(name="default", pattern="*", content={
-              "index_patterns": ["my*"],
-              "template": {
-                "settings" : {
-                    "index.number_of_shards" : 3
-                }
-              },
-              "composed_of": ["ct1", "ct2"]
-            })
+        tpl = track.IndexTemplate(
+            name="default",
+            pattern="*",
+            content={
+                "index_patterns": ["my*"],
+                "template": {"settings": {"index.number_of_shards": 3}},
+                "composed_of": ["ct1", "ct2"],
+            },
+        )
 
-        source = params.CreateComposableTemplateParamSource(track=track.Track(name="unit-test", composable_templates=[tpl]), params={
-            "settings": {
-                "index.number_of_replicas": 1
-            }
-        })
+        source = params.CreateComposableTemplateParamSource(
+            track=track.Track(name="unit-test", composable_templates=[tpl]),
+            params={
+                "settings": {"index.number_of_replicas": 1},
+            },
+        )
 
         p = source.params()
 
@@ -1893,81 +2176,127 @@ class CreateComposableTemplateParamSourceTests(TestCase):
         self.assertDictEqual({}, p["request-params"])
         template, body = p["templates"][0]
         self.assertEqual("default", template)
-        self.assertDictEqual({
-              "index_patterns": ["my*"],
-              "template": {
-                "settings" : {
-                    "index.number_of_shards" : 3,
-                    "index.number_of_replicas": 1
-                }
-              },
-              "composed_of": ["ct1", "ct2"]
-            }, body)
+        self.assertDictEqual(
+            {
+                "index_patterns": ["my*"],
+                "template": {"settings": {"index.number_of_shards": 3, "index.number_of_replicas": 1}},
+                "composed_of": ["ct1", "ct2"],
+            },
+            body,
+        )
 
     def test_create_or_merge(self):
-        content = params.CreateComposableTemplateParamSource._create_or_merge({"parent": {}}, ["parent", "child", "grandchild"],
-                                                       {"name": "Mike"})
-        assert content["parent"]["child"]["grandchild"]["name"] == "Mike"
-        content = params.CreateComposableTemplateParamSource._create_or_merge({"parent": {"child": {}}}, ["parent", "child", "grandchild"],
-                                                       {"name": "Mike"})
-        assert content["parent"]["child"]["grandchild"]["name"] == "Mike"
-        content = params.CreateComposableTemplateParamSource._create_or_merge({"parent": {"child": {"grandchild": {}}}},
-                                                       ["parent", "child", "grandchild"], {"name": "Mike"})
+        content = params.CreateComposableTemplateParamSource._create_or_merge(
+            {"parent": {}},
+            ["parent", "child", "grandchild"],
+            {
+                "name": "Mike",
+            },
+        )
         assert content["parent"]["child"]["grandchild"]["name"] == "Mike"
         content = params.CreateComposableTemplateParamSource._create_or_merge(
-            {"parent": {"child": {"name": "Mary", "grandchild": {"name": "Dale", "age": 38}}}},
-            ["parent", "child", "grandchild"], {"name": "Mike"})
+            {"parent": {"child": {}}},
+            ["parent", "child", "grandchild"],
+            {
+                "name": "Mike",
+            },
+        )
+        assert content["parent"]["child"]["grandchild"]["name"] == "Mike"
+        content = params.CreateComposableTemplateParamSource._create_or_merge(
+            {"parent": {"child": {"grandchild": {}}}},
+            ["parent", "child", "grandchild"],
+            {
+                "name": "Mike",
+            },
+        )
+        assert content["parent"]["child"]["grandchild"]["name"] == "Mike"
+        content = params.CreateComposableTemplateParamSource._create_or_merge(
+            {
+                "parent": {
+                    "child": {
+                        "name": "Mary",
+                        "grandchild": {"name": "Dale", "age": 38},
+                    },
+                },
+            },
+            ["parent", "child", "grandchild"],
+            {"name": "Mike"},
+        )
         assert content["parent"]["child"]["name"] == "Mary"
         assert content["parent"]["child"]["grandchild"]["name"] == "Mike"
         assert content["parent"]["child"]["grandchild"]["age"] == 38
         content = params.CreateComposableTemplateParamSource._create_or_merge(
-            {"parent": {
-                "child": {"name": "Mary", "grandchild": {"name": {"first": "Dale", "last": "Smith"}, "age": 38}}}},
-            ["parent", "child", "grandchild"], {"name": "Mike"})
+            {
+                "parent": {
+                    "child": {
+                        "name": "Mary",
+                        "grandchild": {"name": {"first": "Dale", "last": "Smith"}, "age": 38},
+                    },
+                },
+            },
+            ["parent", "child", "grandchild"],
+            {"name": "Mike"},
+        )
         assert content["parent"]["child"]["grandchild"]["name"] == "Mike"
         assert content["parent"]["child"]["grandchild"]["age"] == 38
         content = params.CreateComposableTemplateParamSource._create_or_merge(
-            {"parent": {
-                "child": {"name": "Mary", "grandchild": {"name": {"first": "Dale", "last": "Smith"}, "age": 38}}}},
-            ["parent", "child", "grandchild"], {"name": {"first": "Mike"}})
+            {
+                "parent": {
+                    "child": {
+                        "name": "Mary",
+                        "grandchild": {"name": {"first": "Dale", "last": "Smith"}, "age": 38},
+                    },
+                },
+            },
+            ["parent", "child", "grandchild"],
+            {"name": {"first": "Mike"}},
+        )
         assert content["parent"]["child"]["grandchild"]["name"]["first"] == "Mike"
         assert content["parent"]["child"]["grandchild"]["name"]["last"] == "Smith"
 
     def test_no_templates_specified(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
             params.CreateComposableTemplateParamSource(
-                track=track.Track(name="unit-test"), params={
+                track=track.Track(name="unit-test"),
+                params={
                     "settings": {
                         "index.number_of_shards": 1,
-                        "index.number_of_replicas": 1
+                        "index.number_of_replicas": 1,
                     },
-                    "operation-type": "create-composable-template"
-                })
-        self.assertEqual("Please set the properties 'template' and 'body' for the create-composable-template operation "
-                         "or declare composable and/or component templates in the track", ctx.exception.args[0])
+                    "operation-type": "create-composable-template",
+                },
+            )
+        self.assertEqual(
+            "Please set the properties 'template' and 'body' for the create-composable-template operation "
+            "or declare composable and/or component templates in the track",
+            ctx.exception.args[0],
+        )
 
 
 class CreateComponentTemplateParamSourceTests(TestCase):
     def test_create_component_index_template_from_track(self):
-        tpl = track.ComponentTemplate(name="default", content={
-          "template": {
-            "mappings": {
-              "properties": {
-                "@timestamp": {
-                  "type": "date"
-                }
-              }
-            }
-          }
-        })
+        tpl = track.ComponentTemplate(
+            name="default",
+            content={
+                "template": {
+                    "mappings": {
+                        "properties": {
+                            "@timestamp": {"type": "date"},
+                        },
+                    },
+                },
+            },
+        )
 
         source = params.CreateComponentTemplateParamSource(
-            track=track.Track(name="unit-test", component_templates=[tpl]), params={
+            track=track.Track(name="unit-test", component_templates=[tpl]),
+            params={
                 "settings": {
                     "index.number_of_shards": 1,
-                    "index.number_of_replicas": 1
-                }
-            })
+                    "index.number_of_replicas": 1,
+                },
+            },
+        )
 
         p = source.params()
 
@@ -1975,21 +2304,22 @@ class CreateComponentTemplateParamSourceTests(TestCase):
         self.assertDictEqual({}, p["request-params"])
         template, body = p["templates"][0]
         self.assertEqual("default", template)
-        self.assertDictEqual({
-          "template": {
-            "settings": {
-              "index.number_of_shards": 1,
-              "index.number_of_replicas": 1
-            },
-            "mappings": {
-              "properties": {
-                "@timestamp": {
-                  "type": "date"
+        self.assertDictEqual(
+            {
+                "template": {
+                    "settings": {
+                        "index.number_of_shards": 1,
+                        "index.number_of_replicas": 1,
+                    },
+                    "mappings": {
+                        "properties": {
+                            "@timestamp": {"type": "date"},
+                        },
+                    },
                 }
-              }
-            }
-          }
-        }, body)
+            },
+            body,
+        )
 
 
 class DeleteComponentTemplateParamSource(TestCase):
@@ -2003,37 +2333,37 @@ class DeleteComponentTemplateParamSource(TestCase):
 
     def test_delete_index_template_no_name(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.DeleteComponentTemplateParamSource(track.Track(name="unit-test"),
-                                                  params={"operation-type": "delete-component-template"})
-        self.assertEqual("Please set the property 'template' for the delete-component-template operation.",
-                         ctx.exception.args[0])
+            params.DeleteComponentTemplateParamSource(track.Track(name="unit-test"), params={"operation-type": "delete-component-template"})
+        self.assertEqual("Please set the property 'template' for the delete-component-template operation.", ctx.exception.args[0])
 
     def test_delete_index_template_from_track(self):
-        tpl1 = track.ComponentTemplate(name="logs", content={
-          "template": {
-            "mappings": {
-              "properties": {
-                "@timestamp": {
-                  "type": "date"
-                }
-              }
-            }
-          }
-        })
-        tpl2 = track.ComponentTemplate(name="metrics", content={
-          "template": {
-            "settings": {
-              "index.number_of_shards": 1,
-              "index.number_of_replicas": 1
-            }
-          }
-        })
-        source = params.DeleteComponentTemplateParamSource(track.Track(name="unit-test", templates=[tpl1, tpl2]), params={
-            "request-params": {
-                "master_timeout": 20
+        tpl1 = track.ComponentTemplate(
+            name="logs",
+            content={
+                "template": {
+                    "mappings": {
+                        "properties": {
+                            "@timestamp": {"type": "date"},
+                        },
+                    },
+                },
             },
-            "only-if-exists": False
-        })
+        )
+        tpl2 = track.ComponentTemplate(
+            name="metrics",
+            content={
+                "template": {
+                    "settings": {
+                        "index.number_of_shards": 1,
+                        "index.number_of_replicas": 1,
+                    },
+                },
+            },
+        )
+        source = params.DeleteComponentTemplateParamSource(
+            track.Track(name="unit-test", templates=[tpl1, tpl2]),
+            params={"request-params": {"master_timeout": 20}, "only-if-exists": False},
+        )
 
         p = source.params()
 
@@ -2048,17 +2378,18 @@ class SearchParamSourceTests(TestCase):
     def test_passes_cache(self):
         index1 = track.Index(name="index1", types=["type1"])
 
-        source = params.SearchParamSource(track=track.Track(name="unit-test", indices=[index1]), params={
-            "body": {
-                "query": {
-                    "match_all": {}
-                }
+        source = params.SearchParamSource(
+            track=track.Track(name="unit-test", indices=[index1]),
+            params={
+                "body": {
+                    "query": {
+                        "match_all": {},
+                    },
+                },
+                "headers": {"header1": "value1"},
+                "cache": True,
             },
-            "headers": {
-                "header1": "value1"
-            },
-            "cache": True
-        })
+        )
         p = source.params()
 
         self.assertEqual(10, len(p))
@@ -2072,76 +2403,84 @@ class SearchParamSourceTests(TestCase):
         self.assertEqual(True, p["cache"])
         self.assertEqual(True, p["response-compression-enabled"])
         self.assertEqual(False, p["detailed-results"])
-        self.assertEqual({
-            "query": {
-                "match_all": {}
-            }
-        }, p["body"])
+        self.assertEqual(
+            {
+                "query": {
+                    "match_all": {},
+                },
+            },
+            p["body"],
+        )
 
     def test_uses_data_stream(self):
         ds1 = track.DataStream(name="data-stream-1")
 
-        source = params.SearchParamSource(track=track.Track(name="unit-test", data_streams=[ds1]), params={
-            "body": {
-                "query": {
-                    "match_all": {}
-                }
+        source = params.SearchParamSource(
+            track=track.Track(name="unit-test", data_streams=[ds1]),
+            params={
+                "body": {
+                    "query": {
+                        "match_all": {},
+                    },
+                },
+                "request-timeout": 1.0,
+                "headers": {"header1": "value1", "header2": "value2"},
+                "opaque-id": "12345abcde",
+                "cache": True,
             },
-            "request-timeout": 1.0,
-            "headers": {
-                "header1": "value1",
-                "header2": "value2"
-            },
-            "opaque-id": "12345abcde",
-            "cache": True
-        })
+        )
         p = source.params()
 
         self.assertEqual(10, len(p))
         self.assertEqual("data-stream-1", p["index"])
         self.assertIsNone(p["type"])
         self.assertEqual(1.0, p["request-timeout"])
-        self.assertDictEqual({
-            "header1": "value1",
-            "header2": "value2"
-        }, p["headers"])
+        self.assertDictEqual({"header1": "value1", "header2": "value2"}, p["headers"])
         self.assertEqual("12345abcde", p["opaque-id"])
         self.assertEqual({}, p["request-params"])
         self.assertEqual(True, p["cache"])
         self.assertEqual(True, p["response-compression-enabled"])
         self.assertEqual(False, p["detailed-results"])
-        self.assertEqual({
-            "query": {
-                "match_all": {}
-            }
-        }, p["body"])
+        self.assertEqual(
+            {
+                "query": {
+                    "match_all": {},
+                },
+            },
+            p["body"],
+        )
 
     def test_create_without_index(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
-            params.SearchParamSource(track=track.Track(name="unit-test"), params={
-                "type": "type1",
-                "body": {
-                    "query": {
-                        "match_all": {}
-                    }
-                }
-            }, operation_name="test_operation")
+            params.SearchParamSource(
+                track=track.Track(name="unit-test"),
+                params={
+                    "type": "type1",
+                    "body": {
+                        "query": {
+                            "match_all": {},
+                        },
+                    },
+                },
+                operation_name="test_operation",
+            )
 
         self.assertEqual("'index' or 'data-stream' is mandatory and is missing for operation 'test_operation'", ctx.exception.args[0])
 
     def test_passes_request_parameters(self):
         index1 = track.Index(name="index1", types=["type1"])
 
-        source = params.SearchParamSource(track=track.Track(name="unit-test", indices=[index1]), params={
-            "request-params": {
-                "_source_include": "some_field"
+        source = params.SearchParamSource(
+            track=track.Track(name="unit-test", indices=[index1]),
+            params={
+                "request-params": {"_source_include": "some_field"},
+                "body": {
+                    "query": {
+                        "match_all": {},
+                    },
+                },
             },
-            "body": {
-                "query": {
-                    "match_all": {}
-                }
-            }
-        })
+        )
         p = source.params()
 
         self.assertEqual(10, len(p))
@@ -2150,34 +2489,38 @@ class SearchParamSourceTests(TestCase):
         self.assertIsNone(p["request-timeout"])
         self.assertIsNone(p["headers"])
         self.assertIsNone(p["opaque-id"])
-        self.assertEqual({
-            "_source_include": "some_field"
-        }, p["request-params"])
+        self.assertEqual({"_source_include": "some_field"}, p["request-params"])
         self.assertIsNone(p["cache"])
         self.assertEqual(True, p["response-compression-enabled"])
         self.assertEqual(False, p["detailed-results"])
-        self.assertEqual({
-            "query": {
-                "match_all": {}
-            }
-        }, p["body"])
+        self.assertEqual(
+            {
+                "query": {
+                    "match_all": {},
+                },
+            },
+            p["body"],
+        )
 
     def test_user_specified_overrides_defaults(self):
         index1 = track.Index(name="index1", types=["type1"])
 
-        source = params.SearchParamSource(track=track.Track(name="unit-test", indices=[index1]), params={
-            "index": "_all",
-            "type": "type1",
-            "cache": False,
-            "response-compression-enabled": False,
-            "detailed-results": True,
-            "opaque-id": "12345abcde",
-            "body": {
-                "query": {
-                    "match_all": {}
-                }
-            }
-        })
+        source = params.SearchParamSource(
+            track=track.Track(name="unit-test", indices=[index1]),
+            params={
+                "index": "_all",
+                "type": "type1",
+                "cache": False,
+                "response-compression-enabled": False,
+                "detailed-results": True,
+                "opaque-id": "12345abcde",
+                "body": {
+                    "query": {
+                        "match_all": {},
+                    },
+                },
+            },
+        )
         p = source.params()
 
         self.assertEqual(10, len(p))
@@ -2191,26 +2534,32 @@ class SearchParamSourceTests(TestCase):
         self.assertEqual(False, p["cache"])
         self.assertEqual(False, p["response-compression-enabled"])
         self.assertEqual(True, p["detailed-results"])
-        self.assertEqual({
-            "query": {
-                "match_all": {}
-            }
-        }, p["body"])
+        self.assertEqual(
+            {
+                "query": {
+                    "match_all": {},
+                },
+            },
+            p["body"],
+        )
 
     def test_user_specified_data_stream_overrides_defaults(self):
         ds1 = track.DataStream(name="data-stream-1")
 
-        source = params.SearchParamSource(track=track.Track(name="unit-test", data_streams=[ds1]), params={
-            "data-stream": "data-stream-2",
-            "cache": False,
-            "response-compression-enabled": False,
-            "request-timeout": 1.0,
-            "body": {
-                "query": {
-                    "match_all": {}
-                }
-            }
-        })
+        source = params.SearchParamSource(
+            track=track.Track(name="unit-test", data_streams=[ds1]),
+            params={
+                "data-stream": "data-stream-2",
+                "cache": False,
+                "response-compression-enabled": False,
+                "request-timeout": 1.0,
+                "body": {
+                    "query": {
+                        "match_all": {},
+                    },
+                },
+            },
+        )
         p = source.params()
 
         self.assertEqual(10, len(p))
@@ -2224,59 +2573,64 @@ class SearchParamSourceTests(TestCase):
         self.assertEqual(False, p["cache"])
         self.assertEqual(False, p["response-compression-enabled"])
         self.assertEqual(False, p["detailed-results"])
-        self.assertEqual({
-            "query": {
-                "match_all": {}
-            }
-        }, p["body"])
+        self.assertEqual(
+            {
+                "query": {
+                    "match_all": {},
+                },
+            },
+            p["body"],
+        )
 
     def test_invalid_data_stream_with_type(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
             ds1 = track.DataStream(name="data-stream-1")
 
-            params.SearchParamSource(track=track.Track(name="unit-test", data_streams=[ds1]), params={
-                "data-stream": "data-stream-2",
-                "type": "_doc",
-                "cache": False,
-                "response-compression-enabled": False,
-                "body": {
-                    "query": {
-                        "match_all": {}
-                    }
-                }
-            }, operation_name="test_operation")
+            params.SearchParamSource(
+                track=track.Track(name="unit-test", data_streams=[ds1]),
+                params={
+                    "data-stream": "data-stream-2",
+                    "type": "_doc",
+                    "cache": False,
+                    "response-compression-enabled": False,
+                    "body": {
+                        "query": {
+                            "match_all": {},
+                        },
+                    },
+                },
+                operation_name="test_operation",
+            )
 
-        self.assertEqual("'type' not supported with 'data-stream' for operation 'test_operation'",
-                         ctx.exception.args[0])
+        self.assertEqual("'type' not supported with 'data-stream' for operation 'test_operation'", ctx.exception.args[0])
 
     def test_assertions_without_detailed_results_are_invalid(self):
         index1 = track.Index(name="index1", types=["type1"])
-        with self.assertRaisesRegex(exceptions.InvalidSyntax,
-                                    r"The property \[detailed-results\] must be \[true\] if assertions are defined"):
-            params.SearchParamSource(track=track.Track(name="unit-test", indices=[index1]), params={
-                "index": "_all",
-                # unset!
-                #"detailed-results": True,
-                "assertions": [{
-                    "property": "hits",
-                    "condition": ">",
-                    "value": 0
-                }],
-                "body": {
-                    "query": {
-                        "match_all": {}
-                    }
-                }
-            })
+        with self.assertRaisesRegex(
+            exceptions.InvalidSyntax, r"The property \[detailed-results\] must be \[true\] if assertions are defined"
+        ):
+            params.SearchParamSource(
+                track=track.Track(name="unit-test", indices=[index1]),
+                params={
+                    "index": "_all",
+                    # unset!
+                    # "detailed-results": True,
+                    "assertions": [{"property": "hits", "condition": ">", "value": 0}],
+                    "body": {
+                        "query": {
+                            "match_all": {},
+                        },
+                    },
+                },
+            )
 
 
 class ForceMergeParamSourceTests(TestCase):
     def test_force_merge_index_from_track(self):
-        source = params.ForceMergeParamSource(track.Track(name="unit-test", indices=[
-            track.Index(name="index1"),
-            track.Index(name="index2"),
-            track.Index(name="index3")
-        ]), params={})
+        source = params.ForceMergeParamSource(
+            track.Track(name="unit-test", indices=[track.Index(name="index1"), track.Index(name="index2"), track.Index(name="index3")]),
+            params={},
+        )
 
         p = source.params()
 
@@ -2284,11 +2638,17 @@ class ForceMergeParamSourceTests(TestCase):
         self.assertEqual("blocking", p["mode"])
 
     def test_force_merge_data_stream_from_track(self):
-        source = params.ForceMergeParamSource(track.Track(name="unit-test", data_streams=[
-            track.DataStream(name="data-stream-1"),
-            track.DataStream(name="data-stream-2"),
-            track.DataStream(name="data-stream-3")
-        ]), params={})
+        source = params.ForceMergeParamSource(
+            track.Track(
+                name="unit-test",
+                data_streams=[
+                    track.DataStream(name="data-stream-1"),
+                    track.DataStream(name="data-stream-2"),
+                    track.DataStream(name="data-stream-3"),
+                ],
+            ),
+            params={},
+        )
 
         p = source.params()
 
@@ -2320,11 +2680,10 @@ class ForceMergeParamSourceTests(TestCase):
         self.assertEqual("blocking", p["mode"])
 
     def test_force_merge_all_params(self):
-        source = params.ForceMergeParamSource(track.Track(name="unit-test"), params={"index": "index2",
-                                                                                     "request-timeout": 30,
-                                                                                     "max-num-segments": 1,
-                                                                                     "polling-period": 20,
-                                                                                     "mode": "polling"})
+        source = params.ForceMergeParamSource(
+            track.Track(name="unit-test"),
+            params={"index": "index2", "request-timeout": 30, "max-num-segments": 1, "polling-period": 20, "mode": "polling"},
+        )
 
         p = source.params()
 

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -26,46 +26,56 @@ class TrackTests(TestCase):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        self.assertEqual(default_challenge,
-                         track.Track(name="unittest",
-                                     description="unittest track",
-                                     challenges=[another_challenge, default_challenge])
-                         .default_challenge)
+        self.assertEqual(
+            default_challenge,
+            track.Track(
+                name="unittest",
+                description="unittest track",
+                challenges=[another_challenge, default_challenge],
+            ).default_challenge,
+        )
 
     def test_default_challenge_none_if_no_challenges(self):
-        self.assertIsNone(track.Track(name="unittest",
-                                      description="unittest track",
-                                      challenges=[])
-                          .default_challenge)
+        self.assertIsNone(
+            track.Track(name="unittest", description="unittest track", challenges=[]).default_challenge,
+        )
 
     def test_finds_challenge_by_name(self):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        self.assertEqual(another_challenge,
-                         track.Track(name="unittest",
-                                     description="unittest track",
-                                     challenges=[another_challenge, default_challenge])
-                         .find_challenge_or_default("other"))
+        self.assertEqual(
+            another_challenge,
+            track.Track(
+                name="unittest",
+                description="unittest track",
+                challenges=[another_challenge, default_challenge],
+            ).find_challenge_or_default("other"),
+        )
 
     def test_uses_default_challenge_if_no_name_given(self):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        self.assertEqual(default_challenge,
-                         track.Track(name="unittest",
-                                     description="unittest track",
-                                     challenges=[another_challenge, default_challenge])
-                         .find_challenge_or_default(""))
+        self.assertEqual(
+            default_challenge,
+            track.Track(
+                name="unittest",
+                description="unittest track",
+                challenges=[another_challenge, default_challenge],
+            ).find_challenge_or_default(""),
+        )
 
     def test_does_not_find_unknown_challenge(self):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
         with self.assertRaises(exceptions.InvalidName) as ctx:
-            track.Track(name="unittest",
-                        description="unittest track",
-                        challenges=[another_challenge, default_challenge]).find_challenge_or_default("unknown-name")
+            track.Track(
+                name="unittest",
+                description="unittest track",
+                challenges=[another_challenge, default_challenge],
+            ).find_challenge_or_default("unknown-name")
 
         self.assertEqual("Unknown challenge [unknown-name] for track [unittest]", ctx.exception.args[0])
 
@@ -104,14 +114,16 @@ class DataStreamTests(TestCase):
 
 class DocumentCorpusTests(TestCase):
     def test_do_not_filter(self):
-        corpus = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
-            track.Documents(source_format="other", number_of_documents=6, target_index="logs-02"),
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
-            track.Documents(source_format=None, number_of_documents=8, target_index=None)
-        ], meta_data={
-            "average-document-size-in-bytes": 12
-        })
+        corpus = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
+                track.Documents(source_format="other", number_of_documents=6, target_index="logs-02"),
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
+                track.Documents(source_format=None, number_of_documents=8, target_index=None),
+            ],
+            meta_data={"average-document-size-in-bytes": 12},
+        )
 
         filtered_corpus = corpus.filter()
 
@@ -120,12 +132,15 @@ class DocumentCorpusTests(TestCase):
         self.assertDictEqual(corpus.meta_data, filtered_corpus.meta_data)
 
     def test_filter_documents_by_format(self):
-        corpus = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
-            track.Documents(source_format="other", number_of_documents=6, target_index="logs-02"),
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
-            track.Documents(source_format=None, number_of_documents=8, target_index=None)
-        ])
+        corpus = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
+                track.Documents(source_format="other", number_of_documents=6, target_index="logs-02"),
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
+                track.Documents(source_format=None, number_of_documents=8, target_index=None),
+            ],
+        )
 
         filtered_corpus = corpus.filter(source_format=track.Documents.SOURCE_FORMAT_BULK)
 
@@ -135,12 +150,15 @@ class DocumentCorpusTests(TestCase):
         self.assertEqual("logs-03", filtered_corpus.documents[1].target_index)
 
     def test_filter_documents_by_indices(self):
-        corpus = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
-            track.Documents(source_format="other", number_of_documents=6, target_index="logs-02"),
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
-            track.Documents(source_format=None, number_of_documents=8, target_index=None)
-        ])
+        corpus = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
+                track.Documents(source_format="other", number_of_documents=6, target_index="logs-02"),
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
+                track.Documents(source_format=None, number_of_documents=8, target_index=None),
+            ],
+        )
 
         filtered_corpus = corpus.filter(target_indices=["logs-02"])
 
@@ -149,14 +167,15 @@ class DocumentCorpusTests(TestCase):
         self.assertEqual("logs-02", filtered_corpus.documents[0].target_index)
 
     def test_filter_documents_by_data_streams(self):
-        corpus = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5,
-                            target_data_stream="logs-01"),
-            track.Documents(source_format="other", number_of_documents=6, target_data_stream="logs-02"),
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7,
-                            target_data_stream="logs-03"),
-            track.Documents(source_format=None, number_of_documents=8, target_data_stream=None)
-        ])
+        corpus = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_data_stream="logs-01"),
+                track.Documents(source_format="other", number_of_documents=6, target_data_stream="logs-02"),
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_data_stream="logs-03"),
+                track.Documents(source_format=None, number_of_documents=8, target_data_stream=None),
+            ],
+        )
 
         filtered_corpus = corpus.filter(target_data_streams=["logs-02"])
         self.assertEqual("test", filtered_corpus.name)
@@ -164,12 +183,15 @@ class DocumentCorpusTests(TestCase):
         self.assertEqual("logs-02", filtered_corpus.documents[0].target_data_stream)
 
     def test_filter_documents_by_format_and_indices(self):
-        corpus = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=6, target_index="logs-02"),
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=8, target_index=None)
-        ])
+        corpus = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=6, target_index="logs-02"),
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=8, target_index=None),
+            ],
+        )
 
         filtered_corpus = corpus.filter(source_format=track.Documents.SOURCE_FORMAT_BULK, target_indices=["logs-01", "logs-02"])
 
@@ -179,50 +201,68 @@ class DocumentCorpusTests(TestCase):
         self.assertEqual("logs-02", filtered_corpus.documents[1].target_index)
 
     def test_union_document_corpus_is_reflexive(self):
-        corpus = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=6, target_index="logs-02"),
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=8, target_index=None)
-        ])
+        corpus = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=6, target_index="logs-02"),
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=7, target_index="logs-03"),
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=8, target_index=None),
+            ],
+        )
         self.assertTrue(corpus.union(corpus) is corpus)
 
     def test_union_document_corpora_is_symmetric(self):
-        a = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
-        ])
-        b = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-02"),
-        ])
+        a = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
+            ],
+        )
+        b = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-02"),
+            ],
+        )
         self.assertEqual(b.union(a), a.union(b))
         self.assertEqual(2, len(a.union(b).documents))
 
     def test_cannot_union_mixed_document_corpora_by_name(self):
-        a = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
-        ])
-        b = track.DocumentCorpus("other", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-02"),
-        ])
+        a = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
+            ],
+        )
+        b = track.DocumentCorpus(
+            "other",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-02"),
+            ],
+        )
         with self.assertRaises(exceptions.RallyAssertionError) as ae:
             a.union(b)
         self.assertEqual(ae.exception.message, "Corpora names differ: [test] and [other].")
 
     def test_cannot_union_mixed_document_corpora_by_meta_data(self):
-        a = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
-        ], meta_data={
-            "with-metadata": False
-        })
-        b = track.DocumentCorpus("test", documents=[
-            track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-02"),
-        ], meta_data={
-            "with-metadata": True
-        })
+        a = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-01"),
+            ],
+            meta_data={"with-metadata": False},
+        )
+        b = track.DocumentCorpus(
+            "test",
+            documents=[
+                track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-02"),
+            ],
+            meta_data={"with-metadata": True},
+        )
         with self.assertRaises(exceptions.RallyAssertionError) as ae:
             a.union(b)
-        self.assertEqual(ae.exception.message,
-                         "Corpora meta-data differ: [{'with-metadata': False}] and [{'with-metadata': True}].")
+        self.assertEqual(ae.exception.message, "Corpora meta-data differ: [{'with-metadata': False}] and [{'with-metadata': True}].")
 
 
 class OperationTypeTests(TestCase):
@@ -233,16 +273,16 @@ class OperationTypeTests(TestCase):
 
 class TaskFilterTests(TestCase):
     def create_index_task(self):
-        return track.Task("create-index-task",
-                          track.Operation("create-index-op",
-                                          operation_type=track.OperationType.CreateIndex.to_hyphenated_string()),
-                          tags=["write-op", "admin-op"])
+        return track.Task(
+            "create-index-task",
+            track.Operation("create-index-op", operation_type=track.OperationType.CreateIndex.to_hyphenated_string()),
+            tags=["write-op", "admin-op"],
+        )
 
     def search_task(self):
-        return track.Task("search-task",
-                          track.Operation("search-op",
-                                          operation_type=track.OperationType.Search.to_hyphenated_string()),
-                          tags="read-op")
+        return track.Task(
+            "search-task", track.Operation("search-op", operation_type=track.OperationType.Search.to_hyphenated_string()), tags="read-op"
+        )
 
     def test_task_name_filter(self):
         f = track.TaskNameFilter("create-index-task")
@@ -307,16 +347,19 @@ class TaskTests(TestCase):
         with self.assertRaises(exceptions.InvalidSyntax) as e:
             # pylint: disable=pointless-statement
             task.target_throughput
-        self.assertEqual("Task [test] specifies target-interval [1] and target-throughput [1] but only one "
-                         "of them is allowed.", e.exception.args[0])
+        self.assertEqual(
+            "Task [test] specifies target-interval [1] and target-throughput [1] but only one of them is allowed.", e.exception.args[0]
+        )
 
     def test_invalid_ignore_response_error_level_is_rejected(self):
         task = self.task(ignore_response_error_level="invalid-value")
         with self.assertRaises(exceptions.InvalidSyntax) as e:
             # pylint: disable=pointless-statement
             task.ignore_response_error_level
-        self.assertEqual("Task [test] specifies ignore-response-error-level to [invalid-value] but "
-                         "the only allowed values are [non-fatal].", e.exception.args[0])
+        self.assertEqual(
+            "Task [test] specifies ignore-response-error-level to [invalid-value] but the only allowed values are [non-fatal].",
+            e.exception.args[0],
+        )
 
     def test_task_continues_with_global_continue(self):
         task = self.task()

--- a/tests/tracker/__init__.py
+++ b/tests/tracker/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tests/tracker/corpus_test.py
+++ b/tests/tracker/corpus_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -28,20 +28,15 @@ def serialize_doc(doc):
 @mock.patch("builtins.open", new_callable=mock.mock_open)
 @mock.patch("elasticsearch.Elasticsearch")
 def test_extract(client, mo):
-    doc = {
-        "field1": "stuff",
-        "field2": "things"
-    }
+    doc = {"field1": "stuff", "field2": "things"}
     doc_data = serialize_doc(doc)
-    client.count.return_value = {
-        "count": 1001
-    }
+    client.count.return_value = {"count": 1001}
     client.search.return_value = {
         "_scroll_id": "uohialjrknf",
         "_shards": {
             "successful": 1,
             "total": 1,
-            "skipped": 0
+            "skipped": 0,
         },
         "hits": {
             "hits": [
@@ -49,10 +44,10 @@ def test_extract(client, mo):
                     "_index": "test",
                     "_id": "0",
                     "_score": 0,
-                    "_source": doc
-                }
-            ]
-        }
+                    "_source": doc,
+                },
+            ],
+        },
     }
 
     def set_corp_size(*args, **kwargs):
@@ -73,11 +68,15 @@ def test_extract(client, mo):
         osstat.side_effect = set_corp_size
         res = corpus.extract(client, outdir, index)
     assert mo.call_count == 4
-    mo.assert_has_calls([call("/abs/outpath/to/tracks/test-documents.json", "wb"),
-                         call("/abs/outpath/to/tracks/test-documents.json.bz2", "wb"),
-                         call("/abs/outpath/to/tracks/test-documents-1k.json", "wb"),
-                         call("/abs/outpath/to/tracks/test-documents-1k.json.bz2", "wb")
-                         ], any_order=True)
+    mo.assert_has_calls(
+        [
+            call("/abs/outpath/to/tracks/test-documents.json", "wb"),
+            call("/abs/outpath/to/tracks/test-documents.json.bz2", "wb"),
+            call("/abs/outpath/to/tracks/test-documents-1k.json", "wb"),
+            call("/abs/outpath/to/tracks/test-documents-1k.json.bz2", "wb"),
+        ],
+        any_order=True,
+    )
 
     assert res == {
         "filename": "test-documents.json.bz2",
@@ -85,7 +84,7 @@ def test_extract(client, mo):
         "compressed_bytes": 500,
         "index_name": "test",
         "doc_count": 1001,
-        "uncompressed_bytes": 1000
+        "uncompressed_bytes": 1000,
     }
 
     file_mock = mo.return_value

--- a/tests/tracker/index_test.py
+++ b/tests/tracker/index_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -16,7 +16,12 @@
 # under the License.
 
 from unittest import mock
-from esrally.tracker.index import filter_ephemeral_index_settings, extract_index_mapping_and_settings, update_index_setting_parameters
+
+from esrally.tracker.index import (
+    extract_index_mapping_and_settings,
+    filter_ephemeral_index_settings,
+    update_index_setting_parameters,
+)
 
 
 def test_index_setting_filter():
@@ -25,23 +30,15 @@ def test_index_setting_filter():
         "provided_name": "queries",
         "creation_date": "1579230289084",
         "requests": {
-            "cache": {
-                "enable": "false"
-            }
+            "cache": {"enable": "false"},
         },
         "number_of_replicas": "0",
         "queries": {
-            "cache": {
-                "enabled": "false"
-            }
+            "cache": {"enabled": "false"},
         },
         "uuid": "jdzVt-dDS1aRlqdZWK4pdA",
-        "version": {
-            "created": "7050099"
-        },
-        "store": {
-            "type": "fs"
-        }
+        "version": {"created": "7050099"},
+        "store": {"type": "fs"},
     }
     settings = filter_ephemeral_index_settings(unfiltered_index_settings)
     assert settings.keys() == {"number_of_shards", "number_of_replicas", "requests", "queries"}
@@ -53,9 +50,7 @@ def test_index_setting_parameters():
         "provided_name": "queries",
         "creation_date": "1579230289084",
         "requests": {
-            "cache": {
-                "enable": "false"
-            }
+            "cache": {"enable": "false"},
         },
         "number_of_replicas": "0",
     }
@@ -65,9 +60,7 @@ def test_index_setting_parameters():
         "provided_name": "queries",
         "creation_date": "1579230289084",
         "requests": {
-            "cache": {
-                "enable": "false"
-            }
+            "cache": {"enable": "false"},
         },
         "number_of_replicas": "{{number_of_replicas | default(0)}}",
     }
@@ -86,9 +79,9 @@ def test_extract_index_create(client):
                 "dynamic": "strict",
                 "properties": {
                     "location": {
-                        "type": "geo_point"
-                    }
-                }
+                        "type": "geo_point",
+                    },
+                },
             },
             "settings": {
                 "index": {
@@ -96,38 +89,32 @@ def test_extract_index_create(client):
                     "provided_name": "osmgeopoints",
                     "creation_date": "1579210032233",
                     "requests": {
-                        "cache": {
-                            "enable": "false"
-                        }
+                        "cache": {"enable": "false"},
                     },
                     "number_of_replicas": "2",
                     "uuid": "vOOsPNfxTJyQekkIo9TjPA",
-                    "version": {
-                        "created": "7050099"
-                    },
-                    "store": {
-                        "type": "fs"
-                    }
+                    "version": {"created": "7050099"},
+                    "store": {"type": "fs"},
                 }
-            }
+            },
         },
         # should be filtered
         ".security": {
             "mappings": {},
             "settings": {
                 "index": {
-                    "number_of_shards": "1"
-                }
-            }
+                    "number_of_shards": "1",
+                },
+            },
         },
         "geodata": {
             "mappings": {},
             "settings": {
                 "index": {
-                    "number_of_shards": "1"
-                }
-            }
-        }
+                    "number_of_shards": "1",
+                },
+            },
+        },
     }
     expected = {
         "osmgeopoints": {
@@ -135,30 +122,28 @@ def test_extract_index_create(client):
                 "dynamic": "strict",
                 "properties": {
                     "location": {
-                        "type": "geo_point"
-                    }
-                }
+                        "type": "geo_point",
+                    },
+                },
             },
             "settings": {
                 "index": {
                     "number_of_replicas": "{{number_of_replicas | default(2)}}",
                     "number_of_shards": "{{number_of_shards | default(3)}}",
                     "requests": {
-                        "cache": {
-                            "enable": "false"
-                        }
-                    }
+                        "cache": {"enable": "false"},
+                    },
                 }
-            }
+            },
         },
         "geodata": {
             "mappings": {},
             "settings": {
                 "index": {
-                    "number_of_shards": "{{number_of_shards | default(1)}}"
-                }
-            }
-        }
+                    "number_of_shards": "{{number_of_shards | default(1)}}",
+                },
+            },
+        },
     }
     res = extract_index_mapping_and_settings(client, "_all")
     assert res == expected

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tests/utils/collections_test.py
+++ b/tests/utils/collections_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -44,13 +44,8 @@ class TestMergeDicts:
         d1 = {
             "params": {
                 "car": "4gheap",
-                "car-params": {
-                    "additional_cluster_settings": {
-                        "indices.queries.cache.size": "5%",
-                        "transport.tcp.compress": True
-                    }
-                },
-                "unique-param": "foobar"
+                "car-params": {"additional_cluster_settings": {"indices.queries.cache.size": "5%", "transport.tcp.compress": True}},
+                "unique-param": "foobar",
             }
         }
 
@@ -59,53 +54,30 @@ class TestMergeDicts:
         assert dict(collections.merge_dicts(d1, d2)) == {
             "params": {
                 "car-params": {
-                    "additional_cluster_settings": {
-                        "indices.queries.cache.size": "5%",
-                        "transport.tcp.compress": True
-                    },
-                    "data_paths": "/mnt/local_ssd"},
+                    "additional_cluster_settings": {"indices.queries.cache.size": "5%", "transport.tcp.compress": True},
+                    "data_paths": "/mnt/local_ssd",
+                },
                 "car": "4gheap",
-                "unique-param": "foobar"
+                "unique-param": "foobar",
             }
         }
 
     def test_can_merge_nested_lists_in_dicts(self):
-        d1 = {
-            "params": {
-                "foo": [1, 2, 3]
-            }
-        }
+        d1 = {"params": {"foo": [1, 2, 3]}}
 
-        d2 = {
-            "params": {
-                "foo": [3, 4, 5]
-            }
-        }
+        d2 = {"params": {"foo": [3, 4, 5]}}
 
-        assert dict(collections.merge_dicts(d1, d2)) == {
-            "params": {
-                "foo": [1, 2, 3, 4, 5]
-            }
-        }
+        assert dict(collections.merge_dicts(d1, d2)) == {"params": {"foo": [1, 2, 3, 4, 5]}}
 
     def test_can_merge_nested_booleans_in_dicts(self):
-        d1 = {
-            "params": {
-                "foo": True,
-                "other": [1, 2, 3]
-            }
-        }
+        d1 = {"params": {"foo": True, "other": [1, 2, 3]}}
 
-        d2 = {
-            "params": {
-                "foo": False
-            }
-        }
+        d2 = {"params": {"foo": False}}
 
         assert dict(collections.merge_dicts(d1, d2)) == {
             "params": {
                 # d2 wins
                 "foo": False,
-                "other": [1, 2, 3]
+                "other": [1, 2, 3],
             }
         }

--- a/tests/utils/console_test.py
+++ b/tests/utils/console_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -66,9 +66,7 @@ class ConsoleFunctionTests(TestCase):
         console.RALLY_RUNNING_IN_DOCKER = not random_boolean
 
         console.println(msg="Unittest message")
-        patched_print.assert_called_once_with(
-            "Unittest message", end="\n", flush=False
-        )
+        patched_print.assert_called_once_with("Unittest message", end="\n", flush=False)
 
     @mock.patch("sys.stdout.isatty")
     @mock.patch("builtins.print")
@@ -77,9 +75,7 @@ class ConsoleFunctionTests(TestCase):
         console.init(quiet=False, assume_tty=not random_boolean)
         patched_isatty.return_value = random_boolean
         console.println(msg="Unittest message")
-        patched_print.assert_called_once_with(
-            "Unittest message", end="\n", flush=False
-        )
+        patched_print.assert_called_once_with("Unittest message", end="\n", flush=False)
 
     @mock.patch("sys.stdout.isatty")
     @mock.patch("builtins.print")
@@ -98,9 +94,7 @@ class ConsoleFunctionTests(TestCase):
         patched_isatty.return_value = random.choice([True, False])
 
         console.println(msg="Unittest message", force=True)
-        patched_print.assert_called_once_with(
-            "Unittest message", end="\n", flush=False
-        )
+        patched_print.assert_called_once_with("Unittest message", end="\n", flush=False)
 
 
 # pytest style class names need to start with Test and don't need to subclass
@@ -169,10 +163,12 @@ class TestCmdLineProgressReporter:
         mock_printer = mock.Mock()
         progress_reporter = console.CmdLineProgressReporter(width=width, printer=mock_printer)
         progress_reporter.print(message=message, progress=".")
-        mock_printer.assert_has_calls([
-            mock.call(" " * width, end=""),
-            mock.call("\x1b[{}D{}{}.".format(width, message, " "*(width-len(message)-1)), end="")
-        ])
+        mock_printer.assert_has_calls(
+            [
+                mock.call(" " * width, end=""),
+                mock.call("\x1b[{}D{}{}.".format(width, message, " " * (width - len(message) - 1)), end=""),
+            ]
+        )
         patched_flush.assert_called_once_with()
 
     @mock.patch("sys.stdout.flush")
@@ -190,10 +186,12 @@ class TestCmdLineProgressReporter:
         mock_printer = mock.Mock()
         progress_reporter = console.CmdLineProgressReporter(width=width, printer=mock_printer)
         progress_reporter.print(message=message, progress=".")
-        mock_printer.assert_has_calls([
-            mock.call(" " * width, end=""),
-            mock.call("\x1b[{}D{}{}.".format(width, message, " "*(width-len(message)-1)), end="")
-        ])
+        mock_printer.assert_has_calls(
+            [
+                mock.call(" " * width, end=""),
+                mock.call("\x1b[{}D{}{}.".format(width, message, " " * (width - len(message) - 1)), end=""),
+            ]
+        )
         patched_flush.assert_called_once_with()
 
     @mock.patch("sys.stdout.flush")

--- a/tests/utils/convert_test.py
+++ b/tests/utils/convert_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -103,10 +103,7 @@ class GitTests(TestCase):
     def test_rebase(self, run_subprocess_with_logging):
         run_subprocess_with_logging.return_value = 0
         git.rebase("/src", remote="my-origin", branch="feature-branch")
-        calls = [
-            mock.call("git -C /src checkout feature-branch"),
-            mock.call("git -C /src rebase my-origin/feature-branch")
-        ]
+        calls = [mock.call("git -C /src checkout feature-branch"), mock.call("git -C /src rebase my-origin/feature-branch")]
         run_subprocess_with_logging.assert_has_calls(calls)
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
@@ -115,16 +112,16 @@ class GitTests(TestCase):
         git.pull("/src", remote="my-origin", branch="feature-branch")
         calls = [
             # pull
-            mock.call('git -C /src --version', level=logging.DEBUG),
+            mock.call("git -C /src --version", level=logging.DEBUG),
             # fetch
-            mock.call('git -C /src --version', level=logging.DEBUG),
+            mock.call("git -C /src --version", level=logging.DEBUG),
             mock.call("git -C /src fetch --prune --tags my-origin"),
             # rebase
-            mock.call('git -C /src --version', level=logging.DEBUG),
+            mock.call("git -C /src --version", level=logging.DEBUG),
             # checkout
-            mock.call('git -C /src --version', level=logging.DEBUG),
+            mock.call("git -C /src --version", level=logging.DEBUG),
             mock.call("git -C /src checkout feature-branch"),
-            mock.call("git -C /src rebase my-origin/feature-branch")
+            mock.call("git -C /src rebase my-origin/feature-branch"),
         ]
         run_subprocess_with_logging.assert_has_calls(calls)
 
@@ -137,12 +134,8 @@ class GitTests(TestCase):
         run_subprocess.side_effect = [False, False]
         git.pull_ts("/src", "20160101T110000Z")
 
-        run_subprocess_with_output.assert_called_with(
-            "git -C /src rev-list -n 1 --before=\"20160101T110000Z\" --date=iso8601 origin/master")
-        run_subprocess.has_calls([
-            mock.call("git -C /src fetch --prune --tags --quiet origin"),
-            mock.call("git -C /src checkout 3694a07")
-        ])
+        run_subprocess_with_output.assert_called_with('git -C /src rev-list -n 1 --before="20160101T110000Z" --date=iso8601 origin/master')
+        run_subprocess.has_calls([mock.call("git -C /src fetch --prune --tags --quiet origin"), mock.call("git -C /src checkout 3694a07")])
 
     @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
@@ -150,10 +143,12 @@ class GitTests(TestCase):
         run_subprocess_with_logging.return_value = 0
         run_subprocess.side_effect = [False, False]
         git.pull_revision("/src", "3694a07")
-        run_subprocess.has_calls([
-            mock.call("git -C /src fetch --prune --tags --quiet origin"),
-            mock.call("git -C /src checkout --quiet 3694a07"),
-        ])
+        run_subprocess.has_calls(
+            [
+                mock.call("git -C /src fetch --prune --tags --quiet origin"),
+                mock.call("git -C /src checkout --quiet 3694a07"),
+            ]
+        )
 
     @mock.patch("esrally.utils.process.run_subprocess_with_output")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
@@ -167,10 +162,12 @@ class GitTests(TestCase):
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_list_remote_branches(self, run_subprocess_with_logging, run_subprocess):
         run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = ["  origin/HEAD",
-                                       "  origin/master",
-                                       "  origin/5.0.0-alpha1",
-                                       "  origin/5"]
+        run_subprocess.return_value = [
+            "  origin/HEAD",
+            "  origin/master",
+            "  origin/5.0.0-alpha1",
+            "  origin/5",
+        ]
         self.assertEqual(["master", "5.0.0-alpha1", "5"], git.branches("/src", remote=True))
         run_subprocess.assert_called_with("git -C /src for-each-ref refs/remotes/ --format='%(refname:short)'")
 
@@ -178,10 +175,12 @@ class GitTests(TestCase):
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_list_local_branches(self, run_subprocess_with_logging, run_subprocess):
         run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = ["  HEAD",
-                                       "  master",
-                                       "  5.0.0-alpha1",
-                                       "  5"]
+        run_subprocess.return_value = [
+            "  HEAD",
+            "  master",
+            "  5.0.0-alpha1",
+            "  5",
+        ]
         self.assertEqual(["master", "5.0.0-alpha1", "5"], git.branches("/src", remote=False))
         run_subprocess.assert_called_with("git -C /src for-each-ref refs/heads/ --format='%(refname:short)'")
 
@@ -189,8 +188,10 @@ class GitTests(TestCase):
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_list_tags_with_tags_present(self, run_subprocess_with_logging, run_subprocess):
         run_subprocess_with_logging.return_value = 0
-        run_subprocess.return_value = ["  v1",
-                                       "  v2"]
+        run_subprocess.return_value = [
+            "  v1",
+            "  v2",
+        ]
         self.assertEqual(["v1", "v2"], git.tags("/src"))
         run_subprocess.assert_called_with("git -C /src tag")
 

--- a/tests/utils/io_test.py
+++ b/tests/utils/io_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -32,7 +32,7 @@ def mock_debian(args, fallback=None):
             "/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java",
             "/usr/lib/jvm/java-7-oracle/jre/bin/java",
             "/usr/lib/jvm/java-8-oracle/jre/bin/java",
-            "/usr/lib/jvm/java-9-openjdk-amd64/bin/java"
+            "/usr/lib/jvm/java-9-openjdk-amd64/bin/java",
         ]
     else:
         return fallback
@@ -76,10 +76,12 @@ class TestDecompression:
 
             io.decompress(archive_path, target_directory=tmp_dir)
 
-            assert os.path.exists(decompressed_path) is True,\
-                f"Could not decompress [{archive_path}] to [{decompressed_path}] (target file does not exist)"
-            assert self.read(decompressed_path) == "Sample text for DecompressionTests\n",\
-                f"Could not decompress [{archive_path}] to [{decompressed_path}] (target file is corrupt)"
+            assert (
+                os.path.exists(decompressed_path) is True
+            ), f"Could not decompress [{archive_path}] to [{decompressed_path}] (target file does not exist)"
+            assert (
+                self.read(decompressed_path) == "Sample text for DecompressionTests\n"
+            ), f"Could not decompress [{archive_path}] to [{decompressed_path}] (target file is corrupt)"
 
     @mock.patch.object(io, "is_executable", return_value=False)
     def test_decompresses_supported_file_formats_with_lib_as_failover(self, mocked_is_executable):
@@ -92,10 +94,12 @@ class TestDecompression:
             with mock.patch.object(logger, "warning") as mocked_console_warn:
                 io.decompress(archive_path, target_directory=tmp_dir)
 
-                assert os.path.exists(decompressed_path) is True,\
-                    f"Could not decompress [{archive_path}] to [{decompressed_path}] (target file does not exist)"
-                assert self.read(decompressed_path) == "Sample text for DecompressionTests\n",\
-                    f"Could not decompress [{archive_path}] to [{decompressed_path}] (target file is corrupt)"
+                assert (
+                    os.path.exists(decompressed_path) is True
+                ), f"Could not decompress [{archive_path}] to [{decompressed_path}] (target file does not exist)"
+                assert (
+                    self.read(decompressed_path) == "Sample text for DecompressionTests\n"
+                ), f"Could not decompress [{archive_path}] to [{decompressed_path}] (target file is corrupt)"
 
             if ext in ["bz2", "gz"]:
                 assert "not found in PATH. Using standard library, decompression will take longer." in mocked_console_warn.call_args[0][0]
@@ -119,5 +123,5 @@ class TestDecompression:
         assert result is False
 
     def read(self, f):
-        with open(f, 'r') as content_file:
+        with open(f, "r") as content_file:
             return content_file.read()

--- a/tests/utils/jvm_test.py
+++ b/tests/utils/jvm_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -73,16 +73,18 @@ class JvmTests(TestCase):
         # JAVA8_HOME, JAVA_HOME
         getenv.side_effect = [None, "/opt/jdks/jdk/1.7"]
 
-        with self.assertRaisesRegex(expected_exception=exceptions.SystemSetupError,
-                                    expected_regex="JAVA_HOME points to JDK 7 but it should point to JDK 8."):
+        with self.assertRaisesRegex(
+            expected_exception=exceptions.SystemSetupError, expected_regex="JAVA_HOME points to JDK 7 but it should point to JDK 8."
+        ):
             jvm.resolve_path(majors=8, sysprop_reader=self.path_based_prop_version_reader)
 
     @mock.patch("os.getenv")
     def test_resolve_path_for_one_version_no_env_vars_defined(self, getenv):
         getenv.return_value = None
 
-        with self.assertRaisesRegex(expected_exception=exceptions.SystemSetupError,
-                                    expected_regex="Neither JAVA8_HOME nor JAVA_HOME point to a JDK 8 installation."):
+        with self.assertRaisesRegex(
+            expected_exception=exceptions.SystemSetupError, expected_regex="Neither JAVA8_HOME nor JAVA_HOME point to a JDK 8 installation."
+        ):
             jvm.resolve_path(majors=8, sysprop_reader=self.path_based_prop_version_reader)
 
     @mock.patch("os.getenv")

--- a/tests/utils/net_test.py
+++ b/tests/utils/net_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -31,10 +31,12 @@ class TestNetUtils:
         expected_size = random.choice([None, random.randint(0, 1000)])
         progress_indicator = random.choice([None, "some progress indicator"])
 
-        net.download_from_bucket("s3", "s3://mybucket.elasticsearch.org/data/documents.json.bz2", "/tmp/documents.json.bz2",
-                                 expected_size, progress_indicator)
-        download.assert_called_once_with("mybucket.elasticsearch.org", "data/documents.json.bz2",
-                                         "/tmp/documents.json.bz2", expected_size, progress_indicator)
+        net.download_from_bucket(
+            "s3", "s3://mybucket.elasticsearch.org/data/documents.json.bz2", "/tmp/documents.json.bz2", expected_size, progress_indicator
+        )
+        download.assert_called_once_with(
+            "mybucket.elasticsearch.org", "data/documents.json.bz2", "/tmp/documents.json.bz2", expected_size, progress_indicator
+        )
 
     @mock.patch("esrally.utils.console.error")
     @mock.patch("esrally.utils.net._fake_import_boto3")
@@ -42,9 +44,7 @@ class TestNetUtils:
         import_boto3.side_effect = ImportError("no module named 'boto3'")
         with pytest.raises(ImportError, match="no module named 'boto3'"):
             net.download_from_bucket("s3", "s3://mybucket/data", "/tmp/data", None, None)
-        console_error.assert_called_once_with(
-            "S3 support is optional. Install it with `python -m pip install esrally[s3]`"
-        )
+        console_error.assert_called_once_with("S3 support is optional. Install it with `python -m pip install esrally[s3]`")
 
     @pytest.mark.parametrize("seed", range(1))
     @mock.patch("esrally.utils.net._download_from_gcs_bucket")
@@ -53,39 +53,46 @@ class TestNetUtils:
         expected_size = random.choice([None, random.randint(0, 1000)])
         progress_indicator = random.choice([None, "some progress indicator"])
 
-        net.download_from_bucket("gs", "gs://unittest-gcp-bucket.test.org/data/documents.json.bz2", "/tmp/documents.json.bz2",
-                                 expected_size, progress_indicator)
-        download.assert_called_once_with("unittest-gcp-bucket.test.org", "data/documents.json.bz2",
-                                         "/tmp/documents.json.bz2", expected_size, progress_indicator)
+        net.download_from_bucket(
+            "gs", "gs://unittest-gcp-bucket.test.org/data/documents.json.bz2", "/tmp/documents.json.bz2", expected_size, progress_indicator
+        )
+        download.assert_called_once_with(
+            "unittest-gcp-bucket.test.org", "data/documents.json.bz2", "/tmp/documents.json.bz2", expected_size, progress_indicator
+        )
 
     @pytest.mark.parametrize("seed", range(40))
     def test_gcs_object_url(self, seed):
         random.seed(seed)
-        bucket_name = random.choice(["unittest-bucket.test.me", "/unittest-bucket.test.me",
-                                     "/unittest-bucket.test.me/", "unittest-bucket.test.me/"])
-        bucket_path = random.choice(["path/to/object", "/path/to/object",
-                                     "/path/to/object/", "path/to/object/"])
+        bucket_name = random.choice(
+            ["unittest-bucket.test.me", "/unittest-bucket.test.me", "/unittest-bucket.test.me/", "unittest-bucket.test.me/"]
+        )
+        bucket_path = random.choice(["path/to/object", "/path/to/object", "/path/to/object/", "path/to/object/"])
 
         # pylint: disable=protected-access
-        assert net._build_gcs_object_url(bucket_name, bucket_path) == \
-               "https://storage.googleapis.com/storage/v1/b/unittest-bucket.test.me/o/path%2Fto%2Fobject?alt=media"
+        assert (
+            net._build_gcs_object_url(bucket_name, bucket_path)
+            == "https://storage.googleapis.com/storage/v1/b/unittest-bucket.test.me/o/path%2Fto%2Fobject?alt=media"
+        )
 
     def test_add_url_param_elastic_no_kpi(self):
         url = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz"
-        assert net.add_url_param_elastic_no_kpi(url) == \
-               "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?x-elastic-no-kpi=true"
+        assert (
+            net.add_url_param_elastic_no_kpi(url)
+            == "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?x-elastic-no-kpi=true"
+        )
 
     def test_add_url_param_elastic_no_kpi_no_http(self):
         url = "gs://my_bucket/builds/elasticsearch/elasticsearch-8.0.0-SNAPSHOT.tar.gz"
-        assert net.add_url_param_elastic_no_kpi(url) == \
-               "gs://my_bucket/builds/elasticsearch/elasticsearch-8.0.0-SNAPSHOT.tar.gz"
+        assert net.add_url_param_elastic_no_kpi(url) == "gs://my_bucket/builds/elasticsearch/elasticsearch-8.0.0-SNAPSHOT.tar.gz"
 
     def test_add_url_param_encoding_and_update(self):
         url = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?flag1=true"
         params = {"flag1": "test me", "flag2": "test@me"}
         # pylint: disable=protected-access
-        assert net._add_url_param(url, params) == \
-               "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?flag1=test+me&flag2=test%40me"
+        assert (
+            net._add_url_param(url, params)
+            == "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?flag1=test+me&flag2=test%40me"
+        )
 
     def test_progress(self):
         progress = net.Progress("test")
@@ -98,11 +105,13 @@ class TestNetUtils:
         assert mock_progress.print.called
 
     def test_s3_dependency(self):
-        #pylint: disable=import-outside-toplevel,unused-import
+        # pylint: disable=import-outside-toplevel,unused-import
         import boto3
+
         assert True
 
     def test_gcs_dependency(self):
-        #pylint: disable=import-outside-toplevel,unused-import
+        # pylint: disable=import-outside-toplevel,unused-import
         import google.auth
+
         assert True

--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -34,26 +34,21 @@ class ConfigHelperFunctionTests(TestCase):
         self.assertEqual({"k": 3}, opts.kv_to_map(["k:3"]))
         # implicit treatment as string
         self.assertEqual({"k": "v"}, opts.kv_to_map(["k:v"]))
-        self.assertEqual({"k": "v", "size": 4, "empty": False, "temperature": 0.5},
-                         opts.kv_to_map(["k:'v'", "size:4", "empty:false", "temperature:0.5"]))
+        self.assertEqual(
+            {"k": "v", "size": 4, "empty": False, "temperature": 0.5}, opts.kv_to_map(["k:'v'", "size:4", "empty:false", "temperature:0.5"])
+        )
 
 
 class GenericHelperFunctionTests(TestCase):
     def test_list_as_bulleted_list(self):
         src_list = ["param-1", "param-2", "a_longer-parameter"]
 
-        self.assertEqual(
-            ["- param-1", "- param-2", "- a_longer-parameter"],
-            opts.bulleted_list_of(src_list)
-        )
+        self.assertEqual(["- param-1", "- param-2", "- a_longer-parameter"], opts.bulleted_list_of(src_list))
 
     def test_list_as_double_quoted_list(self):
         src_list = ["oneitem", "_another-weird_item", "param-3"]
 
-        self.assertEqual(
-            opts.double_quoted_list_of(src_list),
-            ['"oneitem"', '"_another-weird_item"', '"param-3"']
-        )
+        self.assertEqual(opts.double_quoted_list_of(src_list), ['"oneitem"', '"_another-weird_item"', '"param-3"'])
 
     def test_make_list_of_close_matches(self):
         word_list = [
@@ -63,7 +58,8 @@ class GenericHelperFunctionTests(TestCase):
             "bulk_size",
             "number_of-shards",
             "number_of_replicas",
-            "index_refresh_interval"]
+            "index_refresh_interval",
+        ]
 
         available_word_list = [
             "bulk_indexing_clients",
@@ -106,88 +102,81 @@ class GenericHelperFunctionTests(TestCase):
             "shard_sizing_queries",
             "source_enabled",
             "target_throughput",
-            "translog_sync"]
+            "translog_sync",
+        ]
 
         self.assertEqual(
-            ['bulk_indexing_clients',
-             'bulk_indexing_iterations',
-             'target_throughput',
-             'bulk_size',
-             # number_of-shards had a typo
-             'number_of_shards',
-             'number_of_replicas',
-             'index_refresh_interval'],
-            opts.make_list_of_close_matches(word_list, available_word_list)
+            [
+                "bulk_indexing_clients",
+                "bulk_indexing_iterations",
+                "target_throughput",
+                "bulk_size",
+                # number_of-shards had a typo
+                "number_of_shards",
+                "number_of_replicas",
+                "index_refresh_interval",
+            ],
+            opts.make_list_of_close_matches(word_list, available_word_list),
         )
 
     def test_make_list_of_close_matches_returns_with_empty_word_list(self):
-        self.assertEqual(
-            [],
-            opts.make_list_of_close_matches([], ["number_of_shards"])
-        )
+        self.assertEqual([], opts.make_list_of_close_matches([], ["number_of_shards"]))
 
     def test_make_list_of_close_matches_returns_empty_list_with_no_close_matches(self):
-        self.assertEqual(
-            [],
-            opts.make_list_of_close_matches(
-                ["number_of_shards", "number_of-replicas"],
-                [])
-        )
+        self.assertEqual([], opts.make_list_of_close_matches(["number_of_shards", "number_of-replicas"], []))
 
 
 class TestTargetHosts(TestCase):
     def test_empty_arg_parses_as_empty_list(self):
-        self.assertEqual([], opts.TargetHosts('').default)
-        self.assertEqual({'default': []}, opts.TargetHosts('').all_hosts)
+        self.assertEqual([], opts.TargetHosts("").default)
+        self.assertEqual({"default": []}, opts.TargetHosts("").all_hosts)
 
     def test_csv_hosts_parses(self):
-        target_hosts = '127.0.0.1:9200,10.17.0.5:19200'
+        target_hosts = "127.0.0.1:9200,10.17.0.5:19200"
 
         self.assertEqual(
-            {'default': [{'host': '127.0.0.1', 'port': 9200},{'host': '10.17.0.5', 'port': 19200}]},
-            opts.TargetHosts(target_hosts).all_hosts
+            {"default": [{"host": "127.0.0.1", "port": 9200}, {"host": "10.17.0.5", "port": 19200}]},
+            opts.TargetHosts(target_hosts).all_hosts,
         )
 
         self.assertEqual(
-            [{'host': '127.0.0.1', 'port': 9200},{'host': '10.17.0.5', 'port': 19200}],
-            opts.TargetHosts(target_hosts).default
+            [{"host": "127.0.0.1", "port": 9200}, {"host": "10.17.0.5", "port": 19200}], opts.TargetHosts(target_hosts).default
         )
 
         self.assertEqual(
-            [{'host': '127.0.0.1', 'port': 9200},{'host': '10.17.0.5', 'port': 19200}],
-            opts.TargetHosts(target_hosts).default)
+            [{"host": "127.0.0.1", "port": 9200}, {"host": "10.17.0.5", "port": 19200}], opts.TargetHosts(target_hosts).default
+        )
 
     def test_jsonstring_parses_as_dict_of_clusters(self):
-        target_hosts = ('{"default": ["127.0.0.1:9200","10.17.0.5:19200"],'
-                        ' "remote_1": ["88.33.22.15:19200"],'
-                        ' "remote_2": ["10.18.0.6:19200","10.18.0.7:19201"]}')
-
-        self.assertEqual(
-            {'default': ['127.0.0.1:9200','10.17.0.5:19200'],
-             'remote_1': ['88.33.22.15:19200'],
-             'remote_2': ['10.18.0.6:19200','10.18.0.7:19201']},
-            opts.TargetHosts(target_hosts).all_hosts)
-
-    def test_json_file_parameter_parses(self):
-        self.assertEqual(
-            {"default": ["127.0.0.1:9200","10.127.0.3:19200"] },
-            opts.TargetHosts(os.path.join(os.path.dirname(__file__), "resources", "target_hosts_1.json")).all_hosts)
+        target_hosts = (
+            '{"default": ["127.0.0.1:9200","10.17.0.5:19200"],'
+            ' "remote_1": ["88.33.22.15:19200"],'
+            ' "remote_2": ["10.18.0.6:19200","10.18.0.7:19201"]}'
+        )
 
         self.assertEqual(
             {
-              "default": [
-                {"host": "127.0.0.1", "port": 9200},
-                {"host": "127.0.0.1", "port": 19200}
-              ],
-              "remote_1":[
-                {"host": "10.127.0.3", "port": 9200},
-                {"host": "10.127.0.8", "port": 9201}
-              ],
-              "remote_2":[
-                {"host": "88.33.27.15", "port": 39200}
-              ]
+                "default": ["127.0.0.1:9200", "10.17.0.5:19200"],
+                "remote_1": ["88.33.22.15:19200"],
+                "remote_2": ["10.18.0.6:19200", "10.18.0.7:19201"],
             },
-            opts.TargetHosts(os.path.join(os.path.dirname(__file__), "resources", "target_hosts_2.json")).all_hosts)
+            opts.TargetHosts(target_hosts).all_hosts,
+        )
+
+    def test_json_file_parameter_parses(self):
+        self.assertEqual(
+            {"default": ["127.0.0.1:9200", "10.127.0.3:19200"]},
+            opts.TargetHosts(os.path.join(os.path.dirname(__file__), "resources", "target_hosts_1.json")).all_hosts,
+        )
+
+        self.assertEqual(
+            {
+                "default": [{"host": "127.0.0.1", "port": 9200}, {"host": "127.0.0.1", "port": 19200}],
+                "remote_1": [{"host": "10.127.0.3", "port": 9200}, {"host": "10.127.0.8", "port": 9201}],
+                "remote_2": [{"host": "88.33.27.15", "port": 39200}],
+            },
+            opts.TargetHosts(os.path.join(os.path.dirname(__file__), "resources", "target_hosts_2.json")).all_hosts,
+        )
 
 
 class TestClientOptions(TestCase):
@@ -195,104 +184,98 @@ class TestClientOptions(TestCase):
         client_options_string = "use_ssl:true,verify_certs:true,ca_certs:'/path/to/cacert.pem'"
 
         self.assertEqual(
-            {'use_ssl': True, 'verify_certs': True, 'ca_certs': '/path/to/cacert.pem'},
-            opts.ClientOptions(client_options_string).default)
-
-        self.assertEqual(
-            {'use_ssl': True, 'verify_certs': True, 'ca_certs': '/path/to/cacert.pem'},
-            opts.ClientOptions(client_options_string).default
+            {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem"}, opts.ClientOptions(client_options_string).default
         )
 
         self.assertEqual(
-            {'default': {'use_ssl': True, 'verify_certs': True, 'ca_certs': '/path/to/cacert.pem'}},
-            opts.ClientOptions(client_options_string).all_client_options
+            {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem"}, opts.ClientOptions(client_options_string).default
+        )
+
+        self.assertEqual(
+            {"default": {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem"}},
+            opts.ClientOptions(client_options_string).all_client_options,
         )
 
     def test_jsonstring_client_options_parses(self):
-        client_options_string = '{"default": {"timeout": 60},' \
-            '"remote_1": {"use_ssl":true,"verify_certs":true,"basic_auth_user": "elastic", "basic_auth_password": "changeme"},'\
+        client_options_string = (
+            '{"default": {"timeout": 60},'
+            '"remote_1": {"use_ssl":true,"verify_certs":true,"basic_auth_user": "elastic", "basic_auth_password": "changeme"},'
             '"remote_2": {"use_ssl":true,"verify_certs":true,"ca_certs":"/path/to/cacert.pem"}}'
+        )
+
+        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string).default)
+
+        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string).default)
 
         self.assertEqual(
-            {'timeout': 60},
-            opts.ClientOptions(client_options_string).default)
-
-        self.assertEqual(
-            {'timeout': 60},
-            opts.ClientOptions(client_options_string).default)
-
-        self.assertEqual(
-            {'default': {'timeout':60},
-             'remote_1': {'use_ssl': True,'verify_certs': True,'basic_auth_user':'elastic','basic_auth_password':'changeme'},
-             'remote_2': {'use_ssl': True,'verify_certs': True, 'ca_certs':'/path/to/cacert.pem'}},
-            opts.ClientOptions(client_options_string).all_client_options)
+            {
+                "default": {"timeout": 60},
+                "remote_1": {"use_ssl": True, "verify_certs": True, "basic_auth_user": "elastic", "basic_auth_password": "changeme"},
+                "remote_2": {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem"},
+            },
+            opts.ClientOptions(client_options_string).all_client_options,
+        )
 
     def test_json_file_parameter_parses(self):
         self.assertEqual(
-            {'default': {'timeout':60},
-             'remote_1': {'use_ssl': True,'verify_certs': True,'basic_auth_user':'elastic','basic_auth_password':'changeme'},
-             'remote_2': {'use_ssl': True,'verify_certs': True, 'ca_certs':'/path/to/cacert.pem'}},
-            opts.ClientOptions(os.path.join(os.path.dirname(__file__), "resources", "client_options_1.json")).all_client_options)
+            {
+                "default": {"timeout": 60},
+                "remote_1": {"use_ssl": True, "verify_certs": True, "basic_auth_user": "elastic", "basic_auth_password": "changeme"},
+                "remote_2": {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem"},
+            },
+            opts.ClientOptions(os.path.join(os.path.dirname(__file__), "resources", "client_options_1.json")).all_client_options,
+        )
 
         self.assertEqual(
-            {'default': {'timeout':60}},
-            opts.ClientOptions(os.path.join(os.path.dirname(__file__), "resources", "client_options_2.json")).all_client_options)
+            {"default": {"timeout": 60}},
+            opts.ClientOptions(os.path.join(os.path.dirname(__file__), "resources", "client_options_2.json")).all_client_options,
+        )
 
     def test_no_client_option_parses_to_default(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = None
 
-        self.assertEqual(
-            {"timeout": 60},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
         self.assertEqual(
-            {"default": {"timeout": 60}},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).all_client_options)
+            {"default": {"timeout": 60}}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).all_client_options
+        )
 
-        self.assertEqual(
-            {"timeout": 60},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
     def test_no_client_option_parses_to_default_with_multicluster(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = opts.TargetHosts('{"default": ["127.0.0.1:9200,10.17.0.5:19200"], "remote": ["88.33.22.15:19200"]}')
 
-        self.assertEqual(
-            {"timeout": 60},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
         self.assertEqual(
             {"default": {"timeout": 60}, "remote": {"timeout": 60}},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).all_client_options)
+            opts.ClientOptions(client_options_string, target_hosts=target_hosts).all_client_options,
+        )
 
-        self.assertEqual(
-            {"timeout": 60},
-            opts.ClientOptions(client_options_string,
-                                 target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
     def test_default_client_ops_with_max_connections(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = opts.TargetHosts('{"default": ["10.17.0.5:9200"], "remote": ["88.33.22.15:9200"]}')
         self.assertEqual(
             {"default": {"timeout": 60, "max_connections": 256}, "remote": {"timeout": 60, "max_connections": 256}},
-            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(256))
+            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(256),
+        )
 
     def test_sets_minimum_max_connections(self):
         client_options_string = '{"default": {"timeout":60,"max_connections":5}, "remote": {"timeout":60}}'
         target_hosts = opts.TargetHosts('{"default": ["10.17.0.5:9200"], "remote": ["88.33.22.15:9200"]}')
         self.assertEqual(
             {"default": {"timeout": 60, "max_connections": 256}, "remote": {"timeout": 60, "max_connections": 256}},
-            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(5))
+            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(5),
+        )
 
     def test_keeps_greater_than_minimum_max_connections(self):
         client_options_string = '{"default": {"timeout":60,"max_connections":512}, "remote": {"timeout":60,"max_connections":1024}}'
         target_hosts = opts.TargetHosts('{"default": ["10.17.0.5:9200"], "remote": ["88.33.22.15:9200"]}')
         self.assertEqual(
             {"default": {"timeout": 60, "max_connections": 512}, "remote": {"timeout": 60, "max_connections": 1024}},
-            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(32))
+            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(32),
+        )

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -49,15 +49,39 @@ class ProcessTests(TestCase):
 
     @mock.patch("psutil.process_iter")
     def test_find_other_rally_processes(self, process_iter):
-        rally_es_5_process = ProcessTests.Process(100, "java",
-                                                  ["/usr/lib/jvm/java-8-oracle/bin/java", "-Xms2g", "-Xmx2g", "-Enode.name=rally-node0",
-                                                   "org.elasticsearch.bootstrap.Elasticsearch"])
-        rally_es_1_process = ProcessTests.Process(101, "java",
-                                                  ["/usr/lib/jvm/java-8-oracle/bin/java", "-Xms2g", "-Xmx2g", "-Des.node.name=rally-node0",
-                                                   "org.elasticsearch.bootstrap.Elasticsearch"])
-        metrics_store_process = ProcessTests.Process(102, "java", ["/usr/lib/jvm/java-8-oracle/bin/java", "-Xms2g", "-Xmx2g",
-                                                                   "-Des.path.home=~/rally/metrics/",
-                                                                   "org.elasticsearch.bootstrap.Elasticsearch"])
+        rally_es_5_process = ProcessTests.Process(
+            100,
+            "java",
+            [
+                "/usr/lib/jvm/java-8-oracle/bin/java",
+                "-Xms2g",
+                "-Xmx2g",
+                "-Enode.name=rally-node0",
+                "org.elasticsearch.bootstrap.Elasticsearch",
+            ],
+        )
+        rally_es_1_process = ProcessTests.Process(
+            101,
+            "java",
+            [
+                "/usr/lib/jvm/java-8-oracle/bin/java",
+                "-Xms2g",
+                "-Xmx2g",
+                "-Des.node.name=rally-node0",
+                "org.elasticsearch.bootstrap.Elasticsearch",
+            ],
+        )
+        metrics_store_process = ProcessTests.Process(
+            102,
+            "java",
+            [
+                "/usr/lib/jvm/java-8-oracle/bin/java",
+                "-Xms2g",
+                "-Xmx2g",
+                "-Des.path.home=~/rally/metrics/",
+                "org.elasticsearch.bootstrap.Elasticsearch",
+            ],
+        )
         random_python = ProcessTests.Process(103, "python3", ["/some/django/app"])
         other_process = ProcessTests.Process(104, "init", ["/usr/sbin/init"])
         rally_process_p = ProcessTests.Process(105, "python3", ["/usr/bin/python3", "~/.local/bin/esrally"])
@@ -82,31 +106,62 @@ class ProcessTests(TestCase):
             night_rally_process,
         ]
 
-        self.assertEqual([rally_process_p, rally_process_r, rally_process_e, rally_process_mac],
-                         process.find_all_other_rally_processes())
+        self.assertEqual([rally_process_p, rally_process_r, rally_process_e, rally_process_mac], process.find_all_other_rally_processes())
 
     @mock.patch("psutil.process_iter")
     def test_find_no_other_rally_process_running(self, process_iter):
-        metrics_store_process = ProcessTests.Process(102, "java", ["/usr/lib/jvm/java-8-oracle/bin/java", "-Xms2g", "-Xmx2g",
-                                                                   "-Des.path.home=~/rally/metrics/",
-                                                                   "org.elasticsearch.bootstrap.Elasticsearch"])
+        metrics_store_process = ProcessTests.Process(
+            102,
+            "java",
+            [
+                "/usr/lib/jvm/java-8-oracle/bin/java",
+                "-Xms2g",
+                "-Xmx2g",
+                "-Des.path.home=~/rally/metrics/",
+                "org.elasticsearch.bootstrap.Elasticsearch",
+            ],
+        )
         random_python = ProcessTests.Process(103, "python3", ["/some/django/app"])
 
-        process_iter.return_value = [ metrics_store_process, random_python]
+        process_iter.return_value = [metrics_store_process, random_python]
 
         self.assertEqual(0, len(process.find_all_other_rally_processes()))
 
     @mock.patch("psutil.process_iter")
     def test_kills_only_rally_processes(self, process_iter):
-        rally_es_5_process = ProcessTests.Process(100, "java",
-                                                  ["/usr/lib/jvm/java-8-oracle/bin/java", "-Xms2g", "-Xmx2g", "-Enode.name=rally-node0",
-                                                   "org.elasticsearch.bootstrap.Elasticsearch"])
-        rally_es_1_process = ProcessTests.Process(101, "java",
-                                                  ["/usr/lib/jvm/java-8-oracle/bin/java", "-Xms2g", "-Xmx2g", "-Des.node.name=rally-node0",
-                                                   "org.elasticsearch.bootstrap.Elasticsearch"])
-        metrics_store_process = ProcessTests.Process(102, "java", ["/usr/lib/jvm/java-8-oracle/bin/java", "-Xms2g", "-Xmx2g",
-                                                                   "-Des.path.home=~/rally/metrics/",
-                                                                   "org.elasticsearch.bootstrap.Elasticsearch"])
+        rally_es_5_process = ProcessTests.Process(
+            100,
+            "java",
+            [
+                "/usr/lib/jvm/java-8-oracle/bin/java",
+                "-Xms2g",
+                "-Xmx2g",
+                "-Enode.name=rally-node0",
+                "org.elasticsearch.bootstrap.Elasticsearch",
+            ],
+        )
+        rally_es_1_process = ProcessTests.Process(
+            101,
+            "java",
+            [
+                "/usr/lib/jvm/java-8-oracle/bin/java",
+                "-Xms2g",
+                "-Xmx2g",
+                "-Des.node.name=rally-node0",
+                "org.elasticsearch.bootstrap.Elasticsearch",
+            ],
+        )
+        metrics_store_process = ProcessTests.Process(
+            102,
+            "java",
+            [
+                "/usr/lib/jvm/java-8-oracle/bin/java",
+                "-Xms2g",
+                "-Xmx2g",
+                "-Des.path.home=~/rally/metrics/",
+                "org.elasticsearch.bootstrap.Elasticsearch",
+            ],
+        )
         random_python = ProcessTests.Process(103, "python3", ["/some/django/app"])
         other_process = ProcessTests.Process(104, "init", ["/usr/sbin/init"])
         rally_process_p = ProcessTests.Process(105, "python3", ["/usr/bin/python3", "~/.local/bin/esrally"])

--- a/tests/utils/repo_test.py
+++ b/tests/utils/repo_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -36,10 +36,13 @@ class RallyRepositoryTests(TestCase):
                 root_dir="/rally-resources",
                 repo_name="unit-test",
                 resource_name="unittest-resources",
-                offline=True)
+                offline=True,
+            )
 
-        self.assertEqual("[/rally-resources/unit-test] must be a git repository.\n\n"
-                         "Please run:\ngit -C /rally-resources/unit-test init", ctx.exception.args[0])
+        self.assertEqual(
+            "[/rally-resources/unit-test] must be a git repository.\n\nPlease run:\ngit -C /rally-resources/unit-test init",
+            ctx.exception.args[0],
+        )
 
     @mock.patch("esrally.utils.io.exists", autospec=True)
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
@@ -53,21 +56,24 @@ class RallyRepositoryTests(TestCase):
                 root_dir="/rally-resources",
                 repo_name="unit-test",
                 resource_name="unittest-resources",
-                offline=True)
+                offline=True,
+            )
 
-        self.assertEqual("Expected a git repository at [/rally-resources/unit-test] but the directory does not exist.",
-                         ctx.exception.args[0])
+        self.assertEqual(
+            "Expected a git repository at [/rally-resources/unit-test] but the directory does not exist.", ctx.exception.args[0]
+        )
 
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
     def test_does_nothing_if_working_copy_present(self, is_working_copy):
         is_working_copy.return_value = True
 
         r = repo.RallyRepository(
-                remote_url=None,
-                root_dir="/rally-resources",
-                repo_name="unit-test",
-                resource_name="unittest-resources",
-                offline=True)
+            remote_url=None,
+            root_dir="/rally-resources",
+            repo_name="unit-test",
+            resource_name="unittest-resources",
+            offline=True,
+        )
 
         self.assertFalse(r.remote)
 
@@ -81,7 +87,8 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=False)
+            offline=False,
+        )
 
         self.assertTrue(r.remote)
 
@@ -97,7 +104,8 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=False)
+            offline=False,
+        )
 
         fetch.assert_called_with(src="/rally-resources/unit-test")
 
@@ -112,7 +120,8 @@ class RallyRepositoryTests(TestCase):
             repo_name="unit-test",
             resource_name="unittest-resources",
             offline=False,
-            fetch=False)
+            fetch=False,
+        )
 
         self.assertTrue(r.remote)
 
@@ -129,7 +138,8 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=False)
+            offline=False,
+        )
         # no exception during the call - we reach this here
         self.assertTrue(r.remote)
 
@@ -151,7 +161,8 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=random.choice([True, False]))
+            offline=random.choice([True, False]),
+        )
 
         r.update(distribution_version="1.7.3")
 
@@ -177,7 +188,8 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=False)
+            offline=False,
+        )
 
         r.update(distribution_version="6.0.0")
 
@@ -205,7 +217,8 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=False)
+            offline=False,
+        )
 
         r.update(distribution_version="1.7.4")
 
@@ -230,7 +243,8 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=False)
+            offline=False,
+        )
 
         self.assertTrue(r.remote)
 
@@ -259,8 +273,9 @@ class RallyRepositoryTests(TestCase):
     @mock.patch("esrally.utils.git.checkout", autospec=True)
     @mock.patch("esrally.utils.git.rebase")
     @mock.patch("esrally.utils.git.current_branch")
-    def test_does_not_update_unknown_branch_remotely_local_fallback(self, curr_branch, rebase, checkout, branches, tags,
-                                                                    fetch, is_working_copy, head_revision):
+    def test_does_not_update_unknown_branch_remotely_local_fallback(
+        self, curr_branch, rebase, checkout, branches, tags, fetch, is_working_copy, head_revision
+    ):
         curr_branch.return_value = "master"
         # we have only "master" remotely but a few more branches locally
         branches.side_effect = ["5", ["1", "2", "5", "master"]]
@@ -273,7 +288,8 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=False)
+            offline=False,
+        )
 
         r.update(distribution_version="1.7.3")
 
@@ -305,7 +321,8 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=False)
+            offline=False,
+        )
 
         with self.assertRaises(exceptions.SystemSetupError) as ctx:
             r.update(distribution_version="4.0.0")
@@ -327,7 +344,8 @@ class RallyRepositoryTests(TestCase):
             root_dir="/rally-resources",
             repo_name="unit-test",
             resource_name="unittest-resources",
-            offline=False)
+            offline=False,
+        )
 
         r.checkout("abcdef123")
 

--- a/tests/utils/versions_test.py
+++ b/tests/utils/versions_test.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -64,80 +64,76 @@ class TestsVersions:
         random.shuffle(alternatives)
 
         assert versions.latest_bounded_minor(alternatives, versions.VersionVariants("7.6.3")) == 2
-        assert versions.latest_bounded_minor(alternatives, versions.VersionVariants("7.12.3")) == 10,\
-            "Nearest alternative with major.minor, skip alternatives with major.minor.patch"
-        assert versions.latest_bounded_minor(alternatives, versions.VersionVariants("7.11.2")) == 10,\
-            "Skips all alternatives with major.minor.patch, even if exact match"
-        assert versions.latest_bounded_minor(alternatives, versions.VersionVariants("7.1.0")) is None,\
-            "No matching alternative with minor version"
+        assert (
+            versions.latest_bounded_minor(alternatives, versions.VersionVariants("7.12.3")) == 10
+        ), "Nearest alternative with major.minor, skip alternatives with major.minor.patch"
+        assert (
+            versions.latest_bounded_minor(alternatives, versions.VersionVariants("7.11.2")) == 10
+        ), "Skips all alternatives with major.minor.patch, even if exact match"
+        assert (
+            versions.latest_bounded_minor(alternatives, versions.VersionVariants("7.1.0")) is None
+        ), "No matching alternative with minor version"
 
     def test_components_ignores_invalid_versions(self):
         with pytest.raises(
-                exceptions.InvalidSyntax,
-                match=re.escape(
-                    r"version string '5.0.0a' does not conform to pattern "
-                    r"'^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$'")):
+            exceptions.InvalidSyntax,
+            match=re.escape(r"version string '5.0.0a' does not conform to pattern " r"'^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$'"),
+        ):
             versions.components("5.0.0a")
 
     def test_versionvariants_parses_correct_version_string(self):
-        assert versions.VersionVariants("5.0.3").all_versions == [
-            ("5.0.3", "with_patch"),
-            ("5.0", "with_minor"),
-            ("5", "with_major")]
+        assert versions.VersionVariants("5.0.3").all_versions == [("5.0.3", "with_patch"), ("5.0", "with_minor"), ("5", "with_major")]
         assert versions.VersionVariants("7.12.1-SNAPSHOT").all_versions == [
             ("7.12.1-SNAPSHOT", "with_suffix"),
-             ("7.12.1", "with_patch"),
-             ("7.12", "with_minor"),
-             ("7", "with_major")]
-        assert versions.VersionVariants("10.3.63").all_versions == [
-            ("10.3.63", "with_patch"),
-            ("10.3", "with_minor"),
-            ("10", "with_major")]
+            ("7.12.1", "with_patch"),
+            ("7.12", "with_minor"),
+            ("7", "with_major"),
+        ]
+        assert versions.VersionVariants("10.3.63").all_versions == [("10.3.63", "with_patch"), ("10.3", "with_minor"), ("10", "with_major")]
 
     def test_versions_rejects_invalid_version_strings(self):
         with pytest.raises(
-                exceptions.InvalidSyntax,
-                match=re.escape(r"version string '5.0.0a-SNAPSHOT' does not conform to pattern "
-                                r"'^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$'")
+            exceptions.InvalidSyntax,
+            match=re.escape(r"version string '5.0.0a-SNAPSHOT' does not conform to pattern " r"'^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$'"),
         ):
             versions.VersionVariants("5.0.0a-SNAPSHOT")
 
     def test_find_best_match(self):
-        assert versions.best_match(["1.7", "2", "5.0.0-alpha1", "5", "master"], "6.0.0-alpha1") == "master",\
-            "Assume master for versions newer than latest alternative available"
+        assert (
+            versions.best_match(["1.7", "2", "5.0.0-alpha1", "5", "master"], "6.0.0-alpha1") == "master"
+        ), "Assume master for versions newer than latest alternative available"
 
-        assert versions.best_match(["1.7", "2", "5.0.0-alpha1", "5", "master"], "5.1.0-SNAPSHOT") == "5",\
-            "Best match for specific version"
+        assert versions.best_match(["1.7", "2", "5.0.0-alpha1", "5", "master"], "5.1.0-SNAPSHOT") == "5", "Best match for specific version"
 
-        assert versions.best_match(["1.7", "2", "5.0.0-alpha1", "5", "master"], None) == "master",\
-            "Assume master on unknown version"
+        assert versions.best_match(["1.7", "2", "5.0.0-alpha1", "5", "master"], None) == "master", "Assume master on unknown version"
 
-        assert versions.best_match(["1.7", "2", "5.0.0-alpha1", "5", "master"], "0.4") is None,\
-            "Reject versions that are too old"
+        assert versions.best_match(["1.7", "2", "5.0.0-alpha1", "5", "master"], "0.4") is None, "Reject versions that are too old"
 
-        assert versions.best_match(["7", "7.10.2", "7.11", "7.2", "5", "6", "master"], "7.10.2") == "7.10.2", \
-            "Exact match"
+        assert versions.best_match(["7", "7.10.2", "7.11", "7.2", "5", "6", "master"], "7.10.2") == "7.10.2", "Exact match"
 
-        assert versions.best_match(["7", "7.10", "master"], "7.1.0") == "7", \
-            "Best match is major version"
+        assert versions.best_match(["7", "7.10", "master"], "7.1.0") == "7", "Best match is major version"
 
-        assert versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.11.0") == "7.11",\
-            "Best match for specific minor version"
+        assert versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.11.0") == "7.11", "Best match for specific minor version"
 
-        assert versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.12.0") == "7.11",\
-            "If no exact match, best match is the nearest prior minor"
+        assert (
+            versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.12.0") == "7.11"
+        ), "If no exact match, best match is the nearest prior minor"
 
-        assert versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.3.0") == "7.2",\
-            "If no exact match, best match is the nearest prior minor"
+        assert (
+            versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.3.0") == "7.2"
+        ), "If no exact match, best match is the nearest prior minor"
 
-        assert versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.10.0") == "7.2", \
-            "If no exact match, best match is the nearest prior minor"
+        assert (
+            versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.10.0") == "7.2"
+        ), "If no exact match, best match is the nearest prior minor"
 
-        assert versions.best_match(["7", "7.1", "7.11.1", "7.11.0", "7.2", "5", "6", "master"], "7.12.0") == "7.2",\
-            "Patch or patch-suffix branches are not supported and ignored, best match is nearest prior minor"
+        assert (
+            versions.best_match(["7", "7.1", "7.11.1", "7.11.0", "7.2", "5", "6", "master"], "7.12.0") == "7.2"
+        ), "Patch or patch-suffix branches are not supported and ignored, best match is nearest prior minor"
 
-        assert versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.1.0") == "7",\
-            "If no exact match and no minor match, next best match is major version"
+        assert (
+            versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.1.0") == "7"
+        ), "If no exact match and no minor match, next best match is major version"
 
     def test_version_comparison(self):
         assert versions.Version.from_string("7.10.2") < versions.Version.from_string("7.11.0")


### PR DESCRIPTION
This is a proposal to switch to black (and isort, as black does not sort imports yet.)

@danielmitterdorfer said this in #1276:

> black is on our radar but I fear that we won't have much capacity at the moment to work on it.

I'm not sure whether it was the actual pull request that was the issue, or the work needed to adapt (eg. everyone will have to configure their editors). My experience is that black allows to focus on the interesting parts of the code, which is highly valuable. Here's what Mike Bayer, creator and maintainer of SQLAlchemy [says about black](https://twitter.com/zzzeek/status/1398662789078650884):

> I would say that I can't think of any single tool in my entire programming career that has given me a bigger productivity increase by its introduction.   commits like https://github.com/sqlalchemy/sqlalchemy/commit/ebbbac0a76b3327a829864afb26ee1b7ff1dc780, Black did 90% of the work for me that previously we'd spend days formatting by hand

This time, lint passes (I was confused because lint fails on master with Python 3.9). The actual black run is in its own commit, so this pull request is easy to rebase. We can also tell git to ignore the black commit in `git blame`.