### PR TITLE
pin pip, setuptools, and wheel versions

### DIFF
--- a/.ci/variables.json
+++ b/.ci/variables.json
@@ -1,4 +1,9 @@
 {
+  "prerequisite_versions": {
+    "PIP": "21.2.4",
+    "SETUPTOOLS": "58.0.4",
+    "WHEEL": "0.37.0"
+  },
   "python_versions": {
     "PY38": "3.8.10",
     "PY39": "3.9.2",

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ PY_BIN = python3
 PIP_WRAPPER = $(PY_BIN) -m pip
 export PY38 = $(shell jq -r '.python_versions.PY38' .ci/variables.json)
 export PY39 = $(shell jq -r '.python_versions.PY39' .ci/variables.json)
+export PIP_VERSION = $(shell jq -r '.prerequisite_versions.PIP' .ci/variables.json)
+export SETUPTOOLS_VERSION = $(shell jq -r '.prerequisite_versions.SETUPTOOLS' .ci/variables.json)
+export WHEEL_VERSION = $(shell jq -r '.prerequisite_versions.WHEEL' .ci/variables.json)
 VENV_NAME ?= .venv
 VENV_ACTIVATE_FILE = $(VENV_NAME)/bin/activate
 VENV_ACTIVATE = . $(VENV_ACTIVATE_FILE)
@@ -56,7 +59,7 @@ check-venv:
 	fi
 
 install-user: venv-create
-	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install --upgrade pip setuptools wheel
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install --upgrade pip==$(PIP_VERSION) setuptools==$(SETUPTOOLS_VERSION) wheel==$(WHEEL_VERSION)
 	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .
 
 install: install-user


### PR DESCRIPTION
with this commit we add fixed pip, setuptools, and wheel version numbers instead of always upgrading to latest.  resolves #1323 
