### PR TITLE
Fix num of docs in -1k generated corpus

### DIFF
--- a/esrally/tracker/corpus.py
+++ b/esrally/tracker/corpus.py
@@ -81,7 +81,7 @@ def dump_documents(client, index, out_path, total_docs, progress_message_suffix=
             logger.info("Dumping corpus for index [%s] to [%s].", index, out_path)
             query = {"query": {"match_all": {}}}
             for n, doc in enumerate(helpers.scan(client, query=query, index=index)):
-                if n > total_docs:
+                if n >= total_docs:
                     break
                 data = (json.dumps(doc["_source"], separators=(",", ":")) + "\n").encode("utf-8")
 


### PR DESCRIPTION
Fix number of docs in -1k file generated by the create-track
subcommand.

Closes #1317
