### PR TITLE
Derive correct artifact name for ARM architecture

### DIFF
--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -243,7 +243,8 @@ class TemplateRenderer:
         if arch is not None:
             self.arch = arch
         else:
-            self.arch = sysstats.cpu_arch().lower()
+            derived_arch = sysstats.cpu_arch().lower()
+            self.arch = "aarch64" if derived_arch == "arm64" else derived_arch
 
     def render(self, template):
         substitutions = {"{{VERSION}}": self.version, "{{OSNAME}}": self.os, "{{ARCH}}": self.arch}

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -244,6 +244,7 @@ class TemplateRenderer:
             self.arch = arch
         else:
             derived_arch = sysstats.cpu_arch().lower()
+            # Elasticsearch artifacts for Apple Silicon use "aarch64" as the CPU architecture
             self.arch = "aarch64" if derived_arch == "arm64" else derived_arch
 
     def render(self, template):

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -191,6 +191,15 @@ class TemplateRendererTests(TestCase):
             renderer.render("This is version {{VERSION}} on {{OSNAME}} with a {{ARCH}} CPU."),
         )
 
+    @mock.patch("esrally.utils.sysstats.os_name", return_value="Darwin")
+    @mock.patch("esrally.utils.sysstats.cpu_arch", return_value="arm64")
+    def test_converts_arm_architecture(self, os_name, cpu_arch):
+        renderer = supplier.TemplateRenderer(version="7.16.0")
+        self.assertEqual(
+            "This is version 7.16.0 on darwin with a aarch64 CPU.",
+            renderer.render("This is version {{VERSION}} on {{OSNAME}} with a {{ARCH}} CPU."),
+        )
+
 
 class CachedElasticsearchSourceSupplierTests(TestCase):
     @mock.patch("esrally.utils.io.ensure_dir")


### PR DESCRIPTION
To download an Elasticsearch artifact, Rally needs to resolve the CPU
architecture of the current system to download the correct distribution
tarball. This does not work currently on Macs with ARM M1 chips. These
are reported as `arm64` but the Elasticsearch artifact uses `aarch64` to
refer to this CPU architecture. Consequently, downloading an artifact on
ARM-based Macs fails unless the user specifies `--target-arch=aarch64`.

With this commit we detect this case and ensure that the correct
artifact can be downloaded. We intentionally change the architecture
specifier only in the component that is responsible for deriving the
download URL for artifacts but keep referring to this CPU architecture
as `arm64` in other parts of the code, just as it is reported by the OS.