### PR TITLE
Add master node telemetry device

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -30,6 +30,7 @@ You probably want to gain additional insights from a race. Therefore, we have ad
    searchable-snapshots-stats  Searchable Snapshots Stats  Regularly samples searchable snapshots stats
    shard-stats                 Shard Stats                 Regularly samples nodes stats at shard level
    data-stream-stats           Data Streams Stats          Regularly samples data streams stats
+   master-node-stats           Master Node Stats           Regularly determines the current master node name
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 
@@ -227,3 +228,19 @@ Example of recorded documents given two data streams in the cluster::
 Supported telemetry parameters:
 
 * ``data-stream-stats-sample-interval`` (default 10): A positive number greater than zero denoting the sampling interval in seconds.
+
+
+master-node-stats
+-----------------
+
+The master-node-stats telemetry device regularly reports the name of the master node by using:
+
+ 1. the `Cluster State API <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-state.html>`_, specifically `/_cluster/state/master_node` to determine the id of the master node
+ 2. the `Nodes info API <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html>`_ to determine its name
+
+Example of recorded document::
+
+   {
+     "name": "master-node-stats",
+     "node": "rally-0"
+   }

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -227,19 +227,3 @@ Example of recorded documents given two data streams in the cluster::
 Supported telemetry parameters:
 
 * ``data-stream-stats-sample-interval`` (default 10): A positive number greater than zero denoting the sampling interval in seconds.
-
-
-master-node-stats
------------------
-
-The master-node-stats telemetry device regularly reports the name of the master node by using:
-
- 1. the `Cluster State API <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-state.html>`_, specifically `/_cluster/state/master_node` to determine the id of the master node
- 2. the `Nodes info API <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html>`_ to determine its name
-
-Example of recorded document::
-
-   {
-     "name": "master-node-stats",
-     "node": "rally-0"
-   }

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -30,7 +30,6 @@ You probably want to gain additional insights from a race. Therefore, we have ad
    searchable-snapshots-stats  Searchable Snapshots Stats  Regularly samples searchable snapshots stats
    shard-stats                 Shard Stats                 Regularly samples nodes stats at shard level
    data-stream-stats           Data Streams Stats          Regularly samples data streams stats
-   master-node-stats           Master Node Stats           Regularly determines the current master node name
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -610,6 +610,7 @@ class Driver:
                 telemetry.TransformStats(telemetry_params, es, self.metrics_store),
                 telemetry.SearchableSnapshotsStats(telemetry_params, es, self.metrics_store),
                 telemetry.DataStreamStats(telemetry_params, es, self.metrics_store),
+                telemetry.MasterNodeStats(telemetry_params, es, self.metrics_store),
             ]
         else:
             devices = []

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -610,7 +610,7 @@ class Driver:
                 telemetry.TransformStats(telemetry_params, es, self.metrics_store),
                 telemetry.SearchableSnapshotsStats(telemetry_params, es, self.metrics_store),
                 telemetry.DataStreamStats(telemetry_params, es, self.metrics_store),
-                telemetry.MasterNodeStats(telemetry_params, es, self.metrics_store),
+                telemetry.MasterNodeStats(telemetry_params, es_default, self.metrics_store),
             ]
         else:
             devices = []

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -603,6 +603,7 @@ class Driver:
                 telemetry.JvmStatsSummary(es_default, self.metrics_store),
                 telemetry.IndexStats(es_default, self.metrics_store),
                 telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
+                telemetry.MasterNodeStats(telemetry_params, es_default, self.metrics_store),
                 telemetry.SegmentStats(log_root, es_default),
                 telemetry.CcrStats(telemetry_params, es, self.metrics_store),
                 telemetry.RecoveryStats(telemetry_params, es, self.metrics_store),
@@ -610,7 +611,6 @@ class Driver:
                 telemetry.TransformStats(telemetry_params, es, self.metrics_store),
                 telemetry.SearchableSnapshotsStats(telemetry_params, es, self.metrics_store),
                 telemetry.DataStreamStats(telemetry_params, es, self.metrics_store),
-                telemetry.MasterNodeStats(telemetry_params, es_default, self.metrics_store),
             ]
         else:
             devices = []

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1969,7 +1969,6 @@ class MasterNodeStats(TelemetryDevice):
                 self.metrics_store,
                 self.sample_interval,
             )
-            recorder.record()
             sampler = SamplerThread(recorder)
             self.samplers.append(sampler)
             sampler.daemon = True
@@ -1979,7 +1978,6 @@ class MasterNodeStats(TelemetryDevice):
     def on_benchmark_stop(self):
         if self.samplers:
             for sampler in self.samplers:
-                sampler.recorder.record()
                 sampler.finish()
 
 

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -46,7 +46,6 @@ def list_telemetry():
             SearchableSnapshotsStats,
             ShardStats,
             DataStreamStats,
-            MasterNodeStats,
         ]
     ]
     console.println(tabulate.tabulate(devices, ["Command", "Name", "Description"]))
@@ -1929,12 +1928,11 @@ class IndexSize(InternalTelemetryDevice):
             metrics_store.put_value_node_level(node.node_name, "final_index_size_bytes", self.index_size_bytes, "byte")
 
 
-class MasterNodeStats(TelemetryDevice):
+class MasterNodeStats(InternalTelemetryDevice):
     """
     Collects and pushes the current master node name to the metric store.
     """
 
-    internal = False
     command = "master-node-stats"
     human_name = "Master Node Stats"
     help = "Regularly samples master node name"

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -2013,8 +2013,7 @@ class MasterNodeStatsRecorder:
         import elasticsearch
 
         try:
-            state = self.client.cluster.state(metric="master_node")
-            info = self.client.nodes.info(node_id=state["master_node"], metric="os")
+            info = self.client.cat.master(format="json")
         except elasticsearch.TransportError:
             msg = f"A transport error occurred while collecting master node stats on cluster [{self.cluster_name}]"
             self.logger.exception(msg)
@@ -2024,7 +2023,7 @@ class MasterNodeStatsRecorder:
 
         doc = {
             "name": "master-node-stats",
-            "node": info["nodes"][state["master_node"]]["name"],
+            "node": info[0]["node"],
         }
 
         self.metrics_store.put_doc(doc, level=MetaInfoScope.cluster, meta_data=master_node_metadata)

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -77,6 +77,7 @@ class DriverTests(TestCase):
             DriverTests.StaticClientFactory.PATCHER = mock.patch("elasticsearch.Elasticsearch")
             self.es = DriverTests.StaticClientFactory.PATCHER.start()
             self.es.indices.stats.return_value = {"mocked": True}
+            self.es.cat.master.return_value = {"mocked": True}
 
         def create(self):
             return self.es

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -3673,7 +3673,6 @@ class IndexSizeTests(TestCase):
 
 class MasterNodeStatsTests(TestCase):
     def test_negative_sample_interval_forbidden(self):
-        clients = {"default": Client(), "cluster_b": Client()}
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {"master-node-stats-sample-interval": -1}
@@ -3681,7 +3680,7 @@ class MasterNodeStatsTests(TestCase):
             exceptions.SystemSetupError,
             r"The telemetry parameter 'master-node-stats-sample-interval' must be greater than zero but was .*\.",
         ):
-            telemetry.MasterNodeStats(telemetry_params, clients, metrics_store)
+            telemetry.MasterNodeStats(telemetry_params, Client(), metrics_store)
 
 
 class MasterNodeStatsRecorderTests(TestCase):
@@ -3696,10 +3695,8 @@ class MasterNodeStatsRecorderTests(TestCase):
         client = Client(cat=SubClient(master=self.master_node_cat_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        recorder = telemetry.MasterNodeStatsRecorder(cluster_name="remote", client=client, metrics_store=metrics_store, sample_interval=1)
+        recorder = telemetry.MasterNodeStatsRecorder(client=client, metrics_store=metrics_store, sample_interval=1)
         recorder.record()
-
-        master_node_metadata = {"cluster": "remote"}
 
         metrics_store_put_doc.assert_has_calls(
             [
@@ -3709,7 +3706,6 @@ class MasterNodeStatsRecorderTests(TestCase):
                         "node": "rally-0",
                     },
                     level=MetaInfoScope.cluster,
-                    meta_data=master_node_metadata,
                 ),
             ],
         )


### PR DESCRIPTION
When running benchmarks on clusters with multiple nodes, the master node
could perform worse due to the additional responsibilities it needs to
handle.

To identify this, we add a telemetry device to record the master node.
We don't expect this to change during a typical benchmark, which is why
the default sample interval is 30s. To compensate this large sample
interval, we also record that information on benchmark start/end.

I tested this feature with a short sample interval in test mode, checking that the information was indeed recorded in the test store:

```
esrally race --distribution-version=7.14.1 --car="4gheap" --track=geonames --test-mode --telemetry master-node-stats --telemetry-params="master-node-stats-sample-interval: 0.1"
http localhost:9200/rally-metrics-2021-09/_search\?size=1000 | jq . | grep master-node -c 
```

TODO:

- [x] #1324 mentioned that this device should be always on, how can I do that?
- [x] Is it OK to use those APIs to retrieve the information, or should we revert to the cat API which is much less verbose? (Thanks @b-deam for the help on this!)
- [x] I recorded the master at the start and end of a benchmark, is that OK?
- [x] Fix CI