### PR TITLE
Document challenge's user-info property

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -427,6 +427,7 @@ Each challenge consists of the following properties:
 
 * ``name`` (mandatory): A descriptive name of the challenge. Should not contain spaces in order to simplify handling on the command line for users.
 * ``description`` (optional): A human readable description of the challenge.
+* ``user-info`` (optional): A message that is printed at the beginning of a race. It is intended to be used to notify e.g. about deprecations.
 * ``default`` (optional): If true, Rally selects this challenge by default if the user did not specify a challenge on the command line. If your track only defines one challenge, it is implicitly selected as default, otherwise you need to define ``"default": true`` on exactly one challenge.
 * ``schedule`` (mandatory): Defines the workload. It is described in more detail below.
 


### PR DESCRIPTION
With this commit we document the existing property `user-info` on the
challenge object.

Relates elastic/rally-tracks#200