### PR TITLE
remove formatter function from percentage diff evaluation

### DIFF
--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -889,7 +889,7 @@ class ComparisonReporter:
             color_neutral = console.format.neutral
 
         if as_percentage:
-            diff = formatter(_safe_divide(contender - baseline, baseline) * 100.0)
+            diff = _safe_divide(contender - baseline, baseline) * 100.0
             precision = 2
             suffix = "%"
         else:

--- a/tests/reporter_test.py
+++ b/tests/reporter_test.py
@@ -14,10 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=protected-access
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
-from esrally import reporter
+from esrally import config, reporter
+from esrally.utils import convert
 
 
 class FormatterTests(TestCase):
@@ -50,3 +52,18 @@ class FormatterTests(TestCase):
         formatted = reporter.format_as_csv(self.metrics_header, self.metrics_data)
         # 1 header line, no separation line + 3 data lines
         self.assertEqual(1 + 3, len(formatted.splitlines()))
+
+
+class ComparisonReporterTests(TestCase):
+    def setUp(self):
+        config_mock = mock.Mock(config.Config)
+        config_mock.opts.return_value = True
+        self.reporter = reporter.ComparisonReporter(config_mock)
+
+    def test_diff_percent_divide_by_zero(self):
+        formatted = self.reporter._diff(0, 0, False, as_percentage=True)
+        self.assertEqual("0.00%", formatted)
+
+    def test_diff_percent_ignore_formatter(self):
+        formatted = self.reporter._diff(1, 0, False, formatter=convert.factor(100.0), as_percentage=True)
+        self.assertEqual("-100.00%", formatted)


### PR DESCRIPTION
This commit fixes a small correctness issue with some metrics in the new `Diff %` column.

Before (sample):
```
|                                                        Metric |         Task |    Baseline |   Contender |         Diff |   Unit |     Diff % |
|--------------------------------------------------------------:|-------------:|------------:|------------:|-------------:|-------:|-----------:|
|                    Cumulative indexing time of primary shards |              |   0.0355667 |      0.0667 |      0.03113 |    min |      0.00% |
|             Max cumulative indexing time across primary shard |              |   0.0355667 |      0.0667 |      0.03113 |    min |      0.00% |
|                       Cumulative merge time of primary shards |              |     0.11245 |      0.0516 |     -0.06085 |    min |     -0.00% |
|                Max cumulative merge time across primary shard |              |     0.11245 |      0.0516 |     -0.06085 |    min |     -0.00% |
|                                                    error rate |       search |    0.655664 |           0 |     -0.65566 |      % | -10000.00% |
```

After (same sample):
```

|                                                        Metric |         Task |    Baseline |   Contender |         Diff |   Unit |   Diff % |
|--------------------------------------------------------------:|-------------:|------------:|------------:|-------------:|-------:|---------:|
|                    Cumulative indexing time of primary shards |              |   0.0355667 |      0.0667 |      0.03113 |    min |  +87.54% |
|             Max cumulative indexing time across primary shard |              |   0.0355667 |      0.0667 |      0.03113 |    min |  +87.54% |
|                       Cumulative merge time of primary shards |              |     0.11245 |      0.0516 |     -0.06085 |    min |  -54.11% |
|                Max cumulative merge time across primary shard |              |     0.11245 |      0.0516 |     -0.06085 |    min |  -54.11% |
|                                                    error rate |       search |    0.655664 |           0 |     -0.65566 |      % | -100.00% |
```