### PR TITLE
Allow parallel tasks to exit on any completion

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -593,7 +593,7 @@ All tasks in the ``schedule`` list are executed sequentially in the order in whi
 * ``time-period`` (optional, no default value if not specified): Allows to define a default value for all tasks of the ``parallel`` element.
 * ``warmup-iterations`` (optional, defaults to 0): Allows to define a default value for all tasks of the ``parallel`` element.
 * ``iterations`` (optional, defaults to 1): Allows to define a default value for all tasks of the ``parallel`` element.
-* ``completed-by`` (optional): Allows to define the name of one task in the ``tasks`` list, or the value ``any``. If a specific task name has been provided then as soon as the task has completed the whole ``parallel`` task structure is considered completed. If the value ``any`` is provided, then any task that is first to complete will render the ``parallel`` structure complete. If this property is not explicitly defined, the ``parallel`` task structure is considered completed as soon as all its subtasks have completed. A task is completed if and only if all associated clients have completed execution.
+* ``completed-by`` (optional): Allows to define the name of one task in the ``tasks`` list, or the value ``any``. If a specific task name has been provided then as soon as the named task has completed, the whole ``parallel`` task structure is considered completed. If the value ``any`` is provided, then any task that is first to complete will render the ``parallel`` structure complete. If this property is not explicitly defined, the ``parallel`` task structure is considered completed as soon as all its subtasks have completed (NOTE: this is _not_ true if ``any`` is specified, see below warning and example).
 * ``tasks`` (mandatory): Defines a list of tasks that should be executed concurrently. Each task in the list can define the following properties that have been defined above: ``clients``, ``warmup-time-period``, ``time-period``, ``warmup-iterations`` and ``iterations``.
 
 .. note::
@@ -630,7 +630,7 @@ All tasks in the ``schedule`` list are executed sequentially in the order in whi
                       "operation-type": "bulk",
                       "bulk-size": 1000
                     },
-                  "clients": 8
+                    "clients": 8
                   },
                   {
                     "name": "bulk-task-2",

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -612,7 +612,7 @@ All tasks in the ``schedule`` list are executed sequentially in the order in whi
 
         1. Both ``bulk-task-1`` and ``bulk-task-2`` execute in parallel
         2. ``bulk-task-1`` Client 1/8 is first to complete its assigned partition of work
-        3. ``bulk-task-1`` will now cause the ``parallel`` task to complete and **not** wait for either the remaining 7/8 ``bulk-task-1``'s clients to complete, or for any of ``bulk-task-2``'s clients to complete
+        3. ``bulk-task-1`` will now cause the ``parallel`` task to complete and **not** wait for either the remaining seven ``bulk-task-1``'s clients to complete, or for any of ``bulk-task-2``'s clients to complete
 
     ::
 

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -764,9 +764,32 @@ class Driver:
             self.target.drive_at(worker, worker_start_timestamp)
 
     def may_complete_current_task(self, task_allocations):
+        any_jointpoint_completing_parent = [a for a in task_allocations if a.task.any_task_completes_parent]
         joinpoints_completing_parent = [a for a in task_allocations if a.task.preceding_task_completes_parent]
-        # we need to actively send CompleteCurrentTask messages to all remaining workers.
-        if len(joinpoints_completing_parent) > 0 and not self.complete_current_task_sent:
+
+        # If 'completed-by' is set to 'any', then we *do* want to check for completion by
+        # any client and *not* wait until the remaining runner has completed. This way the 'parallel' task will exit
+        # on the completion of _any_ client for any task, i.e. given a contrived track with two tasks to execute inside
+        # a parallel block:
+        #   * parallel:
+        #     * bulk-1, with clients 8
+        #     * bulk-2, with clients: 8
+        #
+        # 1. Both 'bulk-1' and 'bulk-2' execute in parallel
+        # 2. 'bulk-1' client[0]'s runner is first to complete and reach the next joinpoint successfully
+        # 3. 'bulk-1' will now cause the parent task to complete and _not_ wait for all 8 clients' runner to complete, or for 'bulk-2' at all
+
+        if len(any_jointpoint_completing_parent) > 0 and not self.complete_current_task_sent :
+            self.logger.info(f"Any task before join point [{any_jointpoint_completing_parent[0].task}] is able to "
+                             f"complete the parent structure. Telling all clients to exit immediately.")
+
+            self.complete_current_task_sent = True
+            for worker in self.workers:
+                self.target.complete_current_task(worker)
+
+        # If we have a specific 'completed-by' task specified, then we want to make sure that all clients for that task
+        # are able to complete their runners as expected before completing the parent
+        elif len(joinpoints_completing_parent) > 0 and not self.complete_current_task_sent:
             # while this list could contain multiple items, it should always be the same task (but multiple
             # different clients) so any item is sufficient.
             current_join_point = joinpoints_completing_parent[0].task
@@ -776,7 +799,6 @@ class Driver:
                 current_join_point,
                 len(current_join_point.clients_executing_completing_task),
             )
-
             pending_client_ids = []
             for client_id in current_join_point.clients_executing_completing_task:
                 # We assume that all clients have finished if their corresponding worker has finished
@@ -1754,18 +1776,6 @@ class AsyncExecutor:
                 # worker (process) could run multiple clients that execute the same task. We do not want all clients to
                 # finish this task as soon as the first of these clients has finished but rather continue until the last
                 # client has finished that task.
-                #
-                # Alternatively, if 'completed-by' is set to 'any' (any_task_completes_parent), then we *do* want to
-                # check for completion by another client and *not* wait until our own runner has completed. This way the
-                # 'parallel' task will exit on the completion of _any_ client for any task, i.e. given a contrived track
-                # with two tasks to execute inside a parallel block:
-                #   * parallel:
-                #     * check-cluster-health, with clients: 1
-                #     * bulk, with clients: 8
-                #
-                # 1. Both 'check-cluster-health' and 'bulk' begin executing in parallel
-                # 2. 'check-cluster-health' completes successfully, and signals to parent that it is complete
-                # 3. 'bulk' will now exit and _not_ wait for all 8 clients' runner to complete
                 if task_completes_parent:
                     completed = runner.completed
                 else:
@@ -1804,17 +1814,9 @@ class AsyncExecutor:
             raise exceptions.RallyError(f"Cannot run task [{self.task}]: {e}") from None
         finally:
             # Actively set it if this task completes its parent
-            if task_completes_parent:
+            if task_completes_parent or any_task_completes_parent:
                 self.logger.info(
                     "Task [%s] completes parent. Client id [%s] is finished executing it and signals completion.",
-                    self.task,
-                    self.client_id,
-                )
-                self.complete.set()
-            elif any_task_completes_parent:
-                self.logger.info(
-                    "Task [%s] was the first to complete parent. Client id [%s] is finished executing it and signals "
-                    "completion of its parent.",
                     self.task,
                     self.client_id,
                 )
@@ -1886,7 +1888,7 @@ async def execute_single(runner, es, params, on_error):
 
 
 class JoinPoint:
-    def __init__(self, id, clients_executing_completing_task=None):
+    def __init__(self, id, clients_executing_completing_task=None, any_task_completes_parent=None):
         """
 
         :param id: The join point's id.
@@ -1895,10 +1897,14 @@ class JoinPoint:
         """
         if clients_executing_completing_task is None:
             clients_executing_completing_task = []
+        if any_task_completes_parent is None:
+            any_task_completes_parent = []
         self.id = id
+        self.any_task_completes_parent = any_task_completes_parent
         self.clients_executing_completing_task = clients_executing_completing_task
         self.num_clients_executing_completing_task = len(clients_executing_completing_task)
         self.preceding_task_completes_parent = self.num_clients_executing_completing_task > 0
+
 
     def __hash__(self):
         return hash(self.id)
@@ -1974,6 +1980,7 @@ class Allocator:
         for task in self.schedule:
             start_client_index = 0
             clients_executing_completing_task = []
+            any_task_completes_parent = []
             for sub_task in task:
                 for client_index in range(start_client_index, start_client_index + sub_task.clients):
                     # this is the actual client that will execute the task. It may differ from the logical one in case we over-commit (i.e.
@@ -1982,7 +1989,7 @@ class Allocator:
                     if sub_task.completes_parent:
                         clients_executing_completing_task.append(physical_client_index)
                     elif sub_task.any_completes_parent:
-                        clients_executing_completing_task.append(physical_client_index)
+                        any_task_completes_parent.append(physical_client_index)
 
                     ta = TaskAllocation(
                         task=sub_task,
@@ -1994,7 +2001,6 @@ class Allocator:
                     )
                     allocations[physical_client_index].append(ta)
                 start_client_index += sub_task.clients
-
             # uneven distribution between tasks and clients, e.g. there are 5 (parallel) tasks but only 2 clients. Then, one of them
             # executes three tasks, the other one only two. So we need to fill in a `None` for the second one.
             if start_client_index % max_clients > 0:
@@ -2004,7 +2010,7 @@ class Allocator:
                     allocations[client_index].append(None)
 
             # let all clients join after each task, then we go on
-            next_join_point = JoinPoint(join_point_id, clients_executing_completing_task)
+            next_join_point = JoinPoint(join_point_id, clients_executing_completing_task, any_task_completes_parent)
             for client_index in range(max_clients):
                 allocations[client_index].append(next_join_point)
             join_point_id += 1

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -777,11 +777,14 @@ class Driver:
         #
         # 1. Both 'bulk-1' and 'bulk-2' execute in parallel
         # 2. 'bulk-1' client[0]'s runner is first to complete and reach the next joinpoint successfully
-        # 3. 'bulk-1' will now cause the parent task to complete and _not_ wait for all 8 clients' runner to complete, or for 'bulk-2' at all
+        # 3. 'bulk-1' will now cause the parent task to complete and _not_ wait for all 8 clients' runner to complete,
+        # or for 'bulk-2' at all
 
-        if len(any_jointpoint_completing_parent) > 0 and not self.complete_current_task_sent :
-            self.logger.info(f"Any task before join point [{any_jointpoint_completing_parent[0].task}] is able to "
-                             f"complete the parent structure. Telling all clients to exit immediately.")
+        if len(any_jointpoint_completing_parent) > 0 and not self.complete_current_task_sent:
+            self.logger.info(
+                "Any task before join point [%s] is able to " "complete the parent structure. Telling all clients to exit immediately.",
+                any_jointpoint_completing_parent[0].task,
+            )
 
             self.complete_current_task_sent = True
             for worker in self.workers:
@@ -1904,7 +1907,6 @@ class JoinPoint:
         self.clients_executing_completing_task = clients_executing_completing_task
         self.num_clients_executing_completing_task = len(clients_executing_completing_task)
         self.preceding_task_completes_parent = self.num_clients_executing_completing_task > 0
-
 
     def __hash__(self):
         return hash(self.id)

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1829,7 +1829,8 @@ class AsyncExecutor:
                 self.complete.set()
             elif any_task_completes_parent:
                 self.logger.info(
-                    "Task [%s] completes parent. Client id [%s] is finished executing it and signals completion of all remaining clients, immediately.",
+                    "Task [%s] completes parent. Client id [%s] is finished executing it and signals completion of all "
+                    "remaining clients, immediately.",
                     self.task,
                     self.client_id,
                 )

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1487,17 +1487,17 @@ class TrackSpecificationReader:
                     )
 
         if completed_by:
-            completion_task = None
+            completion_task = False
             for task in tasks:
                 if task.completes_parent and not completion_task:
-                    completion_task = task
+                    completion_task = True
                 elif task.completes_parent:
                     self._error(
                         f"'parallel' element for challenge '{challenge_name}' contains multiple tasks with the "
                         f"name '{completed_by}' marked with 'completed-by' but only task is allowed to match."
                     )
                 elif task.any_completes_parent:
-                    completion_task = "any"
+                    completion_task = True
             if not completion_task:
                 self._error(
                     f"'parallel' element for challenge '{challenge_name}' is marked with 'completed-by' with "

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1487,18 +1487,18 @@ class TrackSpecificationReader:
                     )
 
         if completed_by:
-            completion_task = False
+            has_completion_task = False
             for task in tasks:
-                if task.completes_parent and not completion_task:
-                    completion_task = True
+                if task.completes_parent and not has_completion_task:
+                    has_completion_task = True
                 elif task.completes_parent:
                     self._error(
                         f"'parallel' element for challenge '{challenge_name}' contains multiple tasks with the "
                         f"name '{completed_by}' marked with 'completed-by' but only task is allowed to match."
                     )
                 elif task.any_completes_parent:
-                    completion_task = True
-            if not completion_task:
+                    has_completion_task = True
+            if not has_completion_task:
                 self._error(
                     f"'parallel' element for challenge '{challenge_name}' is marked with 'completed-by' with "
                     f"task name '{completed_by}' but no task with this name exists."

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1489,17 +1489,15 @@ class TrackSpecificationReader:
         if completed_by:
             completion_task = None
             for task in tasks:
-                if task.completes_parent:
-                    if completed_by == "any":
-                        completion_task = "any"
-                    else:
-                        completion_task = task
-                    console.println(f"{task} has completion task: {completion_task}")
-                elif task.completes_parent and completion_task != "any":
+                if task.completes_parent and not completion_task:
+                    completion_task = task
+                elif task.completes_parent:
                     self._error(
                         f"'parallel' element for challenge '{challenge_name}' contains multiple tasks with the "
                         f"name '{completed_by}' marked with 'completed-by' but only task is allowed to match."
                     )
+                elif task.any_completes_parent:
+                    completion_task = "any"
             if not completion_task:
                 self._error(
                     f"'parallel' element for challenge '{challenge_name}' is marked with 'completed-by' with "
@@ -1547,12 +1545,12 @@ class TrackSpecificationReader:
                 task_spec, "ramp-up-time-period", error_ctx=op.name, mandatory=False, default_value=default_ramp_up_time_period
             ),
             clients=self._r(task_spec, "clients", error_ctx=op.name, mandatory=False, default_value=1),
-            completes_parent=(task_name == completed_by_name or completed_by_name == "any"),
+            completes_parent=(task_name == completed_by_name),
+            any_completes_parent=(completed_by_name == "any"),
             schedule=schedule,
             # this is to provide scheduler-specific parameters for custom schedulers.
             params=task_spec,
         )
-        console.println(f"In parse_task for {task.name}, completes parent = {task.completes_parent}")
         if task.warmup_iterations is not None and task.time_period is not None:
             self._error(
                 f"Operation '{op.name}' in challenge '{challenge_name}' defines {task.warmup_iterations} "

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -953,6 +953,7 @@ class Task:
         ramp_up_time_period=None,
         clients=1,
         completes_parent=False,
+        any_completes_parent=False,
         schedule=None,
         params=None,
     ):
@@ -972,6 +973,7 @@ class Task:
         self.ramp_up_time_period = ramp_up_time_period
         self.clients = clients
         self.completes_parent = completes_parent
+        self.any_completes_parent = any_completes_parent
         self.schedule = schedule
         self.params = params if params else {}
         self.nested = False
@@ -1061,6 +1063,7 @@ class Task:
             ^ hash(self.clients)
             ^ hash(self.schedule)
             ^ hash(self.completes_parent)
+            ^ hash(self.any_completes_parent)
         )
 
     def __eq__(self, other):
@@ -1076,6 +1079,7 @@ class Task:
             self.clients,
             self.schedule,
             self.completes_parent,
+            self.any_completes_parent,
         ) == (
             other.name,
             other.operation,
@@ -1087,6 +1091,7 @@ class Task:
             other.clients,
             other.schedule,
             other.completes_parent,
+            other.any_completes_parent,
         )
 
     def __iter__(self):

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -650,9 +650,8 @@ class AllocatorTests(TestCase):
         self.assertEqual(2, len(allocator.join_points))
         self.assertEqual([{taskA, taskB}], allocator.tasks_per_joinpoint)
         final_join_point = allocator.join_points[-1]
-        self.assertTrue(final_join_point.preceding_task_completes_parent)
-        self.assertEqual(2, final_join_point.num_clients_executing_completing_task)
-        self.assertEqual([0, 1], final_join_point.clients_executing_completing_task)
+        self.assertEqual(2, len(final_join_point.any_task_completes_parent))
+        self.assertEqual([0, 1], final_join_point.any_task_completes_parent)
 
     def test_allocates_mixed_tasks(self):
         index = track.Task("index", op("index", track.OperationType.Bulk))


### PR DESCRIPTION
With this commit we add the ability to specify a new `any` value
for the `completed-by` param for `parallel` task blocks. This 
allows the `parallel` block to be completed by whichever task is
first to complete successfully.

Closes https://github.com/elastic/rally/issues/1261

Tested with track:
```
{
  "description": "'any' testing ",
  "challenges": [
    {
      "name": "parallel-any",
      "description": "Track completed-by property",
      "schedule": [
        {
          "name": "outside-cluster-health",
          "operation": {
            "operation-type": "cluster-health"
          }
        },
        {
          "parallel": {
            "completed-by": "any",
            "tasks": [
              {
                "name": "check-cluster-health",
                "operation": {
                  "operation-type": "cluster-health"
                }
              },
              {
                "name": "run-node-stats",
                "operation": {
                  "operation-type": "node-stats"
                },
                "iterations": 300000000
              }
            ]
          }
        }
      ]
    }
  ]
}
```