### PR TITLE
Rename 'indices stats API' to 'index stats API'

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -129,23 +129,23 @@ Rally stores the following metrics:
 * ``node_total_young_gen_gc_count``: The total number of young generation garbage collections across the whole cluster as reported by the node stats API.
 * ``node_total_old_gen_gc_time``: The total runtime of the old generation garbage collector across the whole cluster as reported by the node stats API.
 * ``node_total_old_gen_gc_count``: The total number of old generation garbage collections across the whole cluster as reported by the node stats API.
-* ``segments_count``: Total number of segments as reported by the indices stats API.
-* ``segments_memory_in_bytes``: Number of bytes used for segments as reported by the indices stats API.
-* ``segments_doc_values_memory_in_bytes``: Number of bytes used for doc values as reported by the indices stats API.
-* ``segments_stored_fields_memory_in_bytes``: Number of bytes used for stored fields as reported by the indices stats API.
-* ``segments_terms_memory_in_bytes``: Number of bytes used for terms as reported by the indices stats API.
-* ``segments_norms_memory_in_bytes``: Number of bytes used for norms as reported by the indices stats API.
-* ``segments_points_memory_in_bytes``: Number of bytes used for points as reported by the indices stats API.
-* ``merges_total_time``: Cumulative runtime of merges of primary shards, as reported by the indices stats API. Note that this is not Wall clock time (i.e. if M merge threads ran for N minutes, we will report M * N minutes, not N minutes). These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
-* ``merges_total_count``: Cumulative number of merges of primary shards, as reported by indices stats API under ``_all/primaries``.
-* ``merges_total_throttled_time``: Cumulative time within merges have been throttled as reported by the indices stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
-* ``indexing_total_time``: Cumulative time used for indexing of primary shards, as reported by the indices stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
-* ``indexing_throttle_time``: Cumulative time that indexing has been throttled, as reported by the indices stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
-* ``refresh_total_time``: Cumulative time used for index refresh of primary shards, as reported by the indices stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
-* ``refresh_total_count``: Cumulative number of refreshes of primary shards, as reported by indices stats API under ``_all/primaries``.
-* ``flush_total_time``: Cumulative time used for index flush of primary shards, as reported by the indices stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
-* ``flush_total_count``: Cumulative number of flushes of primary shards, as reported by indices stats API under ``_all/primaries``.
+* ``segments_count``: Total number of segments as reported by the index stats API.
+* ``segments_memory_in_bytes``: Number of bytes used for segments as reported by the index stats API.
+* ``segments_doc_values_memory_in_bytes``: Number of bytes used for doc values as reported by the index stats API.
+* ``segments_stored_fields_memory_in_bytes``: Number of bytes used for stored fields as reported by the index stats API.
+* ``segments_terms_memory_in_bytes``: Number of bytes used for terms as reported by the index stats API.
+* ``segments_norms_memory_in_bytes``: Number of bytes used for norms as reported by the index stats API.
+* ``segments_points_memory_in_bytes``: Number of bytes used for points as reported by the index stats API.
+* ``merges_total_time``: Cumulative runtime of merges of primary shards, as reported by the index stats API. Note that this is not Wall clock time (i.e. if M merge threads ran for N minutes, we will report M * N minutes, not N minutes). These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
+* ``merges_total_count``: Cumulative number of merges of primary shards, as reported by index stats API under ``_all/primaries``.
+* ``merges_total_throttled_time``: Cumulative time within merges have been throttled as reported by the index stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
+* ``indexing_total_time``: Cumulative time used for indexing of primary shards, as reported by the index stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
+* ``indexing_throttle_time``: Cumulative time that indexing has been throttled, as reported by the index stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
+* ``refresh_total_time``: Cumulative time used for index refresh of primary shards, as reported by the index stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
+* ``refresh_total_count``: Cumulative number of refreshes of primary shards, as reported by index stats API under ``_all/primaries``.
+* ``flush_total_time``: Cumulative time used for index flush of primary shards, as reported by the index stats API. Note that this is not Wall clock time.  These metrics records also have a ``per-shard`` property that contains the times across primary shards in an array.
+* ``flush_total_count``: Cumulative number of flushes of primary shards, as reported by index stats API under ``_all/primaries``.
 * ``final_index_size_bytes``: Final resulting index size on the file system after all nodes have been shutdown at the end of the benchmark. It includes all files in the nodes' data directories (actual index files and translog).
-* ``store_size_in_bytes``: The size in bytes of the index (excluding the translog), as reported by the indices stats API.
-* ``translog_size_in_bytes``: The size in bytes of the translog, as reported by the indices stats API.
+* ``store_size_in_bytes``: The size in bytes of the index (excluding the translog), as reported by the index stats API.
+* ``translog_size_in_bytes``: The size in bytes of the translog, as reported by the index stats API.
 * ``ml_processing_time``: A structure containing the minimum, mean, median and maximum bucket processing time in milliseconds per machine learning job. These metrics are only available if a machine learning job has been created in the respective benchmark.

--- a/docs/summary_report.rst
+++ b/docs/summary_report.rst
@@ -6,91 +6,91 @@ At the end of each :doc:`race </race>`, Rally shows a summary report. Below we'l
 Cumulative indexing time of primary shards
 ------------------------------------------
 
-* **Definition**: Cumulative time used for indexing as reported by the indices stats API. Note that this is not Wall clock time (i.e. if M indexing threads ran for N minutes, we will report M * N minutes, not N minutes).
+* **Definition**: Cumulative time used for indexing as reported by the index stats API. Note that this is not Wall clock time (i.e. if M indexing threads ran for N minutes, we will report M * N minutes, not N minutes).
 * **Corresponding metrics key**: ``indexing_total_time``
 
 Cumulative indexing time across primary shards
 ----------------------------------------------
 
-* **Definition**: Minimum, median and maximum cumulative time used for indexing across primary shards as reported by the indices stats API.
+* **Definition**: Minimum, median and maximum cumulative time used for indexing across primary shards as reported by the index stats API.
 * **Corresponding metrics key**: ``indexing_total_time`` (property: ``per-shard``)
 
 Cumulative indexing throttle time of primary shards
 ---------------------------------------------------
 
-* **Definition**: Cumulative time that indexing has been throttled as reported by the indices stats API. Note that this is not Wall clock time (i.e. if M indexing threads ran for N minutes, we will report M * N minutes, not N minutes).
+* **Definition**: Cumulative time that indexing has been throttled as reported by the index stats API. Note that this is not Wall clock time (i.e. if M indexing threads ran for N minutes, we will report M * N minutes, not N minutes).
 * **Corresponding metrics key**: ``indexing_throttle_time``
 
 Cumulative indexing throttle time across primary shards
 -------------------------------------------------------
 
-* **Definition**: Minimum, median and maximum cumulative time used that indexing has been throttled across primary shards as reported by the indices stats API.
+* **Definition**: Minimum, median and maximum cumulative time used that indexing has been throttled across primary shards as reported by the index stats API.
 * **Corresponding metrics key**: ``indexing_throttle_time`` (property: ``per-shard``)
 
 Cumulative merge time of primary shards
 ---------------------------------------
 
-* **Definition**: Cumulative runtime of merges of primary shards, as reported by the indices stats API. Note that this is not Wall clock time.
+* **Definition**: Cumulative runtime of merges of primary shards, as reported by the index stats API. Note that this is not Wall clock time.
 * **Corresponding metrics key**: ``merges_total_time``
 
 Cumulative merge count of primary shards
 ----------------------------------------
 
-* **Definition**: Cumulative number of merges of primary shards, as reported by indices stats API under ``_all/primaries``.
+* **Definition**: Cumulative number of merges of primary shards, as reported by index stats API under ``_all/primaries``.
 * **Corresponding metrics key**: ``merges_total_count``
 
 Cumulative merge time across primary shards
 -------------------------------------------
 
-* **Definition**: Minimum, median and maximum cumulative time of merges across primary shards, as reported by the indices stats API.
+* **Definition**: Minimum, median and maximum cumulative time of merges across primary shards, as reported by the index stats API.
 * **Corresponding metrics key**: ``merges_total_time`` (property: ``per-shard``)
 
 Cumulative refresh time of primary shards
 -----------------------------------------
 
-* **Definition**: Cumulative time used for index refresh of primary shards, as reported by the indices stats API. Note that this is not Wall clock time.
+* **Definition**: Cumulative time used for index refresh of primary shards, as reported by the index stats API. Note that this is not Wall clock time.
 * **Corresponding metrics key**: ``refresh_total_time``
 
 Cumulative refresh count of primary shards
 ------------------------------------------
 
-* **Definition**: Cumulative number of refreshes of primary shards, as reported by indices stats API under ``_all/primaries``.
+* **Definition**: Cumulative number of refreshes of primary shards, as reported by index stats API under ``_all/primaries``.
 * **Corresponding metrics key**: ``refresh_total_count``
 
 Cumulative refresh time across primary shards
 ---------------------------------------------
 
-* **Definition**: Minimum, median and maximum cumulative time for index refresh across primary shards, as reported by the indices stats API.
+* **Definition**: Minimum, median and maximum cumulative time for index refresh across primary shards, as reported by the index stats API.
 * **Corresponding metrics key**: ``refresh_total_time`` (property: ``per-shard``)
 
 Cumulative flush time of primary shards
 ---------------------------------------
 
-* **Definition**: Cumulative time used for index flush of primary shards, as reported by the indices stats API. Note that this is not Wall clock time.
+* **Definition**: Cumulative time used for index flush of primary shards, as reported by the index stats API. Note that this is not Wall clock time.
 * **Corresponding metrics key**: ``flush_total_time``
 
 Cumulative flush count of primary shards
 ----------------------------------------
 
-* **Definition**: Cumulative number of flushes of primary shards, as reported by indices stats API under ``_all/primaries``.
+* **Definition**: Cumulative number of flushes of primary shards, as reported by index stats API under ``_all/primaries``.
 * **Corresponding metrics key**: ``flush_total_count``
 
 Cumulative flush time across primary shards
 -------------------------------------------
 
-* **Definition**: Minimum, median and maximum time for index flush across primary shards as reported by the indices stats API.
+* **Definition**: Minimum, median and maximum time for index flush across primary shards as reported by the index stats API.
 * **Corresponding metrics key**: ``flush_total_time`` (property: ``per-shard``)
 
 Cumulative merge throttle time of primary shards
 ------------------------------------------------
 
-* **Definition**: Cumulative time within merges that have been throttled, as reported by the indices stats API. Note that this is not Wall clock time.
+* **Definition**: Cumulative time within merges that have been throttled, as reported by the index stats API. Note that this is not Wall clock time.
 * **Corresponding metrics key**: ``merges_total_throttled_time``
 
 Cumulative merge throttle time across primary shards
 ----------------------------------------------------
 
-* **Definition**: Minimum, median and maximum cumulative time that merges have been throttled across primary shards as reported by the indices stats API.
+* **Definition**: Minimum, median and maximum cumulative time that merges have been throttled across primary shards as reported by the index stats API.
 * **Corresponding metrics key**: ``merges_total_throttled_time`` (property: ``per-shard``)
 
 
@@ -130,13 +130,13 @@ Total Old Gen GC count
 Store size
 ----------
 
-* **Definition**: The size in bytes of the index (excluding the translog) as reported by the indices stats API.
+* **Definition**: The size in bytes of the index (excluding the translog) as reported by the index stats API.
 * **Corresponding metrics key**: ``store_size_in_bytes``
 
 Translog size
 -------------
 
-* **Definition**: The size in bytes of the translog as reported by the indices stats API.
+* **Definition**: The size in bytes of the translog as reported by the index stats API.
 * **Corresponding metrics key**: ``translog_size_in_bytes``
 
 Heap used for ``X``
@@ -153,13 +153,13 @@ Where ``X`` is one of:
 
 ..
 
-* **Definition**: Number of bytes used for the corresponding item as reported by the indices stats API.
+* **Definition**: Number of bytes used for the corresponding item as reported by the index stats API.
 * **Corresponding metrics keys**: ``segments_*_in_bytes``
 
 Segment count
 -------------
 
-* **Definition**: Total number of segments as reported by the indices stats API.
+* **Definition**: Total number of segments as reported by the index stats API.
 * **Corresponding metrics key**: ``segments_count``
 
 

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -107,7 +107,7 @@ node-stats
 
 The node-stats telemetry device regularly calls the `cluster node-stats API <https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html>`_ and records metrics from the following sections:
 
-* Indices stats (key ``indices`` in the node-stats API)
+* Index stats (key ``indices`` in the node-stats API)
 * Thread pool stats (key ``thread_pool`` in the node-stats API)
 * JVM buffer pool stats (key ``jvm.buffer_pools`` in the node-stats API)
 * JVM gc stats (key ``jvm.gc`` in the node-stats API)
@@ -119,10 +119,10 @@ The node-stats telemetry device regularly calls the `cluster node-stats API <htt
 Supported telemetry parameters:
 
 * ``node-stats-sample-interval`` (default: 1): A positive number greater than zero denoting the sampling interval in seconds.
-* ``node-stats-include-indices`` (default: ``false``): A boolean indicating whether indices stats should be included.
-* ``node-stats-include-indices-metrics`` (default: ``docs,store,indexing,search,merges,query_cache,fielddata,segments,translog,request_cache``): A comma-separated string specifying the Indices stats metrics to include. This is useful, for example, to restrict the collected Indices stats metrics. Specifying this parameter implicitly enables collection of Indices stats, so you don't also need to specify ``node-stats-include-indices: true``.
+* ``node-stats-include-indices`` (default: ``false``): A boolean indicating whether index stats should be included.
+* ``node-stats-include-indices-metrics`` (default: ``docs,store,indexing,search,merges,query_cache,fielddata,segments,translog,request_cache``): A comma-separated string specifying the Index stats metrics to include. This is useful, for example, to restrict the collected Index stats metrics. Specifying this parameter implicitly enables collection of Index stats, so you don't also need to specify ``node-stats-include-indices: true``.
 
-  Example: ``--telemetry-params="node-stats-include-indices-metrics:'docs'"`` will **only** collect the ``docs`` metrics from Indices stats. If you want to use multiple fields, pass a JSON file to ``telemetry-params`` (see the :ref:`command line reference <clr_telemetry_params>` for details).
+  Example: ``--telemetry-params="node-stats-include-indices-metrics:'docs'"`` will **only** collect the ``docs`` metrics from Index stats. If you want to use multiple fields, pass a JSON file to ``telemetry-params`` (see the :ref:`command line reference <clr_telemetry_params>` for details).
 * ``node-stats-include-thread-pools`` (default: ``true``): A boolean indicating whether thread pool stats should be included.
 * ``node-stats-include-buffer-pools`` (default: ``true``): A boolean indicating whether buffer pool stats should be included.
 * ``node-stats-include-breakers`` (default: ``true``): A boolean indicating whether circuit breaker stats should be included.

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -905,13 +905,13 @@ This operation returns no meta-data.
 index-stats
 ~~~~~~~~~~~
 
-With the operation type ``index-stats`` you can call the `indices stats API <http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html>`_.
+With the operation type ``index-stats`` you can call the `index stats API <http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html>`_.
 
 Properties
 """"""""""
 
 * ``index`` (optional, defaults to `_all`): An `index pattern <https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html>`_ that defines which indices should be targeted by this operation.
-* ``condition`` (optional, defaults to no condition): A structured object with the properties ``path`` and ``expected-value``. If the actual value returned by indices stats API is equal to the expected value at the provided path, this operation will return successfully. See below for an example how this can be used.
+* ``condition`` (optional, defaults to no condition): A structured object with the properties ``path`` and ``expected-value``. If the actual value returned by index stats API is equal to the expected value at the provided path, this operation will return successfully. See below for an example how this can be used.
 
 In the following example the ``index-stats`` operation will wait until all segments have been merged::
 

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1942,10 +1942,10 @@ class IndexStats(InternalTelemetryDevice):
             self.first_time = False
 
     def on_benchmark_stop(self):
-        self.logger.info("Gathering indices stats for all primaries on benchmark stop.")
+        self.logger.info("Gathering index stats for all primaries on benchmark stop.")
         index_stats = self.index_stats()
         # import json
-        # self.logger.debug("Returned indices stats:\n%s", json.dumps(index_stats, indent=2))
+        # self.logger.debug("Returned index stats:\n%s", json.dumps(index_stats, indent=2))
         if "_all" not in index_stats or "primaries" not in index_stats["_all"]:
             return
         p = index_stats["_all"]["primaries"]


### PR DESCRIPTION
It was [renamed in 2019](https://github.com/elastic/elasticsearch/pull/46322) and is documented as "index stats" since 7.3: https://www.elastic.co/guide/en/elasticsearch/reference/7.3/indices-stats.html. (The URL did not change, but the title did.)

I'm not changing the `node-stats-include-indices` to avoid having a lengthy migration. Should I have done that?