### PR TITLE
Run integration tests with the default distro

### DIFF
--- a/it/__init__.py
+++ b/it/__init__.py
@@ -198,7 +198,7 @@ class EsMetricsStore:
         self.cluster.install(
             distribution_version=EsMetricsStore.VERSION,
             node_name="metrics-store",
-            car="defaults",
+            car="defaults,basic-license",
             http_port=10200,
         )
         self.cluster.start(race_id="metrics-store")

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -36,7 +36,9 @@ def test_tar_distributions(cfg):
             it.wait_until_port_is_free(port_number=port)
             assert (
                 it.race(
-                    cfg, f'--distribution-version="{dist}" --track="{track}" ' f"--test-mode --car=4gheap --target-hosts=127.0.0.1:{port}"
+                    cfg,
+                    f'--distribution-version="{dist}" --track="{track}" '
+                    f"--test-mode --car=4gheap,basic-license --target-hosts=127.0.0.1:{port}",
                 )
                 == 0
             )
@@ -53,7 +55,7 @@ def test_docker_distribution(cfg):
             cfg,
             f'--pipeline="docker" --distribution-version="{dist}" '
             f'--track="geonames" --challenge="append-no-conflicts-index-only" --test-mode '
-            f"--car=4gheap --target-hosts=127.0.0.1:{port}",
+            f"--car=4gheap,basic-license --target-hosts=127.0.0.1:{port}",
         )
         == 0
     )
@@ -80,7 +82,7 @@ def test_interrupt(cfg):
         cfg,
         f'race --distribution-version="{dist}" --track="geonames" '
         f"--kill-running-processes --target-hosts=127.0.0.1:{port} --test-mode "
-        f"--car=4gheap",
+        f"--car=4gheap,basic-license",
     )
     assert run_subprocess_and_interrupt(cmd, 2, 15) == 130
 
@@ -94,7 +96,7 @@ def test_cluster():
     race_id = str(uuid.uuid4())
 
     it.wait_until_port_is_free(port_number=port)
-    cluster.install(distribution_version=dist, node_name="rally-node", car="4gheap", http_port=port)
+    cluster.install(distribution_version=dist, node_name="rally-node", car="4gheap,basic-license", http_port=port)
     cluster.start(race_id=race_id)
     yield cluster
     cluster.stop()

--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -26,7 +26,7 @@ def test_sources(cfg):
         it.race(
             cfg,
             f"--revision=latest --track=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
-            f"--challenge=append-no-conflicts --car=4gheap --elasticsearch-plugins=analysis-icu",
+            f"--challenge=append-no-conflicts --car=4gheap,basic-license --elasticsearch-plugins=analysis-icu",
         )
         == 0
     )
@@ -36,7 +36,7 @@ def test_sources(cfg):
         it.race(
             cfg,
             f"--pipeline=from-sources --track=geonames --test-mode --target-hosts=127.0.0.1:{port} "
-            f'--challenge=append-no-conflicts-index-only --car="4gheap,ea"',
+            f'--challenge=append-no-conflicts-index-only --car="4gheap,basic-license,ea"',
         )
         == 0
     )


### PR DESCRIPTION
With this commit we enforce usage of the default distribution in our
integration tests. As this distribution is the default one, we should
also run our integration tests with it.