### PR TITLE
Check benchmark stop at least every second in SamplerThread

### DIFF
--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -164,9 +164,21 @@ class Sampler:
     def run(self):
         # noinspection PyBroadException
         try:
-            while not self.stop:
-                self.recorder.record()
-                self.sleep(self.recorder.sample_interval)
+            sleep_left = self.recorder.sample_interval
+            while True:
+                if sleep_left <= 0:
+                    self.recorder.record()
+                    sleep_left = self.recorder.sample_interval
+
+                if self.stop:
+                    break
+
+                sleep_seconds = sleep_left
+                if sleep_left >= 1:
+                    sleep_seconds = 1
+
+                self.sleep(sleep_seconds)
+                sleep_left -= sleep_seconds
         except BaseException:
             logging.getLogger(__name__).exception("Could not determine %s", self.recorder)
 

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -172,11 +172,8 @@ class Sampler:
 
                 if self.stop:
                     break
-
-                sleep_seconds = sleep_left
-                if sleep_left >= 1:
-                    sleep_seconds = 1
-
+                # check for self.stop at least every second
+                sleep_seconds = min(sleep_left, 1)
                 self.sleep(sleep_seconds)
                 sleep_left -= sleep_seconds
         except BaseException:

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -150,24 +150,35 @@ class InternalTelemetryDevice(TelemetryDevice):
     internal = True
 
 
-class SamplerThread(threading.Thread):
-    def __init__(self, recorder):
-        threading.Thread.__init__(self)
+class Sampler:
+    """This class contains the actual logic of SamplerThread for unit test purposes."""
+
+    def __init__(self, recorder, *, sleep=time.sleep):
         self.stop = False
         self.recorder = recorder
+        self.sleep = sleep
 
     def finish(self):
         self.stop = True
-        self.join()
 
     def run(self):
         # noinspection PyBroadException
         try:
             while not self.stop:
                 self.recorder.record()
-                time.sleep(self.recorder.sample_interval)
+                self.sleep(self.recorder.sample_interval)
         except BaseException:
             logging.getLogger(__name__).exception("Could not determine %s", self.recorder)
+
+
+class SamplerThread(Sampler, threading.Thread):
+    def __init__(self, recorder):
+        threading.Thread.__init__(self)
+        Sampler.__init__(self, recorder)
+
+    def finish(self):
+        super().finish()
+        self.join()
 
 
 class FlightRecorder(TelemetryDevice):

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -58,8 +58,8 @@ class TestSamplerThread:
         sampler = telemetry.Sampler(recorder, sleep=record_sleep)
         sampler.run()
 
-        assert sleep_record == [10, 10, 10]
-        assert recorder.record.call_count == 3
+        assert sleep_record == [1] * 21
+        assert recorder.record.call_count == 2
 
     def test_sampler_sleep_short_interval(self):
         time_left = 1.5


### PR DESCRIPTION
The first commit does not change the logic, but extracts it and tests it. The second commit introduces the actual fix. See the issue for test instructions.

Closes #1334 