### PR TITLE
Ensure max_connections value is logged correctly

### DIFF
--- a/esrally/async_connection.py
+++ b/esrally/async_connection.py
@@ -168,7 +168,7 @@ class AIOHttpConnection(elasticsearch.AIOHttpConnection):
                          ssl_assert_fingerprint=ssl_assert_fingerprint,
                          # provided to the base class via `maxsize` to keep base class state consistent despite Rally
                          # calling the attribute differently.
-                         maxsize=max(256, kwargs.get("max_connections", 0)),
+                         maxsize=kwargs.get("max_connections", 0),
                          headers=headers,
                          ssl_context=ssl_context,
                          http_compress=http_compress,

--- a/esrally/utils/opts.py
+++ b/esrally/utils/opts.py
@@ -211,7 +211,6 @@ class ClientOptions(ConnectOptions):
         final_client_options = {}
         for cluster, original_opts in self.all_client_options.items():
             amended_opts = dict(original_opts)
-            if "max_connections" not in amended_opts:
-                amended_opts["max_connections"] = max_connections
+            amended_opts["max_connections"] = max(256, amended_opts.get("max_connections", max_connections))
             final_client_options[cluster] = amended_opts
         return final_client_options

--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -276,16 +276,23 @@ class TestClientOptions(TestCase):
             opts.ClientOptions(client_options_string,
                                  target_hosts=target_hosts).default)
 
-    def test_amends_with_max_connections(self):
+    def test_default_client_ops_with_max_connections(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = opts.TargetHosts('{"default": ["10.17.0.5:9200"], "remote": ["88.33.22.15:9200"]}')
         self.assertEqual(
-            {"default": {"timeout": 60, "max_connections": 128}, "remote": {"timeout": 60, "max_connections": 128}},
-            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(128))
+            {"default": {"timeout": 60, "max_connections": 256}, "remote": {"timeout": 60, "max_connections": 256}},
+            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(256))
 
-    def test_keeps_already_specified_max_connections(self):
+    def test_sets_minimum_max_connections(self):
         client_options_string = '{"default": {"timeout":60,"max_connections":5}, "remote": {"timeout":60}}'
         target_hosts = opts.TargetHosts('{"default": ["10.17.0.5:9200"], "remote": ["88.33.22.15:9200"]}')
         self.assertEqual(
-            {"default": {"timeout": 60, "max_connections": 5}, "remote": {"timeout": 60, "max_connections": 32}},
+            {"default": {"timeout": 60, "max_connections": 256}, "remote": {"timeout": 60, "max_connections": 256}},
+            opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(5))
+
+    def test_keeps_greater_than_minimum_max_connections(self):
+        client_options_string = '{"default": {"timeout":60,"max_connections":512}, "remote": {"timeout":60,"max_connections":1024}}'
+        target_hosts = opts.TargetHosts('{"default": ["10.17.0.5:9200"], "remote": ["88.33.22.15:9200"]}')
+        self.assertEqual(
+            {"default": {"timeout": 60, "max_connections": 512}, "remote": {"timeout": 60, "max_connections": 1024}},
             opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(32))


### PR DESCRIPTION
  With this commit we ensure that the value for max_connections per
    Elasticsearch client is correctly logged in a way that is not misleading
    for users. Prior to this, the value was misleadingly logged as equal to
    the number of simulated clients per worker.

Closes #1278