### PR TITLE
Allow running `make` commands with active virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,14 @@ export PY39 = $(shell jq -r '.python_versions.PY39' .ci/variables.json)
 export PIP_VERSION = $(shell jq -r '.prerequisite_versions.PIP' .ci/variables.json)
 export SETUPTOOLS_VERSION = $(shell jq -r '.prerequisite_versions.SETUPTOOLS' .ci/variables.json)
 export WHEEL_VERSION = $(shell jq -r '.prerequisite_versions.WHEEL' .ci/variables.json)
-VENV_NAME ?= .venv
-VENV_ACTIVATE_FILE = $(VENV_NAME)/bin/activate
+VIRTUAL_ENV ?= .venv
+VENV_ACTIVATE_FILE = $(VIRTUAL_ENV)/bin/activate
 VENV_ACTIVATE = . $(VENV_ACTIVATE_FILE)
-VEPYTHON = $(VENV_NAME)/bin/$(PY_BIN)
-VEPYLINT = $(VENV_NAME)/bin/pylint
+VEPYTHON = $(VIRTUAL_ENV)/bin/$(PY_BIN)
+VEPYLINT = $(VIRTUAL_ENV)/bin/pylint
 PYENV_ERROR = "\033[0;31mIMPORTANT\033[0m: Please install pyenv.\n"
 PYENV_PREREQ_HELP = "\033[0;31mIMPORTANT\033[0m: please type \033[0;31mpyenv init\033[0m, follow the instructions there and restart your terminal before proceeding any further.\n"
-VE_MISSING_HELP = "\033[0;31mIMPORTANT\033[0m: Couldn't find $(PWD)/$(VENV_NAME); have you executed make venv-create?\033[0m\n"
+VE_MISSING_HELP = "\033[0;31mIMPORTANT\033[0m: Couldn't find $(PWD)/$(VIRTUAL_ENV); have you executed make venv-create?\033[0m\n"
 
 prereq:
 	pyenv install --skip-existing $(PY38)
@@ -49,8 +49,8 @@ venv-create:
 		exit 1; \
 	fi;
 	@if [[ ! -f $(VENV_ACTIVATE_FILE) ]]; then \
-		eval "$$(pyenv init -)" && eval "$$(pyenv init --path)" && $(PY_BIN) -mvenv $(VENV_NAME); \
-		printf "Created python3 venv under $(PWD)/$(VENV_NAME).\n"; \
+		eval "$$(pyenv init -)" && eval "$$(pyenv init --path)" && $(PY_BIN) -mvenv $(VIRTUAL_ENV); \
+		printf "Created python3 venv under $(PWD)/$(VIRTUAL_ENV).\n"; \
 	fi;
 
 check-venv:


### PR DESCRIPTION
Inside an active Python virtual environment, the `VIRTUAL_ENV` environment variable is set, pointing to the virtual environment folder (where bin/activate and bin/python are). Using `VIRTUAL_ENV` instead of `VENV_NAME` in the `Makefile` means that `make` will use a virtual environment when one is active. pyenv continues to be the preferred method, though.