### PR TITLE
remove coverage dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,6 @@ check-all: lint test it
 benchmark: check-venv
 	. $(VENV_ACTIVATE_FILE); pytest benchmarks/
 
-coverage: check-venv
-	. $(VENV_ACTIVATE_FILE); coverage run setup.py test
-	. $(VENV_ACTIVATE_FILE); coverage html
-
 release-checks: check-venv
 	. $(VENV_ACTIVATE_FILE); ./release-checks.sh $(release_version) $(next_version)
 
@@ -131,4 +127,4 @@ release-checks: check-venv
 release: check-venv release-checks clean docs it
 	. $(VENV_ACTIVATE_FILE); ./release.sh $(release_version) $(next_version)
 
-.PHONY: install clean nondocs-clean docs-clean python-caches-clean tox-env-clean docs serve-docs test it it38 benchmark coverage release release-checks prereq venv-create check-env
+.PHONY: install clean nondocs-clean docs-clean python-caches-clean tox-env-clean docs serve-docs test it it38 benchmark release release-checks prereq venv-create check-env

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ tests_require = [
 # These packages are only required when developing Rally
 develop_require = [
     "tox==3.14.0",
-    "coverage==4.5.4",
     "sphinx==2.2.0",
     "sphinx_rtd_theme==0.5.1",
     "twine==1.15.0",


### PR DESCRIPTION
This commit removes the rarely used `coverage` dependency from Rally, perhaps to be re-introduced at a later date