### PR TITLE
Fix load track behavior on multiple load driver machines

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -142,6 +142,7 @@ class StartWorker:
     def __init__(self, worker_id, config, track, client_allocations):
         """
         :param worker_id: Unique (numeric) id of the worker.
+        :param config: Rally internal configuration object.
         :param track: The track to use.
         :param client_allocations: A structure describing which clients need to run which tasks.
         """

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -464,7 +464,6 @@ class TrackPreparationActor(actor.RallyActor):
 
     @actor.no_retry("track preparator")  # pylint: disable=no-value-for-parameter
     def receiveMsg_RallyConfig(self, msg, sender):
-        self.logger.info(f"Track Preparator received config object {msg.config}")
         # load node-specific config to have correct paths available
         self.cfg = load_local_config(msg.config)
         load_track(self.cfg)

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -71,9 +71,9 @@ class StartBenchmark:
     pass
 
 
-class RallyConfig:
+class Bootstrap:
     """
-    Prompts loading of a track
+    Prompts loading of track code on new actors
     """
 
     def __init__(self, cfg):
@@ -301,7 +301,7 @@ class DriverActor(actor.RallyActor):
 
     def create_client(self, host, cfg):
         worker = self.createActor(Worker, targetActorRequirements=self._requirements(host))
-        self.send(worker, RallyConfig(cfg))
+        self.send(worker, Bootstrap(cfg))
         return worker
 
     def start_worker(self, driver, worker_id, cfg, track, allocations):
@@ -330,7 +330,7 @@ class DriverActor(actor.RallyActor):
         self.track = track
         self.logger.info("Starting prepare track process on hosts [%s]", hosts)
         self.children = [self._create_track_preparator(h) for h in hosts]
-        msg = RallyConfig(cfg)
+        msg = Bootstrap(cfg)
         for child in self.children:
             self.send(child, msg)
 
@@ -465,7 +465,7 @@ class TrackPreparationActor(actor.RallyActor):
         self.send(self.original_sender, actor.BenchmarkFailure("Fatal track preparation indication", poisonmsg.details))
 
     @actor.no_retry("track preparator")  # pylint: disable=no-value-for-parameter
-    def receiveMsg_RallyConfig(self, msg, sender):
+    def receiveMsg_Bootstrap(self, msg, sender):
         # load node-specific config to have correct paths available
         self.cfg = load_local_config(msg.config)
         load_track(self.cfg)

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -263,9 +263,7 @@ class DriverActor(actor.RallyActor):
     @actor.no_retry("driver")  # pylint: disable=no-value-for-parameter
     def receiveMsg_PrepareBenchmark(self, msg, sender):
         self.start_sender = sender
-        self.config = load_local_config(msg.config)
-        load_track(self.config)
-        self.coordinator = Driver(self, self.config)
+        self.coordinator = Driver(self, msg.config)
         self.coordinator.prepare_benchmark(msg.track)
 
     @actor.no_retry("driver")  # pylint: disable=no-value-for-parameter
@@ -1117,6 +1115,11 @@ class Worker(actor.RallyActor):
         self.start_driving = False
         self.wakeup_interval = Worker.WAKEUP_INTERVAL_SECONDS
         self.sample_queue_size = None
+
+    @actor.no_retry("worker")  # pylint: disable=no-value-for-parameter
+    def receiveMsg_RallyConfig(self, msg, sender):
+        self.config = load_local_config(msg.config)
+        load_track(self.config)
 
     @actor.no_retry("worker")  # pylint: disable=no-value-for-parameter
     def receiveMsg_StartWorker(self, msg, sender):

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -75,6 +75,7 @@ class RallyConfig:
     """
     Prompts loading of a track
     """
+
     def __init__(self, cfg):
         self.config = cfg
 

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -300,6 +300,7 @@ class DriverActor(actor.RallyActor):
     def create_client(self, host, cfg):
         worker = self.createActor(Worker, targetActorRequirements=self._requirements(host))
         self.send(worker, RallyConfig(cfg))
+        return worker
 
     def start_worker(self, driver, worker_id, cfg, track, allocations):
         self.send(driver, StartWorker(worker_id, cfg, track, allocations))

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -262,7 +262,9 @@ class DriverActor(actor.RallyActor):
     @actor.no_retry("driver")  # pylint: disable=no-value-for-parameter
     def receiveMsg_PrepareBenchmark(self, msg, sender):
         self.start_sender = sender
-        self.coordinator = Driver(self, msg.config)
+        self.config = load_local_config(msg.config)
+        load_track(self.config)
+        self.coordinator = Driver(self, self.config)
         self.coordinator.prepare_benchmark(msg.track)
 
     @actor.no_retry("driver")  # pylint: disable=no-value-for-parameter
@@ -1114,11 +1116,6 @@ class Worker(actor.RallyActor):
         self.start_driving = False
         self.wakeup_interval = Worker.WAKEUP_INTERVAL_SECONDS
         self.sample_queue_size = None
-
-    @actor.no_retry("worker")  # pylint: disable=no-value-for-parameter
-    def receiveMsg_RallyConfig(self, msg, sender):
-        self.config = load_local_config(msg.config)
-        load_track(self.config)
 
     @actor.no_retry("worker")  # pylint: disable=no-value-for-parameter
     def receiveMsg_StartWorker(self, msg, sender):

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1115,7 +1115,7 @@ class Worker(actor.RallyActor):
         self.sample_queue_size = None
 
     @actor.no_retry("worker")  # pylint: disable=no-value-for-parameter
-    def receiveMsg_RallyConfig(self, msg):
+    def receiveMsg_RallyConfig(self, msg, sender):
         self.config = load_local_config(msg.config)
 
     @actor.no_retry("worker")  # pylint: disable=no-value-for-parameter

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -145,6 +145,7 @@ class StartWorker:
         :param client_allocations: A structure describing which clients need to run which tasks.
         """
         self.worker_id = worker_id
+        self.config = config
         self.track = track
         self.client_allocations = client_allocations
 
@@ -1122,6 +1123,7 @@ class Worker(actor.RallyActor):
         self.logger.info("Worker[%d] is about to start.", msg.worker_id)
         self.master = sender
         self.worker_id = msg.worker_id
+        self.config = load_local_config(msg.config)
         self.on_error = self.config.opts("driver", "on.error")
         self.sample_queue_size = int(self.config.opts("reporting", "sample.queue.size", mandatory=False, default_value=1 << 20))
         self.track = msg.track

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1118,7 +1118,7 @@ class Worker(actor.RallyActor):
     @actor.no_retry("worker")  # pylint: disable=no-value-for-parameter
     def receiveMsg_RallyConfig(self, msg, sender):
         self.config = load_local_config(msg.config)
-        load_track(self.cfg)
+        load_track(self.config)
 
     @actor.no_retry("worker")  # pylint: disable=no-value-for-parameter
     def receiveMsg_StartWorker(self, msg, sender):

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -320,7 +320,9 @@ class GitTrackRepository:
         self.repo = repo_class(remote_url, tracks_dir, repo_name, "tracks", offline, fetch)
         if update:
             if repo_revision:
-                self.repo.checkout(repo_revision)
+                # skip checkout if already on correct version.  this is helpful in case of multiple actors loading simultaneously.
+                if not self.repo.correct_revision(repo_revision):
+                    self.repo.checkout(repo_revision)
             else:
                 self.repo.update(distribution_version)
                 cfg.add(config.Scope.applicationOverride, "track", "repository.revision", self.repo.revision)

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -124,3 +124,7 @@ class RallyRepository:
     def checkout(self, revision):
         self.logger.info("Checking out revision [%s] in [%s].", revision, self.repo_dir)
         git.checkout(self.repo_dir, revision)
+
+    def correct_revision(self, revision):
+        self.logger.debug(f"Checking whether [{self.repo_dir}] is on revision [{revision}]")
+        return git.current_branch(self.repo_dir) == revision

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -126,6 +126,4 @@ class RallyRepository:
         git.checkout(self.repo_dir, revision)
 
     def correct_revision(self, revision):
-        self.logger.info(f"Checking whether [{self.repo_dir}] is on revision [{revision}]")
-        self.logger.info(f"{git.head_revision(self.repo_dir)} == {revision}")
         return git.head_revision(self.repo_dir) == revision

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -127,5 +127,5 @@ class RallyRepository:
 
     def correct_revision(self, revision):
         self.logger.info(f"Checking whether [{self.repo_dir}] is on revision [{revision}]")
-        self.logger.info(f"{git.current_branch(self.repo_dir)} == {revision}")
-        return git.current_branch(self.repo_dir) == revision
+        self.logger.info(f"{git.head_revision(self.repo_dir)} == {revision}")
+        return git.head_revision(self.repo_dir) == revision

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -126,5 +126,6 @@ class RallyRepository:
         git.checkout(self.repo_dir, revision)
 
     def correct_revision(self, revision):
-        self.logger.debug(f"Checking whether [{self.repo_dir}] is on revision [{revision}]")
+        self.logger.info(f"Checking whether [{self.repo_dir}] is on revision [{revision}]")
+        self.logger.info(f"{git.current_branch(self.repo_dir)} == {revision}")
         return git.current_branch(self.repo_dir) == revision

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -135,10 +135,10 @@ class DriverTests(TestCase):
 
         target.create_client.assert_has_calls(
             calls=[
-                mock.call("10.5.5.1"),
-                mock.call("10.5.5.1"),
-                mock.call("10.5.5.2"),
-                mock.call("10.5.5.2"),
+                mock.call("10.5.5.1", d.config),
+                mock.call("10.5.5.1", d.config),
+                mock.call("10.5.5.2", d.config),
+                mock.call("10.5.5.2", d.config),
             ]
         )
 
@@ -157,10 +157,10 @@ class DriverTests(TestCase):
 
         target.create_client.assert_has_calls(
             calls=[
-                mock.call("localhost"),
-                mock.call("localhost"),
-                mock.call("localhost"),
-                mock.call("localhost"),
+                mock.call("localhost", d.config),
+                mock.call("localhost", d.config),
+                mock.call("localhost", d.config),
+                mock.call("localhost", d.config),
             ]
         )
 


### PR DESCRIPTION
This commit fixes #1206 by causing the TrackPreparationActor and the Driver actor to register the local track repository/code prior to attempting to receive the loaded track as a serialized message.