### PR TITLE
Call the correct functions for `scroll-search` and `paginated-search` operations

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -968,7 +968,7 @@ Properties
 * ``body`` (mandatory): The query body.
 * ``response-compression-enabled`` (optional, defaults to ``true``): Allows to disable HTTP compression of responses. As these responses are sometimes large and decompression may be a bottleneck on the client, it is possible to turn off response compression.
 * ``detailed-results`` (optional, defaults to ``false``): Records more detailed meta-data about queries. As it analyzes the corresponding response in more detail, this might incur additional overhead which can skew measurement results. This flag is ineffective for scroll queries.
-* ``pages`` (optional): Number of pages to retrieve. If this parameter is present, a scroll query will be executed. If you want to retrieve all result pages, use the value "all".  See also the ``scroll-search`` operation type.
+* ``pages`` (optional, deprecated): Number of pages to retrieve. If this parameter is present, a scroll query will be executed. If you want to retrieve all result pages, use the value "all". This parameter is deprecated and will be replaced with the ``scroll-search`` operation in a future release.
 * ``results-per-page`` (optional):  Number of documents to retrieve per page. This maps to the Search API's ``size`` parameter, and can be used for scroll and non-scroll searches. Defaults to ``10``
 
 Example::

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -980,7 +980,8 @@ class Query(Runner):
             if "pages" in params:
                 logging.getLogger(__name__).warning(
                     "Invoking a scroll search with the 'search' operation is deprecated "
-                    "and will be removed in a future release. Use 'scroll-search' instead.")
+                    "and will be removed in a future release. Use 'scroll-search' instead."
+                )
             else:
                 return await _request_body_query(es, params)
         else:

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -103,7 +103,7 @@ def runner_for(operation_type):
     try:
         return __RUNNERS[operation_type]
     except KeyError:
-        raise exceptions.RallyError("No runner available for operation type [%s]" % operation_type)
+        raise exceptions.RallyError(f"No runner available for operation-type: {operation_type}]")
 
 
 def enable_assertions(enabled):
@@ -982,10 +982,11 @@ class Query(Runner):
                     "Invoking a scroll search with the 'search' operation is deprecated "
                     "and will be removed in a future release. Use 'scroll-search' instead."
                 )
+                return await _scroll_query(es, params)
             else:
                 return await _request_body_query(es, params)
         else:
-            raise exceptions.RallyError("No runner available for operation type [%s]" % operation_type)
+            raise exceptions.RallyError(f"No runner available for operation-type: {operation_type}")
 
     async def _raw_search(self, es, doc_type, index, body, params, headers=None):
         components = []

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -986,7 +986,7 @@ class Query(Runner):
             else:
                 return await _request_body_query(es, params)
         else:
-            raise exceptions.RallyError(f"No runner available for operation-type: {operation_type}")
+            raise exceptions.RallyError(f"No runner available for operation-type: [{operation_type}]")
 
     async def _raw_search(self, es, doc_type, index, body, params, headers=None):
         components = []

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -817,7 +817,7 @@ class Query(Runner):
         # by the composite's parameter source.
         index = mandatory(params, "index", self)
         body = mandatory(params, "body", self)
-        operation_type = params.get("operation-type", "search")
+        operation_type = params.get("operation-type")
         size = params.get("results-per-page")
         if size:
             body["size"] = size

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -815,9 +815,9 @@ class Query(Runner):
         # Mandatory to ensure it is always provided. This is especially important when this runner is used in a
         # composite context where there is no actual parameter source and the entire request structure must be provided
         # by the composite's parameter source.
-        operation_type = mandatory(params, "operation-type", self)
         index = mandatory(params, "index", self)
         body = mandatory(params, "body", self)
+        operation_type = params.get("operation-type", "search")
         size = params.get("results-per-page")
         if size:
             body["size"] = size

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -103,7 +103,7 @@ def runner_for(operation_type):
     try:
         return __RUNNERS[operation_type]
     except KeyError:
-        raise exceptions.RallyError(f"No runner available for operation-type: {operation_type}]")
+        raise exceptions.RallyError(f"No runner available for operation-type: [{operation_type}]")
 
 
 def enable_assertions(enabled):

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -515,7 +515,7 @@ class SearchParamSource(ParamSource):
             "request-params": request_params,
             "response-compression-enabled": response_compression_enabled,
             "body": query_body,
-            "operation-type": operation_type
+            "operation-type": operation_type,
         }
 
         if not target_name:
@@ -783,6 +783,7 @@ class PartitionBulkIndexParamSource:
     @property
     def percent_completed(self):
         return self.current_bulk / self.total_bulks
+
 
 class OpenPointInTimeParamSource(ParamSource):
     def __init__(self, track, params, **kwargs):

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -493,6 +493,7 @@ class CreateComponentTemplateParamSource(CreateTemplateParamSource):
 class SearchParamSource(ParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
+        operation_type = params.get("operation-type", "search")
         target_name = get_target(track, params)
         type_name = params.get("type")
         if params.get("data-stream") and type_name:
@@ -514,6 +515,7 @@ class SearchParamSource(ParamSource):
             "request-params": request_params,
             "response-compression-enabled": response_compression_enabled,
             "body": query_body,
+            "operation-type": operation_type
         }
 
         if not target_name:
@@ -781,7 +783,6 @@ class PartitionBulkIndexParamSource:
     @property
     def percent_completed(self):
         return self.current_bulk / self.total_bulks
-
 
 class OpenPointInTimeParamSource(ParamSource):
     def __init__(self, track, params, **kwargs):
@@ -1324,6 +1325,8 @@ class SourceOnlyIndexDataReader(IndexDataReader):
 
 register_param_source_for_operation(track.OperationType.Bulk, BulkIndexParamSource)
 register_param_source_for_operation(track.OperationType.Search, SearchParamSource)
+register_param_source_for_operation(track.OperationType.ScrollSearch, SearchParamSource)
+register_param_source_for_operation(track.OperationType.PaginatedSearch, SearchParamSource)
 register_param_source_for_operation(track.OperationType.CreateIndex, CreateIndexParamSource)
 register_param_source_for_operation(track.OperationType.DeleteIndex, DeleteIndexParamSource)
 register_param_source_for_operation(track.OperationType.CreateDataStream, CreateDataStreamParamSource)

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -493,7 +493,6 @@ class CreateComponentTemplateParamSource(CreateTemplateParamSource):
 class SearchParamSource(ParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
-        operation_type = params.get("operation-type", "search")
         target_name = get_target(track, params)
         type_name = params.get("type")
         if params.get("data-stream") and type_name:
@@ -515,7 +514,6 @@ class SearchParamSource(ParamSource):
             "request-params": request_params,
             "response-compression-enabled": response_compression_enabled,
             "body": query_body,
-            "operation-type": operation_type,
         }
 
         if not target_name:

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1591,6 +1591,7 @@ class AsyncExecutorTests(TestCase):
                         "request-params": {},
                         "cache": False,
                         "response-compression-enabled": True,
+                        "operation-type": "search"
                     },
                     param_source="driver-test-param-source",
                 ),

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1591,7 +1591,7 @@ class AsyncExecutorTests(TestCase):
                         "request-params": {},
                         "cache": False,
                         "response-compression-enabled": True,
-                        "operation-type": "search"
+                        "operation-type": "search",
                     },
                     param_source="driver-test-param-source",
                 ),

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -958,14 +958,14 @@ class SchedulerTests(TestCase):
         schedule = driver.schedule_for(task_allocation, param_source)
 
         expected_schedule = [
-            (0, metrics.SampleType.Warmup, 1 / 8, {}),
-            (0.1, metrics.SampleType.Warmup, 2 / 8, {}),
-            (0.2, metrics.SampleType.Warmup, 3 / 8, {}),
-            (0.3, metrics.SampleType.Normal, 4 / 8, {}),
-            (0.4, metrics.SampleType.Normal, 5 / 8, {}),
-            (0.5, metrics.SampleType.Normal, 6 / 8, {}),
-            (0.6, metrics.SampleType.Normal, 7 / 8, {}),
-            (0.7, metrics.SampleType.Normal, 8 / 8, {}),
+            (0, metrics.SampleType.Warmup, 1 / 8, {"operation-type": "search"}),
+            (0.1, metrics.SampleType.Warmup, 2 / 8, {"operation-type": "search"}),
+            (0.2, metrics.SampleType.Warmup, 3 / 8, {"operation-type": "search"}),
+            (0.3, metrics.SampleType.Normal, 4 / 8, {"operation-type": "search"}),
+            (0.4, metrics.SampleType.Normal, 5 / 8, {"operation-type": "search"}),
+            (0.5, metrics.SampleType.Normal, 6 / 8, {"operation-type": "search"}),
+            (0.6, metrics.SampleType.Normal, 7 / 8, {"operation-type": "search"}),
+            (0.7, metrics.SampleType.Normal, 8 / 8, {"operation-type": "search"}),
         ]
         await self.assert_schedule(expected_schedule, schedule)
 
@@ -984,12 +984,12 @@ class SchedulerTests(TestCase):
         schedule = driver.schedule_for(task_allocation, param_source)
 
         expected_schedule = [
-            (0, metrics.SampleType.Warmup, 1 / 6, {}),
-            (0.2, metrics.SampleType.Normal, 2 / 6, {}),
-            (0.4, metrics.SampleType.Normal, 3 / 6, {}),
-            (0.6, metrics.SampleType.Normal, 4 / 6, {}),
-            (0.8, metrics.SampleType.Normal, 5 / 6, {}),
-            (1.0, metrics.SampleType.Normal, 6 / 6, {}),
+            (0, metrics.SampleType.Warmup, 1 / 6, {"operation-type": "search"}),
+            (0.2, metrics.SampleType.Normal, 2 / 6, {"operation-type": "search"}),
+            (0.4, metrics.SampleType.Normal, 3 / 6, {"operation-type": "search"}),
+            (0.6, metrics.SampleType.Normal, 4 / 6, {"operation-type": "search"}),
+            (0.8, metrics.SampleType.Normal, 5 / 6, {"operation-type": "search"}),
+            (1.0, metrics.SampleType.Normal, 6 / 6, {"operation-type": "search"}),
         ]
         await self.assert_schedule(expected_schedule, schedule)
 
@@ -1014,9 +1014,9 @@ class SchedulerTests(TestCase):
 
         await self.assert_schedule(
             [
-                (0.0, metrics.SampleType.Normal, 1 / 3, {"body": ["a"], "size": 3}),
-                (1.0, metrics.SampleType.Normal, 2 / 3, {"body": ["a"], "size": 3}),
-                (2.0, metrics.SampleType.Normal, 3 / 3, {"body": ["a"], "size": 3}),
+                (0.0, metrics.SampleType.Normal, 1 / 3, {"body": ["a"], "operation-type": "bulk", "size": 3}),
+                (1.0, metrics.SampleType.Normal, 2 / 3, {"body": ["a"], "operation-type": "bulk", "size": 3}),
+                (2.0, metrics.SampleType.Normal, 3 / 3, {"body": ["a"], "operation-type": "bulk", "size": 3}),
             ],
             schedule,
         )
@@ -1042,11 +1042,11 @@ class SchedulerTests(TestCase):
 
         await self.assert_schedule(
             [
-                (0.0, metrics.SampleType.Warmup, 1 / 5, {"body": ["a"], "size": 5}),
-                (1.0, metrics.SampleType.Warmup, 2 / 5, {"body": ["a"], "size": 5}),
-                (2.0, metrics.SampleType.Normal, 3 / 5, {"body": ["a"], "size": 5}),
-                (3.0, metrics.SampleType.Normal, 4 / 5, {"body": ["a"], "size": 5}),
-                (4.0, metrics.SampleType.Normal, 5 / 5, {"body": ["a"], "size": 5}),
+                (0.0, metrics.SampleType.Warmup, 1 / 5, {"body": ["a"], "operation-type": "bulk", "size": 5}),
+                (1.0, metrics.SampleType.Warmup, 2 / 5, {"body": ["a"], "operation-type": "bulk", "size": 5}),
+                (2.0, metrics.SampleType.Normal, 3 / 5, {"body": ["a"], "operation-type": "bulk", "size": 5}),
+                (3.0, metrics.SampleType.Normal, 4 / 5, {"body": ["a"], "operation-type": "bulk", "size": 5}),
+                (4.0, metrics.SampleType.Normal, 5 / 5, {"body": ["a"], "operation-type": "bulk", "size": 5}),
             ],
             schedule,
         )
@@ -1072,7 +1072,7 @@ class SchedulerTests(TestCase):
 
         await self.assert_schedule(
             [
-                (0.0, metrics.SampleType.Normal, 1 / 1, {"body": ["a"]}),
+                (0.0, metrics.SampleType.Normal, 1 / 1, {"body": ["a"], "operation-type": "bulk"}),
             ],
             schedule,
         )
@@ -1098,17 +1098,17 @@ class SchedulerTests(TestCase):
 
         await self.assert_schedule(
             [
-                (0.0, metrics.SampleType.Normal, 1 / 11, {"body": ["a"], "size": 11}),
-                (1.0, metrics.SampleType.Normal, 2 / 11, {"body": ["a"], "size": 11}),
-                (2.0, metrics.SampleType.Normal, 3 / 11, {"body": ["a"], "size": 11}),
-                (3.0, metrics.SampleType.Normal, 4 / 11, {"body": ["a"], "size": 11}),
-                (4.0, metrics.SampleType.Normal, 5 / 11, {"body": ["a"], "size": 11}),
-                (5.0, metrics.SampleType.Normal, 6 / 11, {"body": ["a"], "size": 11}),
-                (6.0, metrics.SampleType.Normal, 7 / 11, {"body": ["a"], "size": 11}),
-                (7.0, metrics.SampleType.Normal, 8 / 11, {"body": ["a"], "size": 11}),
-                (8.0, metrics.SampleType.Normal, 9 / 11, {"body": ["a"], "size": 11}),
-                (9.0, metrics.SampleType.Normal, 10 / 11, {"body": ["a"], "size": 11}),
-                (10.0, metrics.SampleType.Normal, 11 / 11, {"body": ["a"], "size": 11}),
+                (0.0, metrics.SampleType.Normal, 1 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
+                (1.0, metrics.SampleType.Normal, 2 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
+                (2.0, metrics.SampleType.Normal, 3 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
+                (3.0, metrics.SampleType.Normal, 4 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
+                (4.0, metrics.SampleType.Normal, 5 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
+                (5.0, metrics.SampleType.Normal, 6 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
+                (6.0, metrics.SampleType.Normal, 7 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
+                (7.0, metrics.SampleType.Normal, 8 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
+                (8.0, metrics.SampleType.Normal, 9 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
+                (9.0, metrics.SampleType.Normal, 10 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
+                (10.0, metrics.SampleType.Normal, 11 / 11, {"body": ["a"], "operation-type": "bulk", "size": 11}),
             ],
             schedule,
         )
@@ -1134,11 +1134,11 @@ class SchedulerTests(TestCase):
 
         await self.assert_schedule(
             [
-                (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-                (1.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-                (2.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-                (3.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-                (4.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+                (0.0, metrics.SampleType.Normal, None, {"body": ["a"], "operation-type": "bulk"}),
+                (1.0, metrics.SampleType.Normal, None, {"body": ["a"], "operation-type": "bulk"}),
+                (2.0, metrics.SampleType.Normal, None, {"body": ["a"], "operation-type": "bulk"}),
+                (3.0, metrics.SampleType.Normal, None, {"body": ["a"], "operation-type": "bulk"}),
+                (4.0, metrics.SampleType.Normal, None, {"body": ["a"], "operation-type": "bulk"}),
             ],
             schedule,
             infinite_schedule=True,
@@ -1165,11 +1165,11 @@ class SchedulerTests(TestCase):
 
         await self.assert_schedule(
             [
-                (0.0, metrics.SampleType.Normal, 1 / 5, {"body": ["a"], "size": 5}),
-                (1.0, metrics.SampleType.Normal, 2 / 5, {"body": ["a"], "size": 5}),
-                (2.0, metrics.SampleType.Normal, 3 / 5, {"body": ["a"], "size": 5}),
-                (3.0, metrics.SampleType.Normal, 4 / 5, {"body": ["a"], "size": 5}),
-                (4.0, metrics.SampleType.Normal, 5 / 5, {"body": ["a"], "size": 5}),
+                (0.0, metrics.SampleType.Normal, 1 / 5, {"body": ["a"], "operation-type": "bulk", "size": 5}),
+                (1.0, metrics.SampleType.Normal, 2 / 5, {"body": ["a"], "operation-type": "bulk", "size": 5}),
+                (2.0, metrics.SampleType.Normal, 3 / 5, {"body": ["a"], "operation-type": "bulk", "size": 5}),
+                (3.0, metrics.SampleType.Normal, 4 / 5, {"body": ["a"], "operation-type": "bulk", "size": 5}),
+                (4.0, metrics.SampleType.Normal, 5 / 5, {"body": ["a"], "operation-type": "bulk", "size": 5}),
             ],
             schedule,
             infinite_schedule=False,
@@ -1192,11 +1192,11 @@ class SchedulerTests(TestCase):
 
         await self.assert_schedule(
             [
-                (0.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-                (1.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-                (2.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-                (3.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
-                (4.0, metrics.SampleType.Normal, None, {"body": ["a"]}),
+                (0.0, metrics.SampleType.Normal, None, {"body": ["a"], "operation-type": "driver-test-runner-with-completion"}),
+                (1.0, metrics.SampleType.Normal, None, {"body": ["a"], "operation-type": "driver-test-runner-with-completion"}),
+                (2.0, metrics.SampleType.Normal, None, {"body": ["a"], "operation-type": "driver-test-runner-with-completion"}),
+                (3.0, metrics.SampleType.Normal, None, {"body": ["a"], "operation-type": "driver-test-runner-with-completion"}),
+                (4.0, metrics.SampleType.Normal, None, {"body": ["a"], "operation-type": "driver-test-runner-with-completion"}),
             ],
             schedule,
             infinite_schedule=True,
@@ -1240,7 +1240,7 @@ class SchedulerTests(TestCase):
             self.assertTrue(round(progress_percent, 2) >= 0.0, "progress should be >= 0.0 but was [%f]" % progress_percent)
             self.assertTrue(round(progress_percent, 2) <= 1.0, "progress should be <= 1.0 but was [%f]" % progress_percent)
             self.assertIsNotNone(runner, "runner must be defined")
-            self.assertEqual({"body": ["a"], "size": 11}, params)
+            self.assertEqual({"body": ["a"], "operation-type": "bulk", "size": 11}, params)
 
     @run_async
     async def test_schedule_for_time_based_with_multiple_clients(self):
@@ -1287,7 +1287,7 @@ class SchedulerTests(TestCase):
             self.assertTrue(round(progress_percent, 2) >= 0.0, "progress should be >= 0.0 but was [%f]" % progress_percent)
             self.assertTrue(round(progress_percent, 2) <= 1.0, "progress should be <= 1.0 but was [%f]" % progress_percent)
             self.assertIsNotNone(runner, "runner must be defined")
-            self.assertEqual({"body": ["a"], "size": 11}, params)
+            self.assertEqual({"body": ["a"], "operation-type": "bulk", "size": 11}, params)
 
 
 class AsyncExecutorTests(TestCase):

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1591,7 +1591,6 @@ class AsyncExecutorTests(TestCase):
                         "request-params": {},
                         "cache": False,
                         "response-compression-enabled": True,
-                        "operation-type": "search",
                     },
                     param_source="driver-test-param-source",
                 ),

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1365,6 +1365,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "search",
             "index": "_all",
             "detailed-results": True,
             "cache": True,
@@ -1410,6 +1411,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "search",
             "index": "_all",
             "detailed-results": True,
             "cache": True,
@@ -1460,6 +1462,7 @@ class QueryRunnerTests(TestCase):
 
         query_runner = runner.Query()
         params = {
+            "operation-type": "search",
             "index": "_all",
             "cache": False,
             "detailed-results": True,
@@ -1513,6 +1516,7 @@ class QueryRunnerTests(TestCase):
 
         query_runner = runner.Query()
         params = {
+            "operation-type": "search",
             "index": "_all",
             "body": None,
             "request-params": {"q": "user:kimchy"},
@@ -1560,6 +1564,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "search",
             "index": "_all",
             "cache": True,
             "detailed-results": True,
@@ -1614,6 +1619,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "search",
             "index": "unittest",
             "detailed-results": True,
             "response-compression-enabled": False,
@@ -1666,6 +1672,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "search",
             "index": "unittest",
             "type": "type",
             "detailed-results": True,
@@ -1720,6 +1727,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "scroll-search",
             "pages": 1,
             "results-per-page": 100,
             "index": "unittest",
@@ -1780,6 +1788,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "scroll-search",
             "pages": 1,
             "results-per-page": 100,
             "index": "unittest",
@@ -1835,6 +1844,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "scroll-search",
             "index": "_all",
             "pages": 1,
             "results-per-page": 100,
@@ -1916,6 +1926,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "scroll-search",
             "pages": 2,
             "results-per-page": 2,
             "index": "unittest",
@@ -1963,6 +1974,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "scroll-search",
             "pages": 5,
             "results-per-page": 100,
             "index": "unittest",
@@ -2027,6 +2039,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "scroll-search",
             "pages": "all",
             "results-per-page": 4,
             "index": "unittest",
@@ -2051,6 +2064,32 @@ class QueryRunnerTests(TestCase):
         self.assertFalse("error-type" in results)
 
         es.clear_scroll.assert_awaited_once_with(body={"scroll_id": ["some-scroll-id"]})
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_query_runner_missing_operation_type(self, es):
+        query_runner = runner.Query()
+
+        params = {
+            "index": "_all",
+            "detailed-results": True,
+            "cache": True,
+            "body": {
+                "query": {
+                    "match_all": {},
+                },
+            },
+        }
+
+        with self.assertRaises(exceptions.DataError) as ctx:
+            await query_runner(es, params)
+        self.assertEqual(
+            "Parameter source for operation 'query' did not provide the mandatory parameter 'operation-type'. "
+            "Add it to your parameter source and try again.",
+            ctx.exception.args[0],
+        )
+
+        self.assertEqual(0, es.call_count)
 
 
 class PutPipelineRunnerTests(TestCase):

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2131,7 +2131,7 @@ class QueryRunnerTests(TestCase):
         with self.assertRaises(exceptions.RallyError) as ctx:
             await query_runner(es, params)
         self.assertEqual(
-            "No runner available for operation-type: unknown",
+            "No runner available for operation-type: [unknown]",
             ctx.exception.args[0],
         )
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2067,32 +2067,6 @@ class QueryRunnerTests(TestCase):
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
-    async def test_query_runner_missing_operation_type(self, es):
-        query_runner = runner.Query()
-
-        params = {
-            "index": "_all",
-            "detailed-results": True,
-            "cache": True,
-            "body": {
-                "query": {
-                    "match_all": {},
-                },
-            },
-        }
-
-        with self.assertRaises(exceptions.DataError) as ctx:
-            await query_runner(es, params)
-        self.assertEqual(
-            "Parameter source for operation 'query' did not provide the mandatory parameter 'operation-type'. "
-            "Add it to your parameter source and try again.",
-            ctx.exception.args[0],
-        )
-
-        self.assertEqual(0, es.call_count)
-
-    @mock.patch("elasticsearch.Elasticsearch")
-    @run_async
     async def test_query_runner_search_with_pages_logs_warning_and_executes(self, es):
         # page 1
         search_response = {

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1365,7 +1365,6 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
-            "operation-type": "search",
             "index": "_all",
             "detailed-results": True,
             "cache": True,
@@ -1411,7 +1410,6 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
-            "operation-type": "search",
             "index": "_all",
             "detailed-results": True,
             "cache": True,
@@ -1462,7 +1460,6 @@ class QueryRunnerTests(TestCase):
 
         query_runner = runner.Query()
         params = {
-            "operation-type": "search",
             "index": "_all",
             "cache": False,
             "detailed-results": True,
@@ -1516,7 +1513,6 @@ class QueryRunnerTests(TestCase):
 
         query_runner = runner.Query()
         params = {
-            "operation-type": "search",
             "index": "_all",
             "body": None,
             "request-params": {"q": "user:kimchy"},
@@ -1564,7 +1560,6 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
-            "operation-type": "search",
             "index": "_all",
             "cache": True,
             "detailed-results": True,
@@ -1619,7 +1614,6 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
-            "operation-type": "search",
             "index": "unittest",
             "detailed-results": True,
             "response-compression-enabled": False,
@@ -1672,7 +1666,6 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
-            "operation-type": "search",
             "index": "unittest",
             "type": "type",
             "detailed-results": True,

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1365,6 +1365,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "search",
             "index": "_all",
             "detailed-results": True,
             "cache": True,
@@ -1410,6 +1411,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "search",
             "index": "_all",
             "detailed-results": True,
             "cache": True,
@@ -1460,6 +1462,7 @@ class QueryRunnerTests(TestCase):
 
         query_runner = runner.Query()
         params = {
+            "operation-type": "search",
             "index": "_all",
             "cache": False,
             "detailed-results": True,
@@ -1513,6 +1516,7 @@ class QueryRunnerTests(TestCase):
 
         query_runner = runner.Query()
         params = {
+            "operation-type": "search",
             "index": "_all",
             "body": None,
             "request-params": {"q": "user:kimchy"},
@@ -1560,6 +1564,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "search",
             "index": "_all",
             "cache": True,
             "detailed-results": True,
@@ -1614,6 +1619,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "search",
             "index": "unittest",
             "detailed-results": True,
             "response-compression-enabled": False,
@@ -1666,6 +1672,7 @@ class QueryRunnerTests(TestCase):
         query_runner = runner.Query()
 
         params = {
+            "operation-type": "search",
             "index": "unittest",
             "type": "type",
             "detailed-results": True,

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2470,7 +2470,8 @@ class SearchParamSourceTests(TestCase):
         )
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
+        self.assertEqual("search", p["operation-type"])
         self.assertEqual("index1", p["index"])
         self.assertIsNone(p["type"])
         self.assertIsNone(p["request-timeout"])
@@ -2509,7 +2510,8 @@ class SearchParamSourceTests(TestCase):
         )
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
+        self.assertEqual("search", p["operation-type"])
         self.assertEqual("data-stream-1", p["index"])
         self.assertIsNone(p["type"])
         self.assertEqual(1.0, p["request-timeout"])
@@ -2561,7 +2563,8 @@ class SearchParamSourceTests(TestCase):
         )
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
+        self.assertEqual("search", p["operation-type"])
         self.assertEqual("index1", p["index"])
         self.assertIsNone(p["type"])
         self.assertIsNone(p["request-timeout"])
@@ -2580,7 +2583,7 @@ class SearchParamSourceTests(TestCase):
             p["body"],
         )
 
-    def test_user_specified_overrides_defaults(self):
+    def test_user_specified_index_overrides_defaults(self):
         index1 = track.Index(name="index1", types=["type1"])
 
         source = params.SearchParamSource(
@@ -2601,7 +2604,8 @@ class SearchParamSourceTests(TestCase):
         )
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
+        self.assertEqual("search", p["operation-type"])
         self.assertEqual("_all", p["index"])
         self.assertEqual("type1", p["type"])
         self.assertDictEqual({}, p["request-params"])
@@ -2620,6 +2624,40 @@ class SearchParamSourceTests(TestCase):
             },
             p["body"],
         )
+
+    def test_passes_search_operation_type_by_default(self):
+        index1 = track.Index(name="index1")
+
+        source = params.SearchParamSource(
+            track = track.Track(name="unit-test", indices=[index1]),
+            params = { }
+        )
+
+        p = source.params()
+        self.assertEqual("search", p["operation-type"])
+
+    def test_user_specified_operation_type_overrides_defaults(self):
+        index1 = track.Index(name="index1")
+
+        source_scroll = params.SearchParamSource(
+            track = track.Track(name="unit-test", indices=[index1]),
+            params = {
+                "operation-type": "scroll-search"
+            }
+        )
+
+        source_paginated = params.SearchParamSource(
+            track = track.Track(name="unit-test", indices=[index1]),
+            params = {
+                "operation-type": "paginated-search"
+            }
+        )
+
+        p1 = source_scroll.params()
+        self.assertEqual("scroll-search", p1["operation-type"])
+
+        p2 = source_paginated.params()
+        self.assertEqual("paginated-search", p2["operation-type"])
 
     def test_user_specified_data_stream_overrides_defaults(self):
         ds1 = track.DataStream(name="data-stream-1")
@@ -2640,7 +2678,8 @@ class SearchParamSourceTests(TestCase):
         )
         p = source.params()
 
-        self.assertEqual(10, len(p))
+        self.assertEqual(11, len(p))
+        self.assertEqual("search", p["operation-type"])
         self.assertEqual("data-stream-2", p["index"])
         self.assertIsNone(p["type"])
         self.assertEqual(1.0, p["request-timeout"])

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2628,10 +2628,7 @@ class SearchParamSourceTests(TestCase):
     def test_passes_search_operation_type_by_default(self):
         index1 = track.Index(name="index1")
 
-        source = params.SearchParamSource(
-            track = track.Track(name="unit-test", indices=[index1]),
-            params = { }
-        )
+        source = params.SearchParamSource(track=track.Track(name="unit-test", indices=[index1]), params={})
 
         p = source.params()
         self.assertEqual("search", p["operation-type"])
@@ -2640,17 +2637,11 @@ class SearchParamSourceTests(TestCase):
         index1 = track.Index(name="index1")
 
         source_scroll = params.SearchParamSource(
-            track = track.Track(name="unit-test", indices=[index1]),
-            params = {
-                "operation-type": "scroll-search"
-            }
+            track=track.Track(name="unit-test", indices=[index1]), params={"operation-type": "scroll-search"}
         )
 
         source_paginated = params.SearchParamSource(
-            track = track.Track(name="unit-test", indices=[index1]),
-            params = {
-                "operation-type": "paginated-search"
-            }
+            track=track.Track(name="unit-test", indices=[index1]), params={"operation-type": "paginated-search"}
         )
 
         p1 = source_scroll.params()

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2470,8 +2470,7 @@ class SearchParamSourceTests(TestCase):
         )
         p = source.params()
 
-        self.assertEqual(11, len(p))
-        self.assertEqual("search", p["operation-type"])
+        self.assertEqual(10, len(p))
         self.assertEqual("index1", p["index"])
         self.assertIsNone(p["type"])
         self.assertIsNone(p["request-timeout"])
@@ -2510,8 +2509,7 @@ class SearchParamSourceTests(TestCase):
         )
         p = source.params()
 
-        self.assertEqual(11, len(p))
-        self.assertEqual("search", p["operation-type"])
+        self.assertEqual(10, len(p))
         self.assertEqual("data-stream-1", p["index"])
         self.assertIsNone(p["type"])
         self.assertEqual(1.0, p["request-timeout"])
@@ -2563,8 +2561,7 @@ class SearchParamSourceTests(TestCase):
         )
         p = source.params()
 
-        self.assertEqual(11, len(p))
-        self.assertEqual("search", p["operation-type"])
+        self.assertEqual(10, len(p))
         self.assertEqual("index1", p["index"])
         self.assertIsNone(p["type"])
         self.assertIsNone(p["request-timeout"])
@@ -2604,8 +2601,7 @@ class SearchParamSourceTests(TestCase):
         )
         p = source.params()
 
-        self.assertEqual(11, len(p))
-        self.assertEqual("search", p["operation-type"])
+        self.assertEqual(10, len(p))
         self.assertEqual("_all", p["index"])
         self.assertEqual("type1", p["type"])
         self.assertDictEqual({}, p["request-params"])
@@ -2624,31 +2620,6 @@ class SearchParamSourceTests(TestCase):
             },
             p["body"],
         )
-
-    def test_passes_search_operation_type_by_default(self):
-        index1 = track.Index(name="index1")
-
-        source = params.SearchParamSource(track=track.Track(name="unit-test", indices=[index1]), params={})
-
-        p = source.params()
-        self.assertEqual("search", p["operation-type"])
-
-    def test_user_specified_operation_type_overrides_defaults(self):
-        index1 = track.Index(name="index1")
-
-        source_scroll = params.SearchParamSource(
-            track=track.Track(name="unit-test", indices=[index1]), params={"operation-type": "scroll-search"}
-        )
-
-        source_paginated = params.SearchParamSource(
-            track=track.Track(name="unit-test", indices=[index1]), params={"operation-type": "paginated-search"}
-        )
-
-        p1 = source_scroll.params()
-        self.assertEqual("scroll-search", p1["operation-type"])
-
-        p2 = source_paginated.params()
-        self.assertEqual("paginated-search", p2["operation-type"])
 
     def test_user_specified_data_stream_overrides_defaults(self):
         ds1 = track.DataStream(name="data-stream-1")
@@ -2669,8 +2640,7 @@ class SearchParamSourceTests(TestCase):
         )
         p = source.params()
 
-        self.assertEqual(11, len(p))
-        self.assertEqual("search", p["operation-type"])
+        self.assertEqual(10, len(p))
         self.assertEqual("data-stream-2", p["index"])
         self.assertIsNone(p["type"])
         self.assertEqual(1.0, p["request-timeout"])


### PR DESCRIPTION
In the course of getting started on https://github.com/elastic/rally/issues/1215, I discovered that `scroll-search` operations don't default to the index (or data stream) defined at the top level of the track under the `indices` key. The `pmc` and `geonames` tracks expose this. But if you explicitly provide an `index` parameter to the operation (as `http_logs` does)[^1] it works...

...by accident, it turns out. After digging into it, the core issue seems to be that there was no parameter source registered for `scroll-search` or `paginated-search` operations. So, neither the track object's `indices` attribute (necessary for choosing a default `index` parameter for the operation) nor the `operation-type` parameter (necessary for choosing the right function to call) was getting passed down the chain. But, the way the control flow works for dispatching to the appropriate function in the in the `Query.__call__` method, it wound up just issuing a request body query with a `pages` parameter, which happens to be the legacy implementation of scroll searches.

So, this commit addresses this by doing three things:

1. Augmenting `SearchParamSource` to pass the `operation-type` it receives through to its callers.
2. Registering `SearchParamSource` for both scrolls and paginated queries.
3. Enforcing `operation-type` as a mandatory paramater when calling the `Query` runner (necessary for custom parameter sources to avoid unexpected behavior.)

_That said_, I do wonder if it'd make sense to have separate classes (perhaps subclasses of `Query`) for each of these three operations. Their logic is distinct, it's possible that they should have their own parameter sources, and dispatching on the operation type within one large `__call__` method feels a little indirect given that we already have a mechanism for explicitly registering runners on a per-operation basis. I worry there may be some other trappy behavior lurking in here somewhere, but I opted to fix the bug within the current implementation instead of doing a larger refactoring along those lines. Happy to hear any thoughts on that front.

[^1]: https://github.com/michaelbaamonde/rally-tracks/commit/b700eac059ab42246768f44d0e656caf144a0269 contains the relevant changes that sparked this investigation.