### PR TITLE
always set default client timeout to 60

### DIFF
--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -17,7 +17,7 @@ If you already have a cluster with data in it you can use the ``create-track`` s
 
 If you want to connect to a cluster with TLS and basic authentication enabled, for example via Elastic Cloud, also specify :ref:`--client-options <clr_client_options>` and change ``basic_auth_user`` and ``basic_auth_password`` accordingly::
 
-    esrally create-track --track=acme --target-hosts=abcdef123.us-central-1.gcp.cloud.es.io:9243 --client-options="timeout:60,use_ssl:true,verify_certs:true,basic_auth_user:'elastic',basic_auth_password:'secret-password'" --indices="products,companies" --output-path=~/tracks
+    esrally create-track --track=acme --target-hosts=abcdef123.us-central-1.gcp.cloud.es.io:9243 --client-options="use_ssl:true,verify_certs:true,basic_auth_user:'elastic',basic_auth_password:'secret-password'" --indices="products,companies" --output-path=~/tracks
 
 The track generator will create a folder with the track's name in the specified output directory::
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -651,10 +651,7 @@ We support the following data types:
 * Numbers: There is nothing special about numbers. Example: ``sniffer_timeout:60``
 * Booleans: Specify either ``true`` or ``false``. Example: ``use_ssl:true``
 
-Default value: ``timeout:10``
-
-.. warning::
-   If you provide your own client options, the default value will not be magically merged. You have to specify all client options explicitly. The only exceptions to this rule is ``ca_cert`` (see below).
+Default value: ``timeout:60`` (applies any time ``timeout`` is not specified)
 
 Rally recognizes the following client options in addition:
 
@@ -931,7 +928,7 @@ Examples:
 ``client-options``
 ~~~~~~~~~~~~~~~~~~
 
-``client-options`` can optionally specify options for the Elasticsearch clients when multiple clusters have been defined with ``target-hosts``. If omitted, the default is ``timeout:10`` for all cluster connections.
+``client-options`` can optionally specify options for the Elasticsearch clients when multiple clusters have been defined with ``target-hosts``. The default is ``timeout:60`` for all cluster connections.
 
 The format is similar to ``target-hosts``, supporting both filenames ending in ``.json`` or inline JSON, however, the parameters are a collection of name:value pairs, as opposed to arrays.
 
@@ -941,7 +938,7 @@ Examples, assuming that two clusters have been specified with ``--target-hosts``
 
     {
       "default": {
-        "timeout": 60
+        "timeout": 120
     },
       "remote": {
         "use_ssl": true,
@@ -952,7 +949,7 @@ Examples, assuming that two clusters have been specified with ``--target-hosts``
 
 * json inline string defining two clusters::
 
-    --client-options="{\"default\":{\"timeout\": 60}, \"remote\": {\"use_ssl\":true,\"verify_certs\":false,\"ca_certs\":\"/path/to/cacert.pem\"}}"
+    --client-options="{\"default\":{\"timeout\": 120}, \"remote\": {\"use_ssl\":true,\"verify_certs\":false,\"ca_certs\":\"/path/to/cacert.pem\"}}"
 
 .. WARNING::
    If you use ``client-options`` you must specify options for **every** cluster name defined with ``target-hosts``. Rally will raise an error if there is a mismatch.

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -651,7 +651,7 @@ We support the following data types:
 * Numbers: There is nothing special about numbers. Example: ``sniffer_timeout:60``
 * Booleans: Specify either ``true`` or ``false``. Example: ``use_ssl:true``
 
-Default value: ``timeout:60``
+Default value: ``timeout:10``
 
 .. warning::
    If you provide your own client options, the default value will not be magically merged. You have to specify all client options explicitly. The only exceptions to this rule is ``ca_cert`` (see below).
@@ -931,7 +931,7 @@ Examples:
 ``client-options``
 ~~~~~~~~~~~~~~~~~~
 
-``client-options`` can optionally specify options for the Elasticsearch clients when multiple clusters have been defined with ``target-hosts``. If omitted, the default is ``timeout:60`` for all cluster connections.
+``client-options`` can optionally specify options for the Elasticsearch clients when multiple clusters have been defined with ``target-hosts``. If omitted, the default is ``timeout:10`` for all cluster connections.
 
 The format is similar to ``target-hosts``, supporting both filenames ending in ``.json`` or inline JSON, however, the parameters are a collection of name:value pairs, as opposed to arrays.
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -12,7 +12,7 @@ Benchmarking an Elastic Cloud cluster
 
 Benchmarking an `Elastic Cloud <https://www.elastic.co/cloud/>`_ cluster with Rally is similar to :ref:`benchmarking any other existing cluster <recipe_benchmark_existing_cluster>`. In the following example we will run a benchmark against a cluster reachable via the endpoint ``https://abcdef123456.europe-west1.gcp.cloud.es.io:9243`` by the user ``elastic`` with the password ``changeme``::
 
-    esrally race --track=pmc --target-hosts=abcdef123456.europe-west1.gcp.cloud.es.io:9243 --pipeline=benchmark-only --client-options="timeout:60,use_ssl:true,verify_certs:true,basic_auth_user:'elastic',basic_auth_password:'changeme'"
+    esrally race --track=pmc --target-hosts=abcdef123456.europe-west1.gcp.cloud.es.io:9243 --pipeline=benchmark-only --client-options="use_ssl:true,verify_certs:true,basic_auth_user:'elastic',basic_auth_password:'changeme'"
 
 .. _recipe_benchmark_existing_cluster:
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -888,7 +888,7 @@ def configure_connection_params(arg_parser, args, cfg):
     client_options = opts.ClientOptions(args.client_options, target_hosts=target_hosts)
     cfg.add(config.Scope.applicationOverride, "client", "options", client_options)
     if "timeout" not in client_options.default:
-        console.info("You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.")
+        console.info("You did not provide an explicit timeout in the client options. Assuming default of 60 seconds.")
     if list(target_hosts.all_hosts) != list(client_options.all_client_options):
         arg_parser.error("--target-hosts and --client-options must define the same keys for multi cluster setups.")
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -887,8 +887,6 @@ def configure_connection_params(arg_parser, args, cfg):
     cfg.add(config.Scope.applicationOverride, "client", "hosts", target_hosts)
     client_options = opts.ClientOptions(args.client_options, target_hosts=target_hosts)
     cfg.add(config.Scope.applicationOverride, "client", "options", client_options)
-    if "timeout" not in client_options.default:
-        console.info("You did not provide an explicit timeout in the client options. Assuming default of 60 seconds.")
     if list(target_hosts.all_hosts) != list(client_options.all_client_options):
         arg_parser.error("--target-hosts and --client-options must define the same keys for multi cluster setups.")
 

--- a/esrally/utils/opts.py
+++ b/esrally/utils/opts.py
@@ -165,7 +165,7 @@ class TargetHosts(ConnectOptions):
 
 
 class ClientOptions(ConnectOptions):
-    DEFAULT_CLIENT_OPTIONS = "timeout:60"
+    DEFAULT_CLIENT_OPTIONS = "timeout:10"
 
     """
     Convert --client-options arg to a dict.

--- a/esrally/utils/opts.py
+++ b/esrally/utils/opts.py
@@ -185,9 +185,7 @@ class ClientOptions(ConnectOptions):
         default_client_map = kv_to_map([ClientOptions.DEFAULT_CLIENT_OPTIONS])
         if self.argvalue == ClientOptions.DEFAULT_CLIENT_OPTIONS and self.target_hosts is not None:
             # --client-options unset but multi-clusters used in --target-hosts? apply options defaults for all cluster names.
-            self.parsed_options = {
-                cluster_name: default_client_map for cluster_name in self.target_hosts.all_hosts.keys()
-            }
+            self.parsed_options = {cluster_name: default_client_map for cluster_name in self.target_hosts.all_hosts.keys()}
         else:
             self.parsed_options = to_dict(self.argvalue, default_parser=ClientOptions.normalize_to_dict)
 

--- a/esrally/utils/opts.py
+++ b/esrally/utils/opts.py
@@ -165,7 +165,7 @@ class TargetHosts(ConnectOptions):
 
 
 class ClientOptions(ConnectOptions):
-    DEFAULT_CLIENT_OPTIONS = "timeout:10"
+    DEFAULT_CLIENT_OPTIONS = "timeout:60"
 
     """
     Convert --client-options arg to a dict.
@@ -182,23 +182,27 @@ class ClientOptions(ConnectOptions):
         self.parse_options()
 
     def parse_options(self):
-        def normalize_to_dict(arg):
-            """
-            When --client-options is a non-json csv string (single cluster mode),
-            return parsed client options as dict with "default" key
-            This is needed to support single cluster use of --client-options when not
-            defined as a json string or file.
-            """
-
-            return {TargetHosts.DEFAULT: kv_to_map(arg)}
-
+        default_client_map = kv_to_map([ClientOptions.DEFAULT_CLIENT_OPTIONS])
         if self.argvalue == ClientOptions.DEFAULT_CLIENT_OPTIONS and self.target_hosts is not None:
             # --client-options unset but multi-clusters used in --target-hosts? apply options defaults for all cluster names.
             self.parsed_options = {
-                cluster_name: kv_to_map([ClientOptions.DEFAULT_CLIENT_OPTIONS]) for cluster_name in self.target_hosts.all_hosts.keys()
+                cluster_name: default_client_map for cluster_name in self.target_hosts.all_hosts.keys()
             }
         else:
-            self.parsed_options = to_dict(self.argvalue, default_parser=normalize_to_dict)
+            self.parsed_options = to_dict(self.argvalue, default_parser=ClientOptions.normalize_to_dict)
+
+    @staticmethod
+    def normalize_to_dict(arg):
+
+        """
+        When --client-options is a non-json csv string (single cluster mode),
+        return parsed client options as dict with "default" key
+        This is needed to support single cluster use of --client-options when not
+        defined as a json string or file.
+        """
+        default_client_map = kv_to_map([ClientOptions.DEFAULT_CLIENT_OPTIONS])
+
+        return {TargetHosts.DEFAULT: {**default_client_map, **kv_to_map(arg)}}
 
     @property
     def all_client_options(self):

--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -186,17 +186,17 @@ class TestClientOptions(TestCase):
 
         self.assertEqual(
             {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem", "timeout": 60},
-            opts.ClientOptions(client_options_string).default
+            opts.ClientOptions(client_options_string).default,
         )
 
         self.assertEqual(
             {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem", "timeout": 60},
-            opts.ClientOptions(client_options_string).default
+            opts.ClientOptions(client_options_string).default,
         )
 
         self.assertEqual(
             {"default": {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem", "timeout": 60}},
-            opts.ClientOptions(client_options_string).all_client_options
+            opts.ClientOptions(client_options_string).all_client_options,
         )
 
     def test_jsonstring_client_options_parses(self):

--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -235,32 +235,32 @@ class TestClientOptions(TestCase):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = None
 
-        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 10}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
         self.assertEqual(
-            {"default": {"timeout": 60}}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).all_client_options
+            {"default": {"timeout": 10}}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).all_client_options
         )
 
-        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 10}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
     def test_no_client_option_parses_to_default_with_multicluster(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = opts.TargetHosts('{"default": ["127.0.0.1:9200,10.17.0.5:19200"], "remote": ["88.33.22.15:19200"]}')
 
-        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 10}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
         self.assertEqual(
-            {"default": {"timeout": 60}, "remote": {"timeout": 60}},
+            {"default": {"timeout": 10}, "remote": {"timeout": 10}},
             opts.ClientOptions(client_options_string, target_hosts=target_hosts).all_client_options,
         )
 
-        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 10}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
     def test_default_client_ops_with_max_connections(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = opts.TargetHosts('{"default": ["10.17.0.5:9200"], "remote": ["88.33.22.15:9200"]}')
         self.assertEqual(
-            {"default": {"timeout": 60, "max_connections": 256}, "remote": {"timeout": 60, "max_connections": 256}},
+            {"default": {"timeout": 10, "max_connections": 256}, "remote": {"timeout": 10, "max_connections": 256}},
             opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(256),
         )
 

--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -235,32 +235,32 @@ class TestClientOptions(TestCase):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = None
 
-        self.assertEqual({"timeout": 10}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
         self.assertEqual(
-            {"default": {"timeout": 10}}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).all_client_options
+            {"default": {"timeout": 60}}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).all_client_options
         )
 
-        self.assertEqual({"timeout": 10}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
     def test_no_client_option_parses_to_default_with_multicluster(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = opts.TargetHosts('{"default": ["127.0.0.1:9200,10.17.0.5:19200"], "remote": ["88.33.22.15:19200"]}')
 
-        self.assertEqual({"timeout": 10}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
         self.assertEqual(
-            {"default": {"timeout": 10}, "remote": {"timeout": 10}},
+            {"default": {"timeout": 60}, "remote": {"timeout": 60}},
             opts.ClientOptions(client_options_string, target_hosts=target_hosts).all_client_options,
         )
 
-        self.assertEqual({"timeout": 10}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
+        self.assertEqual({"timeout": 60}, opts.ClientOptions(client_options_string, target_hosts=target_hosts).default)
 
     def test_default_client_ops_with_max_connections(self):
         client_options_string = opts.ClientOptions.DEFAULT_CLIENT_OPTIONS
         target_hosts = opts.TargetHosts('{"default": ["10.17.0.5:9200"], "remote": ["88.33.22.15:9200"]}')
         self.assertEqual(
-            {"default": {"timeout": 10, "max_connections": 256}, "remote": {"timeout": 10, "max_connections": 256}},
+            {"default": {"timeout": 60, "max_connections": 256}, "remote": {"timeout": 60, "max_connections": 256}},
             opts.ClientOptions(client_options_string, target_hosts=target_hosts).with_max_connections(256),
         )
 

--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -181,19 +181,22 @@ class TestTargetHosts(TestCase):
 
 class TestClientOptions(TestCase):
     def test_csv_client_options_parses(self):
+        # "timeout": 60 should automatically get added to each configuration unless overridden
         client_options_string = "use_ssl:true,verify_certs:true,ca_certs:'/path/to/cacert.pem'"
 
         self.assertEqual(
-            {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem"}, opts.ClientOptions(client_options_string).default
+            {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem", "timeout": 60},
+            opts.ClientOptions(client_options_string).default
         )
 
         self.assertEqual(
-            {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem"}, opts.ClientOptions(client_options_string).default
+            {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem", "timeout": 60},
+            opts.ClientOptions(client_options_string).default
         )
 
         self.assertEqual(
-            {"default": {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem"}},
-            opts.ClientOptions(client_options_string).all_client_options,
+            {"default": {"use_ssl": True, "verify_certs": True, "ca_certs": "/path/to/cacert.pem", "timeout": 60}},
+            opts.ClientOptions(client_options_string).all_client_options
         )
 
     def test_jsonstring_client_options_parses(self):


### PR DESCRIPTION
Currently, when no client options are defined, Rally uses a hard-coded default of 60 for the timeout value.  If client options are defined, but `timeout` specifically is omitted, then Rally uses the ES Client's default of 10 for the timeout value. 

This commit causes the default timeout behavior to be 60 seconds in all cases, to simplify behavior for the user.  We use 60 instead of the elasticsearch-py's default of 10 in order to avoid many timeout errors in e.g. bulks and refreshes when there is a lot of load on the benchmark target.