### PR TITLE
Update rally-* index template settings to default to Elasticsearch defaults 

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,8 +69,8 @@ The following settings are applicable only if ``datastore.type`` is set to "elas
 * ``datastore.user``: Sets the name of the Elasticsearch user for the metrics store.
 * ``datastore.password``: Sets the password of the Elasticsearch user for the metrics store.
 * ``datastore.probe.cluster_version`` (default: true): Enables automatic detection of the metric store's version.
-* ``datastore.number_of_shards`` (default: 1): The number of primary shards that the ``rally-*`` indices should have. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
-* ``datastore.number_of_replicas`` (default: 1): The number of replicas each primary shard has. Defaults to 1. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
+* ``datastore.number_of_shards`` (default: `Elasticsearch default value <https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#_static_index_settings>`_): The number of primary shards that the ``rally-*`` indices should have. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
+* ``datastore.number_of_replicas`` (default: `Elasticsearch default value <https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#_static_index_settings>`_): The number of replicas each primary shard has. Defaults to . Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
 
 **Examples**
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -70,7 +70,7 @@ The following settings are applicable only if ``datastore.type`` is set to "elas
 * ``datastore.password``: Sets the password of the Elasticsearch user for the metrics store.
 * ``datastore.probe.cluster_version`` (default: true): Enables automatic detection of the metric store's version.
 * ``datastore.number_of_shards`` (default: 1): The number of primary shards that the ``rally-*`` indices should have. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
-* ``datastore.number_of_replicas`` (default: 0): The number of replicas each primary shard has. Defaults to 0. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
+* ``datastore.number_of_replicas`` (default: 1): The number of replicas each primary shard has. Defaults to 1. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
 
 **Examples**
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -258,7 +258,7 @@ class IndexTemplateProvider:
                 if int(self._number_of_shards) < 1:
                     raise exceptions.SystemSetupError(
                         f"The setting: datastore.number_of_shards must be >= 1. Please "
-                        f"check the configuration in {self._config.config_file.location}/rally.ini"
+                        f"check the configuration in {self._config.config_file.location}"
                     )
                 template["settings"]["index"]["number_of_shards"] = int(self._number_of_shards)
             if self._number_of_replicas is not None:

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -255,9 +255,14 @@ class IndexTemplateProvider:
         with open("%s/resources/%s.json" % (self.script_dir, template_name), encoding="utf-8") as f:
             template = json.load(f)
             if self._number_of_shards is not None:
-                template["settings"]["index"]["number_of_shards"] = self._number_of_shards
+                if int(self._number_of_shards) < 1:
+                    raise exceptions.SystemSetupError(
+                        f"The setting: datastore.number_of_shards must be >= 1. Please "
+                        f"check the configuration in {paths.rally_confdir()}/rally.ini"
+                    )
+                template["settings"]["index"]["number_of_shards"] = int(self._number_of_shards)
             if self._number_of_replicas is not None:
-                template["settings"]["index"]["number_of_replicas"] = self._number_of_replicas
+                template["settings"]["index"]["number_of_replicas"] = int(self._number_of_replicas)
             return json.dumps(template)
 
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -238,8 +238,8 @@ class IndexTemplateProvider:
 
     def __init__(self, cfg):
         self._config = cfg
-        self._number_of_shards = self._config.opts("reporting", "datastore.number_of_shards", default_value=1, mandatory=False)
-        self._number_of_replicas = self._config.opts("reporting", "datastore.number_of_replicas", default_value=1, mandatory=False)
+        self._number_of_shards = self._config.opts("reporting", "datastore.number_of_shards", default_value=None, mandatory=False)
+        self._number_of_replicas = self._config.opts("reporting", "datastore.number_of_replicas", default_value=None, mandatory=False)
         self.script_dir = self._config.opts("node", "rally.root")
 
     def metrics_template(self):
@@ -254,8 +254,10 @@ class IndexTemplateProvider:
     def _read(self, template_name):
         with open("%s/resources/%s.json" % (self.script_dir, template_name), encoding="utf-8") as f:
             template = json.load(f)
-            template["settings"]["index"]["number_of_shards"] = self._number_of_shards
-            template["settings"]["index"]["number_of_replicas"] = self._number_of_replicas
+            if self._number_of_shards is not None:
+                template["settings"]["index"]["number_of_shards"] = self._number_of_shards
+            if self._number_of_replicas is not None:
+                template["settings"]["index"]["number_of_replicas"] = self._number_of_replicas
             return json.dumps(template)
 
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -258,7 +258,7 @@ class IndexTemplateProvider:
                 if int(self._number_of_shards) < 1:
                     raise exceptions.SystemSetupError(
                         f"The setting: datastore.number_of_shards must be >= 1. Please "
-                        f"check the configuration in {config.ConfigFile().location}/rally.ini"
+                        f"check the configuration in {self._config.config_file.location}/rally.ini"
                     )
                 template["settings"]["index"]["number_of_shards"] = int(self._number_of_shards)
             if self._number_of_replicas is not None:

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -239,7 +239,7 @@ class IndexTemplateProvider:
     def __init__(self, cfg):
         self._config = cfg
         self._number_of_shards = self._config.opts("reporting", "datastore.number_of_shards", default_value=1, mandatory=False)
-        self._number_of_replicas = self._config.opts("reporting", "datastore.number_of_replicas", default_value=0, mandatory=False)
+        self._number_of_replicas = self._config.opts("reporting", "datastore.number_of_replicas", default_value=1, mandatory=False)
         self.script_dir = self._config.opts("node", "rally.root")
 
     def metrics_template(self):

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -258,7 +258,7 @@ class IndexTemplateProvider:
                 if int(self._number_of_shards) < 1:
                     raise exceptions.SystemSetupError(
                         f"The setting: datastore.number_of_shards must be >= 1. Please "
-                        f"check the configuration in {paths.rally_confdir()}/rally.ini"
+                        f"check the configuration in {config.ConfigFile().location}/rally.ini"
                     )
                 template["settings"]["index"]["number_of_shards"] = int(self._number_of_shards)
             if self._number_of_replicas is not None:

--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -3,7 +3,8 @@
   "settings": {
     "index": {
       "refresh_interval": "5s",
-      "number_of_shards": 1
+      "number_of_shards": 1,
+      "number_of_replicas": 1
     }
   },
   "mappings": {

--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -2,9 +2,6 @@
   "index_patterns": ["rally-metrics-*"],
   "settings": {
     "index": {
-      "refresh_interval": "5s",
-      "number_of_shards": 1,
-      "number_of_replicas": 1
     }
   },
   "mappings": {

--- a/esrally/resources/races-template.json
+++ b/esrally/resources/races-template.json
@@ -2,8 +2,6 @@
   "index_patterns": ["rally-races-*"],
   "settings": {
     "index": {
-      "refresh_interval": "5s",
-      "number_of_shards": 1
     }
   },
   "mappings": {

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -2,8 +2,6 @@
   "index_patterns": ["rally-results-*"],
   "settings": {
     "index": {
-      "refresh_interval": "5s",
-      "number_of_shards": 1
     }
   },
   "mappings": {

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2343,7 +2343,7 @@ class IndexTemplateProviderTests(TestCase):
     def test_datastore_type_elasticsearch_index_template_update(self):
         _datastore_type = "elasticsearch"
         _datastore_number_of_shards = random.randint(1, 100)
-        _datastore_number_of_replicas = random.randint(1, 100)
+        _datastore_number_of_replicas = random.randint(0,100)
 
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2416,7 +2416,8 @@ class IndexTemplateProviderTests(TestCase):
 
         with self.assertRaisesRegex(
             expected_exception=exceptions.SystemSetupError,
-            expected_regex="The setting: datastore.number_of_shards must be >= 1. Please check the configuration in .*/rally.ini",
+            expected_regex=f"The setting: datastore.number_of_shards must be >= 1. Please check the configuration in "
+            f"{config.ConfigFile().location}/rally.ini",
         ):
             # pylint: disable=unused-variable
             templates = [

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2416,8 +2416,7 @@ class IndexTemplateProviderTests(TestCase):
 
         with self.assertRaisesRegex(
             expected_exception=exceptions.SystemSetupError,
-            expected_regex=f"The setting: datastore.number_of_shards must be >= 1. "
-            f"Please check the configuration in .*/rally.ini",
+            expected_regex="The setting: datastore.number_of_shards must be >= 1. Please check the configuration in .*/rally.ini",
         ):
             # pylint: disable=unused-variable
             templates = [

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2421,8 +2421,11 @@ class IndexTemplateProviderTests(TestCase):
                 _index_template_provider.races_template(),
                 _index_template_provider.results_template(),
             ]
-        self.assertEqual("The setting: datastore.number_of_shards must be >= 1. Please check the configuration in "
-                         f"{_index_template_provider._config.config_file.location}", ctx.exception.args[0])
+        self.assertEqual(
+            "The setting: datastore.number_of_shards must be >= 1. Please check the configuration in "
+            f"{_index_template_provider._config.config_file.location}",
+            ctx.exception.args[0],
+        )
 
     def test_primary_and_replica_shard_counts_passed_as_strings(self):
         _datastore_type = "elasticsearch"

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2414,17 +2414,15 @@ class IndexTemplateProviderTests(TestCase):
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)
         _index_template_provider = metrics.IndexTemplateProvider(self.cfg)
 
-        with self.assertRaisesRegex(
-            expected_exception=exceptions.SystemSetupError,
-            expected_regex=f"The setting: datastore.number_of_shards must be >= 1. Please check the configuration in "
-            f"{_index_template_provider._config.config_file.location}/rally.ini",
-        ):
+        with self.assertRaises(exceptions.SystemSetupError) as ctx:
             # pylint: disable=unused-variable
             templates = [
                 _index_template_provider.metrics_template(),
                 _index_template_provider.races_template(),
                 _index_template_provider.results_template(),
             ]
+        self.assertEqual("The setting: datastore.number_of_shards must be >= 1. Please check the configuration in "
+                         f"{_index_template_provider._config.config_file.location}", ctx.exception.args[0])
 
     def test_primary_and_replica_shard_counts_passed_as_strings(self):
         _datastore_type = "elasticsearch"

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2417,7 +2417,7 @@ class IndexTemplateProviderTests(TestCase):
         with self.assertRaisesRegex(
             expected_exception=exceptions.SystemSetupError,
             expected_regex=f"The setting: datastore.number_of_shards must be >= 1. "
-            f"Please check the configuration in {paths.rally_confdir()}/rally.ini",
+            f"Please check the configuration in .*/rally.ini",
         ):
             # pylint: disable=unused-variable
             templates = [

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2417,7 +2417,7 @@ class IndexTemplateProviderTests(TestCase):
         with self.assertRaisesRegex(
             expected_exception=exceptions.SystemSetupError,
             expected_regex=f"The setting: datastore.number_of_shards must be >= 1. Please check the configuration in "
-            f"{config.ConfigFile().location}/rally.ini",
+            f"{_index_template_provider._config.config_file.location}/rally.ini",
         ):
             # pylint: disable=unused-variable
             templates = [

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2343,7 +2343,7 @@ class IndexTemplateProviderTests(TestCase):
     def test_datastore_type_elasticsearch_index_template_update(self):
         _datastore_type = "elasticsearch"
         _datastore_number_of_shards = random.randint(1, 100)
-        _datastore_number_of_replicas = random.randint(0,100)
+        _datastore_number_of_replicas = random.randint(0, 100)
 
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.type", _datastore_type)
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)


### PR DESCRIPTION
~~In https://github.com/elastic/rally/issues/1309 we added
configurable shard and replica shard counts to `rally.ini`.
In that commit, the default number of replicas was set to 0,
which is trappy given that Elasticsearch defaults to 1 replica.~~

~~This commit changes the default behaviour to add 1 replica to
the `rally-*` indices by default.~~

See comment: https://github.com/elastic/rally/pull/1312#issuecomment-899177300