### PR TITLE
Document how to use stat on GNU/Linux too

### DIFF
--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -209,7 +209,7 @@ Finally, store the track as ``track.json`` in the tutorial directory::
     }
 
 
-The numbers under the ``documents`` property are needed to verify integrity and provide progress reports. Determine the correct document count with ``wc -l documents.json`` and the size in bytes with ``stat -f "%z" documents.json``.
+The numbers under the ``documents`` property are needed to verify integrity and provide progress reports. Determine the correct document count with ``wc -l documents.json``. For the size in bytes, use ``stat -f %z documents.json`` on macOS and ``stat -c %s documents.json`` on GNU/Linux.
 
 .. note::
    This tutorial assumes that you want to benchmark a version of Elasticsearch prior to 7.0.0. If you want to benchmark Elasticsearch 7.0.0 or later you need to remove the ``types`` property above.


### PR DESCRIPTION
stat(1) is not standardized.