### PR TITLE
Add data streams telemetry device

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -29,7 +29,7 @@ You probably want to gain additional insights from a race. Therefore, we have ad
    transform-stats             Transform Stats             Regularly samples transform stats
    searchable-snapshots-stats  Searchable Snapshots Stats  Regularly samples searchable snapshots stats
    shard-stats                 Shard Stats                 Regularly samples nodes stats at shard level
-   data-stream-stats           Data Streams Stats         Regularly samples data streams stats
+   data-stream-stats           Data Streams Stats          Regularly samples data streams stats
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -29,6 +29,7 @@ You probably want to gain additional insights from a race. Therefore, we have ad
    transform-stats             Transform Stats             Regularly samples transform stats
    searchable-snapshots-stats  Searchable Snapshots Stats  Regularly samples searchable snapshots stats
    shard-stats                 Shard Stats                 Regularly samples nodes stats at shard level
+   data-stream-stats           Data Streams Stats         Regularly samples data streams stats
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 
@@ -188,3 +189,39 @@ Example of a recorded document::
 Supported telemetry parameters:
 
 * ``shard-stats-sample-interval`` (default 60): A positive number greater than zero denoting the sampling interval in seconds.
+
+data-stream-stats
+-----------------
+
+The data-stream-stats telemetry device regularly calls the `data stream stats API <https://https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-stats-api.html>`_ and records one metrics document for cluster level stats (``_all``), and one metrics document per data stream.
+
+Example of recorded documents given two data streams in the cluster::
+
+   {
+      "data_stream": "_all",
+      "name": "data-stream-stats",
+      "shards": {
+        "total": 4,
+        "successful_shards": 2,
+        "failed_shards": 0
+      },
+      "data_stream_count": 2,
+      "backing_indices": 2,
+      "total_store_size_bytes": 878336
+   },
+   {
+     "data_stream": "my-data-stream-1",
+     "backing_indices": 1,
+     "store_size_bytes": 439137,
+     "maximum_timestamp": 1579936446448
+   },
+   {
+     "data_stream": "my-data-stream-2",
+     "backing_indices": 1,
+     "store_size_bytes": 439199,
+     "maximum_timestamp": 1579936446448
+   }
+
+Supported telemetry parameters:
+
+* ``data-stream-stats-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -210,12 +210,14 @@ Example of recorded documents given two data streams in the cluster::
       "total_store_size_bytes": 878336
    },
    {
+     "name": "data-stream-stats",
      "data_stream": "my-data-stream-1",
      "backing_indices": 1,
      "store_size_bytes": 439137,
      "maximum_timestamp": 1579936446448
    },
    {
+     "name": "data-stream-stats",
      "data_stream": "my-data-stream-2",
      "backing_indices": 1,
      "store_size_bytes": 439199,

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -226,4 +226,4 @@ Example of recorded documents given two data streams in the cluster::
 
 Supported telemetry parameters:
 
-* ``data-stream-stats-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.
+* ``data-stream-stats-sample-interval`` (default 10): A positive number greater than zero denoting the sampling interval in seconds.

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -592,6 +592,7 @@ class Driver:
                 telemetry.ShardStats(telemetry_params, es, self.metrics_store),
                 telemetry.TransformStats(telemetry_params, es, self.metrics_store),
                 telemetry.SearchableSnapshotsStats(telemetry_params, es, self.metrics_store),
+                telemetry.DataStreamStats(telemetry_params, es, self.metrics_store),
             ]
         else:
             devices = []

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -26,7 +26,7 @@ import tabulate
 from esrally import exceptions, metrics, time
 from esrally.metrics import MetaInfoScope
 from esrally.utils import console, io, opts, process, sysstats
-from esrally.utils.versions import Version, components
+from esrally.utils.versions import Version
 
 
 def list_telemetry():
@@ -729,9 +729,7 @@ class NodeStats(TelemetryDevice):
     def on_benchmark_start(self):
         default_client = self.clients["default"]
         distribution_version = default_client.info()["version"]["number"]
-        major, minor = components(distribution_version)[:2]
-
-        if major < 7 or (major == 7 and minor < 2):
+        if Version.from_string(distribution_version) < Version(major=7, minor=2, patch=0):
             console.warn(NodeStats.warning, logger=self.logger)
 
         for cluster_name in self.specified_cluster_names:
@@ -1282,7 +1280,8 @@ class DataStreamStats(TelemetryDevice):
         """
         :param telemetry_params: The configuration object for telemetry_params.
             May optionally specify:
-            ``data-stream-stats-sample-interval``: An integer controlling the interval, in seconds, between collecting samples. Default: 10s.
+            ``data-stream-stats-sample-interval``: An integer controlling the interval, in seconds,
+            between collecting samples. Default: 10s.
         :param clients: A dict of clients to all clusters.
         :param metrics_store: The configured metrics store we write to.
         """

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -116,11 +116,12 @@ class Client:
 
 
 class SubClient:
-    def __init__(self, stats=None, info=None, recovery=None, transform_stats=None):
+    def __init__(self, stats=None, info=None, recovery=None, transform_stats=None, data_streams_stats=None):
         self._stats = wrap(stats)
         self._info = wrap(info)
         self._recovery = wrap(recovery)
         self._transform_stats = wrap(transform_stats)
+        self._data_streams_stats = wrap(data_streams_stats)
 
     def stats(self, *args, **kwargs):
         return self._stats()
@@ -133,6 +134,9 @@ class SubClient:
 
     def get_transform_stats(self, *args, **kwargs):
         return self._transform_stats()
+
+    def data_streams_stats(self, *args, **kwargs):
+        return self._data_streams_stats()
 
 
 def wrap(it):
@@ -939,6 +943,135 @@ class RecoveryStatsTests(TestCase):
             ],
             any_order=True,
         )
+
+
+class DataStreamStatsTests(TestCase):
+
+    def test_failure_if_data_streams_feature_not_available(self):
+        # Data Streams aren't available prior to 7.9
+        clients = {"default": Client(info={"version": {"number": "7.6.0"}})}
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        telemetry_params = {
+            "data-stream-stats-sample-interval": random.randint(1, 100)
+        }
+        t = telemetry.DataStreamStats(telemetry_params, clients, metrics_store)
+        with self.assertRaisesRegex(exceptions.SystemSetupError,
+                                    r"The data-stream-stats telemetry device can only be used with clusters from version 7.9 onwards"):
+            t.on_benchmark_start()
+
+    def test_negative_sample_interval_forbidden(self):
+        clients = {"default": Client(), "cluster_b": Client()}
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        telemetry_params = {
+            "data-stream-stats-sample-interval": -1 * random.random()
+        }
+        with self.assertRaisesRegex(exceptions.SystemSetupError,
+                                    r"The telemetry parameter 'data-stream-stats-sample-interval' must be greater than zero but was .*\."):
+            telemetry.DataStreamStats(telemetry_params, clients, metrics_store)
+
+
+class DataStreamStatsRecorderTests(TestCase):
+    data_streams_stats_response = {
+        "_shards": {
+            "total": 4,
+            "successful": 2,
+            "failed": 0
+        },
+        "data_stream_count": 2,
+        "backing_indices": 2,
+        "total_store_size_bytes": 878336,
+        "data_streams": [
+            {
+                "data_stream": "my-data-stream-1",
+                "backing_indices": 1,
+                "store_size_bytes": 439137,
+                "maximum_timestamp": 1579936446448
+            },
+            {
+                "data_stream": "my-data-stream-2",
+                "backing_indices": 1,
+                "store_size_bytes": 439199,
+                "maximum_timestamp": 1579936446448
+            }
+        ]
+    }
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    def test_store_multiple_data_stream_stats(self, metrics_store_put_doc):
+        client = Client(indices=SubClient(data_streams_stats=self.data_streams_stats_response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        recorder = telemetry.DataStreamStatsRecorder(cluster_name="remote",
+                                                      client=client,
+                                                      metrics_store=metrics_store,
+                                                      sample_interval=1 * random.randint(1, 100),
+                                                      target_data_streams="_all")
+        recorder.record()
+
+        data_stream_metadata = {
+            "cluster": "remote"
+        }
+
+        metrics_store_put_doc.assert_has_calls([
+            mock.call({
+                "data_stream": "_all",
+                "name": "data-stream-stats",
+                "shards": {
+                    "total": 4,
+                    "successful_shards": 2,
+                    "failed_shards": 0
+                },
+                "data_stream_count": 2,
+                "backing_indices": 2,
+                "total_store_size_bytes": 878336
+            }, level=MetaInfoScope.cluster, meta_data=data_stream_metadata),
+            mock.call({
+                "data_stream": "my-data-stream-1",
+                "backing_indices": 1,
+                "store_size_bytes": 439137,
+                "maximum_timestamp": 1579936446448
+            }, level=MetaInfoScope.cluster, meta_data=data_stream_metadata),
+            mock.call({
+                "data_stream": "my-data-stream-2",
+                "backing_indices": 1,
+                "store_size_bytes": 439199,
+                "maximum_timestamp": 1579936446448
+            }, level=MetaInfoScope.cluster, meta_data=data_stream_metadata)
+        ], any_order=True)
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    def test_empty_data_stream_stats(self, metrics_store_put_doc):
+        response = {
+            "_shards" : {
+                "total" : 0,
+                "successful" : 0,
+                "failed" : 0
+            },
+            "data_stream_count" : 0,
+            "backing_indices" : 0,
+            "total_store_size_bytes" : 0,
+            "data_streams" : [ ]
+        }
+
+        client = Client(indices=SubClient(data_streams_stats=response))
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        recorder = telemetry.DataStreamStatsRecorder(cluster_name="default",
+                                                     client=client,
+                                                     metrics_store=metrics_store,
+                                                     sample_interval=1 * random.randint(1, 100),
+                                                     target_data_streams="_all")
+        recorder.record()
+
+        data_stream_metadata = {
+            "cluster": "default"
+        }
+
+        # Given an empty list of 'data_streams' we should only be
+        # sending a total of one metric document containing both the `_shards` and overall stats
+        self.assertEqual(1, metrics_store_put_doc.call_count)
 
 
 class ShardStatsTests(TestCase):

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -1041,12 +1041,14 @@ class DataStreamStatsRecorderTests(TestCase):
                 "total_store_size_bytes": 878336
             }, level=MetaInfoScope.cluster, meta_data=data_stream_metadata),
             mock.call({
+                "name": "data-stream-stats",
                 "data_stream": "my-data-stream-1",
                 "backing_indices": 1,
                 "store_size_bytes": 439137,
                 "maximum_timestamp": 1579936446448
             }, level=MetaInfoScope.cluster, meta_data=data_stream_metadata),
             mock.call({
+                "name": "data-stream-stats",
                 "data_stream": "my-data-stream-2",
                 "backing_indices": 1,
                 "store_size_bytes": 439199,


### PR DESCRIPTION
With this commit we add a data streams telemetry device that regularly
samples the count and store size of all data streams within a cluster.

Closes #1161

Tested locally with [this test track (that uses my Weatherbeat data](https://github.com/elastic/rally/files/6737330/weatherbeat-track.tar.gz), invoked with these commands for both in-memory and external metrics stores: 
```
# This should fail due to major version < 7
esrally race --distribution-version=6.3.0 --car="4gheap,x-pack-security" --track=rally/tracks/weatherbeat --track-params=rally/tracks/weatherbeat/params.json --client-options="timeout:180,use_ssl:true,verify_certs:false,basic_auth_user:'rally',basic_auth_password:'rally-password'" --telemetry data-stream-stats --telemetry-params="data-stream-stats-sample-interval: 1" --kill-running-processes 

# This should fail due to minor version < 7.9.0
esrally race --distribution-version=7.8.0 --car="4gheap,x-pack-security" --track=rally/tracks/weatherbeat --track-params=rally/tracks/weatherbeat/params.json --client-options="timeout:180,use_ssl:true,verify_certs:false,basic_auth_user:'rally',basic_auth_password:'rally-password'" --telemetry data-stream-stats --telemetry-params="data-stream-stats-sample-interval: 1" --kill-running-processes

# This should fail due to OSS distribution 
esrally race --distribution-version=7.9.0 --track=rally/tracks/weatherbeat --track-params=rally/tracks/weatherbeat/params.json --client-options="timeout:180" --telemetry data-stream-stats --telemetry-params="data-stream-stats-sample-interval: 1" --kill-running-processes

esrally race --distribution-version=7.9.0 --car="4gheap,x-pack-security" --track=rally/tracks/weatherbeat --track-params=rally/tracks/weatherbeat/params.json --client-options="timeout:180,use_ssl:true,verify_certs:false,basic_auth_user:'rally',basic_auth_password:'rally-password'" --telemetry data-stream-stats --telemetry-params="data-stream-stats-sample-interval: 1" --kill-running-processes

esrally race --distribution-version=7.10.0 --car="4gheap,x-pack-security" --track=rally/tracks/weatherbeat --track-params=rally/tracks/weatherbeat/params.json --client-options="timeout:180,use_ssl:true,verify_certs:false,basic_auth_user:'rally',basic_auth_password:'rally-password'" --telemetry data-stream-stats --telemetry-params="data-stream-stats-sample-interval: 1" --kill-running-processes

esrally race --distribution-version=7.11.0 --car="4gheap,x-pack-security" --track=rally/tracks/weatherbeat --track-params=rally/tracks/weatherbeat/params.json --client-options="timeout:180,use_ssl:true,verify_certs:false,basic_auth_user:'rally',basic_auth_password:'rally-password'" --telemetry data-stream-stats --telemetry-params="data-stream-stats-sample-interval: 1" --kill-running-processes

# Version 7.11+ no longer needs x-pack explicitly defined due to no OSS build distribution
esrally race --distribution-version=7.11.0 --track=rally/tracks/weatherbeat --track-params=rally/tracks/weatherbeat/params.json --client-options="timeout:180" --telemetry data-stream-stats --telemetry-params="data-stream-stats-sample-interval: 1" --kill-running-processes

esrally race --distribution-version=7.12.0 --track=rally/tracks/weatherbeat --track-params=rally/tracks/weatherbeat/params.json --client-options="timeout:180" --telemetry data-stream-stats --telemetry-params="data-stream-stats-sample-interval: 1" --kill-running-processes

# Tested with params file
esrally race --distribution-version=7.11.0 --car="4gheap,x-pack-security" --track=/Users/bradleydeam/perf/onboarding/rally/tracks/weatherbeat --track-params=/Users/bradleydeam/perf/onboarding/rally/tracks/weatherbeat/params.json --client-options="timeout:180,use_ssl:true,verify_certs:false,basic_auth_user:'rally',basic_auth_password:'rally-password'" --telemetry data-stream-stats --telemetry-params=/Users/bradleydeam/perf/onboarding/rally/tracks/weatherbeat/telemetry-params.json --kill-running-processes
```

Also tested with `telemetry-params.json`:
```
{
    "data-stream-stats-sample-interval": 5
}
```