### PR TITLE
Tell pip to install latest Rally on newer Pythons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,13 +91,13 @@ tox-env-clean:
 	rm -rf .tox
 
 lint: check-venv
-	@find esrally benchmarks scripts tests it -name "*.py" -exec $(VEPYLINT) -j0 -rn --rcfile=$(CURDIR)/.pylintrc \{\} +
-	@. $(VENV_ACTIVATE_FILE); black --config=black.toml --check esrally benchmarks scripts tests it
-	@. $(VENV_ACTIVATE_FILE); isort --check esrally benchmarks scripts tests it
+	@find esrally benchmarks scripts tests it setup.py -name "*.py" -exec $(VEPYLINT) -j0 -rn --rcfile=$(CURDIR)/.pylintrc \{\} +
+	@. $(VENV_ACTIVATE_FILE); black --config=black.toml --check esrally benchmarks scripts tests it setup.py
+	@. $(VENV_ACTIVATE_FILE); isort --check esrally benchmarks scripts tests it setup.py
 
 format: check-venv
-	@. $(VENV_ACTIVATE_FILE); black --config=black.toml esrally benchmarks scripts tests it
-	@. $(VENV_ACTIVATE_FILE); isort esrally benchmarks scripts tests it
+	@. $(VENV_ACTIVATE_FILE); black --config=black.toml esrally benchmarks scripts tests it setup.py
+	@. $(VENV_ACTIVATE_FILE); isort esrally benchmarks scripts tests it setup.py
 
 docs: check-venv
 	@. $(VENV_ACTIVATE_FILE); cd docs && $(MAKE) html

--- a/setup.py
+++ b/setup.py
@@ -108,8 +108,6 @@ develop_require = [
 python_version_classifiers = ["Programming Language :: Python :: {}.{}".format(major, minor) for major, minor in supported_python_versions]
 
 first_supported_version = "{}.{}".format(supported_python_versions[0][0], supported_python_versions[0][1])
-# next minor after the latest supported version
-first_unsupported_version = "{}.{}".format(supported_python_versions[-1][0], supported_python_versions[-1][1] + 1)
 
 # we call the tool rally, but it will be published as esrally on pypi
 setup(
@@ -123,19 +121,7 @@ setup(
     license="Apache License, Version 2.0",
     packages=find_packages(where=".", exclude=("tests*", "benchmarks*", "it*")),
     include_package_data=True,
-    # supported Python versions. This will prohibit pip (> 9.0.0) from even installing Rally on an unsupported
-    # Python version.
-    # See also https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    #
-    # According to https://www.python.org/dev/peps/pep-0440/#version-matching, a trailing ".*" should
-    # ignore patch versions:
-    #
-    # "additional trailing segments will be ignored when determining whether or not a version identifier matches
-    # the clause"
-    #
-    # However, with the pattern ">=3.5.*,<=3.8.*", the version "3.8.0" is not accepted. Therefore, we match
-    # the minor version after the last supported one (i.e. if 3.8 is the last supported, we'll emit "<3.9")
-    python_requires=">={},<{}".format(first_supported_version, first_unsupported_version),
+    python_requires=">={}".format(first_supported_version),
     package_data={"": ["*.json", "*.yml"]},
     install_requires=install_requires,
     test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from os.path import join, dirname
 import re
+from os.path import dirname, join
 
 try:
-    from setuptools import setup, find_packages
+    from setuptools import find_packages, setup
 except ImportError:
     print("*** Could not find setuptools. Did you install pip3? *** \n\n")
     raise
@@ -78,7 +78,7 @@ install_requires = [
     #   google-crc32c: Apache 2.0
     "google-resumable-media[requests]==1.1.0",
     # License: Apache 2.0
-    "google-auth==1.22.1"
+    "google-auth==1.22.1",
 ]
 
 s3_require = [
@@ -90,12 +90,7 @@ s3_require = [
     "boto3==1.10.32",
 ]
 
-tests_require = [
-    "ujson",
-    "pytest==6.2.5",
-    "pytest-benchmark==3.2.2",
-    "pytest-asyncio==0.16.0"
-]
+tests_require = ["ujson", "pytest==6.2.5", "pytest-benchmark==3.2.2", "pytest-asyncio==0.16.0"]
 
 # These packages are only required when developing Rally
 develop_require = [
@@ -110,62 +105,55 @@ develop_require = [
     "isort==5.8.0",
 ]
 
-python_version_classifiers = ["Programming Language :: Python :: {}.{}".format(major, minor)
-                              for major, minor in supported_python_versions]
+python_version_classifiers = ["Programming Language :: Python :: {}.{}".format(major, minor) for major, minor in supported_python_versions]
 
 first_supported_version = "{}.{}".format(supported_python_versions[0][0], supported_python_versions[0][1])
 # next minor after the latest supported version
 first_unsupported_version = "{}.{}".format(supported_python_versions[-1][0], supported_python_versions[-1][1] + 1)
 
 # we call the tool rally, but it will be published as esrally on pypi
-setup(name="esrally",
-      maintainer="Daniel Mitterdorfer",
-      maintainer_email="daniel.mitterdorfer@gmail.com",
-      version=version,
-      description="Macrobenchmarking framework for Elasticsearch",
-      long_description=long_description,
-      url="https://github.com/elastic/rally",
-      license="Apache License, Version 2.0",
-      packages=find_packages(
-          where=".",
-          exclude=("tests*", "benchmarks*", "it*")
-      ),
-      include_package_data=True,
-      # supported Python versions. This will prohibit pip (> 9.0.0) from even installing Rally on an unsupported
-      # Python version.
-      # See also https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-      #
-      # According to https://www.python.org/dev/peps/pep-0440/#version-matching, a trailing ".*" should
-      # ignore patch versions:
-      #
-      # "additional trailing segments will be ignored when determining whether or not a version identifier matches
-      # the clause"
-      #
-      # However, with the pattern ">=3.5.*,<=3.8.*", the version "3.8.0" is not accepted. Therefore, we match
-      # the minor version after the last supported one (i.e. if 3.8 is the last supported, we'll emit "<3.9")
-      python_requires=">={},<{}".format(first_supported_version, first_unsupported_version),
-      package_data={"": ["*.json", "*.yml"]},
-      install_requires=install_requires,
-      test_suite="tests",
-      tests_require=tests_require,
-      extras_require={
-          "develop": tests_require + develop_require + s3_require,
-          "s3": s3_require
-      },
-      entry_points={
-          "console_scripts": [
-              "esrally=esrally.rally:main",
-              "esrallyd=esrally.rallyd:main"
-          ],
-      },
-      classifiers=[
-          "Topic :: System :: Benchmark",
-          "Development Status :: 5 - Production/Stable",
-          "License :: OSI Approved :: Apache Software License",
-          "Intended Audience :: Developers",
-          "Operating System :: MacOS :: MacOS X",
-          "Operating System :: POSIX",
-          "Programming Language :: Python",
-          "Programming Language :: Python :: 3",
-      ] + python_version_classifiers,
-      zip_safe=False)
+setup(
+    name="esrally",
+    maintainer="Daniel Mitterdorfer",
+    maintainer_email="daniel.mitterdorfer@gmail.com",
+    version=version,
+    description="Macrobenchmarking framework for Elasticsearch",
+    long_description=long_description,
+    url="https://github.com/elastic/rally",
+    license="Apache License, Version 2.0",
+    packages=find_packages(where=".", exclude=("tests*", "benchmarks*", "it*")),
+    include_package_data=True,
+    # supported Python versions. This will prohibit pip (> 9.0.0) from even installing Rally on an unsupported
+    # Python version.
+    # See also https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
+    #
+    # According to https://www.python.org/dev/peps/pep-0440/#version-matching, a trailing ".*" should
+    # ignore patch versions:
+    #
+    # "additional trailing segments will be ignored when determining whether or not a version identifier matches
+    # the clause"
+    #
+    # However, with the pattern ">=3.5.*,<=3.8.*", the version "3.8.0" is not accepted. Therefore, we match
+    # the minor version after the last supported one (i.e. if 3.8 is the last supported, we'll emit "<3.9")
+    python_requires=">={},<{}".format(first_supported_version, first_unsupported_version),
+    package_data={"": ["*.json", "*.yml"]},
+    install_requires=install_requires,
+    test_suite="tests",
+    tests_require=tests_require,
+    extras_require={"develop": tests_require + develop_require + s3_require, "s3": s3_require},
+    entry_points={
+        "console_scripts": ["esrally=esrally.rally:main", "esrallyd=esrally.rallyd:main"],
+    },
+    classifiers=[
+        "Topic :: System :: Benchmark",
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: Apache Software License",
+        "Intended Audience :: Developers",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: POSIX",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+    ]
+    + python_version_classifiers,
+    zip_safe=False,
+)


### PR DESCRIPTION
Currently, running `pip install esrally` on Python 3.10 installs Rally
1.4.0. Installing the latest version is much more likely to be helpful.

:warning: Please rebase instead of squash due to the lint commit.