### PR TITLE
Migrate CI job definitions into the .ci directory.

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,85 @@
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: elasticsearch-ci
+
+##### JOB DEFAULTS
+
+- job:
+    vault: []
+    node: "rally"
+    concurrent: true
+    logrotate:
+      daysToKeep: 30
+      numToKeep: 500
+      artifactDaysToKeep: 7
+    parameters:
+      - string:
+          name: branch_specifier
+          default: "refs/heads/{branch}"
+          description: "the Git branch specifier to build (&lt;branchName&gt;,
+    &lt;tagName&gt;, &lt;commitId&gt;, etc.)\n"
+    scm:
+      - git:
+          name: origin
+          # master node jenkins user ~/.ssh
+          credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          reference-repo: "/var/lib/jenkins/.git-references/rally.git"
+          branches:
+            - "${branch_specifier}"
+          url: "https://github.com/elastic/rally.git"
+          basedir: ""
+          wipe-workspace: true
+    triggers: []
+    wrappers:
+      - ansicolor
+      - timeout:
+          type: absolute
+          timeout: 80
+          fail: true
+      - timestamps
+    properties:
+      - github:
+          url: https://github.com/elastic/rally/
+      - inject:
+          properties-content: |
+            JOB_BRANCH=%BRANCH%
+            HOME=$JENKINS_HOME
+    builders:
+      - inject:
+          properties-content: |
+            HOME=$JENKINS_HOME
+            JAVA7_HOME=$HOME/.java/java7
+            JAVA8_HOME=$HOME/.java/java8
+            JAVA9_HOME=$HOME/.java/java9
+            JAVA10_HOME=$HOME/.java/java10
+            JAVA11_HOME=$HOME/.java/java11
+            JAVA12_HOME=$HOME/.java/openjdk12
+            JAVA13_HOME=$HOME/.java/openjdk13
+            JAVA14_HOME=$HOME/.java/openjdk14
+            JAVA15_HOME=$HOME/.java/openjdk15
+            JAVA16_HOME=$HOME/.java/openjdk16
+            JAVA17_HOME=$HOME/.java/openjdk17
+            ES_JAVA_HOME=$JAVA17_HOME
+            RALLY_HOME=$WORKSPACE
+      - shell: |
+          #!/usr/local/bin/runbld
+          bash .ci/build.sh build
+          bash .ci/build.sh archive
+    publishers:
+      - email:
+          recipients: infra-root+build@elastic.co
+      - junit:
+          results: 'junit-py*.xml'
+          keep-long-stdio: true
+      - google-cloud-storage:
+          credentials-id: 'elasticsearch-ci-gcs-plugin'
+          uploads:
+            - classic:
+                file-pattern: '.rally/$BUILD_NUMBER.tar.bz2'
+                storage-location: 'gs://elasticsearch-ci-artifacts/jobs/$JOB_NAME'
+                share-publicly: false
+                upload-for-failed-jobs: true
+                show-inline: true

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -44,7 +44,6 @@
           url: https://github.com/elastic/rally/
       - inject:
           properties-content: |
-            JOB_BRANCH=%BRANCH%
             HOME=$JENKINS_HOME
     builders:
       - inject:

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -19,8 +19,7 @@
       - string:
           name: branch_specifier
           default: "refs/heads/{branch}"
-          description: "the Git branch specifier to build (&lt;branchName&gt;,
-    &lt;tagName&gt;, &lt;commitId&gt;, etc.)\n"
+          description: "the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;, &lt;commitId&gt;, etc.)\n"
     scm:
       - git:
           name: origin

--- a/.ci/jobs/periodic.yml
+++ b/.ci/jobs/periodic.yml
@@ -1,0 +1,5 @@
+---
+
+jjbb-template: periodic.yml
+vars:
+  - branch: master

--- a/.ci/jobs/pull-request.yml
+++ b/.ci/jobs/pull-request.yml
@@ -1,0 +1,22 @@
+---
+
+- job:
+    name: "elastic+rally+pull-request"
+    display-name: "elastic / rally # pull-request"
+    description: "CI testing for rally pull requests"
+    scm:
+      - git:
+          refspec: "+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*"
+          branches:
+            - "${ghprbActualCommit}"
+    triggers:
+      - github-pull-request:
+          org-list:
+            - elastic
+          allow-whitelist-orgs-as-admins: true
+          trigger-phrase: '.*run\W+tests.*'
+          github-hooks: true
+          status-context: tests
+          cancel-builds-on-update: true
+          black-list-labels:
+            - '>test-mute'

--- a/.ci/jobs/push.yml
+++ b/.ci/jobs/push.yml
@@ -1,0 +1,5 @@
+---
+
+jjbb-template: push.yml
+vars:
+  - branch: master

--- a/.ci/jobs/release-docker.yml
+++ b/.ci/jobs/release-docker.yml
@@ -1,0 +1,34 @@
+---
+
+- job:
+    name: "elastic+rally-release-docker+master"
+    display-name: "elastic / rally # master - release docker"
+    description: "Release Docker Artifacts for Rally"
+    parameters:
+      - string:
+          name: branch_specifier
+          default: "refs/heads/master"
+          description: "the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
+          name: RELEASE_VERSION
+          default: ""
+          description: "The version to release e.g. '1.2.1'."
+    triggers: []
+    builders:
+      - shell: |
+          #!/usr/bin/env bash
+          set -eo pipefail
+          set +x
+          VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          # login to docker registry
+          DOCKER_PASSWORD=$(vault read -field token secret/release/docker-hub-rally)
+          unset VAULT_TOKEN
+          source /usr/local/bin/bash_standard_lib.sh
+          retry 5 docker login -u elasticmachine -p $DOCKER_PASSWORD
+          unset DOCKER_PASSWORD
+          set -x
+          export TERM=dumb
+          export LC_ALL=en_US.UTF-8
+          ./release-docker.sh "$RELEASE_VERSION"

--- a/.ci/templates/periodic.yml
+++ b/.ci/templates/periodic.yml
@@ -1,0 +1,8 @@
+---
+
+- job:
+    name: elastic+rally+{branch}+periodic
+    display-name: "elastic / rally # {branch} - periodic"
+    description: "CI testing for Rally"
+    triggers:
+      - timed: "H H * * *"

--- a/.ci/templates/push.yml
+++ b/.ci/templates/push.yml
@@ -1,0 +1,6 @@
+---
+
+- job:
+    name: elastic+rally+{branch}
+    display-name: "elastic / rally # {branch}"
+    description: "CI testing for Rally #{branch}"

--- a/.ci/views/views.yml
+++ b/.ci/views/views.yml
@@ -1,0 +1,4 @@
+- view:
+    name: "rally"
+    view-type: list
+    regex: '^elastic[-+]rally.*$'


### PR DESCRIPTION
This commit migrates our Jenkins job definitions into the Rally repository. It also adds a view called "Rally" to the CI cluster's landing page that includes the jobs defined here.

I tested each of these jobs--except for the `docker-release` job--with a local Jenkins master that is configured identically to the one controlling https://elasticsearch-ci.elastic.co. It spun up ephemeral workers in GCP to run the builds, which were also configured identically to those that a production build would run on.

Regarding `docker-release`, I didn't want to assume that running the job with an already-released version of Rally would be a true no-op. The actual contents of the job are identical to what we've been using, but if folks would like to test it out somehow anyway, I'm happy to figure out how to do that safely.