### PR TITLE
expose more diagnostic info in console when an actor throws an exception

### DIFF
--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -96,7 +96,7 @@ def no_retry(f, actor_name):
             return f(self, msg, sender)
         except BaseException as e:
             # log here as the full trace might get lost.
-            logging.getLogger(__name__).exception(f"Error in {actor_name}")
+            logging.getLogger(__name__).exception("Error in %s", actor_name)
             # don't forward the exception as is because the main process might not have this class available on the load path
             # and will fail then while deserializing the cause.
             parsed_exception = _format_exception(e)

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -87,9 +87,10 @@ def no_retry(f, actor_name):
     """
 
     def guard(self, msg, sender):
+        # noinspection PyBroadException
         try:
             return f(self, msg, sender)
-        except BaseException as e:
+        except BaseException:
             # log here as the full trace might get lost.
             logging.getLogger(__name__).exception("Error in %s", actor_name)
             # don't forward the exception as is because the main process might not have this class available on the load path

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -86,10 +86,9 @@ def no_retry(f, actor_name):
     """
 
     def _format_exception(e):
-        if hasattr(e, "message"):
-            return f"{type(e).__name__}: {e.message}"
-        else:
-            return str(e)
+        clazz = type(e)
+        message = getattr(e, "message", lambda: e)
+        return f"{'.'.join([clazz.__module__, clazz.__name__])}: {message}"
 
     def guard(self, msg, sender):
         try:

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -95,8 +95,7 @@ def no_retry(f, actor_name):
             logging.getLogger(__name__).exception("Error in %s", actor_name)
             # don't forward the exception as is because the main process might not have this class available on the load path
             # and will fail then while deserializing the cause.
-            parsed_exception = traceback.format_exc()
-            self.send(sender, BenchmarkFailure(parsed_exception))
+            self.send(sender, BenchmarkFailure(traceback.format_exc()))
 
     return guard
 

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1004,7 +1004,6 @@ class TrackFileReader:
         except Exception as e:
             self.logger.exception("Could not load [%s].", track_spec_file)
             msg = "Could not load '{}'. The complete track has been written to '{}' for diagnosis.".format(track_spec_file, tmp.name)
-            # Convert to string early on to avoid serialization errors with Jinja exceptions.
             raise TrackSyntaxError(msg, e)
         # check the track version before even attempting to validate the JSON format to avoid bogus errors.
         raw_version = track_spec.get("version", TrackFileReader.MAXIMUM_SUPPORTED_TRACK_VERSION)

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1005,7 +1005,7 @@ class TrackFileReader:
             self.logger.exception("Could not load [%s].", track_spec_file)
             msg = "Could not load '{}'. The complete track has been written to '{}' for diagnosis.".format(track_spec_file, tmp.name)
             # Convert to string early on to avoid serialization errors with Jinja exceptions.
-            raise TrackSyntaxError(msg, str(e))
+            raise TrackSyntaxError(msg, e)
         # check the track version before even attempting to validate the JSON format to avoid bogus errors.
         raw_version = track_spec.get("version", TrackFileReader.MAXIMUM_SUPPORTED_TRACK_VERSION)
         try:

--- a/esrally/utils/modules.py
+++ b/esrally/utils/modules.py
@@ -52,7 +52,7 @@ class ComponentLoader:
         for path in module_paths:
             for filename in os.listdir(path):
                 name, ext = os.path.splitext(filename)
-                if ext.endswith(".py") and name != "__init__":
+                if ext.endswith(".py"):
                     root_relative_path = os.path.join(path, name)[len(self.root_path) + len(os.path.sep) :]
                     module_name = "%s.%s" % (component_name, root_relative_path.replace(os.path.sep, "."))
                     yield module_name

--- a/esrally/utils/modules.py
+++ b/esrally/utils/modules.py
@@ -52,7 +52,7 @@ class ComponentLoader:
         for path in module_paths:
             for filename in os.listdir(path):
                 name, ext = os.path.splitext(filename)
-                if ext.endswith(".py"):
+                if ext.endswith(".py") and name != "__init__":
                     root_relative_path = os.path.join(path, name)[len(self.root_path) + len(os.path.sep) :]
                     module_name = "%s.%s" % (component_name, root_relative_path.replace(os.path.sep, "."))
                     yield module_name


### PR DESCRIPTION
Resolves #1187 

With this commit, we expose more information to the console to help troubleshoot a failed command.  For example, if one changes `runtime_fields` to `runtime-fields` in https://github.com/elastic/rally-tracks/blob/master/http_logs/track.json#L48, a Jinja error occurs.  Previously, the console output would look like this:

```
 % esrally race --track-path ../rally-tracks/http_logs --test-mode

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/

[INFO] Race id is [51e50d00-8d63-4ee6-9c5c-2f8757871a82]
[ERROR] Cannot race. Error in race control (Could not load '/Users/rick.boyd/dev/rally-tracks/http_logs/track.json'. The complete track has been written to '/var/folders/_j/86s8k_jd4md2k6ch_290_0mr0000gn/T/tmpippzkj_l.json' for diagnosis.)

Getting further help:
*********************
* Check the log files in /Users/rick.boyd/.rally/logs for errors.
* Read the documentation at https://esrally.readthedocs.io/en/latest/.
* Ask a question on the forum at https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally.
* Raise an issue at https://github.com/elastic/rally/issues and include the log files in /Users/rick.boyd/.rally/logs.

-------------------------------
[INFO] FAILURE (took 4 seconds)
-------------------------------
```

With this change, the output is more descriptive:
```
 % esrally race --track-path ../rally-tracks/http_logs --test-mode     

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/

[INFO] Race id is [df2c8410-83e9-4cd0-9c30-aa15d84a03bf]
[ERROR] Cannot race. esrally.track.loader.TrackSyntaxError: Could not load '/Users/rick.boyd/dev/rally-tracks/http_logs/track.json'. The complete track has been written to '/var/folders/_j/86s8k_jd4md2k6ch_290_0mr0000gn/T/tmp48mzhxww.json' for diagnosis. (Caused by: jinja2.exceptions.UndefinedError: 'runtime' is undefined)

Getting further help:
*********************
* Check the log files in /Users/rick.boyd/.rally/logs for errors.
* Read the documentation at https://esrally.readthedocs.io/en/latest/.
* Ask a question on the forum at https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally.
* Raise an issue at https://github.com/elastic/rally/issues and include the log files in /Users/rick.boyd/.rally/logs.

-------------------------------
[INFO] FAILURE (took 4 seconds)
-------------------------------


```
