### PR TITLE
Allow paginated-search in CompositeContext

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2320,6 +2320,7 @@ class Composite(Runner):
         self.supported_op_types = [
             "open-point-in-time",
             "close-point-in-time",
+            "paginated-search",
             "search",
             "raw-request",
             "sleep",

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2320,8 +2320,8 @@ class Composite(Runner):
         self.supported_op_types = [
             "open-point-in-time",
             "close-point-in-time",
-            "paginated-search",
             "search",
+            "paginated-search",
             "raw-request",
             "sleep",
             "submit-async-search",

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -5517,7 +5517,7 @@ class CompositeTests(TestCase):
 
         self.assertEqual(
             "Unsupported operation-type [bulk]. Use one of [open-point-in-time, close-point-in-time, "
-            "search, raw-request, sleep, submit-async-search, get-async-search, delete-async-search].",
+            "search, paginated-search, raw-request, sleep, submit-async-search, get-async-search, delete-async-search].",
             ctx.exception.args[0],
         )
 


### PR DESCRIPTION
This is the documented way to run paginated searches.

Unfortunately, the functionality is tested but at a lower-level that does not involve the `Composite` class. I considered fixing the tests but this is a short-time fix: we agreed offline that the long-term fix should be to let the runner tell whether it supports composite, following the [single responsibility principle](https://en.wikipedia.org/wiki/Single-responsibility_principle).