### PR TITLE
Revert "Retrieve master node using cat API"

### DIFF
--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -2022,7 +2022,8 @@ class MasterNodeStatsRecorder:
         import elasticsearch
 
         try:
-            info = self.client.cat.master(format="json")
+            state = self.client.cluster.state(metric="master_node")
+            info = self.client.nodes.info(node_id=state["master_node"], metric="os")
         except elasticsearch.TransportError:
             msg = f"A transport error occurred while collecting master node stats on cluster [{self.cluster_name}]"
             self.logger.exception(msg)
@@ -2030,7 +2031,7 @@ class MasterNodeStatsRecorder:
 
         doc = {
             "name": "master-node-stats",
-            "node": info[0]["node"],
+            "node": info["nodes"][state["master_node"]]["name"],
         }
 
         self.metrics_store.put_doc(doc, level=MetaInfoScope.cluster)

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -153,12 +153,12 @@ class StartupTimeTests(TestCase):
 
 
 class Client:
-    def __init__(self, nodes=None, info=None, indices=None, transform=None, cat=None, transport_client=None):
+    def __init__(self, nodes=None, info=None, indices=None, transform=None, cluster=None, transport_client=None):
         self.nodes = nodes
         self._info = wrap(info)
         self.indices = indices
         self.transform = transform
-        self.cat = cat
+        self.cluster = cluster
         if transport_client:
             self.transport = transport_client
 
@@ -167,13 +167,13 @@ class Client:
 
 
 class SubClient:
-    def __init__(self, stats=None, info=None, recovery=None, transform_stats=None, data_streams_stats=None, master=None):
+    def __init__(self, stats=None, info=None, recovery=None, transform_stats=None, data_streams_stats=None, state=None):
         self._stats = wrap(stats)
         self._info = wrap(info)
         self._recovery = wrap(recovery)
         self._transform_stats = wrap(transform_stats)
         self._data_streams_stats = wrap(data_streams_stats)
-        self._master = wrap(master)
+        self._state = wrap(state)
 
     def stats(self, *args, **kwargs):
         return self._stats()
@@ -190,8 +190,8 @@ class SubClient:
     def data_streams_stats(self, *args, **kwargs):
         return self._data_streams_stats()
 
-    def master(self, *args, **kwargs):
-        return self._master()
+    def state(self, *args, **kwargs):
+        return self._state()
 
 
 def wrap(it):
@@ -3734,15 +3734,24 @@ class MasterNodeStatsTests(TestCase):
 
 
 class MasterNodeStatsRecorderTests(TestCase):
-    master_node_cat_response = [
-        {
-            "node": "rally-0",
+    master_node_state_response = {
+        "master_node": "12345",
+    }
+
+    master_node_info_response = {
+        "nodes": {
+            "12345": {
+                "name": "rally-0",
+            }
         }
-    ]
+    }
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_store_master_node_stats(self, metrics_store_put_doc):
-        client = Client(cat=SubClient(master=self.master_node_cat_response))
+        client = Client(
+            cluster=SubClient(state=self.master_node_state_response),
+            nodes=SubClient(info=self.master_node_info_response),
+        )
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         recorder = telemetry.MasterNodeStatsRecorder(client=client, metrics_store=metrics_store, sample_interval=1)


### PR DESCRIPTION
This reverts commit fbcf365671fcb9279cca735d02d56efc347381a3. The _cat APIs are not meant for programmatic use, can be slower and don't have any backwards compatibility guarantees.

I had this commit ready in [`fbcf365` (#1330)](https://github.com/elastic/rally/pull/1330/commits/fbcf365671fcb9279cca735d02d56efc347381a3), and I just learned about _cat APIs lack of guarantees, so I figured out it would make sense to revert it.

Tested like this:

```
esrally race --distribution-version=7.14.1 --car="4gheap" --track=geonames --test-mode --telemetry master-node-stats --telemetry-params="master-node-stats-sample-interval: 0.1"
http localhost:9200/rally-metrics-2021-10/_search\?size=1000 | jq . | grep master-node -c  # should return more than 0 values
```