### PR TITLE
Drop support for Elasticsearch 6.x metrics store

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -4,6 +4,11 @@ Migration Guide
 Migrating to Rally 2.3.0
 ------------------------
 
+Support for Elasticsearch 6.x as a metrics store has been dropped
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can still benchmark Elasticsearch 6.x nodes, but can no longer use an Elasticsearch 6.x :doc:`metrics store </metrics>`.
+
 ``relative-time-ms`` is removed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -10,3 +10,8 @@ End-of-life Policy
 ==================
 
 The latest version of Rally allows to benchmark all currently supported versions of Elasticsearch. Once an `Elasticsearch version reaches end-of-life <https://www.elastic.co/support/eol>`_, Rally will support benchmarking the corresponding version for two more years. For example, Elasticsearch 1.7.x has been supported until 2017-01-16. Rally drops support for Elasticsearch 1.7.x two years after that date on 2019-01-16. Version support is dropped in the next Rally maintenance release after that date.
+
+Metrics store
+=============
+
+Rally only supports Elasticsearch 7.x and above when using Elasticsearch as a :doc:`metrics store </metrics>`.

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -90,21 +90,18 @@ class EsClient:
     def refresh(self, index):
         return self.guarded(self._client.indices.refresh, index=index)
 
-    def bulk_index(self, index, doc_type, items):
+    def bulk_index(self, index, items):
         # TODO #653: Remove version-specific support for metrics stores before 7.0.0.
         # pylint: disable=import-outside-toplevel
         import elasticsearch.helpers
 
-        if self._cluster_version[0] > 6:
-            self.guarded(elasticsearch.helpers.bulk, self._client, items, index=index, chunk_size=5000)
-        else:
-            self.guarded(elasticsearch.helpers.bulk, self._client, items, index=index, doc_type=doc_type, chunk_size=5000)
+        self.guarded(elasticsearch.helpers.bulk, self._client, items, index=index, chunk_size=5000)
 
-    def index(self, index, doc_type, item, id=None):
+    def index(self, index, item, id=None):
         doc = {"_source": item}
         if id:
             doc["_id"] = id
-        self.bulk_index(index, doc_type, [doc])
+        self.bulk_index(index, [doc])
 
     def search(self, index, body):
         return self.guarded(self._client.search, index=index, body=body)
@@ -850,8 +847,6 @@ class EsMetricsStore(MetricsStore):
     A metrics store backed by Elasticsearch.
     """
 
-    METRICS_DOC_TYPE = "_doc"
-
     def __init__(
         self,
         cfg,
@@ -910,7 +905,7 @@ class EsMetricsStore(MetricsStore):
         if self._docs:
             sw = time.StopWatch()
             sw.start()
-            self._client.bulk_index(index=self._index, doc_type=EsMetricsStore.METRICS_DOC_TYPE, items=self._docs)
+            self._client.bulk_index(index=self._index, items=self._docs)
             sw.stop()
             self.logger.info(
                 "Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",
@@ -1599,7 +1594,6 @@ class FileRaceStore(RaceStore):
 
 class EsRaceStore(RaceStore):
     INDEX_PREFIX = "rally-races-"
-    RACE_DOC_TYPE = "_doc"
 
     def __init__(self, cfg, client_factory_class=EsClientFactory, index_template_provider_class=IndexTemplateProvider):
         """
@@ -1617,7 +1611,7 @@ class EsRaceStore(RaceStore):
         doc = race.as_dict()
         # always update the mapping to the latest version
         self.client.put_template("rally-races", self.index_template_provider.races_template())
-        self.client.index(index=self.index_name(race), doc_type=EsRaceStore.RACE_DOC_TYPE, item=doc, id=race.race_id)
+        self.client.index(index=self.index_name(race), item=doc, id=race.race_id)
 
     def index_name(self, race):
         race_timestamp = race.race_timestamp
@@ -1692,7 +1686,6 @@ class EsResultsStore:
     """
 
     INDEX_PREFIX = "rally-results-"
-    RESULTS_DOC_TYPE = "_doc"
 
     def __init__(self, cfg, client_factory_class=EsClientFactory, index_template_provider_class=IndexTemplateProvider):
         """
@@ -1709,7 +1702,7 @@ class EsResultsStore:
     def store_results(self, race):
         # always update the mapping to the latest version
         self.client.put_template("rally-results", self.index_template_provider.results_template())
-        self.client.bulk_index(index=self.index_name(race), doc_type=EsResultsStore.RESULTS_DOC_TYPE, items=race.to_result_dicts())
+        self.client.bulk_index(index=self.index_name(race), items=race.to_result_dicts())
 
     def index_name(self, race):
         race_timestamp = race.race_timestamp

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -46,7 +46,7 @@ class EsClient:
         self.logger = logging.getLogger(__name__)
         self._cluster_version = cluster_version
 
-    # TODO #653: Remove version-specific support for metrics stores before 7.0.0.
+    # TODO #1335: Use version-specific support for metrics stores after 7.8.0.
     def probe_version(self):
         info = self.guarded(self._client.info)
         try:
@@ -57,19 +57,7 @@ class EsClient:
             raise exceptions.RallyError(msg)
 
     def put_template(self, name, template):
-        # TODO #653: Remove version-specific support for metrics stores before 7.0.0 (also adjust template)
-        if self._cluster_version[0] > 6:
-            return self.guarded(
-                self._client.indices.put_template,
-                name=name,
-                body=template,
-                params={
-                    # allows to include the type name although it is not allowed anymore by default
-                    "include_type_name": "true"
-                },
-            )
-        else:
-            return self.guarded(self._client.indices.put_template, name=name, body=template)
+        return self.guarded(self._client.indices.put_template, name=name, body=template)
 
     def template_exists(self, name):
         return self.guarded(self._client.indices.exists_template, name)
@@ -91,7 +79,6 @@ class EsClient:
         return self.guarded(self._client.indices.refresh, index=index)
 
     def bulk_index(self, index, items):
-        # TODO #653: Remove version-specific support for metrics stores before 7.0.0.
         # pylint: disable=import-outside-toplevel
         import elasticsearch.helpers
 

--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -5,90 +5,88 @@
     }
   },
   "mappings": {
-    "_doc": {
-      "date_detection": false,
-      "dynamic_templates": [
-        {
-          "strings": {
-            "match": "*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "keyword"
-            }
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match": "*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
           }
         }
-      ],
-      "_source": {
-        "enabled": true
+      }
+    ],
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "@timestamp": {
+        "type": "date",
+        "format": "epoch_millis"
       },
-      "properties": {
-        "@timestamp": {
-          "type": "date",
-          "format": "epoch_millis"
-        },
-        "relative-time": {
-          "type": "float"
-        },
-        "race-id": {
-          "type": "keyword"
-        },
-        "race-timestamp": {
-          "type": "date",
-          "format": "basic_date_time_no_millis",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
+      "relative-time": {
+        "type": "float"
+      },
+      "race-id": {
+        "type": "keyword"
+      },
+      "race-timestamp": {
+        "type": "date",
+        "format": "basic_date_time_no_millis",
+        "fields": {
+          "raw": {
+            "type": "keyword"
           }
-        },
-        "environment": {
-          "type": "keyword"
-        },
-        "track": {
-          "type": "keyword"
-        },
-        "challenge": {
-          "type": "keyword"
-        },
-        "car": {
-          "type": "keyword"
-        },
-        "name": {
-          "type": "keyword"
-        },
-        "value": {
-          "type": "float"
-        },
-        "min": {
-          "type": "float"
-        },
-        "max": {
-          "type": "float"
-        },
-        "mean": {
-          "type": "float"
-        },
-        "median": {
-          "type": "float"
-        },
-        "unit": {
-          "type": "keyword"
-        },
-        "sample-type": {
-          "type": "keyword"
-        },
-        "task": {
-          "type": "keyword"
-        },
-        "operation": {
-          "type": "keyword"
-        },
-        "operation-type": {
-          "type": "keyword"
-        },
-        "job": {
-          "type": "keyword"
         }
+      },
+      "environment": {
+        "type": "keyword"
+      },
+      "track": {
+        "type": "keyword"
+      },
+      "challenge": {
+        "type": "keyword"
+      },
+      "car": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "float"
+      },
+      "min": {
+        "type": "float"
+      },
+      "max": {
+        "type": "float"
+      },
+      "mean": {
+        "type": "float"
+      },
+      "median": {
+        "type": "float"
+      },
+      "unit": {
+        "type": "keyword"
+      },
+      "sample-type": {
+        "type": "keyword"
+      },
+      "task": {
+        "type": "keyword"
+      },
+      "operation": {
+        "type": "keyword"
+      },
+      "operation-type": {
+        "type": "keyword"
+      },
+      "job": {
+        "type": "keyword"
       }
     }
   }

--- a/esrally/resources/races-template.json
+++ b/esrally/resources/races-template.json
@@ -5,67 +5,65 @@
     }
   },
   "mappings": {
-    "_doc": {
-      "date_detection": false,
-      "dynamic_templates": [
-        {
-          "strings": {
-            "match": "*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "keyword"
-            }
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match": "*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
           }
         }
-      ],
-      "_source": {
-        "enabled": true
+      }
+    ],
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "race-id": {
+        "type": "keyword"
       },
-      "properties": {
-        "race-id": {
-          "type": "keyword"
-        },
-        "race-timestamp": {
-          "type": "date",
-          "format": "basic_date_time_no_millis",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
+      "race-timestamp": {
+        "type": "date",
+        "format": "basic_date_time_no_millis",
+        "fields": {
+          "raw": {
+            "type": "keyword"
           }
-        },
-        "rally-version": {
-          "type": "keyword"
-        },
-        "rally-revision": {
-          "type": "keyword"
-        },
-        "environment": {
-          "type": "keyword"
-        },
-        "pipeline": {
-          "type": "keyword"
-        },
-        "track": {
-          "type": "keyword"
-        },
-        "challenge": {
-          "type": "keyword"
-        },
-        "car": {
-          "type": "keyword"
-        },
-        "node-count": {
-          "type": "short"
-        },
-        "plugins": {
-          "type": "keyword"
-        },
-        "results": {
-          "properties": {
-            "op_metrics": {
-              "type": "nested"
-            }
+        }
+      },
+      "rally-version": {
+        "type": "keyword"
+      },
+      "rally-revision": {
+        "type": "keyword"
+      },
+      "environment": {
+        "type": "keyword"
+      },
+      "pipeline": {
+        "type": "keyword"
+      },
+      "track": {
+        "type": "keyword"
+      },
+      "challenge": {
+        "type": "keyword"
+      },
+      "car": {
+        "type": "keyword"
+      },
+      "node-count": {
+        "type": "short"
+      },
+      "plugins": {
+        "type": "keyword"
+      },
+      "results": {
+        "properties": {
+          "op_metrics": {
+            "type": "nested"
           }
         }
       }

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -5,101 +5,99 @@
     }
   },
   "mappings": {
-    "_doc": {
-      "date_detection": false,
-      "dynamic_templates": [
-        {
-          "strings": {
-            "match": "*",
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "keyword"
-            }
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match": "*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
           }
         }
-      ],
-      "_source": {
-        "enabled": true
+      }
+    ],
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "race-id": {
+        "type": "keyword"
       },
-      "properties": {
-        "race-id": {
-          "type": "keyword"
-        },
-        "race-timestamp": {
-          "type": "date",
-          "format": "basic_date_time_no_millis",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
+      "race-timestamp": {
+        "type": "date",
+        "format": "basic_date_time_no_millis",
+        "fields": {
+          "raw": {
+            "type": "keyword"
           }
-        },
-        "active": {
-          "type": "boolean"
-        },
-        "rally-version": {
-          "type": "keyword"
-        },
-        "rally-revision": {
-          "type": "keyword"
-        },
-        "environment": {
-          "type": "keyword"
-        },
-        "track": {
-          "type": "keyword"
-        },
-        "challenge": {
-          "type": "keyword"
-        },
-        "car": {
-          "type": "keyword"
-        },
-        "node-count": {
-          "type": "short"
-        },
-        "plugins": {
-          "type": "keyword"
-        },
-        "distribution-flavor": {
-          "type": "keyword"
-        },
-        "distribution-version": {
-          "type": "keyword"
-        },
-        "distribution-major-version": {
-          "type": "short"
-        },
-        "task": {
-          "type": "keyword"
-        },
-        "operation": {
-          "type": "keyword"
-        },
-        "job": {
-          "type": "keyword"
-        },
-        "name": {
-          "type": "keyword"
-        },
-        "value": {
-          "type": "object",
-          "properties": {
-            "single": {
-              "type": "double"
-            },
-            "min": {
-              "type": "double"
-            },
-            "mean": {
-              "type": "double"
-            },
-            "median": {
-              "type": "double"
-            },
-            "max": {
-              "type": "double"
-            }
+        }
+      },
+      "active": {
+        "type": "boolean"
+      },
+      "rally-version": {
+        "type": "keyword"
+      },
+      "rally-revision": {
+        "type": "keyword"
+      },
+      "environment": {
+        "type": "keyword"
+      },
+      "track": {
+        "type": "keyword"
+      },
+      "challenge": {
+        "type": "keyword"
+      },
+      "car": {
+        "type": "keyword"
+      },
+      "node-count": {
+        "type": "short"
+      },
+      "plugins": {
+        "type": "keyword"
+      },
+      "distribution-flavor": {
+        "type": "keyword"
+      },
+      "distribution-version": {
+        "type": "keyword"
+      },
+      "distribution-major-version": {
+        "type": "short"
+      },
+      "task": {
+        "type": "keyword"
+      },
+      "operation": {
+        "type": "keyword"
+      },
+      "job": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "object",
+        "properties": {
+          "single": {
+            "type": "double"
+          },
+          "min": {
+            "type": "double"
+          },
+          "mean": {
+            "type": "double"
+          },
+          "median": {
+            "type": "double"
+          },
+          "max": {
+            "type": "double"
           }
         }
       }

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -337,7 +337,7 @@ class EsMetricsTests(TestCase):
         self.metrics_store.close()
         self.es_mock.exists.assert_called_with(index="rally-metrics-2016-01")
         self.es_mock.create_index.assert_called_with(index="rally-metrics-2016-01")
-        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", doc_type="_doc", items=[expected_doc])
+        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc])
 
     def test_put_value_with_explicit_timestamps(self):
         throughput = 5000
@@ -365,7 +365,7 @@ class EsMetricsTests(TestCase):
         self.metrics_store.close()
         self.es_mock.exists.assert_called_with(index="rally-metrics-2016-01")
         self.es_mock.create_index.assert_called_with(index="rally-metrics-2016-01")
-        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", doc_type="_doc", items=[expected_doc])
+        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc])
 
     def test_put_value_with_meta_info(self):
         throughput = 5000
@@ -407,7 +407,7 @@ class EsMetricsTests(TestCase):
         self.metrics_store.close()
         self.es_mock.exists.assert_called_with(index="rally-metrics-2016-01")
         self.es_mock.create_index.assert_called_with(index="rally-metrics-2016-01")
-        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", doc_type="_doc", items=[expected_doc])
+        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc])
 
     def test_put_doc_no_meta_data(self):
         self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
@@ -438,7 +438,7 @@ class EsMetricsTests(TestCase):
         self.metrics_store.close()
         self.es_mock.exists.assert_called_with(index="rally-metrics-2016-01")
         self.es_mock.create_index.assert_called_with(index="rally-metrics-2016-01")
-        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", doc_type="_doc", items=[expected_doc])
+        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc])
 
     def test_put_doc_with_metadata(self):
         # add a user-defined tag
@@ -492,7 +492,7 @@ class EsMetricsTests(TestCase):
         self.metrics_store.close()
         self.es_mock.exists.assert_called_with(index="rally-metrics-2016-01")
         self.es_mock.create_index.assert_called_with(index="rally-metrics-2016-01")
-        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", doc_type="_doc", items=[expected_doc])
+        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc])
 
     def test_get_one(self):
         duration = StaticClock.NOW * 1000
@@ -1028,7 +1028,7 @@ class EsRaceStoreTests(TestCase):
                 ],
             },
         }
-        self.es_mock.index.assert_called_with(index="rally-races-2016-01", doc_type="_doc", id=EsRaceStoreTests.RACE_ID, item=expected_doc)
+        self.es_mock.index.assert_called_with(index="rally-races-2016-01", id=EsRaceStoreTests.RACE_ID, item=expected_doc)
 
 
 class EsResultsStoreTests(TestCase):
@@ -1185,7 +1185,7 @@ class EsResultsStoreTests(TestCase):
                 },
             },
         ]
-        self.es_mock.bulk_index.assert_called_with(index="rally-results-2016-01", doc_type="_doc", items=expected_docs)
+        self.es_mock.bulk_index.assert_called_with(index="rally-results-2016-01", items=expected_docs)
 
     def test_store_results_with_missing_version(self):
         schedule = [track.Task("index #1", track.Operation("index", track.OperationType.Bulk))]
@@ -1319,7 +1319,7 @@ class EsResultsStoreTests(TestCase):
                 },
             },
         ]
-        self.es_mock.bulk_index.assert_called_with(index="rally-results-2016-01", doc_type="_doc", items=expected_docs)
+        self.es_mock.bulk_index.assert_called_with(index="rally-results-2016-01", items=expected_docs)
 
 
 class InMemoryMetricsStoreTests(TestCase):


### PR DESCRIPTION
Thanks @danielmitterdorfer for preparing the ground here, it was easy to do. :) I tested that indexes created with the old templates on 7.x still work with the new code. I'm not sure how to test the 6.x -> 7.x upgrade path, though. Is it useful to test?

As usual, this can be reviewed commit by commit if you're so inclined.

Closes #653 