### PR TITLE
Use explicit config files for black and isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile = black

--- a/Makefile
+++ b/Makefile
@@ -88,11 +88,11 @@ tox-env-clean:
 
 lint: check-venv
 	@find esrally benchmarks scripts tests it -name "*.py" -exec $(VEPYLINT) -j0 -rn --rcfile=$(CURDIR)/.pylintrc \{\} +
-	@. $(VENV_ACTIVATE_FILE); black --check esrally benchmarks scripts tests it
+	@. $(VENV_ACTIVATE_FILE); black --config=black.toml --check esrally benchmarks scripts tests it
 	@. $(VENV_ACTIVATE_FILE); isort --check esrally benchmarks scripts tests it
 
 format: check-venv
-	@. $(VENV_ACTIVATE_FILE); black esrally benchmarks scripts tests it
+	@. $(VENV_ACTIVATE_FILE); black --config=black.toml esrally benchmarks scripts tests it
 	@. $(VENV_ACTIVATE_FILE); isort esrally benchmarks scripts tests it
 
 docs: check-venv

--- a/black.toml
+++ b/black.toml
@@ -1,6 +1,3 @@
 [tool.black]
 line-length = 140
 target-version = ['py38']
-
-[tool.isort]
-profile = 'black'


### PR DESCRIPTION
Using `pyproject.toml` for black and isort configuration has unwanted
side effects when Rally is installed in certain environments (and in
editable mode). While this should be addressed at a later point because
editable mode is about to removed anyway (see PEP-517 and PEP-518) we
will use explicitly specified config files for now.

Relates #1281
Relates https://github.com/pypa/pip/issues/6433