### PR TITLE
pin setuptools and wheel versions to working point-in-time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ check-venv:
 	fi
 
 install-user: venv-create
-	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install --upgrade pip setuptools==58.0.1 wheel=0.37.0
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install --upgrade pip setuptools==58.0.1 wheel==0.37.0
 	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .
 
 install: install-user

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ check-venv:
 	fi
 
 install-user: venv-create
-	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install --upgrade pip setuptools wheel
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install --upgrade pip setuptools==58.0.1 wheel=0.37.0
 	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .
 
 install: install-user


### PR DESCRIPTION
We encountered a breaking change by going with latest setuptools in our CI.  This commit pins the version of setuptools to the last known functioning version.

We should take this approach or the approach in #1321, and close the other.