### PR TITLE
Show race id in console

### DIFF
--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -339,7 +339,7 @@ def run(cfg):
     logger = logging.getLogger(__name__)
     name = cfg.opts("race", "pipeline")
     race_id = cfg.opts("system", "race.id")
-    logger.info("Race id [%s]", race_id)
+    console.info(f"Race id is [{race_id}]", logger=logger)
     if len(name) == 0:
         # assume from-distribution pipeline if distribution.version has been specified and --pipeline cli arg not set
         if cfg.exists("mechanic", "distribution.version"):


### PR DESCRIPTION
Users can retrieve details about a race from the metrics store or via
Rally subcommands via the race id. While we log the race id at the
beginning of a race such an important piece of information should be
more visible to users. Therefore, we print the race id also at the
beginning of a race to the console.