### PR TITLE
Fix formatting commit in .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Migrate to black and isort
-6ec0d1cddc8202775f2e1a5f68ed78393f20107e
+f4302fbbc38bf4e7c00cd43ac9b363f26e579196


### PR DESCRIPTION
The commit got rebased when merging https://github.com/elastic/rally/pull/1281, which changed the SHA-1. To test:

* Run `git config --global blame.ignoreRevsFile .git-blame-ignore-revs`
* Then, try `git blame esrally/reporter.py` (say) with and without this pull request.