### PR TITLE
add transform-stats operation type

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2327,14 +2327,14 @@ Meta-data
 This operation returns no meta-data.
 
 transform-stats
-~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
-With the operation type ``transform-stats`` you can call the `transform stats API https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html`_.
+With the operation type ``transform-stats`` you can call the `transform stats API <https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html>`_.
 
 Properties
 """"""""""
 
-* ``transform_id`` (mandatory): The id of the transform.
+* ``transform-id`` (mandatory): The id of the transform.
 * ``condition`` (optional, defaults to no condition): A structured object with the properties ``path`` and ``expected-value``. If the actual value returned by transform stats API is equal to the expected value at the provided path, this operation will return successfully. See below for an example how this can be used.
 
 In the following example the ``transform-stats`` operation will wait until all data has been processed::
@@ -2349,7 +2349,7 @@ In the following example the ``transform-stats`` operation will wait until all d
         "retry-until-success": true
     }
 
-Throughput will be reported as number of completed `transform-stats` operations per second.
+Throughput will be reported as number of completed ``transform-stats`` operations per second.
 
 This operation is :ref:`retryable <track_operations>`.
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2359,7 +2359,6 @@ Meta-data
 * ``weight``: Always 1.
 * ``unit``: Always "ops".
 * ``success``: A boolean indicating whether the operation has succeeded.
-* ``transform-stats``: The stats for the given transform id.
 
 composite
 ~~~~~~~~~

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2326,6 +2326,41 @@ Meta-data
 
 This operation returns no meta-data.
 
+transform-stats
+~~~~~~~~~~~
+
+With the operation type ``transform-stats`` you can call the `transform stats API https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html`_.
+
+Properties
+""""""""""
+
+* ``transform_id`` (mandatory): The id of the transform.
+* ``condition`` (optional, defaults to no condition): A structured object with the properties ``path`` and ``expected-value``. If the actual value returned by transform stats API is equal to the expected value at the provided path, this operation will return successfully. See below for an example how this can be used.
+
+In the following example the ``transform-stats`` operation will wait until all data has been processed::
+
+    {
+        "operation-type": "transform-stats",
+        "transform-id": "mytransform",
+        "condition": {
+            "path": "checkpointing.operations_behind",
+            "expected-value": null
+        },
+        "retry-until-success": true
+    }
+
+Throughput will be reported as number of completed `transform-stats` operations per second.
+
+This operation is :ref:`retryable <track_operations>`.
+
+Meta-data
+"""""""""
+
+* ``weight``: Always 1.
+* ``unit``: Always "ops".
+* ``success``: A boolean indicating whether the operation has succeeded.
+* ``transform-stats``: The stats for the given transform id.
+
 composite
 ~~~~~~~~~
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2154,15 +2154,13 @@ class TransformStats(Runner):
                     "expected-value": self._safe_string(expected_value)
                 },
                 # currently we only support "==" as a predicate but that might change in the future
-                "success": actual_value == expected_value,
-                "transform-stats": transform_stats
+                "success": actual_value == expected_value
             }
         else:
             return {
                 "weight": 1,
                 "unit": "ops",
-                "success": True,
-                "transform-stats": transform_stats
+                "success": True
             }
 
     def __repr__(self, *args, **kwargs):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -94,6 +94,7 @@ def register_default_runners():
     register_runner(track.OperationType.StartTransform, Retry(StartTransform()), async_runner=True)
     register_runner(track.OperationType.WaitForTransform, Retry(WaitForTransform()), async_runner=True)
     register_runner(track.OperationType.DeleteTransform, Retry(DeleteTransform()), async_runner=True)
+    register_runner(track.OperationType.TransformStats, Retry(TransformStats()), async_runner=True)
 
 
 def runner_for(operation_type):
@@ -2114,6 +2115,58 @@ class DeleteTransform(Runner):
 
     def __repr__(self, *args, **kwargs):
         return "delete-transform"
+
+
+class TransformStats(Runner):
+    """
+    Gather index stats for one or all transforms.
+    """
+
+    def _get(self, v, path):
+        if v is None:
+            return None
+        elif len(path) == 1:
+            return v.get(path[0])
+        else:
+            return self._get(v.get(path[0]), path[1:])
+
+    def _safe_string(self, v):
+        return str(v) if v is not None else None
+
+    async def __call__(self, es, params):
+        api_kwargs = self._default_kw_params(params)
+        transform_id = mandatory(params, "transform-id", self)
+        condition = params.get("condition")
+        response = await es.transform.get_transform_stats(transform_id=transform_id, **api_kwargs)
+        transforms = response.get("transforms", [])
+        transform_stats = transforms[0] if len(transforms) > 0 else {}
+        if condition:
+            path = mandatory(condition, "path", repr(self))
+            expected_value = mandatory(condition, "expected-value", repr(self))
+            actual_value = self._get(transform_stats, path.split("."))
+            return {
+                "weight": 1,
+                "unit": "ops",
+                "condition": {
+                    "path": path,
+                    # avoid mapping issues in the ES metrics store by always rendering values as strings
+                    "actual-value": self._safe_string(actual_value),
+                    "expected-value": self._safe_string(expected_value)
+                },
+                # currently we only support "==" as a predicate but that might change in the future
+                "success": actual_value == expected_value,
+                "transform-stats": transform_stats
+            }
+        else:
+            return {
+                "weight": 1,
+                "unit": "ops",
+                "success": True,
+                "transform-stats": transform_stats
+            }
+
+    def __repr__(self, *args, **kwargs):
+        return "transform-stats"
 
 
 class SubmitAsyncSearch(Runner):

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -607,6 +607,7 @@ class OperationType(Enum):
     DeleteComposableTemplate = 1031
     CreateComponentTemplate = 1032
     DeleteComponentTemplate = 1033
+    TransformStats = 1034
 
     @property
     def admin_op(self):
@@ -704,6 +705,8 @@ class OperationType(Enum):
             return OperationType.WaitForTransform
         elif v == "delete-transform":
             return OperationType.DeleteTransform
+        elif v == "transform-stats":
+            return OperationType.TransformStats
         elif v == "create-data-stream":
             return OperationType.CreateDataStream
         elif v == "delete-data-stream":

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -4709,7 +4709,7 @@ class TransformStatsRunnerTests(TestCase):
             "transform-id": transform_id,
             "condition": {
                 "path": "checkpointing.operations_behind",
-                "expected-value": 0
+                "expected-value": None
             }
         })
         self.assertEqual(1, result["weight"])
@@ -4718,7 +4718,7 @@ class TransformStatsRunnerTests(TestCase):
         self.assertDictEqual({
             "path": "checkpointing.operations_behind",
             "actual-value": "10000",
-            "expected-value": "0"
+            "expected-value": None
         }, result["condition"])
 
         es.transform.get_transform_stats.assert_called_once_with(transform_id=transform_id)
@@ -4735,8 +4735,7 @@ class TransformStatsRunnerTests(TestCase):
                     "state": "started",
                     "stats": {},
                     "checkpointing": {
-                        "last": {},
-                        "operations_behind": 0
+                        "last": {}
                     }
                 }
             ]
@@ -4748,7 +4747,7 @@ class TransformStatsRunnerTests(TestCase):
             "transform-id": transform_id,
             "condition": {
                 "path": "checkpointing.operations_behind",
-                "expected-value": 0
+                "expected-value": None
             }
         })
         self.assertEqual(1, result["weight"])
@@ -4756,8 +4755,8 @@ class TransformStatsRunnerTests(TestCase):
         self.assertTrue(result["success"])
         self.assertDictEqual({
             "path": "checkpointing.operations_behind",
-            "actual-value": "0",
-            "expected-value": "0"
+            "actual-value": None,
+            "expected-value": None
         }, result["condition"])
 
         es.transform.get_transform_stats.assert_called_once_with(transform_id=transform_id)
@@ -4774,8 +4773,7 @@ class TransformStatsRunnerTests(TestCase):
                     "state": "started",
                     "stats": {},
                     "checkpointing": {
-                        "last": {},
-                        "operations_behind": 0
+                        "last": {}
                     }
                 }
             ]


### PR DESCRIPTION
add a transform-stats operation type with a optional condition. The condition can
be used to wait until transform has processed all data.