### PR TITLE
Fix deleting component/composable templates

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1344,7 +1344,7 @@ class DeleteComposableTemplate(Runner):
             if not only_if_exists:
                 await es.indices.delete_index_template(name=template_name, params=request_params, ignore=[404])
                 ops_count += 1
-            elif only_if_exists and await es.indices.exists_template(template_name):
+            elif only_if_exists and await es.indices.exists_index_template(template_name):
                 self.logger.info("Composable Index template [%s] already exists. Deleting it.", template_name)
                 await es.indices.delete_index_template(name=template_name, params=request_params)
                 ops_count += 1

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -355,15 +355,15 @@ class CreateIndexTemplateParamSource(ParamSource):
         return p
 
 
-class DeleteIndexTemplateParamSource(ParamSource):
-    def __init__(self, track, params, **kwargs):
+class DeleteTemplateParamSource(ABC, ParamSource):
+    def __init__(self, track, params, templates, **kwargs):
         super().__init__(track, params, **kwargs)
         self.only_if_exists = params.get("only-if-exists", True)
         self.request_params = params.get("request-params", {})
         self.template_definitions = []
-        if track.templates:
+        if templates:
             filter_template = params.get("template")
-            for template in track.templates:
+            for template in templates:
                 if not filter_template or template.name == filter_template:
                     self.template_definitions.append((template.name, template.delete_matching_indices, template.pattern))
         else:
@@ -395,15 +395,25 @@ class DeleteIndexTemplateParamSource(ParamSource):
         return p
 
 
-class DeleteTemplateParamSource(ABC, ParamSource):
-    def __init__(self, track, params, templates, **kwargs):
+class DeleteIndexTemplateParamSource(DeleteTemplateParamSource):
+    def __init__(self, track, params, **kwargs):
+        super().__init__(track, params, track.templates, **kwargs)
+
+
+class DeleteComposableTemplateParamSource(DeleteTemplateParamSource):
+    def __init__(self, track, params, **kwargs):
+        super().__init__(track, params, track.composable_templates, **kwargs)
+
+
+class DeleteComponentTemplateParamSource(ParamSource):
+    def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
         self.only_if_exists = params.get("only-if-exists", True)
         self.request_params = params.get("request-params", {})
         self.template_definitions = []
-        if templates:
+        if track.component_templates:
             filter_template = params.get("template")
-            for template in templates:
+            for template in track.component_templates:
                 if not filter_template or template.name == filter_template:
                     self.template_definitions.append(template.name)
         else:
@@ -419,16 +429,6 @@ class DeleteTemplateParamSource(ABC, ParamSource):
             "only-if-exists": self.only_if_exists,
             "request-params": self.request_params,
         }
-
-
-class DeleteComposableTemplateParamSource(DeleteTemplateParamSource):
-    def __init__(self, track, params, **kwargs):
-        super().__init__(track, params, track.composable_templates, **kwargs)
-
-
-class DeleteComponentTemplateParamSource(DeleteTemplateParamSource):
-    def __init__(self, track, params, **kwargs):
-        super().__init__(track, params, track.component_templates, **kwargs)
 
 
 class CreateTemplateParamSource(ABC, ParamSource):

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -395,15 +395,15 @@ class DeleteIndexTemplateParamSource(ParamSource):
         return p
 
 
-class DeleteComponentTemplateParamSource(ParamSource):
-    def __init__(self, track, params, **kwargs):
+class DeleteTemplateParamSource(ABC, ParamSource):
+    def __init__(self, track, params, templates, **kwargs):
         super().__init__(track, params, **kwargs)
         self.only_if_exists = params.get("only-if-exists", True)
         self.request_params = params.get("request-params", {})
         self.template_definitions = []
-        if track.templates:
+        if templates:
             filter_template = params.get("template")
-            for template in track.templates:
+            for template in templates:
                 if not filter_template or template.name == filter_template:
                     self.template_definitions.append(template.name)
         else:
@@ -419,6 +419,16 @@ class DeleteComponentTemplateParamSource(ParamSource):
             "only-if-exists": self.only_if_exists,
             "request-params": self.request_params,
         }
+
+
+class DeleteComposableTemplateParamSource(DeleteTemplateParamSource):
+    def __init__(self, track, params, **kwargs):
+        super().__init__(track, params, track.composable_templates, **kwargs)
+
+
+class DeleteComponentTemplateParamSource(DeleteTemplateParamSource):
+    def __init__(self, track, params, **kwargs):
+        super().__init__(track, params, track.component_templates, **kwargs)
 
 
 class CreateTemplateParamSource(ABC, ParamSource):
@@ -1323,7 +1333,7 @@ register_param_source_for_operation(track.OperationType.DeleteIndexTemplate, Del
 register_param_source_for_operation(track.OperationType.CreateComponentTemplate, CreateComponentTemplateParamSource)
 register_param_source_for_operation(track.OperationType.DeleteComponentTemplate, DeleteComponentTemplateParamSource)
 register_param_source_for_operation(track.OperationType.CreateComposableTemplate, CreateComposableTemplateParamSource)
-register_param_source_for_operation(track.OperationType.DeleteComposableTemplate, DeleteIndexTemplateParamSource)
+register_param_source_for_operation(track.OperationType.DeleteComposableTemplate, DeleteComposableTemplateParamSource)
 register_param_source_for_operation(track.OperationType.Sleep, SleepParamSource)
 register_param_source_for_operation(track.OperationType.ForceMerge, ForceMergeParamSource)
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2794,7 +2794,7 @@ class DeleteComposableTemplateRunnerTests(TestCase):
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_deletes_only_existing_index_templates(self, es):
-        es.indices.exists_template.side_effect = [as_future(False), as_future(True)]
+        es.indices.exists_index_template.side_effect = [as_future(False), as_future(True)]
         es.indices.delete_index_template.return_value = as_future()
 
         r = runner.DeleteComposableTemplate()

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2390,7 +2390,7 @@ class DeleteComposableTemplateParamSource(TestCase):
         source = params.DeleteComposableTemplateParamSource(track.Track(name="unit-test"), params={"template": "default"})
         p = source.params()
         self.assertEqual(1, len(p["templates"]))
-        self.assertEqual("default", p["templates"][0])
+        self.assertEqual("default", p["templates"][0][0])
         self.assertTrue(p["only-if-exists"])
         self.assertDictEqual({}, p["request-params"])
 
@@ -2435,8 +2435,8 @@ class DeleteComposableTemplateParamSource(TestCase):
         p = source.params()
 
         self.assertEqual(2, len(p["templates"]))
-        self.assertEqual("logs", p["templates"][0])
-        self.assertEqual("metrics", p["templates"][1])
+        self.assertEqual("logs", p["templates"][0][0])
+        self.assertEqual("metrics", p["templates"][1][0])
         self.assertFalse(p["only-if-exists"])
         self.assertDictEqual({"master_timeout": 20}, p["request-params"])
 
@@ -2449,7 +2449,7 @@ class DeleteComposableTemplateParamSource(TestCase):
         p = source.params()
 
         self.assertEqual(1, len(p["templates"]))
-        self.assertEqual("logs", p["templates"][0])
+        self.assertEqual("logs", p["templates"][0][0])
 
 
 class SearchParamSourceTests(TestCase):

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2323,7 +2323,7 @@ class CreateComponentTemplateParamSourceTests(TestCase):
 
 
 class DeleteComponentTemplateParamSource(TestCase):
-    def test_delete_index_template_by_name(self):
+    def test_delete_component_template_by_name(self):
         source = params.DeleteComponentTemplateParamSource(track.Track(name="unit-test"), params={"template": "default"})
         p = source.params()
         self.assertEqual(1, len(p["templates"]))
@@ -2331,12 +2331,12 @@ class DeleteComponentTemplateParamSource(TestCase):
         self.assertTrue(p["only-if-exists"])
         self.assertDictEqual({}, p["request-params"])
 
-    def test_delete_index_template_no_name(self):
+    def test_no_component_templates(self):
         with self.assertRaises(exceptions.InvalidSyntax) as ctx:
             params.DeleteComponentTemplateParamSource(track.Track(name="unit-test"), params={"operation-type": "delete-component-template"})
         self.assertEqual("Please set the property 'template' for the delete-component-template operation.", ctx.exception.args[0])
 
-    def test_delete_index_template_from_track(self):
+    def test_delete_component_template_from_track(self):
         tpl1 = track.ComponentTemplate(
             name="logs",
             content={
@@ -2361,7 +2361,7 @@ class DeleteComponentTemplateParamSource(TestCase):
             },
         )
         source = params.DeleteComponentTemplateParamSource(
-            track.Track(name="unit-test", templates=[tpl1, tpl2]),
+            track.Track(name="unit-test", component_templates=[tpl1, tpl2]),
             params={"request-params": {"master_timeout": 20}, "only-if-exists": False},
         )
 
@@ -2372,6 +2372,84 @@ class DeleteComponentTemplateParamSource(TestCase):
         self.assertEqual("metrics", p["templates"][1])
         self.assertFalse(p["only-if-exists"])
         self.assertDictEqual({"master_timeout": 20}, p["request-params"])
+
+        # test filtering
+        source = params.DeleteComponentTemplateParamSource(
+            track.Track(name="unit-test", component_templates=[tpl1, tpl2]),
+            params={"template": "logs"},
+        )
+
+        p = source.params()
+
+        self.assertEqual(1, len(p["templates"]))
+        self.assertEqual("logs", p["templates"][0])
+
+
+class DeleteComposableTemplateParamSource(TestCase):
+    def test_delete_composable_template_by_name(self):
+        source = params.DeleteComposableTemplateParamSource(track.Track(name="unit-test"), params={"template": "default"})
+        p = source.params()
+        self.assertEqual(1, len(p["templates"]))
+        self.assertEqual("default", p["templates"][0])
+        self.assertTrue(p["only-if-exists"])
+        self.assertDictEqual({}, p["request-params"])
+
+    def test_no_composable_templates(self):
+        with self.assertRaises(exceptions.InvalidSyntax) as ctx:
+            params.DeleteComponentTemplateParamSource(
+                track.Track(name="unit-test"), params={"operation-type": "delete-composable-template"}
+            )
+        self.assertEqual("Please set the property 'template' for the delete-composable-template operation.", ctx.exception.args[0])
+
+    def test_delete_composable_template_from_track(self):
+        tpl1 = track.IndexTemplate(
+            name="logs",
+            pattern="logs-*",
+            content={
+                "template": {
+                    "mappings": {
+                        "properties": {
+                            "@timestamp": {"type": "date"},
+                        },
+                    },
+                },
+            },
+        )
+        tpl2 = track.IndexTemplate(
+            name="metrics",
+            pattern="metrics-*",
+            content={
+                "template": {
+                    "settings": {
+                        "index.number_of_shards": 1,
+                        "index.number_of_replicas": 1,
+                    },
+                },
+            },
+        )
+        source = params.DeleteComposableTemplateParamSource(
+            track.Track(name="unit-test", composable_templates=[tpl1, tpl2]),
+            params={"request-params": {"master_timeout": 20}, "only-if-exists": False},
+        )
+
+        p = source.params()
+
+        self.assertEqual(2, len(p["templates"]))
+        self.assertEqual("logs", p["templates"][0])
+        self.assertEqual("metrics", p["templates"][1])
+        self.assertFalse(p["only-if-exists"])
+        self.assertDictEqual({"master_timeout": 20}, p["request-params"])
+
+        # test filtering
+        source = params.DeleteComposableTemplateParamSource(
+            track.Track(name="unit-test", composable_templates=[tpl1, tpl2]),
+            params={"template": "logs"},
+        )
+
+        p = source.params()
+
+        self.assertEqual(1, len(p["templates"]))
+        self.assertEqual("logs", p["templates"][0])
 
 
 class SearchParamSourceTests(TestCase):


### PR DESCRIPTION
This fixes an issue with the deletion of component and composable templates. This brings behaviour in line with the documentation. We now support deleting all component/composable templates defined in the track.

The implementation mirrors that of the creation of these templates.

