### PR TITLE
update elasticsearch client to 7.13.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
     # transitive dependencies:
     #   urllib3: MIT
     #   aiohttp: Apache 2.0
-    "elasticsearch[async]==7.10.1",
+    "elasticsearch[async]==7.13.2",
     # License: BSD
     "psutil==5.8.0",
     # License: MIT


### PR DESCRIPTION
In order to benefit from elastic/elasticsearch-py#1604, this commit updates elasticsearch[async] python dependency from 7.10.1 to 7.13.2
