### PR TITLE
Update Rally docker base image to Debian 11 and Python 3.8.12

### DIFF
--- a/docker/Dockerfiles/Dockerfile-dev
+++ b/docker/Dockerfiles/Dockerfile-dev
@@ -3,7 +3,7 @@
 # Install Rally from source inside a virtualenv
 ################################################################################
 
-FROM python:3.8.2-slim as builder
+FROM python:3.8.12-slim-bullseye as builder
 
 RUN apt-get -y update && \
     apt-get install -y curl git gcc && \
@@ -35,7 +35,7 @@ RUN pip3 install /rally
 # Add entrypoint
 ################################################################################
 
-FROM python:3.8.2-slim
+FROM python:3.8.12-slim-bullseye
 ARG RALLY_VERSION
 ARG RALLY_LICENSE
 ENV RALLY_RUNNING_IN_DOCKER True

--- a/docker/Dockerfiles/Dockerfile-release
+++ b/docker/Dockerfiles/Dockerfile-release
@@ -1,4 +1,4 @@
-FROM python:3.8.2-slim
+FROM python:3.8.12-slim-bullseye
 ARG RALLY_VERSION
 ARG RALLY_LICENSE
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -109,14 +109,14 @@ For example, after executing our earlier quickstart example ``docker run elastic
 
 To further examine the contents we can bind mount it from another image e.g.::
 
-    $ docker run --rm -i -v=96256462c3a1f61120443e6d69d9cb0091b28a02234318bdabc52b6801972199:/rallyvolume -ti python:3.8.2-slim /bin/bash
+    $ docker run --rm -i -v=96256462c3a1f61120443e6d69d9cb0091b28a02234318bdabc52b6801972199:/rallyvolume -ti python:3.8.12-slim-bullseye /bin/bash
     root@9a7dd7b3d8df:/# cd /rallyvolume/
     root@9a7dd7b3d8df:/rallyvolume# ls
     root@9a7dd7b3d8df:/rallyvolume/.rally# ls
     benchmarks  logging.json  logs	rally.ini
     # head -4 benchmarks/races/1d81930a-4ebe-4640-a09b-3055174bce43/race.json
     {
-     "rally-version": "1.2.1.dev0",
+     "rally-version": "2.2.1",
      "environment": "local",
      "race-id": "1d81930a-4ebe-4640-a09b-3055174bce43",
 
@@ -131,7 +131,7 @@ Extending the Docker image
 You can also create your own customized Docker image on top of the existing one.
 The example below shows how to get started::
 
-    FROM elastic/rally:1.2.1
+    FROM elastic/rally:2.2.1
     COPY --chown=1000:0 rally.ini /rally/.rally/
 
 You can then build and test the image with::

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -107,7 +107,9 @@ For example, after executing our earlier quickstart example ``docker run elastic
     local               96256462c3a1f61120443e6d69d9cb0091b28a02234318bdabc52b6801972199
 
 
-To further examine the contents we can bind mount it from another image e.g.::
+To further examine the contents we can bind mount it from another image e.g.:
+
+.. parsed-literal:: :class: literal-block highlight
 
     $ docker run --rm -i -v=96256462c3a1f61120443e6d69d9cb0091b28a02234318bdabc52b6801972199:/rallyvolume -ti python:3.8.12-slim-bullseye /bin/bash
     root@9a7dd7b3d8df:/# cd /rallyvolume/
@@ -116,7 +118,7 @@ To further examine the contents we can bind mount it from another image e.g.::
     benchmarks  logging.json  logs	rally.ini
     # head -4 benchmarks/races/1d81930a-4ebe-4640-a09b-3055174bce43/race.json
     {
-     "rally-version": "2.2.1",
+     "rally-version": "\ |release|\ ",
      "environment": "local",
      "race-id": "1d81930a-4ebe-4640-a09b-3055174bce43",
 
@@ -129,9 +131,12 @@ Extending the Docker image
 --------------------------
 
 You can also create your own customized Docker image on top of the existing one.
-The example below shows how to get started::
+The example below shows how to get started:
 
-    FROM elastic/rally:2.2.1
+.. parsed-literal:: :class: literal-block highlight
+
+    FROM elastic/rally:\ |release|\
+
     COPY --chown=1000:0 rally.ini /rally/.rally/
 
 You can then build and test the image with::


### PR DESCRIPTION
Currently the Rally docker image is based on a Debian 10 base image and Python 3.8.2.

This commit upgrades both to a more recent version.

Closes #1339
