### PR TITLE
Add create and delete ILM policy runners

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1084,8 +1084,8 @@ With the operation-type ``put-pipeline`` you can execute the `put pipeline API <
 Properties
 """"""""""
 
-* `id` (mandatory): Pipeline id.
-* `body` (mandatory): Pipeline definition.
+* ``id`` (mandatory): Pipeline id.
+* ``body`` (mandatory): Pipeline definition.
 
 In this example we setup a pipeline that adds location information to a ingested document as well as a pipeline failure block to change the index in which the document was supposed to be written. Note that we need to use the ``raw`` and ``endraw`` blocks to ensure that Rally does not attempt to resolve the Mustache template. See :ref:`template language <template_language>` for more information.
 
@@ -1342,6 +1342,101 @@ With the following snippet we will delete all ``logs-*`` indices::
 This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
 
 This operation is :ref:`retryable <track_operations>`.
+
+Meta-data
+"""""""""
+
+* ``weight``: The number of indices that have been deleted.
+* ``unit``: Always "ops".
+* ``success``: A boolean indicating whether the operation has succeeded.
+
+create-ilm-policy
+~~~~~~~~~~~~~~~~~~~
+
+With the ``create-ilm-policy`` operation you can create or update (if the policy already exists) an ILM policy.
+
+Properties
+""""""""""
+
+* ``policy-name`` (mandatory): The identifier for the policy.
+* ``body`` (mandatory): The ILM policy body.
+* ``request-params`` (optional): A structure containing any request parameters that are allowed by the create or update lifecycle policy API. Rally will not attempt to serialize the parameters and pass them as is.
+
+**Example**
+
+In this example, we create an ILM policy (``my-ilm-policy``) with specific ``request-params`` defined::
+
+    {
+      "schedule": [
+        {
+          "operation": {
+            "operation-type": "create-ilm-policy",
+            "policy-name": "my-ilm-policy",
+            "request-params": {
+              "master_timeout": "30s",
+              "timeout": "30s"
+            },
+            "body": {
+              "policy": {
+                "phases": {
+                  "warm": {
+                    "min_age": "10d",
+                    "actions": {
+                      "forcemerge": {
+                        "max_num_segments": 1
+                      }
+                    }
+                  },
+                  "delete": {
+                    "min_age": "30d",
+                    "actions": {
+                      "delete": {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+
+Meta-data
+"""""""""
+
+* ``weight``: The number of indices that have been deleted.
+* ``unit``: Always "ops".
+* ``success``: A boolean indicating whether the operation has succeeded.
+
+delete-ilm-policy
+~~~~~~~~~~~~~~~~~~~
+
+With the ``delete-ilm-policy`` operation you can delete an ILM policy.
+
+Properties
+""""""""""
+
+* ``policy-name`` (mandatory): The identifier for the policy.
+* ``request-params`` (optional): A structure containing any request parameters that are allowed by the create or update lifecycle policy API. Rally will not attempt to serialize the parameters and pass them as is.
+
+**Example**
+
+In this example, we delete an ILM policy (``my-ilm-policy``) with specific ``request-params`` defined::
+
+    {
+      "schedule": [
+        {
+          "operation": {
+            "operation-type": "delete-ilm-policy",
+            "policy-name": "my-ilm-policy",
+            "request-params": {
+              "master_timeout": "30s",
+              "timeout": "30s"
+            }
+          }
+        }
+      ]
+    }
 
 Meta-data
 """""""""

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -708,6 +708,8 @@ class OperationType(Enum):
     CreateComponentTemplate = 1032
     DeleteComponentTemplate = 1033
     TransformStats = 1034
+    CreateIlmPolicy = 1035
+    DeleteIlmPolicy = 1036
 
     @property
     def admin_op(self):
@@ -823,6 +825,10 @@ class OperationType(Enum):
             return OperationType.OpenPointInTime
         elif v == "close-point-in-time":
             return OperationType.ClosePointInTime
+        elif v == "create-ilm-policy":
+            return OperationType.CreateIlmPolicy
+        elif v == "delete-ilm-policy":
+            return OperationType.DeleteIlmPolicy
         else:
             raise KeyError(f"No enum value for [{v}]")
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -16,9 +16,9 @@
 # under the License.
 
 import asyncio
+import copy
 import io
 import json
-import copy
 import random
 import unittest.mock as mock
 from unittest import TestCase

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -4520,13 +4520,14 @@ class CreateIlmPolicyRunner(TestCase):
     async def test_create_ilm_policy_without_request_params(self, es):
         es.ilm.put_lifecycle.return_value = as_future({})
         create_ilm_policy = runner.CreateIlmPolicy()
-        del self.params["request-params"]
-        result = await create_ilm_policy(es, params=self.params)
+        params = self.params
+        del params["request-params"]
+        result = await create_ilm_policy(es, params=params)
         self.assertEqual(1, result["weight"])
         self.assertEqual("ops", result["unit"])
         self.assertTrue(result["success"])
 
-        es.ilm.put_lifecycle.assert_called_once_with(policy=self.params["policy-name"], body=self.params["body"], params={})
+        es.ilm.put_lifecycle.assert_called_once_with(policy=params["policy-name"], body=params["body"], params={})
 
 
 class DeleteIlmPolicyRunner(TestCase):
@@ -4550,13 +4551,14 @@ class DeleteIlmPolicyRunner(TestCase):
     async def test_delete_ilm_policy_without_request_params(self, es):
         es.ilm.delete_lifecycle.return_value = as_future({})
         delete_ilm_policy = runner.DeleteIlmPolicy()
-        del self.params["request-params"]
-        result = await delete_ilm_policy(es, params=self.params)
+        params = self.params
+        del params["request-params"]
+        result = await delete_ilm_policy(es, params=params)
         self.assertEqual(1, result["weight"])
         self.assertEqual("ops", result["unit"])
         self.assertTrue(result["success"])
 
-        es.ilm.delete_lifecycle.assert_called_once_with(policy=self.params["policy-name"], params={})
+        es.ilm.delete_lifecycle.assert_called_once_with(policy=params["policy-name"], params={})
 
 
 class SubmitAsyncSearchTests(TestCase):

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -18,6 +18,7 @@
 import asyncio
 import io
 import json
+import copy
 import random
 import unittest.mock as mock
 from unittest import TestCase
@@ -4520,7 +4521,7 @@ class CreateIlmPolicyRunner(TestCase):
     async def test_create_ilm_policy_without_request_params(self, es):
         es.ilm.put_lifecycle.return_value = as_future({})
         create_ilm_policy = runner.CreateIlmPolicy()
-        params = self.params
+        params = copy.deepcopy(self.params)
         del params["request-params"]
         result = await create_ilm_policy(es, params=params)
         self.assertEqual(1, result["weight"])
@@ -4551,7 +4552,7 @@ class DeleteIlmPolicyRunner(TestCase):
     async def test_delete_ilm_policy_without_request_params(self, es):
         es.ilm.delete_lifecycle.return_value = as_future({})
         delete_ilm_policy = runner.DeleteIlmPolicy()
-        params = self.params
+        params = copy.deepcopy(self.params)
         del params["request-params"]
         result = await delete_ilm_policy(es, params=params)
         self.assertEqual(1, result["weight"])


### PR DESCRIPTION
With this commit we add both `create-ilm-policy` and
`delete-ilm-policy` operations via their respective runners.

Closes https://github.com/elastic/rally/issues/1087

Tested with track:
<details>

<summary> Track JSON </summary>

```
{
  "version": 1,
  "description": "Testing ILM Runners"
  "challenges": [
    {
      "name": "ilm-policy",
      "schedule": [
        {
          "operation": {
            "operation-type": "create-ilm-policy",
            "policy-name": "my-ilm-policy",
            "body": {
              "policy": {
                "phases": {
                  "hot": {
                    "min_age": "0ms",
                    "actions": {
                      "rollover": {
                        "max_age": "30d"
                      },
                      "set_priority": {
                        "priority": 100
                      }
                    }
                  }
                }
              }
            }
          }
        },
        {
          "operation": {
            "operation-type": "delete-ilm-policy",
            "policy-name": "my-ilm-policy"
          }
        }
      ]
    }
  ]
}
```

</details>
