### PR TITLE
Revert "Use explicit config files for black and isort"

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-profile = black

--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,11 @@ tox-env-clean:
 
 lint: check-venv
 	@find esrally benchmarks scripts tests it setup.py -name "*.py" -exec $(VEPYLINT) -j0 -rn --rcfile=$(CURDIR)/.pylintrc \{\} +
-	@. $(VENV_ACTIVATE_FILE); black --config=black.toml --check esrally benchmarks scripts tests it setup.py
+	@. $(VENV_ACTIVATE_FILE); black --check esrally benchmarks scripts tests it setup.py
 	@. $(VENV_ACTIVATE_FILE); isort --check esrally benchmarks scripts tests it setup.py
 
 format: check-venv
-	@. $(VENV_ACTIVATE_FILE); black --config=black.toml esrally benchmarks scripts tests it setup.py
+	@. $(VENV_ACTIVATE_FILE); black esrally benchmarks scripts tests it setup.py
 	@. $(VENV_ACTIVATE_FILE); isort esrally benchmarks scripts tests it setup.py
 
 docs: check-venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.black]
 line-length = 140
 target-version = ['py38']
+
+[tool.isort]
+profile = 'black'

--- a/run.sh
+++ b/run.sh
@@ -37,9 +37,9 @@ install_esrally_with_setuptools () {
     if [[ ${IN_VIRTUALENV} == 0 ]]; then
         # https://setuptools.readthedocs.io/en/latest/setuptools.html suggests not invoking setup.py directly
         # Also workaround system pip conflicts, https://github.com/pypa/pip/issues/5599
-        python3 -m pip install --quiet --user --upgrade --editable .[develop]
+        python3 -m pip install --quiet --user --upgrade --no-use-pep517 --editable .[develop]
     else
-        python3 -m pip install --quiet --upgrade --editable .[develop]
+        python3 -m pip install --quiet --upgrade --no-use-pep517 --editable .[develop]
     fi
 }
 


### PR DESCRIPTION
This reverts commit 9c4505f7f3b64d61e9e102049ff82c2b586a8ab3. The
problem with the pyproject.toml file was that it enabled PEP 517, but we
don't want it because editable installs don't work as PEP 660 is not
implemented yet.

However, having a pyproject.toml file is the only practical way of
configuring black, and we can opt out of PEP 517 using
`--no-use-pep517`.

A few months later, now that our internal tooling is ready, we can have a pyproject.toml file again. This way, we won't have to configure black line length manually in our editors.