### PR TITLE
Add Makefile target to run all CI checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@ attention.
 
 * Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
 * Have you followed the [contributor guidelines](https://github.com/elastic/rally/blob/master/CONTRIBUTING.md)?
-* Have you run `make test` and `make it` and both finish without errors?
+* Have you run `make lint`, `make test` and `make it` and they finish without errors?
 * Did you choose a [descriptive title and description](https://chris.beams.io/posts/git-commit/) for your PR?
 * (Only for maintainers) Did you apply appropriate labels and a milestone?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@ attention.
 
 * Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
 * Have you followed the [contributor guidelines](https://github.com/elastic/rally/blob/master/CONTRIBUTING.md)?
-* Have you run `make lint`, `make test` and `make it` and they finish without errors?
+* Have you run `make check-all` successfully?
 * Did you choose a [descriptive title and description](https://chris.beams.io/posts/git-commit/) for your PR?
 * (Only for maintainers) Did you apply appropriate labels and a milestone?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,15 +50,15 @@ In order to run tests within the IDE, ensure the `Python Integrated Tools` / `Te
 
 Once your changes and tests are ready to submit for review:
 
-1. Test your changes
+1. Format your changes
 
-    Run the test suite to make sure that nothing is broken: `python3 setup.py test`.
-
-2. Format your changes
-
-    Also make sure that lint is passing by running `make lint`. To format your code, run `make format`.
+    Make sure that lint is passing by running `make lint`. To format your code, run `make format`.
 
     Consider using editor integrations to do it automatically: you'll need to configure [black](https://black.readthedocs.io/en/stable/integrations/editors.html) and [isort](https://github.com/PyCQA/isort/wiki/isort-Plugins).
+
+2. Test your changes
+
+    Run the test suite to make sure that nothing is broken: `make test`. You can also run integration tests with `make it` (they're much slower, though). To run everything including lint, use `make check-all`.
 
 3. Sign the Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,9 @@ Once your changes and tests are ready to submit for review:
 
 2. Test your changes
 
-    Run the test suite to make sure that nothing is broken: `make test`. You can also run integration tests with `make it` (they're much slower, though). To run everything including lint, use `make check-all`.
+    Ensure that all tests pass by running `make check-all`. This runs sequentially lint checks, unit tests and integration tests. These can be executed in isolation using `make lint`, `make test` and `make it` respectively, in case you need to iterate over a subset of tests.
+
+    Note: Integration tests are much slower than unit tests.
 
 3. Sign the Contributor License Agreement
 

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ it38: check-venv python-caches-clean tox-env-clean
 it39: check-venv python-caches-clean tox-env-clean
 	. $(VENV_ACTIVATE_FILE); tox -e py39
 
+check-all: lint test it
+
 benchmark: check-venv
 	. $(VENV_ACTIVATE_FILE); pytest benchmarks/
 


### PR DESCRIPTION
And reorganize the docs to mention integration tests and this new target.

I also noticed an opportunity to update the pull request template. I think I prefer not mentioning `make check-all` there because I still haven't managed to run the integration tests locally!

Closes #1297