### PR TITLE
Remove noisy python-caches-clean output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,8 @@ docs-clean:
 
 # Avoid conflicts between .pyc/pycache related files created by local Python interpreters and other interpreters in Docker
 python-caches-clean:
-	-@find . -name "__pycache__" -exec rm -rf -- \{\} \;
-	-@find . -name ".pyc" -exec rm -rf -- \{\} \;
+	-@find . -name "__pycache__" -prune -exec rm -rf -- \{\} \;
+	-@find . -name ".pyc" -exec -prune rm -rf -- \{\} \;
 
 # Force recreation of the virtual environment used by tox.
 #


### PR DESCRIPTION
Without `-prune`, find tries to recurse into the `__pycache__`
directories just after their deletion but fails.

This will avoid hundreds of lines of unnecessary output in jobs like https://elasticsearch-ci.elastic.co/job/elastic+rally+pull-request/285/consoleFull.