### PR TITLE
Configure persistent datastore index settings

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,7 +69,7 @@ The following settings are applicable only if ``datastore.type`` is set to "elas
 * ``datastore.user``: Sets the name of the Elasticsearch user for the metrics store.
 * ``datastore.password``: Sets the password of the Elasticsearch user for the metrics store.
 * ``datastore.probe.cluster_version`` (default: true): Enables automatic detection of the metric store's version.
-* ``datastore.number_of_shards`` (default: 1): The number of primary shards that the ```rally-*`` indices should have. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
+* ``datastore.number_of_shards`` (default: 1): The number of primary shards that the ``rally-*`` indices should have. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
 * ``datastore.number_of_replicas`` (default: 0): The number of replicas each primary shard has. Defaults to 0. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
 
 **Examples**

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,8 +69,8 @@ The following settings are applicable only if ``datastore.type`` is set to "elas
 * ``datastore.user``: Sets the name of the Elasticsearch user for the metrics store.
 * ``datastore.password``: Sets the password of the Elasticsearch user for the metrics store.
 * ``datastore.probe.cluster_version`` (default: true): Enables automatic detection of the metric store's version.
-* ``datastore.number_of_shards`` (default: 1): The number of primary shards that the ```rally-*`` indices should have. Any updates to this setting after the first run will only be applied to _new_ ``rally-*`` indices.
-* ``datastore.number_of_replicas`` (default: 0): The number of replicas each primary shard has. Defaults to 0. Any updates to this setting after the first run will only be applied to _new_ ``rally-*`` indices.
+* ``datastore.number_of_shards`` (default: 1): The number of primary shards that the ```rally-*`` indices should have. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
+* ``datastore.number_of_replicas`` (default: 0): The number of replicas each primary shard has. Defaults to 0. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
 
 **Examples**
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,6 +69,8 @@ The following settings are applicable only if ``datastore.type`` is set to "elas
 * ``datastore.user``: Sets the name of the Elasticsearch user for the metrics store.
 * ``datastore.password``: Sets the password of the Elasticsearch user for the metrics store.
 * ``datastore.probe.cluster_version`` (default: true): Enables automatic detection of the metric store's version.
+* ``datastore.number_of_shards`` (default: 1): The number of primary shards that the ```rally-*`` indices should have. Any updates to this setting after the first run will only be applied to _new_ ``rally-*`` indices.
+* ``datastore.number_of_replicas`` (default: 1): The number of replicas each primary shard has. Defaults to 0. Any updates to this setting after the first run will only be applied to _new_ ``rally-*`` indices.
 
 **Examples**
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -70,7 +70,7 @@ The following settings are applicable only if ``datastore.type`` is set to "elas
 * ``datastore.password``: Sets the password of the Elasticsearch user for the metrics store.
 * ``datastore.probe.cluster_version`` (default: true): Enables automatic detection of the metric store's version.
 * ``datastore.number_of_shards`` (default: 1): The number of primary shards that the ```rally-*`` indices should have. Any updates to this setting after the first run will only be applied to _new_ ``rally-*`` indices.
-* ``datastore.number_of_replicas`` (default: 1): The number of replicas each primary shard has. Defaults to 0. Any updates to this setting after the first run will only be applied to _new_ ``rally-*`` indices.
+* ``datastore.number_of_replicas`` (default: 0): The number of replicas each primary shard has. Defaults to 0. Any updates to this setting after the first run will only be applied to _new_ ``rally-*`` indices.
 
 **Examples**
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -13,6 +13,14 @@ Migrating to Rally 2.3.0
 
 The deprecated property ``relative-time-ms`` has been removed in Rally 2.3.0. Use the property ``relative-time`` instead to retrieve the same metric.
 
+Primary and replica shard counts are now configurable for persistent Elasticsearch metrics stores
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+     Primary and replica shard counts are only configurable for persistent metrics stores (``datastore.type = elasticsearch``).
+
+With this release, the number of primary and replica shards are now configurable for ``rally-*`` indices. These can be set via the ``datastore.number_of_shards`` and ``datastore.number_of_replicas`` options in ``rally.ini``.
 
 Migrating to Rally 2.2.1
 ------------------------

--- a/esrally/config.py
+++ b/esrally/config.py
@@ -210,7 +210,7 @@ class Config:
 
     def config_present(self):
         """
-        :return: true iff a config file already exists.
+        :return: true if a config file already exists.
         """
         return self.config_file.present
 

--- a/esrally/config.py
+++ b/esrally/config.py
@@ -210,7 +210,7 @@ class Config:
 
     def config_present(self):
         """
-        :return: true if a config file already exists.
+        :return: true iff a config file already exists.
         """
         return self.config_file.present
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -237,8 +237,14 @@ class IndexTemplateProvider:
     """
 
     def __init__(self, cfg):
-        self.script_dir = cfg.opts("node", "rally.root")
-        self.cfg = cfg
+        self._config = cfg
+        self._number_of_shards = self._config.opts(
+            "reporting", "datastore.number_of_shards", default_value=1, mandatory=False
+        )
+        self._number_of_replicas = self._config.opts(
+            "reporting", "datastore.number_of_replicas", default_value=0, mandatory=False
+        )
+        self.script_dir = self._config.opts("node", "rally.root")
 
     def metrics_template(self):
         return self._read("metrics-template")
@@ -251,22 +257,10 @@ class IndexTemplateProvider:
 
     def _read(self, template_name):
         with open("%s/resources/%s.json" % (self.script_dir, template_name), encoding="utf-8") as f:
-            # if we're using a persistent metrics store, then we should check and update the index templates settings
-            if self.cfg.opts("reporting", "datastore.type") == "elasticsearch":
-                return self._update_template(f)
-
-            else:
-                return f.read()
-
-    def _update_template(self, template_name):
-        template = json.load(template_name)
-        template["settings"]["index"]["number_of_shards"] = self.cfg.opts(
-            "reporting", "datastore.number_of_shards", default_value=1, mandatory=False
-        )
-        template["settings"]["index"]["number_of_replicas"] = self.cfg.opts(
-            "reporting", "datastore.number_of_replicas", default_value=0, mandatory=False
-        )
-        return json.dumps(template)
+            template = json.load(f)
+            template["settings"]["index"]["number_of_shards"] = self._number_of_shards
+            template["settings"]["index"]["number_of_replicas"] = self._number_of_replicas
+            return json.dumps(template)
 
 
 class MetaInfoScope(Enum):

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -238,12 +238,8 @@ class IndexTemplateProvider:
 
     def __init__(self, cfg):
         self._config = cfg
-        self._number_of_shards = self._config.opts(
-            "reporting", "datastore.number_of_shards", default_value=1, mandatory=False
-        )
-        self._number_of_replicas = self._config.opts(
-            "reporting", "datastore.number_of_replicas", default_value=0, mandatory=False
-        )
+        self._number_of_shards = self._config.opts("reporting", "datastore.number_of_shards", default_value=1, mandatory=False)
+        self._number_of_replicas = self._config.opts("reporting", "datastore.number_of_replicas", default_value=0, mandatory=False)
         self.script_dir = self._config.opts("node", "rally.root")
 
     def metrics_template(self):

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -238,6 +238,7 @@ class IndexTemplateProvider:
 
     def __init__(self, cfg):
         self.script_dir = cfg.opts("node", "rally.root")
+        self.cfg = cfg
 
     def metrics_template(self):
         return self._read("metrics-template")
@@ -250,7 +251,22 @@ class IndexTemplateProvider:
 
     def _read(self, template_name):
         with open("%s/resources/%s.json" % (self.script_dir, template_name), encoding="utf-8") as f:
-            return f.read()
+            # if we're using a persistent metrics store, then we should check and update the index templates settings
+            if self.cfg.opts("reporting", "datastore.type") == "elasticsearch":
+                return self._update_template(f)
+
+            else:
+                return f.read()
+
+    def _update_template(self, template_name):
+        template = json.load(template_name)
+        template["settings"]["index"]["number_of_shards"] = self.cfg.opts(
+            "reporting", "datastore.number_of_shards", default_value=1, mandatory=False
+        )
+        template["settings"]["index"]["number_of_replicas"] = self.cfg.opts(
+            "reporting", "datastore.number_of_replicas", default_value=0, mandatory=False
+        )
+        return json.dumps(template)
 
 
 class MetaInfoScope(Enum):

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2331,7 +2331,6 @@ class SystemStatsTests(TestCase):
 
 
 class IndexTemplateProviderTests(TestCase):
-
     def setUp(self):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "node", "root.dir", os.path.join(tempfile.gettempdir(), str(uuid.uuid4())))
@@ -2343,8 +2342,8 @@ class IndexTemplateProviderTests(TestCase):
 
     def test_datastore_type_elasticsearch_index_template_update(self):
         _datastore_type = "elasticsearch"
-        _datastore_number_of_shards = random.randint(1,100)
-        _datastore_number_of_replicas = random.randint(1,100)
+        _datastore_number_of_shards = random.randint(1, 100)
+        _datastore_number_of_replicas = random.randint(1, 100)
 
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)
@@ -2352,8 +2351,11 @@ class IndexTemplateProviderTests(TestCase):
 
         _index_template_provider = metrics.IndexTemplateProvider(self.cfg)
 
-        templates = [_index_template_provider.metrics_template(), _index_template_provider.races_template(),
-                     _index_template_provider.results_template()]
+        templates = [
+            _index_template_provider.metrics_template(),
+            _index_template_provider.races_template(),
+            _index_template_provider.results_template(),
+        ]
 
         for template in templates:
             t = json.loads(template)
@@ -2362,8 +2364,8 @@ class IndexTemplateProviderTests(TestCase):
 
     def test_datastore_type_in_memory_index_template_update(self):
         _datastore_type = "in-memory"
-        _datastore_number_of_shards = random.randint(1,100)
-        _datastore_number_of_replicas = random.randint(1,100)
+        _datastore_number_of_shards = random.randint(1, 100)
+        _datastore_number_of_replicas = random.randint(1, 100)
 
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)
@@ -2371,11 +2373,15 @@ class IndexTemplateProviderTests(TestCase):
 
         _index_template_provider = metrics.IndexTemplateProvider(self.cfg)
 
-        templates = [_index_template_provider.metrics_template(), _index_template_provider.races_template(),
-                     _index_template_provider.results_template()]
+        templates = [
+            _index_template_provider.metrics_template(),
+            _index_template_provider.races_template(),
+            _index_template_provider.results_template(),
+        ]
 
         for template in templates:
             t = json.loads(template)
             assert t["settings"]["index"]["number_of_shards"] == 1
             with self.assertRaises(KeyError):
+                # pylint: disable=pointless-statement
                 t["settings"]["index"]["number_of_replicas"]

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2361,9 +2361,3 @@ class IndexTemplateProviderTests(TestCase):
             t = json.loads(template)
             assert t["settings"]["index"]["number_of_shards"] == _datastore_number_of_shards
             assert t["settings"]["index"]["number_of_replicas"] == _datastore_number_of_replicas
-
-    def test_datastore_type_in_memory_no_index_template_provider(self):
-        _datastore_type = "in-memory"
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
-        cls = metrics.metrics_store_class(self.cfg)
-        self.assertFalse(hasattr(cls, "index_template_provider_class"))

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2362,26 +2362,8 @@ class IndexTemplateProviderTests(TestCase):
             assert t["settings"]["index"]["number_of_shards"] == _datastore_number_of_shards
             assert t["settings"]["index"]["number_of_replicas"] == _datastore_number_of_replicas
 
-    def test_datastore_type_in_memory_index_template_update(self):
+    def test_datastore_type_in_memory_no_index_template_provider(self):
         _datastore_type = "in-memory"
-        _datastore_number_of_shards = random.randint(1, 100)
-        _datastore_number_of_replicas = random.randint(1, 100)
-
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)
-        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_replicas", _datastore_number_of_replicas)
-
-        _index_template_provider = metrics.IndexTemplateProvider(self.cfg)
-
-        templates = [
-            _index_template_provider.metrics_template(),
-            _index_template_provider.races_template(),
-            _index_template_provider.results_template(),
-        ]
-
-        for template in templates:
-            t = json.loads(template)
-            assert t["settings"]["index"]["number_of_shards"] == 1
-            with self.assertRaises(KeyError):
-                # pylint: disable=pointless-statement
-                t["settings"]["index"]["number_of_replicas"]
+        cls = metrics.metrics_store_class(self.cfg)
+        self.assertFalse(hasattr(cls, "index_template_provider_class"))


### PR DESCRIPTION
With this commit we add the ability for users to specify the number of
primary and replica shard counts for `rally-*` indices when using a 
persistent metrics store through the configuration of `reporting` settings 
in `rally.ini`.

Closes https://github.com/elastic/rally/issues/1309
