### PR TITLE
Fix composable templates runner

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1309,7 +1309,7 @@ class CreateComposableTemplate(Runner):
         templates = mandatory(params, "templates", self)
         request_params = mandatory(params, "request-params", self)
         for template, body in templates:
-            await es.cluster.put_index_template(name=template, body=body, params=request_params)
+            await es.indices.put_index_template(name=template, body=body, params=request_params)
 
         return {
             "weight": len(templates),

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2895,7 +2895,7 @@ class CreateComposableTemplateRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_create_index_templates(self, es):
-        es.cluster.put_index_template.return_value = as_future()
+        es.indices.put_index_template.return_value = as_future()
         r = runner.CreateComposableTemplate()
         params = {
             "templates": [
@@ -2915,7 +2915,7 @@ class CreateComposableTemplateRunnerTests(TestCase):
             "unit": "ops",
             "success": True
         }, result)
-        es.cluster.put_index_template.assert_has_calls([
+        es.indices.put_index_template.assert_has_calls([
             mock.call(name="templateA", body={"index_patterns":["logs-*"],"template":{"settings":{"index.number_of_shards":3}},
                                               "composed_of":["ct1","ct2"]}, params=params["request-params"]),
             mock.call(name="templateB", body={"index_patterns":["metrics-*"],"template":{"settings":{"index.number_of_shards":2}},
@@ -2925,7 +2925,7 @@ class CreateComposableTemplateRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_param_templates_mandatory(self, es):
-        es.cluster.put_index_template.return_value = as_future()
+        es.indices.put_index_template.return_value = as_future()
 
         r = runner.CreateComposableTemplate()
 
@@ -2935,7 +2935,7 @@ class CreateComposableTemplateRunnerTests(TestCase):
                                     "'templates'. Add it to your parameter source and try again."):
             await r(es, params)
 
-        self.assertEqual(0, es.cluster.put_index_template.call_count)
+        self.assertEqual(0, es.indices.put_index_template.call_count)
 
 
 class DeleteComposableTemplateRunnerTests(TestCase):


### PR DESCRIPTION
The `put_index_template` method is not available on the `cluster` class,
so with this commit we change this to the correct `indices` class.

See the [Elasticsearch Python Client docs](https://elasticsearch-py.readthedocs.io/en/v7.10.1/api.html#elasticsearch.client.IndicesClient.put_index_template). 
