### PR TITLE
Add support for listing nested tracks

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -329,7 +329,13 @@ class GitTrackRepository:
 
     @property
     def track_names(self):
-        return filter(lambda p: os.path.exists(self.track_file(p)), next(os.walk(self.repo.repo_dir))[1])
+        retval = []
+        # + 1 to capture trailing slash
+        fully_qualified_path_length = len(self.repo.repo_dir) + 1
+        for root_dir, _, files in os.walk(self.repo.repo_dir):
+            if "track.json" in files:
+                retval.append(root_dir[fully_qualified_path_length:])
+        return retval
 
     def track_dir(self, track_name):
         return os.path.join(self.repo.repo_dir, track_name)

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -135,13 +135,16 @@ class GitRepositoryTests(TestCase):
             src/
                 utils.py
         """
-        walk.return_value = iter([("/tmp/tracks/default", ["unittest", "unittest2", "unittest3", "src"], []),
-                                  ("/tmp/tracks/default/unittest", [], ["track.json"]),
-                                  ("/tmp/tracks/default/unittest2", [], ["track.json"]),
-                                  ("/tmp/tracks/default/unittest3", ["nested"], ["track.json"]),
-                                  ("/tmp/tracks/default/unittest3/nested", [], ["track.json"]),
-                                  ("/tmp/tracks/src", [], ["utils.py"]),
-                                  ])
+        walk.return_value = iter(
+            [
+                ("/tmp/tracks/default", ["unittest", "unittest2", "unittest3", "src"], []),
+                ("/tmp/tracks/default/unittest", [], ["track.json"]),
+                ("/tmp/tracks/default/unittest2", [], ["track.json"]),
+                ("/tmp/tracks/default/unittest3", ["nested"], ["track.json"]),
+                ("/tmp/tracks/default/unittest3/nested", [], ["track.json"]),
+                ("/tmp/tracks/src", [], ["utils.py"]),
+            ]
+        )
         exists.return_value = True
         cfg = config.Config()
         cfg.add(config.Scope.application, "track", "track.name", "unittest")


### PR DESCRIPTION
with this commit we add support for listing nested tracks in git-based track repositories.  Previously, `esrally list tracks` would only list top-level directories in a target track repo which contained a `track.json`.  This change causes full recursive search in the track repository, to better support the idea of "nested" track structures.

Fixes #1086 