### PR TITLE
fix download from s3/gs by moving http query parameter downstream

### DIFF
--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -500,7 +500,7 @@ class ElasticsearchDistributionSupplier:
 
     def fetch(self):
         io.ensure_dir(self.distributions_root)
-        download_url = net.add_url_param_elastic_no_kpi(self.repo.download_url)
+        download_url = self.repo.download_url
         distribution_path = os.path.join(self.distributions_root, self.repo.file_name)
         self.logger.info("Resolved download URL [%s] for version [%s]", download_url, self.version)
         if not os.path.isfile(distribution_path) or not self.repo.cache:

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -500,7 +500,7 @@ class ElasticsearchDistributionSupplier:
 
     def fetch(self):
         io.ensure_dir(self.distributions_root)
-        download_url = self.repo.download_url
+        download_url = net.add_url_param_elastic_no_kpi(self.repo.download_url)
         distribution_path = os.path.join(self.distributions_root, self.repo.file_name)
         self.logger.info("Resolved download URL [%s] for version [%s]", download_url, self.version)
         if not os.path.isfile(distribution_path) or not self.repo.cache:

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -223,7 +223,8 @@ def download(url, local_path, expected_size_in_bytes=None, progress_indicator=No
         if scheme in ["s3", "gs"]:
             expected_size_in_bytes = download_from_bucket(scheme, url, tmp_data_set_path, expected_size_in_bytes, progress_indicator)
         else:
-            expected_size_in_bytes = download_http(_add_url_param_elastic_no_kpi(url), tmp_data_set_path, expected_size_in_bytes, progress_indicator)
+            expected_size_in_bytes = download_http(_add_url_param_elastic_no_kpi(url), tmp_data_set_path,
+                                                   expected_size_in_bytes, progress_indicator)
     except BaseException:
         if os.path.isfile(tmp_data_set_path):
             os.remove(tmp_data_set_path)

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -193,7 +193,8 @@ def download_http(url, local_path, expected_size_in_bytes=None, progress_indicat
                 progress_indicator(bytes_read, size_from_content_header)
         return expected_size_in_bytes
 
-def add_url_param_elastic_no_kpi(url):
+
+def _add_url_param_elastic_no_kpi(url):
     return _add_url_param(url, {"x-elastic-no-kpi": "true"})
 
 
@@ -222,7 +223,7 @@ def download(url, local_path, expected_size_in_bytes=None, progress_indicator=No
         if scheme in ["s3", "gs"]:
             expected_size_in_bytes = download_from_bucket(scheme, url, tmp_data_set_path, expected_size_in_bytes, progress_indicator)
         else:
-            expected_size_in_bytes = download_http(url, tmp_data_set_path, expected_size_in_bytes, progress_indicator)
+            expected_size_in_bytes = download_http(_add_url_param_elastic_no_kpi(url), tmp_data_set_path, expected_size_in_bytes, progress_indicator)
     except BaseException:
         if os.path.isfile(tmp_data_set_path):
             os.remove(tmp_data_set_path)

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -193,8 +193,13 @@ def download_http(url, local_path, expected_size_in_bytes=None, progress_indicat
                 progress_indicator(bytes_read, size_from_content_header)
         return expected_size_in_bytes
 
+
 def add_url_param_elastic_no_kpi(url):
-    return _add_url_param(url, {"x-elastic-no-kpi": "true"})
+    scheme = urllib3.util.parse_url(url).scheme
+    if scheme.startswith("http"):
+        return _add_url_param(url, {"x-elastic-no-kpi": "true"})
+    else:
+        return url
 
 
 def _add_url_param(url, params):

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -223,8 +223,7 @@ def download(url, local_path, expected_size_in_bytes=None, progress_indicator=No
         if scheme in ["s3", "gs"]:
             expected_size_in_bytes = download_from_bucket(scheme, url, tmp_data_set_path, expected_size_in_bytes, progress_indicator)
         else:
-            expected_size_in_bytes = download_http(_add_url_param_elastic_no_kpi(url), tmp_data_set_path,
-                                                   expected_size_in_bytes, progress_indicator)
+            expected_size_in_bytes = download_http(_add_url_param_elastic_no_kpi(url), tmp_data_set_path, expected_size_in_bytes, progress_indicator)
     except BaseException:
         if os.path.isfile(tmp_data_set_path):
             os.remove(tmp_data_set_path)

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -193,8 +193,7 @@ def download_http(url, local_path, expected_size_in_bytes=None, progress_indicat
                 progress_indicator(bytes_read, size_from_content_header)
         return expected_size_in_bytes
 
-
-def _add_url_param_elastic_no_kpi(url):
+def add_url_param_elastic_no_kpi(url):
     return _add_url_param(url, {"x-elastic-no-kpi": "true"})
 
 
@@ -223,7 +222,7 @@ def download(url, local_path, expected_size_in_bytes=None, progress_indicator=No
         if scheme in ["s3", "gs"]:
             expected_size_in_bytes = download_from_bucket(scheme, url, tmp_data_set_path, expected_size_in_bytes, progress_indicator)
         else:
-            expected_size_in_bytes = download_http(_add_url_param_elastic_no_kpi(url), tmp_data_set_path, expected_size_in_bytes, progress_indicator)
+            expected_size_in_bytes = download_http(url, tmp_data_set_path, expected_size_in_bytes, progress_indicator)
     except BaseException:
         if os.path.isfile(tmp_data_set_path):
             os.remove(tmp_data_set_path)

--- a/tests/utils/net_test.py
+++ b/tests/utils/net_test.py
@@ -72,6 +72,7 @@ class TestNetUtils:
 
     def test_add_url_param_elastic_no_kpi(self):
         url = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz"
+        # pylint: disable=protected-access
         assert net._add_url_param_elastic_no_kpi(url) == \
                "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?x-elastic-no-kpi=true"
 

--- a/tests/utils/net_test.py
+++ b/tests/utils/net_test.py
@@ -72,7 +72,7 @@ class TestNetUtils:
 
     def test_add_url_param_elastic_no_kpi(self):
         url = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz"
-        assert net._add_url_param_elastic_no_kpi(url) == \
+        assert net.add_url_param_elastic_no_kpi(url) == \
                "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?x-elastic-no-kpi=true"
 
     def test_add_url_param_encoding_and_update(self):

--- a/tests/utils/net_test.py
+++ b/tests/utils/net_test.py
@@ -75,6 +75,11 @@ class TestNetUtils:
         assert net.add_url_param_elastic_no_kpi(url) == \
                "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?x-elastic-no-kpi=true"
 
+    def test_add_url_param_elastic_no_kpi_no_http(self):
+        url = "gs://my_bucket/builds/elasticsearch/elasticsearch-8.0.0-SNAPSHOT.tar.gz"
+        assert net.add_url_param_elastic_no_kpi(url) == \
+               "gs://my_bucket/builds/elasticsearch/elasticsearch-8.0.0-SNAPSHOT.tar.gz"
+
     def test_add_url_param_encoding_and_update(self):
         url = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?flag1=true"
         params = {"flag1": "test me", "flag2": "test@me"}

--- a/tests/utils/net_test.py
+++ b/tests/utils/net_test.py
@@ -72,7 +72,6 @@ class TestNetUtils:
 
     def test_add_url_param_elastic_no_kpi(self):
         url = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz"
-        # pylint: disable=protected-access
         assert net._add_url_param_elastic_no_kpi(url) == \
                "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?x-elastic-no-kpi=true"
 

--- a/tests/utils/net_test.py
+++ b/tests/utils/net_test.py
@@ -72,7 +72,7 @@ class TestNetUtils:
 
     def test_add_url_param_elastic_no_kpi(self):
         url = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz"
-        assert net.add_url_param_elastic_no_kpi(url) == \
+        assert net._add_url_param_elastic_no_kpi(url) == \
                "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.2.0.tar.gz?x-elastic-no-kpi=true"
 
     def test_add_url_param_encoding_and_update(self):


### PR DESCRIPTION
Fix a regression from #1159, the added no kpi parameter breaks downloads from s3/gs. The change adds a check of the protocol in `add_url_param_elastic_no_kpi` and only adds the parameter if its `http`