### PR TITLE
Specify base-10 for int() for known strings and bytes

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -106,7 +106,7 @@ def wait_for_pidfile(pidfilename, timeout=60, clock=time.Clock):
                 buf = f.read()
                 if not buf:
                     raise EOFError
-                return int(buf)
+                return int(buf, 10)
         except (FileNotFoundError, EOFError):
             time.sleep(0.5)
 

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -50,7 +50,7 @@ def install(cfg):
     sources = not distribution
     build_type = cfg.opts("mechanic", "build.type")
     ip = cfg.opts("mechanic", "network.host")
-    http_port = int(cfg.opts("mechanic", "network.http.port"))
+    http_port = int(cfg.opts("mechanic", "network.http.port"), 10)
     node_name = cfg.opts("mechanic", "node.name")
     master_nodes = cfg.opts("mechanic", "master.nodes")
     seed_hosts = cfg.opts("mechanic", "seed.hosts")

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -60,7 +60,7 @@ class ExitStatus(Enum):
 
 def create_arg_parser():
     def positive_number(v):
-        value = int(v)
+        value = int(v, 10)
         if value <= 0:
             raise argparse.ArgumentTypeError(f"must be positive but was {value}")
         return value

--- a/esrally/utils/console.py
+++ b/esrally/utils/console.py
@@ -110,7 +110,7 @@ def init(quiet=False, assume_tty=True):
     #
     # Set a proper width (see argparse.HelpFormatter)
     try:
-        int(os.environ["COLUMNS"])
+        int(os.environ["COLUMNS"], 10)
     except (KeyError, ValueError):
         # noinspection PyBroadException
         try:

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -181,7 +181,7 @@ def download_http(url, local_path, expected_size_in_bytes=None, progress_indicat
             raise urllib.error.HTTPError(url, r.status, "", None, None)
         # noinspection PyBroadException
         try:
-            size_from_content_header = int(r.getheader("Content-Length"))
+            size_from_content_header = int(r.getheader("Content-Length"), 10)
             if expected_size_in_bytes is None:
                 expected_size_in_bytes = size_from_content_header
         except BaseException:


### PR DESCRIPTION
With this commit, we explicitly specify base-10 for string and bytes `int()` conversions. Specifying the base is known to boost performance for `int()` conversions as mentioned in https://github.com/elastic/rally/issues/1379. This optimization can only be 
applied when we know the input to be a string or bytes.

While I would have liked to have added the optimization to more code paths, there is a limitation when we cannot guarantee non-numeric inputs. Python will throw a `TypeError` when attempting to convert a non-string with an explicit base, therefore we only designate base-10 when we know for certain the input will be a non-numeric type. A full review of every invocation of `int()` in the code base revealed we cannot always make that guarantee. 

Closes https://github.com/elastic/rally/issues/1379