### PR TITLE
Add Ingest Pipeline Telemetry device

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -24,17 +24,18 @@ If you invoke ``esrally list telemetry``, it will show which telemetry devices a
    Command                     Name                        Description
    --------------------------  --------------------------  --------------------------------------------------------------------
    jit                         JIT Compiler Profiler       Enables JIT compiler logs.
-   gc                          GC log                      Enables GC logs.
+   gc                          GC log                      Enables GC logs
    jfr                         Flight Recorder             Enables Java Flight Recorder (requires an Oracle JDK or OpenJDK 11+)
-   heapdump                    Heap Dump                   Captures a heap dump.
+   heapdump                    Heap Dump                   Captures a heap dump
    node-stats                  Node Stats                  Regularly samples node stats
    recovery-stats              Recovery Stats              Regularly samples shard recovery stats
    ccr-stats                   CCR Stats                   Regularly samples Cross Cluster Replication (CCR) related stats
-   segment-stats               Segment Stats               Determines segment stats at the end of the benchmark.
+   segment-stats               Segment Stats               Determines segment stats at the end of the benchmark
    transform-stats             Transform Stats             Regularly samples transform stats
    searchable-snapshots-stats  Searchable Snapshots Stats  Regularly samples searchable snapshots stats
    shard-stats                 Shard Stats                 Regularly samples nodes stats at shard level
    data-stream-stats           Data Streams Stats          Regularly samples data streams stats
+   ingest-pipeline-stats       Ingest Pipeline Stats       Determines ingest pipeline stats at the end of the benchmark
 
    Keep in mind that each telemetry device may incur a runtime overhead which can skew results.
 
@@ -198,7 +199,7 @@ Supported telemetry parameters:
 data-stream-stats
 -----------------
 
-The data-stream-stats telemetry device regularly calls the `data stream stats API <https://https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-stats-api.html>`_ and records one metrics document for cluster level stats (``_all``), and one metrics document per data stream.
+The data-stream-stats telemetry device regularly calls the `data stream stats API <https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-stats-api.html>`_ and records one metrics document for cluster level stats (``_all``), and one metrics document per data stream.
 
 Example of recorded documents given two data streams in the cluster::
 
@@ -232,3 +233,51 @@ Example of recorded documents given two data streams in the cluster::
 Supported telemetry parameters:
 
 * ``data-stream-stats-sample-interval`` (default 10): A positive number greater than zero denoting the sampling interval in seconds.
+
+ingest-pipeline-stats
+---------------------
+
+The ingest-pipeline-stats telemetry device makes a call at the beginning and end of the benchmark to the `node stats API (_nodes/stats/ingest) <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html>`_ and records:
+
+  * Three results documents for each cluster: ``ingest_pipeline_cluster_count``, ``ingest_pipeline_cluster_time``, ``ingest_pipeline_cluster_failed``
+  * One metrics document for each node's respective stats: ``ingest_pipeline_node_count``, ``ingest_pipeline_node_time``, ``ingest_pipeline_node_failed``
+  * One metrics document for each pipeline's respective stats: ``ingest_pipeline_pipeline_count``, ``ingest_pipeline_pipeline_time``, ``ingest_pipeline_pipeline_failed``
+  * One metrics document for each pipeline processor's respective stats: ``ingest_pipeline_processor_count``, ``ingest_pipeline_processor_time``, ``ingest_pipeline_processor_failed``
+
+Example of recorded documents given a single cluster, single node, single pipeline, single processor::
+
+   {
+       "name": "ingest_pipeline_cluster_count",
+       "value": 1001,
+       "meta": {
+         "cluster_name": "docker-cluster"
+     }
+   },
+   {
+       "name": "ingest_pipeline_node_count",
+       "value": 1001,
+       "meta": {
+         "cluster_name": "docker-cluster",
+         "node_name": "node-001"
+     }
+   },
+   {
+       "name": "ingest_pipeline_pipeline_count",
+       "value": 1001,
+       "meta": {
+         "cluster_name": "docker-cluster",
+         "node_name": "node-001",
+         "ingest_pipeline": "test-pipeline-1"
+     }
+   },
+   {
+       "name": "ingest_pipeline_processor_count",
+       "value": 1001,
+       "meta": {
+         "cluster_name": "docker-cluster",
+         "node_name": "node-001",
+         "ingest_pipeline": "test-pipeline-1",
+         "processor_name": "uppercase_1",
+         "type": "uppercase"
+     }
+   }

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -251,7 +251,7 @@ Example of recorded documents given a single cluster, single node, single pipeli
        "value": 1001,
        "meta": {
          "cluster_name": "docker-cluster"
-     }
+       }
    },
    {
        "name": "ingest_pipeline_node_count",
@@ -259,7 +259,7 @@ Example of recorded documents given a single cluster, single node, single pipeli
        "meta": {
          "cluster_name": "docker-cluster",
          "node_name": "node-001"
-     }
+       }
    },
    {
        "name": "ingest_pipeline_pipeline_count",
@@ -268,7 +268,7 @@ Example of recorded documents given a single cluster, single node, single pipeli
          "cluster_name": "docker-cluster",
          "node_name": "node-001",
          "ingest_pipeline": "test-pipeline-1"
-     }
+       }
    },
    {
        "name": "ingest_pipeline_processor_count",
@@ -279,5 +279,5 @@ Example of recorded documents given a single cluster, single node, single pipeli
          "ingest_pipeline": "test-pipeline-1",
          "processor_name": "uppercase_1",
          "type": "uppercase"
-     }
+       }
    }

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -237,7 +237,7 @@ Supported telemetry parameters:
 ingest-pipeline-stats
 ---------------------
 
-The ingest-pipeline-stats telemetry device makes a call at the beginning and end of the benchmark to the `node stats API (_nodes/stats/ingest) <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html>`_ and records:
+The ingest-pipeline-stats telemetry device makes a call at the beginning and end of the benchmark to the `node stats API (_nodes/stats/ingest) <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html>`_ and records the deltas in the form of:
 
   * Three results documents for each cluster: ``ingest_pipeline_cluster_count``, ``ingest_pipeline_cluster_time``, ``ingest_pipeline_cluster_failed``
   * One metrics document for each node's respective stats: ``ingest_pipeline_node_count``, ``ingest_pipeline_node_time``, ``ingest_pipeline_node_failed``

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -611,7 +611,7 @@ class Driver:
                 telemetry.TransformStats(telemetry_params, es, self.metrics_store),
                 telemetry.SearchableSnapshotsStats(telemetry_params, es, self.metrics_store),
                 telemetry.DataStreamStats(telemetry_params, es, self.metrics_store),
-                telemetry.IngestPipelineStats(es, self.metrics_store)
+                telemetry.IngestPipelineStats(es, self.metrics_store),
             ]
         else:
             devices = []

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -611,6 +611,7 @@ class Driver:
                 telemetry.TransformStats(telemetry_params, es, self.metrics_store),
                 telemetry.SearchableSnapshotsStats(telemetry_params, es, self.metrics_store),
                 telemetry.DataStreamStats(telemetry_params, es, self.metrics_store),
+                telemetry.IngestPipelineStats(es, self.metrics_store)
             ]
         else:
             devices = []

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1804,6 +1804,12 @@ class GlobalStatsCalculator:
         result.total_transform_search_times = self.total_transform_metric("total_transform_search_time")
         result.total_transform_throughput = self.total_transform_metric("total_transform_throughput")
 
+        self.logger.debug("Gathering Ingest Pipeline metrics.")
+        result.ingest_pipeline_total_count = self.sum("ingest_pipeline_cluster_count")
+        result.ingest_pipeline_total_time = self.sum("ingest_pipeline_cluster_time")
+        result.ingest_pipeline_total_failed = self.sum("ingest_pipeline_cluster_failed")
+
+
         return result
 
     def merge(self, *args):
@@ -1955,6 +1961,10 @@ class GlobalStats:
         self.total_transform_index_times = self.v(d, "total_transform_index_times")
         self.total_transform_processing_times = self.v(d, "total_transform_processing_times")
         self.total_transform_throughput = self.v(d, "total_transform_throughput")
+
+        self.ingest_pipeline_total_count = self.v(d, "ingest_pipeline_cluster_count")
+        self.ingest_pipeline_total_time = self.v(d, "ingest_pipeline_cluster_time")
+        self.ingest_pipeline_total_failed = self.v(d, "ingest_pipeline_cluster_failed")
 
     def as_dict(self):
         return self.__dict__

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1805,10 +1805,9 @@ class GlobalStatsCalculator:
         result.total_transform_throughput = self.total_transform_metric("total_transform_throughput")
 
         self.logger.debug("Gathering Ingest Pipeline metrics.")
-        result.ingest_pipeline_total_count = self.sum("ingest_pipeline_cluster_count")
-        result.ingest_pipeline_total_time = self.sum("ingest_pipeline_cluster_time")
-        result.ingest_pipeline_total_failed = self.sum("ingest_pipeline_cluster_failed")
-
+        result.ingest_pipeline_cluster_count = self.sum("ingest_pipeline_cluster_count")
+        result.ingest_pipeline_cluster_time = self.sum("ingest_pipeline_cluster_time")
+        result.ingest_pipeline_cluster_failed = self.sum("ingest_pipeline_cluster_failed")
 
         return result
 
@@ -1962,9 +1961,9 @@ class GlobalStats:
         self.total_transform_processing_times = self.v(d, "total_transform_processing_times")
         self.total_transform_throughput = self.v(d, "total_transform_throughput")
 
-        self.ingest_pipeline_total_count = self.v(d, "ingest_pipeline_cluster_count")
-        self.ingest_pipeline_total_time = self.v(d, "ingest_pipeline_cluster_time")
-        self.ingest_pipeline_total_failed = self.v(d, "ingest_pipeline_cluster_failed")
+        self.ingest_pipeline_cluster_count = self.v(d, "ingest_pipeline_cluster_count")
+        self.ingest_pipeline_cluster_time = self.v(d, "ingest_pipeline_cluster_time")
+        self.ingest_pipeline_cluster_failed = self.v(d, "ingest_pipeline_cluster_failed")
 
     def as_dict(self):
         return self.__dict__

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -279,14 +279,7 @@ class SummaryReporter:
         )
 
     def _report_segment_counts(self, stats):
-        return self._join(
-            self._line(
-                "Segment count",
-                "",
-                stats.segment_count,
-                "",
-            )
-        )
+        return self._join(self._line("Segment count", "", stats.segment_count, ""))
 
     def _report_transform_stats(self, stats):
         lines = []
@@ -573,7 +566,6 @@ class ComparisonReporter:
 
     def _report_ingest_pipeline_counts(self, baseline_stats, contender_stats):
         if baseline_stats.ingest_pipeline_cluster_count is None:
-            print(baseline_stats.as_dict())
             return []
         return self._join(
             self._line(

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -279,7 +279,14 @@ class SummaryReporter:
         )
 
     def _report_segment_counts(self, stats):
-        return self._join(self._line("Segment count", "", stats.segment_count, "", ))
+        return self._join(
+            self._line(
+                "Segment count",
+                "",
+                stats.segment_count,
+                "",
+            )
+        )
 
     def _report_transform_stats(self, stats):
         lines = []
@@ -296,9 +303,9 @@ class SummaryReporter:
 
     def _report_ingest_pipeline_stats(self, stats):
         return self._join(
-            self._line("Total Ingest Pipeline count", "", stats.ingest_pipeline_total_count, ""),
-            self._line("Total Ingest Pipeline time", "", stats.ingest_pipeline_total_time, "ms"),
-            self._line("Total Ingest Pipeline failed", "", stats.ingest_pipeline_total_failed, ""),
+            self._line("Total Ingest Pipeline count", "", stats.ingest_pipeline_cluster_count, ""),
+            self._line("Total Ingest Pipeline time", "", stats.ingest_pipeline_cluster_time, "ms"),
+            self._line("Total Ingest Pipeline failed", "", stats.ingest_pipeline_cluster_failed, ""),
         )
 
     def _join(self, *args):
@@ -370,6 +377,9 @@ class ComparisonReporter:
         metrics_table.extend(self._report_segment_memory(baseline_stats, contender_stats))
         metrics_table.extend(self._report_segment_counts(baseline_stats, contender_stats))
         metrics_table.extend(self._report_transform_processing_times(baseline_stats, contender_stats))
+        metrics_table.extend(self._report_ingest_pipeline_counts(baseline_stats, contender_stats))
+        metrics_table.extend(self._report_ingest_pipeline_times(baseline_stats, contender_stats))
+        metrics_table.extend(self._report_ingest_pipeline_failed(baseline_stats, contender_stats))
 
         for t in baseline_stats.tasks():
             if t in contender_stats.tasks():
@@ -560,6 +570,49 @@ class ComparisonReporter:
                         )
                     )
         return lines
+
+    def _report_ingest_pipeline_counts(self, baseline_stats, contender_stats):
+        if baseline_stats.ingest_pipeline_cluster_count is None:
+            print(baseline_stats.as_dict())
+            return []
+        return self._join(
+            self._line(
+                "Total Ingest Pipeline count",
+                baseline_stats.ingest_pipeline_cluster_count,
+                contender_stats.ingest_pipeline_cluster_count,
+                "",
+                "",
+                treat_increase_as_improvement=False,
+            )
+        )
+
+    def _report_ingest_pipeline_times(self, baseline_stats, contender_stats):
+        if baseline_stats.ingest_pipeline_cluster_time is None:
+            return []
+        return self._join(
+            self._line(
+                "Total Ingest Pipeline time",
+                baseline_stats.ingest_pipeline_cluster_time,
+                contender_stats.ingest_pipeline_cluster_time,
+                "",
+                "ms",
+                treat_increase_as_improvement=False,
+            )
+        )
+
+    def _report_ingest_pipeline_failed(self, baseline_stats, contender_stats):
+        if baseline_stats.ingest_pipeline_cluster_failed is None:
+            return []
+        return self._join(
+            self._line(
+                "Total Ingest Pipeline failed",
+                baseline_stats.ingest_pipeline_cluster_failed,
+                contender_stats.ingest_pipeline_cluster_failed,
+                "",
+                "",
+                treat_increase_as_improvement=False,
+            )
+        )
 
     def _report_total_times(self, baseline_stats, contender_stats):
         lines = []

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -297,7 +297,7 @@ class SummaryReporter:
     def _report_ingest_pipeline_stats(self, stats):
         return self._join(
             self._line("Total Ingest Pipeline count", "", stats.ingest_pipeline_cluster_count, ""),
-            self._line("Total Ingest Pipeline time", "", stats.ingest_pipeline_cluster_time, "ms", convert.ms_to_seconds),
+            self._line("Total Ingest Pipeline time", "", stats.ingest_pipeline_cluster_time, "s", convert.ms_to_seconds),
             self._line("Total Ingest Pipeline failed", "", stats.ingest_pipeline_cluster_failed, ""),
         )
 

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -117,6 +117,8 @@ class SummaryReporter:
 
         metrics_table.extend(self._report_transform_stats(stats))
 
+        metrics_table.extend(self._report_ingest_pipeline_stats(stats))
+
         for record in stats.op_metrics:
             task = record["task"]
             metrics_table.extend(self._report_throughput(record, task))
@@ -277,7 +279,7 @@ class SummaryReporter:
         )
 
     def _report_segment_counts(self, stats):
-        return self._join(self._line("Segment count", "", stats.segment_count, ""))
+        return self._join(self._line("Segment count", "", stats.segment_count, "", ))
 
     def _report_transform_stats(self, stats):
         lines = []
@@ -291,6 +293,13 @@ class SummaryReporter:
             lines.append(self._line("Transform throughput", throughput["id"], throughput["mean"], throughput["unit"]))
 
         return lines
+
+    def _report_ingest_pipeline_stats(self, stats):
+        return self._join(
+            self._line("Total Ingest Pipeline count", "", stats.ingest_pipeline_total_count, ""),
+            self._line("Total Ingest Pipeline time", "", stats.ingest_pipeline_total_time, "ms"),
+            self._line("Total Ingest Pipeline failed", "", stats.ingest_pipeline_total_failed, ""),
+        )
 
     def _join(self, *args):
         lines = []

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -297,7 +297,7 @@ class SummaryReporter:
     def _report_ingest_pipeline_stats(self, stats):
         return self._join(
             self._line("Total Ingest Pipeline count", "", stats.ingest_pipeline_cluster_count, ""),
-            self._line("Total Ingest Pipeline time", "", stats.ingest_pipeline_cluster_time, "ms"),
+            self._line("Total Ingest Pipeline time", "", stats.ingest_pipeline_cluster_time, "ms", convert.ms_to_seconds),
             self._line("Total Ingest Pipeline failed", "", stats.ingest_pipeline_cluster_failed, ""),
         )
 

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1474,8 +1474,12 @@ class IngestPipelineStats(TelemetryDevice):
         metadata = {"cluster_name": cluster_name}
         self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_count", self.ingest_pipeline_cluster_count, meta_data=metadata)
 
-        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_time", self.ingest_pipeline_cluster_time, "ms", meta_data=metadata)
-        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_failed", self.ingest_pipeline_cluster_failed, meta_data=metadata)
+        self.metrics_store.put_value_cluster_level(
+            "ingest_pipeline_cluster_time", self.ingest_pipeline_cluster_time, "ms", meta_data=metadata
+        )
+        self.metrics_store.put_value_cluster_level(
+            "ingest_pipeline_cluster_failed", self.ingest_pipeline_cluster_failed, meta_data=metadata
+        )
 
     def _record_node_level_pipeline_stats(self, stats, cluster_name, node_name):
         # Node level statistics are calculated per-benchmark execution. Stats are collected at the beginning, and end of
@@ -1558,6 +1562,7 @@ class IngestPipelineStats(TelemetryDevice):
         # pylint: disable=import-outside-toplevel
 
         import elasticsearch
+
         summaries = {}
         for cluster_name in self.specified_cluster_names:
             try:

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1468,15 +1468,14 @@ class IngestPipelineStats(TelemetryDevice):
                                 continue
                             self._record_pipeline_level_processor_stats(pipeline, pipeline_name, cluster_name, node_name)
 
-            self._record_cluster_level_pipeline_stats()
+            self._record_cluster_level_pipeline_stats(cluster_name)
 
-    def _record_cluster_level_pipeline_stats(self):
-        # Cluster level statistics are calculated from node level statistics. The
-        # difference is reported in Rally's  table output as well as the 'rally-results*' index
-        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_count", self.ingest_pipeline_cluster_count)
+    def _record_cluster_level_pipeline_stats(self, cluster_name):
+        metadata = {"cluster_name": cluster_name}
+        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_count", self.ingest_pipeline_cluster_count, meta_data=metadata)
 
-        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_time", self.ingest_pipeline_cluster_time, "ms")
-        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_failed", self.ingest_pipeline_cluster_failed)
+        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_time", self.ingest_pipeline_cluster_time, "ms", meta_data=metadata)
+        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_failed", self.ingest_pipeline_cluster_failed, meta_data=metadata)
 
     def _record_node_level_pipeline_stats(self, stats, cluster_name, node_name):
         # Node level statistics are calculated per-benchmark execution. Stats are collected at the beginning, and end of

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1515,27 +1515,30 @@ class IngestPipelineStats(InternalTelemetryDevice):
                 metadata = {
                     "processor_name": processor_name,
                     "type": processor_stats.get("type", None),
-                    "ingest_pipeline": pipeline_name,
+                    "pipeline_name": pipeline_name,
                     "cluster_name": cluster_name,
                 }
 
-                ingest_pipeline_processor_count = processor_stats.get("stats", {}).get("count", 0) - start_stats_processors[
-                    processor_name
-                ].get("stats", {}).get("count", 0)
+                start_count = start_stats_processors[processor_name].get("stats", {}).get("count", 0)
+                end_count = processor_stats.get("stats", {}).get("count", 0)
+                ingest_pipeline_processor_count = end_count - start_count
+
                 self.metrics_store.put_value_node_level(
                     node_name, "ingest_pipeline_processor_count", ingest_pipeline_processor_count, meta_data=metadata
                 )
 
-                ingest_pipeline_processor_time = processor_stats.get("stats", {}).get("time_in_millis", 0) - start_stats_processors[
-                    processor_name
-                ].get("stats", {}).get("time_in_millis", 0)
+                start_time = start_stats_processors[processor_name].get("stats", {}).get("time_in_millis", 0)
+                end_time = processor_stats.get("stats", {}).get("time_in_millis", 0)
+                ingest_pipeline_processor_time = end_time - start_time
+
                 self.metrics_store.put_value_node_level(
                     node_name, "ingest_pipeline_processor_time", ingest_pipeline_processor_time, unit="ms", meta_data=metadata
                 )
 
-                ingest_pipeline_processor_failed = processor_stats.get("stats", {}).get("failed", 0) - start_stats_processors[
-                    processor_name
-                ].get("stats", {}).get("failed", 0)
+                start_failed = start_stats_processors[processor_name].get("stats", {}).get("failed", 0)
+                end_failed = processor_stats.get("stats", {}).get("failed", 0)
+                ingest_pipeline_processor_failed = end_failed - start_failed
+
                 self.metrics_store.put_value_node_level(
                     node_name, "ingest_pipeline_processor_failed", ingest_pipeline_processor_failed, meta_data=metadata
                 )
@@ -1543,22 +1546,29 @@ class IngestPipelineStats(InternalTelemetryDevice):
             # We have a top level pipeline stats obj, which contains the total time spent preprocessing documents in
             # the ingest pipeline.
             elif processor_name == "total":
-                metadata = {"ingest_pipeline": pipeline_name, "cluster_name": cluster_name}
 
-                ingest_pipeline_pipeline_count = processor_stats.get("count", 0) - start_stats_processors[processor_name].get("count", 0)
+                metadata = {"pipeline_name": pipeline_name, "cluster_name": cluster_name}
+
+                start_count = start_stats_processors[processor_name].get("count", 0)
+                end_count = processor_stats.get("count", 0)
+                ingest_pipeline_pipeline_count = end_count - start_count
+
                 self.metrics_store.put_value_node_level(
                     node_name, "ingest_pipeline_pipeline_count", ingest_pipeline_pipeline_count, meta_data=metadata
                 )
 
-                ingest_pipeline_pipeline_time = processor_stats.get("time_in_millis", 0) - start_stats_processors[processor_name].get(
-                    "time_in_millis", 0
-                )
+                start_time = start_stats_processors[processor_name].get("time_in_millis", 0)
+                end_time = processor_stats.get("time_in_millis", 0)
+                ingest_pipeline_pipeline_time = end_time - start_time
 
                 self.metrics_store.put_value_node_level(
                     node_name, "ingest_pipeline_pipeline_time", ingest_pipeline_pipeline_time, unit="ms", meta_data=metadata
                 )
 
-                ingest_pipeline_pipeline_failed = processor_stats.get("failed", 0) - start_stats_processors[processor_name].get("failed", 0)
+                start_failed = start_stats_processors[processor_name].get("failed", 0)
+                end_failed = processor_stats.get("failed", 0)
+                ingest_pipeline_pipeline_failed = end_failed - start_failed
+
                 self.metrics_store.put_value_node_level(
                     node_name, "ingest_pipeline_pipeline_failed", ingest_pipeline_pipeline_failed, meta_data=metadata
                 )

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1409,8 +1409,7 @@ class DataStreamStatsRecorder:
             self.metrics_store.put_doc(doc, level=MetaInfoScope.cluster, meta_data=data_stream_metadata)
 
 
-class IngestPipelineStats(TelemetryDevice):
-    internal = False
+class IngestPipelineStats(InternalTelemetryDevice):
     command = "ingest-pipeline-stats"
     human_name = "Ingest Pipeline Stats"
     help = "Reports Ingest Pipeline stats at the end of the benchmark."

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1435,61 +1435,57 @@ class IngestPipelineStats(TelemetryDevice):
         self.logger.debug("Gathering Ingest Pipeline stats at benchmark end")
         end_stats = self.get_ingest_pipeline_stats()
 
+        # The nesting level is ok here given the structure of the Ingest Pipeline stats
+        # pylint: disable=too-many-nested-blocks
         for cluster_name, node in end_stats.items():
-            # Cluster was captured at the beginning
-            if cluster_name in self.start_stats:
-                # Make sure all nodes were captured at the beginning
-                for node_name, summary in node.items():
-                    if node_name in self.start_stats[cluster_name]:
-                        for name, stats in summary.items():
-                            if name == "total" and name in self.start_stats[cluster_name][node_name]:
-                                # The top level "total" contains stats for the node as a whole,
-                                # each node will have exactly one top level "total" key
-                                self._record_node_level_pipeline_stats(stats, cluster_name,
-                                                                       node_name)
-                            elif name == "pipelines":
-                                for pipeline_name, pipeline in stats.items():
-                                    if pipeline_name in self.start_stats[cluster_name][node_name]["pipelines"]:
-                                        self._record_pipeline_level_processor_stats(pipeline, pipeline_name,
-                                                                                    cluster_name, node_name)
-                                    else:
-                                        self.logger.warning(
-                                            f"Cannot determine Ingest Pipeline stats for {pipeline_name} (pipeline "
-                                            f"was not defined at the of the benchmark).")
-                            else:
-                                self.logger.warning(
-                                    f"'{name}' is not an expected field for Ingest Pipeline stats (skipping)")
-                    else:
-                        self.logger.warning(
-                            f"Cannot determine Ingest Pipeline stats for {node_name} (not in the cluster at the start "
-                            f"of the benchmark).")
-            else:
+            if cluster_name not in self.start_stats:
                 self.logger.warning(
-                    f"Cannot determine Ingest Pipeline stats for {cluster_name} (cluster stats weren't collected "
-                    f"at the start of the benchmark).")
+                    "Cannot determine Ingest Pipeline stats for %s (cluster stats weren't collected " "at the start of the benchmark).",
+                    cluster_name,
+                )
+                continue
+            for node_name, summaries in node.items():
+                if node_name not in self.start_stats[cluster_name]:
+                    self.logger.warning(
+                        "Cannot determine Ingest Pipeline stats for %s (not in the cluster at the start " "of the benchmark).", node_name
+                    )
+                    continue
+                for summary_name, stats in summaries.items():
+                    if summary_name not in self.start_stats[cluster_name][node_name]:
+                        self.logger.warning("'%s' is not an expected field for Ingest Pipeline stats (skipping)", summary_name)
+                        continue
+                    if summary_name == "total":
+                        # The top level "total" contains stats for the node as a whole,
+                        # each node will have exactly one top level "total" key
+                        self._record_node_level_pipeline_stats(stats, cluster_name, node_name)
+                    elif summary_name == "pipelines":
+                        for pipeline_name, pipeline in stats.items():
+                            if pipeline_name not in self.start_stats[cluster_name][node_name]["pipelines"]:
+                                self.logger.warning(
+                                    "Cannot determine Ingest Pipeline stats for %s (pipeline " "was not defined at the of the benchmark).",
+                                    pipeline_name,
+                                )
+                                continue
+                            self._record_pipeline_level_processor_stats(pipeline, pipeline_name, cluster_name, node_name)
 
             self._record_cluster_level_pipeline_stats()
 
     def _record_cluster_level_pipeline_stats(self):
         # Cluster level statistics are calculated from node level statistics. The
         # difference is reported in Rally's  table output as well as the 'rally-results*' index
-        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_count",
-                                                   self.ingest_pipeline_cluster_count)
+        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_count", self.ingest_pipeline_cluster_count)
 
-        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_time",
-                                                   self.ingest_pipeline_cluster_time)
-        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_failed",
-                                                   self.ingest_pipeline_cluster_failed)
+        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_time", self.ingest_pipeline_cluster_time, "ms")
+        self.metrics_store.put_value_cluster_level("ingest_pipeline_cluster_failed", self.ingest_pipeline_cluster_failed)
 
     def _record_node_level_pipeline_stats(self, stats, cluster_name, node_name):
         # Node level statistics are calculated per-benchmark execution. Stats are collected at the beginning, and end of
         # each benchmark
-        ingest_pipeline_node_count = stats.get("count", 0) - \
-                                     self.start_stats[cluster_name][node_name]["total"].get("count", 0)
-        ingest_pipeline_node_time = stats.get("time_in_millis", 0) - \
-                                    self.start_stats[cluster_name][node_name]["total"].get("time_in_millis", 0)
-        ingest_pipeline_node_failed = stats.get("failed", 0) - \
-                                      self.start_stats[cluster_name][node_name]["total"].get("failed", 0)
+        ingest_pipeline_node_count = stats.get("count", 0) - self.start_stats[cluster_name][node_name]["total"].get("count", 0)
+        ingest_pipeline_node_time = stats.get("time_in_millis", 0) - self.start_stats[cluster_name][node_name]["total"].get(
+            "time_in_millis", 0
+        )
+        ingest_pipeline_node_failed = stats.get("failed", 0) - self.start_stats[cluster_name][node_name]["total"].get("failed", 0)
 
         self.ingest_pipeline_cluster_count += ingest_pipeline_node_count
         self.ingest_pipeline_cluster_time += ingest_pipeline_node_time
@@ -1501,55 +1497,63 @@ class IngestPipelineStats(TelemetryDevice):
 
     def _record_pipeline_level_processor_stats(self, pipeline, pipeline_name, cluster_name, node_name):
         for processor_name, processor_stats in pipeline.items():
-
             start_stats_processors = self.start_stats[cluster_name][node_name]["pipelines"][pipeline_name]
 
+            if processor_name not in start_stats_processors:
+                self.logger.warning(
+                    "Cannot determine Ingest Pipeline stats in %s for %s (processor was not defined at the " "start of the benchmark).",
+                    pipeline_name,
+                    processor_name,
+                )
+                continue
             # We have an individual processor obj, which contains the stats for each individual processor
-            if processor_stats.get("processor_name") is not None and processor_name in start_stats_processors:
+            if processor_name != "total":
 
-                metadata = {"processor_name": processor_stats["processor_name"],
-                            "type": processor_stats.get("type", None),
-                            "ingest_pipeline": pipeline_name}
+                metadata = {"processor_name": processor_name, "type": processor_stats.get("type", None), "ingest_pipeline": pipeline_name}
 
-                ingest_pipeline_processor_count = processor_stats.get("stats", {}).get("count", 0) - \
-                                                  start_stats_processors[processor_name].get("stats", {}).get("count",
-                                                                                                              0)
-                self.metrics_store.put_value_node_level(node_name, "ingest_pipeline_processor_count",
-                                                        ingest_pipeline_processor_count, meta_data=metadata)
+                ingest_pipeline_processor_count = processor_stats.get("stats", {}).get("count", 0) - start_stats_processors[
+                    processor_name
+                ].get("stats", {}).get("count", 0)
+                self.metrics_store.put_value_node_level(
+                    node_name, "ingest_pipeline_processor_count", ingest_pipeline_processor_count, meta_data=metadata
+                )
 
-                ingest_pipeline_processor_time = processor_stats.get("stats", {}).get("time_in_millis", 0) - \
-                                                 start_stats_processors[processor_name].get("stats", {}).get(
-                                                     "time_in_millis", 0)
-                self.metrics_store.put_value_node_level(node_name, "ingest_pipeline_processor_time",
-                                                        ingest_pipeline_processor_time, unit="ms",
-                                                        meta_data=metadata)
+                ingest_pipeline_processor_time = processor_stats.get("stats", {}).get("time_in_millis", 0) - start_stats_processors[
+                    processor_name
+                ].get("stats", {}).get("time_in_millis", 0)
+                self.metrics_store.put_value_node_level(
+                    node_name, "ingest_pipeline_processor_time", ingest_pipeline_processor_time, unit="ms", meta_data=metadata
+                )
 
-                ingest_pipeline_processor_failed = processor_stats.get("stats", {}).get("failed", 0) - \
-                                                   start_stats_processors[processor_name].get("stats", {}).get("failed",
-                                                                                                               0)
-                self.metrics_store.put_value_node_level(node_name, "ingest_pipeline_processor_failed",
-                                                        ingest_pipeline_processor_failed, meta_data=metadata)
+                ingest_pipeline_processor_failed = processor_stats.get("stats", {}).get("failed", 0) - start_stats_processors[
+                    processor_name
+                ].get("stats", {}).get("failed", 0)
+                self.metrics_store.put_value_node_level(
+                    node_name, "ingest_pipeline_processor_failed", ingest_pipeline_processor_failed, meta_data=metadata
+                )
 
             # We have a top level pipeline stats obj, which contains the total time spent preprocessing documents in
             # the ingest pipeline.
-            else:
-                metadata = {"ingest_pipeline": processor_stats.get("ingest_pipeline")}
+            elif processor_name == "total":
+                metadata = {"ingest_pipeline": pipeline_name}
 
-                ingest_pipeline_pipeline_count = processor_stats.get("count", 0) - \
-                                                 start_stats_processors[processor_name].get("count", 0)
-                self.metrics_store.put_value_node_level(node_name, "ingest_pipeline_pipeline_count",
-                                                        ingest_pipeline_pipeline_count, meta_data=metadata)
+                ingest_pipeline_pipeline_count = processor_stats.get("count", 0) - start_stats_processors[processor_name].get("count", 0)
+                self.metrics_store.put_value_node_level(
+                    node_name, "ingest_pipeline_pipeline_count", ingest_pipeline_pipeline_count, meta_data=metadata
+                )
 
-                ingest_pipeline_pipeline_time = processor_stats.get("time_in_millis", 0) - \
-                                                start_stats_processors[processor_name].get("time_in_millis", 0)
+                ingest_pipeline_pipeline_time = processor_stats.get("time_in_millis", 0) - start_stats_processors[processor_name].get(
+                    "time_in_millis", 0
+                )
 
-                self.metrics_store.put_value_node_level(node_name, "ingest_pipeline_pipeline_time",
-                                                        ingest_pipeline_pipeline_time, unit="ms", meta_data=metadata)
+                self.metrics_store.put_value_node_level(
+                    node_name, "ingest_pipeline_pipeline_time", ingest_pipeline_pipeline_time, unit="ms", meta_data=metadata
+                )
 
-                ingest_pipeline_pipeline_failed = processor_stats.get("failed", 0) - \
-                                                  start_stats_processors[processor_name].get("failed", 0)
-                self.metrics_store.put_value_node_level(node_name, "ingest_pipeline_pipeline_failed",
-                                                        ingest_pipeline_pipeline_failed, meta_data=metadata)
+                ingest_pipeline_pipeline_failed = processor_stats.get("failed", 0) - start_stats_processors[processor_name].get("failed", 0)
+                self.metrics_store.put_value_node_level(
+                    node_name, "ingest_pipeline_pipeline_failed", ingest_pipeline_pipeline_failed, meta_data=metadata
+                )
 
     def get_ingest_pipeline_stats(self):
         # pylint: disable=import-outside-toplevel
@@ -1559,38 +1563,25 @@ class IngestPipelineStats(TelemetryDevice):
         for cluster_name in self.specified_cluster_names:
             try:
                 ingest_stats = self.clients[cluster_name].nodes.stats(metric="ingest")
-                summaries[ingest_stats["cluster_name"]] = self._parse_ingest_pipelines(ingest_stats)
             except elasticsearch.TransportError:
                 msg = f"A transport error occurred while collecting Ingest Pipeline stats on cluster [{cluster_name}]"
                 self.logger.exception(msg)
                 raise exceptions.RallyError(msg)
+            summaries[ingest_stats["cluster_name"]] = self._parse_ingest_pipelines(ingest_stats)
         return summaries
 
     def _parse_ingest_pipelines(self, ingest_stats):
         parsed_stats = {}
 
-        def _build_total_summary():
-            parsed_stats[node_name]["total"] = {
-                "ingest_pipeline": "total",
-                "count": node_stats["ingest"]["total"]["count"],
-                "time_in_millis": node_stats["ingest"]["total"]["time_in_millis"],
-                "failed": node_stats["ingest"]["total"]["failed"],
-            }
-
-        def _build_per_pipeline_summary():
-            parsed_stats[node_name]["pipelines"] = {}
-            for pipeline_name, pipeline_stats in node_stats["ingest"]["pipelines"].items():
-                parsed_stats[node_name]["pipelines"][pipeline_name] = {}
-                parsed_stats[node_name]["pipelines"][pipeline_name]["total"] = \
-                    {
-                        "name": "ingest_pipeline_stats",
-                        "ingest_pipeline": pipeline_name,
-                        "count": pipeline_stats["count"],
-                        "time_in_millis": pipeline_stats["time_in_millis"],
-                        "current": pipeline_stats["current"],
-                        "failed": pipeline_stats["failed"],
-                    }
-
+        for node in ingest_stats["nodes"].values():
+            parsed_stats[node["name"]] = {}
+            parsed_stats[node["name"]]["total"] = node["ingest"]["total"]
+            parsed_stats[node["name"]]["pipelines"] = {}
+            for pipeline_name, pipeline_stats in node["ingest"]["pipelines"].items():
+                parsed_stats[node["name"]]["pipelines"][pipeline_name] = {}
+                parsed_stats[node["name"]]["pipelines"][pipeline_name]["total"] = {
+                    key: pipeline_stats[key] for key in pipeline_stats if key != "processors"
+                }
                 # There may be multiple processors of the same name/type in a single pipeline, so let's just
                 # label them 1-N
                 suffix = 1
@@ -1598,25 +1589,7 @@ class IngestPipelineStats(TelemetryDevice):
                     for processor_name, processor_stats in processor.items():
                         processor_name = f"{str(processor_name)}_{suffix}"
                         suffix += 1
-                        parsed_stats[node_name]["pipelines"][pipeline_name][processor_name] = {
-                            "name": "ingest_pipeline_stats",
-                            "ingest_pipeline": pipeline_name,
-                            "processor_name": processor_name,
-                            "type": processor_stats["type"],
-                            "stats": {
-                                "count": processor_stats["stats"]["count"],
-                                "time_in_millis": processor_stats["stats"]["time_in_millis"],
-                                "current": processor_stats["stats"]["current"],
-                                "failed": processor_stats["stats"]["failed"]
-                            }
-                        }
-
-        for node_stats in ingest_stats["nodes"].values():
-            node_name = node_stats["name"]
-            parsed_stats[node_name] = {}
-            _build_total_summary()
-            _build_per_pipeline_summary()
-
+                        parsed_stats[node["name"]]["pipelines"][pipeline_name][processor_name] = processor_stats
         return parsed_stats
 
 

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -3934,20 +3934,20 @@ class IngestPipelineStatsTests(TestCase):
                     "elasticsearch31",
                     "ingest_pipeline_pipeline_count",
                     1,
-                    meta_data={"ingest_pipeline": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
+                    meta_data={"pipeline_name": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_pipeline_time",
                     1,
                     unit="ms",
-                    meta_data={"ingest_pipeline": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
+                    meta_data={"pipeline_name": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_pipeline_failed",
                     1,
-                    meta_data={"ingest_pipeline": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
+                    meta_data={"pipeline_name": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
                 ),
                 # processor level stats
                 mock.call(
@@ -3957,7 +3957,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "uppercase_1",
                         "type": "uppercase",
-                        "ingest_pipeline": "http-log-baseline-pipeline",
+                        "pipeline_name": "http-log-baseline-pipeline",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -3969,7 +3969,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "uppercase_1",
                         "type": "uppercase",
-                        "ingest_pipeline": "http-log-baseline-pipeline",
+                        "pipeline_name": "http-log-baseline-pipeline",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -3980,7 +3980,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "uppercase_1",
                         "type": "uppercase",
-                        "ingest_pipeline": "http-log-baseline-pipeline",
+                        "pipeline_name": "http-log-baseline-pipeline",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -3989,20 +3989,20 @@ class IngestPipelineStatsTests(TestCase):
                     "elasticsearch31",
                     "ingest_pipeline_pipeline_count",
                     1,
-                    meta_data={"ingest_pipeline": "pipeline-1", "cluster_name": "docker-cluster"},
+                    meta_data={"pipeline_name": "pipeline-1", "cluster_name": "docker-cluster"},
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_pipeline_time",
                     1,
                     unit="ms",
-                    meta_data={"ingest_pipeline": "pipeline-1", "cluster_name": "docker-cluster"},
+                    meta_data={"pipeline_name": "pipeline-1", "cluster_name": "docker-cluster"},
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_pipeline_failed",
                     1,
-                    meta_data={"ingest_pipeline": "pipeline-1", "cluster_name": "docker-cluster"},
+                    meta_data={"pipeline_name": "pipeline-1", "cluster_name": "docker-cluster"},
                 ),
                 # processor 1 stats
                 mock.call(
@@ -4012,7 +4012,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "append_1",
                         "type": "append",
-                        "ingest_pipeline": "pipeline-1",
+                        "pipeline_name": "pipeline-1",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -4024,7 +4024,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "append_1",
                         "type": "append",
-                        "ingest_pipeline": "pipeline-1",
+                        "pipeline_name": "pipeline-1",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -4035,7 +4035,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "append_1",
                         "type": "append",
-                        "ingest_pipeline": "pipeline-1",
+                        "pipeline_name": "pipeline-1",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -4047,7 +4047,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "append_2",
                         "type": "append",
-                        "ingest_pipeline": "pipeline-1",
+                        "pipeline_name": "pipeline-1",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -4059,7 +4059,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "append_2",
                         "type": "append",
-                        "ingest_pipeline": "pipeline-1",
+                        "pipeline_name": "pipeline-1",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -4070,7 +4070,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "append_2",
                         "type": "append",
-                        "ingest_pipeline": "pipeline-1",
+                        "pipeline_name": "pipeline-1",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -4082,7 +4082,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "lowercase_3",
                         "type": "lowercase",
-                        "ingest_pipeline": "pipeline-1",
+                        "pipeline_name": "pipeline-1",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -4094,7 +4094,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "lowercase_3",
                         "type": "lowercase",
-                        "ingest_pipeline": "pipeline-1",
+                        "pipeline_name": "pipeline-1",
                         "cluster_name": "docker-cluster",
                     },
                 ),
@@ -4105,7 +4105,7 @@ class IngestPipelineStatsTests(TestCase):
                     meta_data={
                         "processor_name": "lowercase_3",
                         "type": "lowercase",
-                        "ingest_pipeline": "pipeline-1",
+                        "pipeline_name": "pipeline-1",
                         "cluster_name": "docker-cluster",
                     },
                 ),

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -3926,106 +3926,188 @@ class IngestPipelineStatsTests(TestCase):
         metrics_store_node_level.assert_has_calls(
             [
                 # node level stats
-                mock.call("elasticsearch31", "ingest_pipeline_node_count", 1),
-                mock.call("elasticsearch31", "ingest_pipeline_node_time", 1, "ms"),
-                mock.call("elasticsearch31", "ingest_pipeline_node_failed", 1),
+                mock.call("elasticsearch31", "ingest_pipeline_node_count", 1, meta_data={"cluster_name": "docker-cluster"}),
+                mock.call("elasticsearch31", "ingest_pipeline_node_time", 1, "ms", meta_data={"cluster_name": "docker-cluster"}),
+                mock.call("elasticsearch31", "ingest_pipeline_node_failed", 1, meta_data={"cluster_name": "docker-cluster"}),
                 # pipeline level stats
                 mock.call(
-                    "elasticsearch31", "ingest_pipeline_pipeline_count", 1, meta_data={"ingest_pipeline": "http-log-baseline-pipeline"}
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_count",
+                    1,
+                    meta_data={"ingest_pipeline": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_pipeline_time",
                     1,
                     unit="ms",
-                    meta_data={"ingest_pipeline": "http-log-baseline-pipeline"},
+                    meta_data={"ingest_pipeline": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
                 ),
                 mock.call(
-                    "elasticsearch31", "ingest_pipeline_pipeline_failed", 1, meta_data={"ingest_pipeline": "http-log-baseline-pipeline"}
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_failed",
+                    1,
+                    meta_data={"ingest_pipeline": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
                 ),
                 # processor level stats
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_count",
                     1,
-                    meta_data={"processor_name": "uppercase_1", "type": "uppercase", "ingest_pipeline": "http-log-baseline-pipeline"},
+                    meta_data={
+                        "processor_name": "uppercase_1",
+                        "type": "uppercase",
+                        "ingest_pipeline": "http-log-baseline-pipeline",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_time",
                     1,
                     unit="ms",
-                    meta_data={"processor_name": "uppercase_1", "type": "uppercase", "ingest_pipeline": "http-log-baseline-pipeline"},
+                    meta_data={
+                        "processor_name": "uppercase_1",
+                        "type": "uppercase",
+                        "ingest_pipeline": "http-log-baseline-pipeline",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_failed",
                     1,
-                    meta_data={"processor_name": "uppercase_1", "type": "uppercase", "ingest_pipeline": "http-log-baseline-pipeline"},
+                    meta_data={
+                        "processor_name": "uppercase_1",
+                        "type": "uppercase",
+                        "ingest_pipeline": "http-log-baseline-pipeline",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 # pipeline level stats
-                mock.call("elasticsearch31", "ingest_pipeline_pipeline_count", 1, meta_data={"ingest_pipeline": "pipeline-1"}),
-                mock.call("elasticsearch31", "ingest_pipeline_pipeline_time", 1, unit="ms", meta_data={"ingest_pipeline": "pipeline-1"}),
-                mock.call("elasticsearch31", "ingest_pipeline_pipeline_failed", 1, meta_data={"ingest_pipeline": "pipeline-1"}),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_count",
+                    1,
+                    meta_data={"ingest_pipeline": "pipeline-1", "cluster_name": "docker-cluster"},
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_time",
+                    1,
+                    unit="ms",
+                    meta_data={"ingest_pipeline": "pipeline-1", "cluster_name": "docker-cluster"},
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_failed",
+                    1,
+                    meta_data={"ingest_pipeline": "pipeline-1", "cluster_name": "docker-cluster"},
+                ),
                 # processor 1 stats
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_count",
                     1,
-                    meta_data={"processor_name": "append_1", "type": "append", "ingest_pipeline": "pipeline-1"},
+                    meta_data={
+                        "processor_name": "append_1",
+                        "type": "append",
+                        "ingest_pipeline": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_time",
                     1,
                     unit="ms",
-                    meta_data={"processor_name": "append_1", "type": "append", "ingest_pipeline": "pipeline-1"},
+                    meta_data={
+                        "processor_name": "append_1",
+                        "type": "append",
+                        "ingest_pipeline": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_failed",
                     1,
-                    meta_data={"processor_name": "append_1", "type": "append", "ingest_pipeline": "pipeline-1"},
+                    meta_data={
+                        "processor_name": "append_1",
+                        "type": "append",
+                        "ingest_pipeline": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 # processor 2 stats
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_count",
                     1,
-                    meta_data={"processor_name": "append_2", "type": "append", "ingest_pipeline": "pipeline-1"},
+                    meta_data={
+                        "processor_name": "append_2",
+                        "type": "append",
+                        "ingest_pipeline": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_time",
                     1,
                     unit="ms",
-                    meta_data={"processor_name": "append_2", "type": "append", "ingest_pipeline": "pipeline-1"},
+                    meta_data={
+                        "processor_name": "append_2",
+                        "type": "append",
+                        "ingest_pipeline": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_failed",
                     1,
-                    meta_data={"processor_name": "append_2", "type": "append", "ingest_pipeline": "pipeline-1"},
+                    meta_data={
+                        "processor_name": "append_2",
+                        "type": "append",
+                        "ingest_pipeline": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 # processor 3 stats
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_count",
                     1,
-                    meta_data={"processor_name": "lowercase_3", "type": "lowercase", "ingest_pipeline": "pipeline-1"},
+                    meta_data={
+                        "processor_name": "lowercase_3",
+                        "type": "lowercase",
+                        "ingest_pipeline": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_time",
                     1,
                     unit="ms",
-                    meta_data={"processor_name": "lowercase_3", "type": "lowercase", "ingest_pipeline": "pipeline-1"},
+                    meta_data={
+                        "processor_name": "lowercase_3",
+                        "type": "lowercase",
+                        "ingest_pipeline": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
                 mock.call(
                     "elasticsearch31",
                     "ingest_pipeline_processor_failed",
                     1,
-                    meta_data={"processor_name": "lowercase_3", "type": "lowercase", "ingest_pipeline": "pipeline-1"},
+                    meta_data={
+                        "processor_name": "lowercase_3",
+                        "type": "lowercase",
+                        "ingest_pipeline": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
                 ),
             ]
         )
@@ -4049,7 +4131,7 @@ class IngestPipelineStatsTests(TestCase):
         with mock.patch.object(logger, "warning") as mocked_warning:
             t.on_benchmark_stop()
             mocked_warning.assert_called_once_with(
-                "Cannot determine Ingest Pipeline stats for %s (cluster stats weren't collected " "at the start of the benchmark).",
+                "Cannot determine Ingest Pipeline stats for %s (cluster stats weren't collected at the start of the benchmark).",
                 "docker-cluster",
             )
 
@@ -4062,7 +4144,7 @@ class IngestPipelineStatsTests(TestCase):
         with mock.patch.object(logger, "warning") as mocked_warning:
             t.on_benchmark_stop()
             mocked_warning.assert_called_once_with(
-                "Cannot determine Ingest Pipeline stats for %s (not in the cluster at the start " "of the benchmark).", "elasticsearch31"
+                "Cannot determine Ingest Pipeline stats for %s (not in the cluster at the start of the benchmark).", "elasticsearch31"
             )
 
         # pipeline level
@@ -4074,7 +4156,7 @@ class IngestPipelineStatsTests(TestCase):
         with mock.patch.object(logger, "warning") as mocked_warning:
             t.on_benchmark_stop()
             mocked_warning.assert_called_once_with(
-                "Cannot determine Ingest Pipeline stats for %s (pipeline " "was not defined at the of the benchmark).", "pipeline-1"
+                "Cannot determine Ingest Pipeline stats for %s (pipeline was not defined at the of the benchmark).", "pipeline-1"
             )
 
         # processor level
@@ -4086,7 +4168,7 @@ class IngestPipelineStatsTests(TestCase):
         with mock.patch.object(logger, "warning") as mocked_warning:
             t.on_benchmark_stop()
             mocked_warning.assert_called_once_with(
-                "Cannot determine Ingest Pipeline stats in %s for %s (processor " "was not defined at the start of the benchmark).",
+                "Cannot determine Ingest Pipeline stats in %s for %s (processor was not defined at the start of the benchmark).",
                 "pipeline-1",
                 "append_1",
             )

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -3886,9 +3886,10 @@ class IngestPipelineStatsTests(TestCase):
         },
     }
 
-    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
+    @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     @mock.patch("elasticsearch.Elasticsearch")
-    def test_error_on_retrieval_does_not_store_metrics(self, es, metrics_store_put_doc):
+    def test_error_on_retrieval_does_not_store_metrics(self, es, metrics_store_cluster_level, metrics_store_node_level):
         es.search.side_effect = elasticsearch.TransportError("unit test error")
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
@@ -3897,7 +3898,8 @@ class IngestPipelineStatsTests(TestCase):
         t.on_benchmark_start()
         t.on_benchmark_stop()
 
-        self.assertEqual(0, metrics_store_put_doc.call_count)
+        self.assertEqual(0, metrics_store_cluster_level.call_count)
+        self.assertEqual(0, metrics_store_node_level.call_count)
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -3901,6 +3901,196 @@ class IngestPipelineStatsTests(TestCase):
         self.assertEqual(0, metrics_store_cluster_level.call_count)
         self.assertEqual(0, metrics_store_node_level.call_count)
 
+    def _assert_node_level_calls(self, metrics_store_node_level, *, value):
+        metrics_store_node_level.assert_has_calls(
+            [
+                # node level stats
+                mock.call("elasticsearch31", "ingest_pipeline_node_count", 1, meta_data={"cluster_name": "docker-cluster"}),
+                mock.call("elasticsearch31", "ingest_pipeline_node_time", 1, "ms", meta_data={"cluster_name": "docker-cluster"}),
+                mock.call("elasticsearch31", "ingest_pipeline_node_failed", 1, meta_data={"cluster_name": "docker-cluster"}),
+                # pipeline level stats
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_count",
+                    value,
+                    meta_data={"pipeline_name": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_time",
+                    value,
+                    unit="ms",
+                    meta_data={"pipeline_name": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_failed",
+                    value,
+                    meta_data={"pipeline_name": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
+                ),
+                # processor level stats
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_count",
+                    value,
+                    meta_data={
+                        "processor_name": "uppercase_1",
+                        "type": "uppercase",
+                        "pipeline_name": "http-log-baseline-pipeline",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_time",
+                    value,
+                    unit="ms",
+                    meta_data={
+                        "processor_name": "uppercase_1",
+                        "type": "uppercase",
+                        "pipeline_name": "http-log-baseline-pipeline",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_failed",
+                    value,
+                    meta_data={
+                        "processor_name": "uppercase_1",
+                        "type": "uppercase",
+                        "pipeline_name": "http-log-baseline-pipeline",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                # pipeline level stats
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_count",
+                    value,
+                    meta_data={"pipeline_name": "pipeline-1", "cluster_name": "docker-cluster"},
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_time",
+                    value,
+                    unit="ms",
+                    meta_data={"pipeline_name": "pipeline-1", "cluster_name": "docker-cluster"},
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_pipeline_failed",
+                    value,
+                    meta_data={"pipeline_name": "pipeline-1", "cluster_name": "docker-cluster"},
+                ),
+                # processor 1 stats
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_count",
+                    value,
+                    meta_data={
+                        "processor_name": "append_1",
+                        "type": "append",
+                        "pipeline_name": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_time",
+                    value,
+                    unit="ms",
+                    meta_data={
+                        "processor_name": "append_1",
+                        "type": "append",
+                        "pipeline_name": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_failed",
+                    value,
+                    meta_data={
+                        "processor_name": "append_1",
+                        "type": "append",
+                        "pipeline_name": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                # processor 2 stats
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_count",
+                    value,
+                    meta_data={
+                        "processor_name": "append_2",
+                        "type": "append",
+                        "pipeline_name": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_time",
+                    value,
+                    unit="ms",
+                    meta_data={
+                        "processor_name": "append_2",
+                        "type": "append",
+                        "pipeline_name": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_failed",
+                    value,
+                    meta_data={
+                        "processor_name": "append_2",
+                        "type": "append",
+                        "pipeline_name": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                # processor 3 stats
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_count",
+                    value,
+                    meta_data={
+                        "processor_name": "lowercase_3",
+                        "type": "lowercase",
+                        "pipeline_name": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_time",
+                    value,
+                    unit="ms",
+                    meta_data={
+                        "processor_name": "lowercase_3",
+                        "type": "lowercase",
+                        "pipeline_name": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+                mock.call(
+                    "elasticsearch31",
+                    "ingest_pipeline_processor_failed",
+                    value,
+                    meta_data={
+                        "processor_name": "lowercase_3",
+                        "type": "lowercase",
+                        "pipeline_name": "pipeline-1",
+                        "cluster_name": "docker-cluster",
+                    },
+                ),
+            ]
+        )
+
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     def test_stores_only_diff_of_ingest_pipeline_stats(self, metrics_store_cluster_level, metrics_store_node_level):
@@ -3923,194 +4113,33 @@ class IngestPipelineStatsTests(TestCase):
             ]
         )
 
-        metrics_store_node_level.assert_has_calls(
+        self._assert_node_level_calls(metrics_store_node_level, value=1)
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
+    @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
+    def test_pipeline_created_during_benchmark_stats(self, metrics_store_cluster_level, metrics_store_node_level):
+        ingest_pipeline_stats_start_response = copy.deepcopy(self.ingest_pipeline_stats_start_response)
+        ingest_pipeline_stats_start_response["nodes"]["ZlPBlHtYQDmG4ASbvRrFBg"]["ingest"]["pipelines"] = {}
+        clients = {"default": Client(nodes=SubClient(stats=ingest_pipeline_stats_start_response))}
+        cfg = create_config()
+
+        metrics_store = metrics.EsMetricsStore(cfg)
+        device = telemetry.IngestPipelineStats(clients, metrics_store)
+        t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
+        t.on_benchmark_start()
+
+        clients["default"].nodes = SubClient(stats=self.ingest_pipeline_stats_end_response)
+        t.on_benchmark_stop()
+
+        metrics_store_cluster_level.assert_has_calls(
             [
-                # node level stats
-                mock.call("elasticsearch31", "ingest_pipeline_node_count", 1, meta_data={"cluster_name": "docker-cluster"}),
-                mock.call("elasticsearch31", "ingest_pipeline_node_time", 1, "ms", meta_data={"cluster_name": "docker-cluster"}),
-                mock.call("elasticsearch31", "ingest_pipeline_node_failed", 1, meta_data={"cluster_name": "docker-cluster"}),
-                # pipeline level stats
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_pipeline_count",
-                    1,
-                    meta_data={"pipeline_name": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_pipeline_time",
-                    1,
-                    unit="ms",
-                    meta_data={"pipeline_name": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_pipeline_failed",
-                    1,
-                    meta_data={"pipeline_name": "http-log-baseline-pipeline", "cluster_name": "docker-cluster"},
-                ),
-                # processor level stats
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_count",
-                    1,
-                    meta_data={
-                        "processor_name": "uppercase_1",
-                        "type": "uppercase",
-                        "pipeline_name": "http-log-baseline-pipeline",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_time",
-                    1,
-                    unit="ms",
-                    meta_data={
-                        "processor_name": "uppercase_1",
-                        "type": "uppercase",
-                        "pipeline_name": "http-log-baseline-pipeline",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_failed",
-                    1,
-                    meta_data={
-                        "processor_name": "uppercase_1",
-                        "type": "uppercase",
-                        "pipeline_name": "http-log-baseline-pipeline",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                # pipeline level stats
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_pipeline_count",
-                    1,
-                    meta_data={"pipeline_name": "pipeline-1", "cluster_name": "docker-cluster"},
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_pipeline_time",
-                    1,
-                    unit="ms",
-                    meta_data={"pipeline_name": "pipeline-1", "cluster_name": "docker-cluster"},
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_pipeline_failed",
-                    1,
-                    meta_data={"pipeline_name": "pipeline-1", "cluster_name": "docker-cluster"},
-                ),
-                # processor 1 stats
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_count",
-                    1,
-                    meta_data={
-                        "processor_name": "append_1",
-                        "type": "append",
-                        "pipeline_name": "pipeline-1",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_time",
-                    1,
-                    unit="ms",
-                    meta_data={
-                        "processor_name": "append_1",
-                        "type": "append",
-                        "pipeline_name": "pipeline-1",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_failed",
-                    1,
-                    meta_data={
-                        "processor_name": "append_1",
-                        "type": "append",
-                        "pipeline_name": "pipeline-1",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                # processor 2 stats
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_count",
-                    1,
-                    meta_data={
-                        "processor_name": "append_2",
-                        "type": "append",
-                        "pipeline_name": "pipeline-1",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_time",
-                    1,
-                    unit="ms",
-                    meta_data={
-                        "processor_name": "append_2",
-                        "type": "append",
-                        "pipeline_name": "pipeline-1",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_failed",
-                    1,
-                    meta_data={
-                        "processor_name": "append_2",
-                        "type": "append",
-                        "pipeline_name": "pipeline-1",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                # processor 3 stats
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_count",
-                    1,
-                    meta_data={
-                        "processor_name": "lowercase_3",
-                        "type": "lowercase",
-                        "pipeline_name": "pipeline-1",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_time",
-                    1,
-                    unit="ms",
-                    meta_data={
-                        "processor_name": "lowercase_3",
-                        "type": "lowercase",
-                        "pipeline_name": "pipeline-1",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
-                mock.call(
-                    "elasticsearch31",
-                    "ingest_pipeline_processor_failed",
-                    1,
-                    meta_data={
-                        "processor_name": "lowercase_3",
-                        "type": "lowercase",
-                        "pipeline_name": "pipeline-1",
-                        "cluster_name": "docker-cluster",
-                    },
-                ),
+                mock.call("ingest_pipeline_cluster_count", 1, meta_data={"cluster_name": "docker-cluster"}),
+                mock.call("ingest_pipeline_cluster_time", 1, "ms", meta_data={"cluster_name": "docker-cluster"}),
+                mock.call("ingest_pipeline_cluster_failed", 1, meta_data={"cluster_name": "docker-cluster"}),
             ]
         )
+
+        self._assert_node_level_calls(metrics_store_node_level, value=2)
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
@@ -4145,30 +4174,4 @@ class IngestPipelineStatsTests(TestCase):
             t.on_benchmark_stop()
             mocked_warning.assert_called_once_with(
                 "Cannot determine Ingest Pipeline stats for %s (not in the cluster at the start of the benchmark).", "elasticsearch31"
-            )
-
-        # pipeline level
-        clients["default"].nodes = SubClient(stats=self.ingest_pipeline_stats_start_response)
-        t.on_benchmark_start()
-        del device.start_stats["docker-cluster"]["elasticsearch31"]["pipelines"]["pipeline-1"]
-        clients["default"].nodes = SubClient(stats=self.ingest_pipeline_stats_end_response)
-
-        with mock.patch.object(logger, "warning") as mocked_warning:
-            t.on_benchmark_stop()
-            mocked_warning.assert_called_once_with(
-                "Cannot determine Ingest Pipeline stats for %s (pipeline was not defined at the of the benchmark).", "pipeline-1"
-            )
-
-        # processor level
-        clients["default"].nodes = SubClient(stats=self.ingest_pipeline_stats_start_response)
-        t.on_benchmark_start()
-        del device.start_stats["docker-cluster"]["elasticsearch31"]["pipelines"]["pipeline-1"]["append_1"]
-        clients["default"].nodes = SubClient(stats=self.ingest_pipeline_stats_end_response)
-
-        with mock.patch.object(logger, "warning") as mocked_warning:
-            t.on_benchmark_stop()
-            mocked_warning.assert_called_once_with(
-                "Cannot determine Ingest Pipeline stats in %s for %s (processor was not defined at the start of the benchmark).",
-                "pipeline-1",
-                "append_1",
             )

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -3915,9 +3915,9 @@ class IngestPipelineStatsTests(TestCase):
 
         metrics_store_cluster_level.assert_has_calls(
             [
-                mock.call("ingest_pipeline_cluster_count", 1),
-                mock.call("ingest_pipeline_cluster_time", 1, "ms"),
-                mock.call("ingest_pipeline_cluster_failed", 1),
+                mock.call("ingest_pipeline_cluster_count", 1, meta_data={"cluster_name": "docker-cluster"}),
+                mock.call("ingest_pipeline_cluster_time", 1, "ms", meta_data={"cluster_name": "docker-cluster"}),
+                mock.call("ingest_pipeline_cluster_failed", 1, meta_data={"cluster_name": "docker-cluster"}),
             ]
         )
 


### PR DESCRIPTION
With this commit we had a Ingest Pipeline stats telemetry device. This 
telemetry device utilises the node stats API, but rather than sampling 
these statistics throughout the benchmark (i.e. node stats telemetry 
device) we collect an output at the beginning and end, and report only the 
delta.

The metrics store contains metrics at the cluster, node, pipeline, and processor levels under `rally-metrics*`, and summarised cluster level results under `rally-results*`.

**TODO**:
- [x] Add documentation

<details>
<summary>Sample output</summary>

```diff
$ esrally race --track-path=rally/tracks/ingest-pipelines --telemetry ingest-pipeline-stats --kill-running-processes

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/

[INFO] Race id is [4121d7ec-aee4-405e-a596-84dfa03a89e8]
[INFO] Preparing for race ...
[INFO] Racing on track [ingest-pipelines], challenge [bulk-to-pipeline-with-1001-failures] and car ['defaults'] with version [8.0.0-SNAPSHOT].

Running put-pipeline                                                           [100% done]
Running bulk                                                                   [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                         Metric |   Task |       Value |   Unit |
|---------------------------------------------------------------:|-------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |        |   0.0370333 |    min |
|             Min cumulative indexing time across primary shards |        |   0.0370333 |    min |
|          Median cumulative indexing time across primary shards |        |   0.0370333 |    min |
|             Max cumulative indexing time across primary shards |        |   0.0370333 |    min |
|            Cumulative indexing throttle time of primary shards |        |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |        |           0 |    min |
| Median cumulative indexing throttle time across primary shards |        |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |        |           0 |    min |
|                        Cumulative merge time of primary shards |        |           0 |    min |
|                       Cumulative merge count of primary shards |        |           0 |        |
|                Min cumulative merge time across primary shards |        |           0 |    min |
|             Median cumulative merge time across primary shards |        |           0 |    min |
|                Max cumulative merge time across primary shards |        |           0 |    min |
|               Cumulative merge throttle time of primary shards |        |           0 |    min |
|       Min cumulative merge throttle time across primary shards |        |           0 |    min |
|    Median cumulative merge throttle time across primary shards |        |           0 |    min |
|       Max cumulative merge throttle time across primary shards |        |           0 |    min |
|                      Cumulative refresh time of primary shards |        |   0.0272833 |    min |
|                     Cumulative refresh count of primary shards |        |          14 |        |
|              Min cumulative refresh time across primary shards |        |   0.0272833 |    min |
|           Median cumulative refresh time across primary shards |        |   0.0272833 |    min |
|              Max cumulative refresh time across primary shards |        |   0.0272833 |    min |
|                        Cumulative flush time of primary shards |        |   0.0305667 |    min |
|                       Cumulative flush count of primary shards |        |           3 |        |
|                Min cumulative flush time across primary shards |        |   0.0305667 |    min |
|             Median cumulative flush time across primary shards |        |   0.0305667 |    min |
|                Max cumulative flush time across primary shards |        |   0.0305667 |    min |
|                                        Total Young Gen GC time |        |       0.061 |      s |
|                                       Total Young Gen GC count |        |           1 |        |
|                                          Total Old Gen GC time |        |           0 |      s |
|                                         Total Old Gen GC count |        |           0 |        |
|                                                     Store size |        |   0.0395972 |     GB |
|                                                  Translog size |        | 5.12227e-08 |     GB |
|                                         Heap used for segments |        |           0 |     MB |
|                                       Heap used for doc values |        |           0 |     MB |
|                                            Heap used for terms |        |           0 |     MB |
|                                            Heap used for norms |        |           0 |     MB |
|                                           Heap used for points |        |           0 |     MB |
|                                    Heap used for stored fields |        |           0 |     MB |
|                                                  Segment count |        |           7 |        |
+|                                    Total Ingest Pipeline count |        |        1001 |        |
+|                                     Total Ingest Pipeline time |        |          80 |     ms |
+|                                   Total Ingest Pipeline failed |        |        1001 |        |
|                                                 Min Throughput |   bulk |     3034.45 | docs/s |
|                                                Mean Throughput |   bulk |     3034.45 | docs/s |
|                                              Median Throughput |   bulk |     3034.45 | docs/s |
|                                                 Max Throughput |   bulk |     3034.45 | docs/s |
|                                        50th percentile latency |   bulk |     15.2215 |     ms |
|                                        90th percentile latency |   bulk |     38.0702 |     ms |
|                                       100th percentile latency |   bulk |     55.3849 |     ms |
|                                   50th percentile service time |   bulk |     15.2215 |     ms |
|                                   90th percentile service time |   bulk |     38.0702 |     ms |
|                                  100th percentile service time |   bulk |     55.3849 |     ms |
|                                                     error rate |   bulk |         100 |      % |

[WARNING] Error rate is 100.0 for operation 'bulk'. Please check the logs.

---------------------------------
[INFO] SUCCESS (took 525 seconds)
---------------------------------
```

</details>

<details>
<summary>Sample comparison</summary>

```diff

$ esrally compare --baseline  4121d7ec-aee4-405e-a596-84dfa03a89e8 --contender c6548660-67b7-4263-9591-4c16c04756bb

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/


Comparing baseline
  Race ID: 4121d7ec-aee4-405e-a596-84dfa03a89e8
  Race timestamp: 2022-01-14 05:26:20
  Challenge: bulk-to-pipeline-with-1001-failures
  Car: defaults

with contender
  Race ID: c6548660-67b7-4263-9591-4c16c04756bb
  Race timestamp: 2022-01-14 05:36:28
  Challenge: bulk-to-pipeline-with-1001-failures
  Car: defaults

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                        Metric |   Task |    Baseline |   Contender |     Diff |   Unit |   Diff % |
|--------------------------------------------------------------:|-------:|------------:|------------:|---------:|-------:|---------:|
|                    Cumulative indexing time of primary shards |        |   0.0370333 |   0.0254167 | -0.01162 |    min |  -31.37% |
|             Min cumulative indexing time across primary shard |        |   0.0370333 |   0.0254167 | -0.01162 |    min |  -31.37% |
|          Median cumulative indexing time across primary shard |        |   0.0370333 |   0.0254167 | -0.01162 |    min |  -31.37% |
|             Max cumulative indexing time across primary shard |        |   0.0370333 |   0.0254167 | -0.01162 |    min |  -31.37% |
|           Cumulative indexing throttle time of primary shards |        |           0 |           0 |        0 |    min |    0.00% |
|    Min cumulative indexing throttle time across primary shard |        |           0 |           0 |        0 |    min |    0.00% |
| Median cumulative indexing throttle time across primary shard |        |           0 |           0 |        0 |    min |    0.00% |
|    Max cumulative indexing throttle time across primary shard |        |           0 |           0 |        0 |    min |    0.00% |
|                       Cumulative merge time of primary shards |        |           0 |           0 |        0 |    min |    0.00% |
|                      Cumulative merge count of primary shards |        |           0 |           0 |        0 |        |    0.00% |
|                Min cumulative merge time across primary shard |        |           0 |           0 |        0 |    min |    0.00% |
|             Median cumulative merge time across primary shard |        |           0 |           0 |        0 |    min |    0.00% |
|                Max cumulative merge time across primary shard |        |           0 |           0 |        0 |    min |    0.00% |
|              Cumulative merge throttle time of primary shards |        |           0 |           0 |        0 |    min |    0.00% |
|       Min cumulative merge throttle time across primary shard |        |           0 |           0 |        0 |    min |    0.00% |
|    Median cumulative merge throttle time across primary shard |        |           0 |           0 |        0 |    min |    0.00% |
|       Max cumulative merge throttle time across primary shard |        |           0 |           0 |        0 |    min |    0.00% |
|                     Cumulative refresh time of primary shards |        |   0.0272833 |     0.02825 |  0.00097 |    min |   +3.54% |
|                    Cumulative refresh count of primary shards |        |          14 |          13 |       -1 |        |   -7.14% |
|              Min cumulative refresh time across primary shard |        |   0.0272833 |     0.02825 |  0.00097 |    min |   +3.54% |
|           Median cumulative refresh time across primary shard |        |   0.0272833 |     0.02825 |  0.00097 |    min |   +3.54% |
|              Max cumulative refresh time across primary shard |        |   0.0272833 |     0.02825 |  0.00097 |    min |   +3.54% |
|                       Cumulative flush time of primary shards |        |   0.0305667 |      0.0214 | -0.00917 |    min |  -29.99% |
|                      Cumulative flush count of primary shards |        |           3 |           3 |        0 |        |    0.00% |
|                Min cumulative flush time across primary shard |        |   0.0305667 |      0.0214 | -0.00917 |    min |  -29.99% |
|             Median cumulative flush time across primary shard |        |   0.0305667 |      0.0214 | -0.00917 |    min |  -29.99% |
|                Max cumulative flush time across primary shard |        |   0.0305667 |      0.0214 | -0.00917 |    min |  -29.99% |
|                                       Total Young Gen GC time |        |       0.061 |       0.022 |   -0.039 |      s |  -63.93% |
|                                      Total Young Gen GC count |        |           1 |           1 |        0 |        |    0.00% |
|                                         Total Old Gen GC time |        |           0 |           0 |        0 |      s |    0.00% |
|                                        Total Old Gen GC count |        |           0 |           0 |        0 |        |    0.00% |
|                                                    Store size |        |   0.0395972 |   0.0395972 |        0 |     GB |    0.00% |
|                                                 Translog size |        | 5.12227e-08 | 5.12227e-08 |        0 |     GB |    0.00% |
|                                        Heap used for segments |        |           0 |           0 |        0 |     MB |    0.00% |
|                                      Heap used for doc values |        |           0 |           0 |        0 |     MB |    0.00% |
|                                           Heap used for terms |        |           0 |           0 |        0 |     MB |    0.00% |
|                                           Heap used for norms |        |           0 |           0 |        0 |     MB |    0.00% |
|                                          Heap used for points |        |           0 |           0 |        0 |     MB |    0.00% |
|                                   Heap used for stored fields |        |           0 |           0 |        0 |     MB |    0.00% |
|                                                 Segment count |        |           7 |           7 |        0 |        |    0.00% |
|                                   Total Ingest Pipeline count |        |        1001 |        1001 |        0 |        |    0.00% |
+|                                    Total Ingest Pipeline time |        |          80 |          30 |      -50 |     ms |  -62.50% |
|                                  Total Ingest Pipeline failed |        |        1001 |        1001 |        0 |        |    0.00% |
|                                                Min Throughput |   bulk |     3034.45 |      6486.2 |  3451.75 | docs/s | +113.75% |
|                                               Mean Throughput |   bulk |     3034.45 |      6486.2 |  3451.75 | docs/s | +113.75% |
|                                             Median Throughput |   bulk |     3034.45 |      6486.2 |  3451.75 | docs/s | +113.75% |
|                                                Max Throughput |   bulk |     3034.45 |      6486.2 |  3451.75 | docs/s | +113.75% |
|                                       50th percentile latency |   bulk |     15.2215 |     5.89986 | -9.32163 |     ms |  -61.24% |
|                                       90th percentile latency |   bulk |     38.0702 |     16.4493 | -21.6209 |     ms |  -56.79% |
|                                      100th percentile latency |   bulk |     55.3849 |     26.5535 | -28.8315 |     ms |  -52.06% |
|                                  50th percentile service time |   bulk |     15.2215 |     5.89986 | -9.32163 |     ms |  -61.24% |
|                                  90th percentile service time |   bulk |     38.0702 |     16.4493 | -21.6209 |     ms |  -56.79% |
|                                 100th percentile service time |   bulk |     55.3849 |     26.5535 | -28.8315 |     ms |  -52.06% |
|                                                    error rate |   bulk |         100 |         100 |        0 |      % |    0.00% |


-------------------------------
[INFO] SUCCESS (took 0 seconds)
-------------------------------
```
</details>

<details>
<summary>Sample track</summary>

[ingest-pipelines.zip](https://github.com/elastic/rally/files/7868043/ingest-pipelines.zip)

</details>

Closes https://github.com/elastic/rally/issues/1365