### PR TITLE
Switch to native pytest in tests/track

### DIFF
--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -21,7 +21,8 @@ import re
 import textwrap
 import unittest.mock as mock
 import urllib.error
-from unittest import TestCase
+
+import pytest
 
 from esrally import config, exceptions
 from esrally.track import loader, track
@@ -44,7 +45,7 @@ class StaticClock:
         return None
 
 
-class SimpleTrackRepositoryTests(TestCase):
+class TestSimpleTrackRepository:
     @mock.patch("os.path.exists")
     @mock.patch("os.path.isdir")
     def test_track_from_directory(self, is_dir, path_exists):
@@ -52,10 +53,10 @@ class SimpleTrackRepositoryTests(TestCase):
         path_exists.return_value = True
 
         repo = loader.SimpleTrackRepository("/path/to/track/unit-test")
-        self.assertEqual("unit-test", repo.track_name)
-        self.assertEqual(["unit-test"], repo.track_names)
-        self.assertEqual("/path/to/track/unit-test", repo.track_dir("unit-test"))
-        self.assertEqual("/path/to/track/unit-test/track.json", repo.track_file("unit-test"))
+        assert repo.track_name == "unit-test"
+        assert repo.track_names == ["unit-test"]
+        assert repo.track_dir("unit-test") == "/path/to/track/unit-test"
+        assert repo.track_file("unit-test") == "/path/to/track/unit-test/track.json"
 
     @mock.patch("os.path.exists")
     @mock.patch("os.path.isdir")
@@ -66,10 +67,10 @@ class SimpleTrackRepositoryTests(TestCase):
         path_exists.return_value = True
 
         repo = loader.SimpleTrackRepository("/path/to/track/unit-test/my-track.json")
-        self.assertEqual("my-track", repo.track_name)
-        self.assertEqual(["my-track"], repo.track_names)
-        self.assertEqual("/path/to/track/unit-test", repo.track_dir("my-track"))
-        self.assertEqual("/path/to/track/unit-test/my-track.json", repo.track_file("my-track"))
+        assert repo.track_name == "my-track"
+        assert repo.track_names == ["my-track"]
+        assert repo.track_dir("my-track") == "/path/to/track/unit-test"
+        assert repo.track_file("my-track") == "/path/to/track/unit-test/my-track.json"
 
     @mock.patch("os.path.exists")
     @mock.patch("os.path.isdir")
@@ -79,16 +80,16 @@ class SimpleTrackRepositoryTests(TestCase):
         is_dir.return_value = False
         path_exists.return_value = True
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as exc:
             loader.SimpleTrackRepository("a named pipe cannot point to a track")
-        self.assertEqual("a named pipe cannot point to a track is neither a file nor a directory", ctx.exception.args[0])
+        assert exc.value.args[0] == "a named pipe cannot point to a track is neither a file nor a directory"
 
     @mock.patch("os.path.exists")
     def test_track_from_non_existing_path(self, path_exists):
         path_exists.return_value = False
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as exc:
             loader.SimpleTrackRepository("/path/does/not/exist")
-        self.assertEqual("Track path /path/does/not/exist does not exist", ctx.exception.args[0])
+        assert exc.value.args[0] == "Track path /path/does/not/exist does not exist"
 
     @mock.patch("os.path.isdir")
     @mock.patch("os.path.exists")
@@ -96,9 +97,9 @@ class SimpleTrackRepositoryTests(TestCase):
         # directory exists, but not the file
         path_exists.side_effect = [True, False]
         is_dir.return_value = True
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as exc:
             loader.SimpleTrackRepository("/path/to/not/a/track")
-        self.assertEqual("Could not find track.json in /path/to/not/a/track", ctx.exception.args[0])
+        assert exc.value.args[0] == "Could not find track.json in /path/to/not/a/track"
 
     @mock.patch("os.path.exists")
     @mock.patch("os.path.isdir")
@@ -108,12 +109,12 @@ class SimpleTrackRepositoryTests(TestCase):
         is_dir.return_value = False
         path_exists.return_value = True
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as exc:
             loader.SimpleTrackRepository("/path/to/track/unit-test/my-track.xml")
-        self.assertEqual("/path/to/track/unit-test/my-track.xml has to be a JSON file", ctx.exception.args[0])
+        assert exc.value.args[0] == "/path/to/track/unit-test/my-track.xml has to be a JSON file"
 
 
-class GitRepositoryTests(TestCase):
+class TestGitRepository:
     class MockGitRepo:
         def __init__(self, remote_url, root_dir, repo_name, resource_name, offline, fetch=True):
             self.repo_dir = "%s/%s" % (root_dir, repo_name)
@@ -153,15 +154,15 @@ class GitRepositoryTests(TestCase):
         cfg.add(config.Scope.application, "node", "root.dir", "/tmp")
         cfg.add(config.Scope.application, "benchmarks", "track.repository.dir", "tracks")
 
-        repo = loader.GitTrackRepository(cfg, fetch=False, update=False, repo_class=GitRepositoryTests.MockGitRepo)
+        repo = loader.GitTrackRepository(cfg, fetch=False, update=False, repo_class=self.MockGitRepo)
 
-        self.assertEqual("unittest", repo.track_name)
-        self.assertEqual(["unittest", "unittest2", "unittest3", "unittest3/nested"], list(repo.track_names))
-        self.assertEqual("/tmp/tracks/default/unittest", repo.track_dir("unittest"))
-        self.assertEqual("/tmp/tracks/default/unittest/track.json", repo.track_file("unittest"))
+        assert repo.track_name == "unittest"
+        assert repo.track_names == ["unittest", "unittest2", "unittest3", "unittest3/nested"]
+        assert repo.track_dir("unittest") == "/tmp/tracks/default/unittest"
+        assert repo.track_file("unittest") == "/tmp/tracks/default/unittest/track.json"
 
 
-class TrackPreparationTests(TestCase):
+class TestTrackPreparation:
     @mock.patch("esrally.utils.io.prepare_file_offset_table")
     @mock.patch("os.path.getsize")
     @mock.patch("os.path.isfile")
@@ -230,7 +231,7 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        with self.assertRaises(exceptions.DataError) as ctx:
+        with pytest.raises(exceptions.DataError) as exc:
             p.prepare_document_set(
                 document_set=track.Documents(
                     source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -242,7 +243,7 @@ class TrackPreparationTests(TestCase):
                 ),
                 data_root="/tmp",
             )
-        self.assertEqual("[/tmp/docs.json] is corrupt. Extracted [1] bytes but [2000] bytes are expected.", ctx.exception.args[0])
+        assert exc.value.args[0] == "[/tmp/docs.json] is corrupt. Extracted [1] bytes but [2000] bytes are expected."
 
         decompress.assert_called_with("/tmp/docs.json.bz2", "/tmp")
 
@@ -261,7 +262,7 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        with self.assertRaises(exceptions.DataError) as ctx:
+        with pytest.raises(exceptions.DataError) as exc:
             p.prepare_document_set(
                 document_set=track.Documents(
                     source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -274,10 +275,9 @@ class TrackPreparationTests(TestCase):
                 ),
                 data_root="/tmp",
             )
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Decompressing [/tmp/docs.json.bz2] did not create [/tmp/docs.json]. Please check with the track author if the "
-            "compressed archive has been created correctly.",
-            ctx.exception.args[0],
+            "compressed archive has been created correctly."
         )
 
         decompress.assert_called_with("/tmp/docs.json.bz2", "/tmp")
@@ -423,7 +423,7 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=True, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as exc:
             p.prepare_document_set(
                 document_set=track.Documents(
                     source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -435,10 +435,10 @@ class TrackPreparationTests(TestCase):
                 data_root="/tmp",
             )
 
-        self.assertEqual("Cannot find [/tmp/docs.json]. Please disable offline mode and retry.", ctx.exception.args[0])
+        assert exc.value.args[0] == "Cannot find [/tmp/docs.json]. Please disable offline mode and retry."
 
-        self.assertEqual(0, ensure_dir.call_count)
-        self.assertEqual(0, download.call_count)
+        assert ensure_dir.call_count == 0
+        assert download.call_count == 0
 
     @mock.patch("esrally.utils.net.download")
     @mock.patch("esrally.utils.io.ensure_dir")
@@ -451,7 +451,7 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        with self.assertRaises(exceptions.DataError) as ctx:
+        with pytest.raises(exceptions.DataError) as exc:
             p.prepare_document_set(
                 document_set=track.Documents(
                     source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -464,10 +464,10 @@ class TrackPreparationTests(TestCase):
                 data_root="/tmp",
             )
 
-        self.assertEqual("Cannot download data because no base URL is provided.", ctx.exception.args[0])
+        assert exc.value.args[0] == "Cannot download data because no base URL is provided."
 
-        self.assertEqual(0, ensure_dir.call_count)
-        self.assertEqual(0, download.call_count)
+        assert ensure_dir.call_count == 0
+        assert download.call_count == 0
 
     @mock.patch("esrally.utils.net.download")
     @mock.patch("esrally.utils.io.ensure_dir")
@@ -483,7 +483,7 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        with self.assertRaises(exceptions.DataError) as ctx:
+        with pytest.raises(exceptions.DataError) as exc:
             p.prepare_document_set(
                 document_set=track.Documents(
                     source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -494,14 +494,13 @@ class TrackPreparationTests(TestCase):
                 data_root="/tmp",
             )
 
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "[/tmp/docs.json] is present but does not have the expected size of [2000] bytes and it "
-            "cannot be downloaded because no base URL is provided.",
-            ctx.exception.args[0],
+            "cannot be downloaded because no base URL is provided."
         )
 
-        self.assertEqual(0, ensure_dir.call_count)
-        self.assertEqual(0, download.call_count)
+        assert ensure_dir.call_count == 0
+        assert download.call_count == 0
 
     @mock.patch("esrally.utils.net.download")
     @mock.patch("esrally.utils.io.ensure_dir")
@@ -518,7 +517,7 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=True), decompressor=loader.Decompressor()
         )
 
-        with self.assertRaises(exceptions.DataError) as ctx:
+        with pytest.raises(exceptions.DataError) as exc:
             p.prepare_document_set(
                 document_set=track.Documents(
                     source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -530,10 +529,7 @@ class TrackPreparationTests(TestCase):
                 data_root="/tmp",
             )
 
-        self.assertEqual(
-            "This track does not support test mode. Ask the track author to add it or disable test mode and retry.",
-            ctx.exception.args[0],
-        )
+        assert exc.value.args[0] == "This track does not support test mode. Ask the track author to add it or disable test mode and retry."
 
         ensure_dir.assert_called_with("/tmp")
         download.assert_called_with(
@@ -555,7 +551,7 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        with self.assertRaises(exceptions.DataError) as ctx:
+        with pytest.raises(exceptions.DataError) as exc:
             p.prepare_document_set(
                 document_set=track.Documents(
                     source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -567,10 +563,9 @@ class TrackPreparationTests(TestCase):
                 data_root="/tmp",
             )
 
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Could not download [http://benchmarks.elasticsearch.org/corpora/unit-test/docs.json] "
-            "to [/tmp/docs.json] (HTTP status: 500, reason: Internal Server Error)",
-            ctx.exception.args[0],
+            "to [/tmp/docs.json] (HTTP status: 500, reason: Internal Server Error)"
         )
 
         ensure_dir.assert_called_with("/tmp")
@@ -592,18 +587,16 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        self.assertTrue(
-            p.prepare_bundled_document_set(
-                document_set=track.Documents(
-                    source_format=track.Documents.SOURCE_FORMAT_BULK,
-                    document_file="docs.json",
-                    document_archive="docs.json.bz2",
-                    number_of_documents=5,
-                    compressed_size_in_bytes=200,
-                    uncompressed_size_in_bytes=2000,
-                ),
-                data_root=".",
-            )
+        assert p.prepare_bundled_document_set(
+            document_set=track.Documents(
+                source_format=track.Documents.SOURCE_FORMAT_BULK,
+                document_file="docs.json",
+                document_archive="docs.json.bz2",
+                number_of_documents=5,
+                compressed_size_in_bytes=200,
+                uncompressed_size_in_bytes=2000,
+            ),
+            data_root=".",
         )
 
         prepare_file_offset_table.assert_called_with("./docs.json")
@@ -620,22 +613,20 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        self.assertFalse(
-            p.prepare_bundled_document_set(
-                document_set=track.Documents(
-                    source_format=track.Documents.SOURCE_FORMAT_BULK,
-                    document_file="docs.json",
-                    document_archive="docs.json.bz2",
-                    number_of_documents=5,
-                    compressed_size_in_bytes=200,
-                    uncompressed_size_in_bytes=2000,
-                ),
-                data_root=".",
-            )
+        assert not p.prepare_bundled_document_set(
+            document_set=track.Documents(
+                source_format=track.Documents.SOURCE_FORMAT_BULK,
+                document_file="docs.json",
+                document_archive="docs.json.bz2",
+                number_of_documents=5,
+                compressed_size_in_bytes=200,
+                uncompressed_size_in_bytes=2000,
+            ),
+            data_root=".",
         )
 
-        self.assertEqual(0, decompress.call_count)
-        self.assertEqual(0, prepare_file_offset_table.call_count)
+        assert decompress.call_count == 0
+        assert prepare_file_offset_table.call_count == 0
 
     def test_used_corpora(self):
         track_specification = {
@@ -755,15 +746,13 @@ class TrackPreparationTests(TestCase):
         reader = loader.TrackSpecificationReader(selected_challenge="default-challenge")
         full_track = reader("unittest", track_specification, "/mappings")
         used_corpora = sorted(loader.used_corpora(full_track), key=lambda c: c.name)
-        self.assertEqual(2, len(used_corpora))
-        self.assertEqual("http_logs", used_corpora[0].name)
+        assert len(used_corpora) == 2
+        assert used_corpora[0].name == "http_logs"
         # each bulk operation requires a different data file but they should have been merged properly.
-        self.assertEqual(
-            {"documents-181998.json.bz2", "documents-191998.json.bz2"}, {d.document_archive for d in used_corpora[0].documents}
-        )
+        assert {d.document_archive for d in used_corpora[0].documents} == {"documents-181998.json.bz2", "documents-191998.json.bz2"}
 
-        self.assertEqual("http_logs_unparsed", used_corpora[1].name)
-        self.assertEqual({"documents-201998.unparsed.json.bz2"}, {d.document_archive for d in used_corpora[1].documents})
+        assert used_corpora[1].name == "http_logs_unparsed"
+        assert {d.document_archive for d in used_corpora[1].documents} == {"documents-201998.unparsed.json.bz2"}
 
     @mock.patch("esrally.utils.io.prepare_file_offset_table")
     @mock.patch("esrally.utils.io.decompress")
@@ -785,18 +774,16 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        self.assertTrue(
-            p.prepare_bundled_document_set(
-                document_set=track.Documents(
-                    source_format=track.Documents.SOURCE_FORMAT_BULK,
-                    document_file="docs.json",
-                    document_archive="docs.json.bz2",
-                    number_of_documents=5,
-                    compressed_size_in_bytes=200,
-                    uncompressed_size_in_bytes=2000,
-                ),
-                data_root=".",
-            )
+        assert p.prepare_bundled_document_set(
+            document_set=track.Documents(
+                source_format=track.Documents.SOURCE_FORMAT_BULK,
+                document_file="docs.json",
+                document_archive="docs.json.bz2",
+                number_of_documents=5,
+                compressed_size_in_bytes=200,
+                uncompressed_size_in_bytes=2000,
+            ),
+            data_root=".",
         )
 
         prepare_file_offset_table.assert_called_with("./docs.json")
@@ -814,7 +801,7 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        with self.assertRaises(exceptions.DataError) as ctx:
+        with pytest.raises(exceptions.DataError) as exc:
             p.prepare_bundled_document_set(
                 document_set=track.Documents(
                     source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -827,7 +814,7 @@ class TrackPreparationTests(TestCase):
                 data_root=".",
             )
 
-        self.assertEqual("[./docs.json.bz2] is present but does not have the expected size of [200] bytes.", ctx.exception.args[0])
+        assert exc.value.args[0] == "[./docs.json.bz2] is present but does not have the expected size of [200] bytes."
 
     @mock.patch("esrally.utils.io.prepare_file_offset_table")
     @mock.patch("esrally.utils.io.decompress")
@@ -843,7 +830,7 @@ class TrackPreparationTests(TestCase):
             track_name="unit-test", downloader=loader.Downloader(offline=False, test_mode=False), decompressor=loader.Decompressor()
         )
 
-        with self.assertRaises(exceptions.DataError) as ctx:
+        with pytest.raises(exceptions.DataError) as exc:
             p.prepare_bundled_document_set(
                 document_set=track.Documents(
                     source_format=track.Documents.SOURCE_FORMAT_BULK,
@@ -855,12 +842,12 @@ class TrackPreparationTests(TestCase):
                 ),
                 data_root=".",
             )
-        self.assertEqual("[./docs.json] is present but does not have the expected size of [2000] bytes.", ctx.exception.args[0])
+        assert exc.value.args[0] == "[./docs.json] is present but does not have the expected size of [2000] bytes."
 
-        self.assertEqual(0, prepare_file_offset_table.call_count)
+        assert prepare_file_offset_table.call_count == 0
 
 
-class TemplateSource(TestCase):
+class TestTemplateSource:
     @mock.patch("esrally.utils.io.dirname")
     @mock.patch.object(loader.TemplateSource, "read_glob_files")
     def test_entrypoint_of_replace_includes(self, patched_read_glob, patched_dirname):
@@ -947,7 +934,7 @@ class TemplateSource(TestCase):
             """
         )
 
-        self.assertEqual(expected_response, tmpl_src.replace_includes(base_path, track))
+        assert tmpl_src.replace_includes(base_path, track) == expected_response
 
     def test_read_glob_files(self):
         tmpl_obj = loader.TemplateSource(
@@ -961,10 +948,10 @@ class TemplateSource(TestCase):
         response = tmpl_obj.read_glob_files("*track_fragment_*.json")
         expected_response = '{\n  "item1": "value1"\n}\n,\n{\n  "item2": "value2"\n}\n'
 
-        self.assertEqual(expected_response, response)
+        assert response == expected_response
 
 
-class TemplateRenderTests(TestCase):
+class TestTemplateRender:
     unittest_template_internal_vars = loader.default_internal_template_vars(clock=StaticClock)
 
     def test_render_simple_template(self):
@@ -975,7 +962,7 @@ class TemplateRenderTests(TestCase):
         }
         """
 
-        rendered = loader.render_template(template, template_internal_vars=TemplateRenderTests.unittest_template_internal_vars)
+        rendered = loader.render_template(template, template_internal_vars=self.unittest_template_internal_vars)
 
         expected = """
         {
@@ -983,7 +970,7 @@ class TemplateRenderTests(TestCase):
             "key2": "static value"
         }
         """
-        self.assertEqual(expected, rendered)
+        assert rendered == expected
 
     def test_render_template_with_external_variables(self):
         template = """
@@ -994,7 +981,7 @@ class TemplateRenderTests(TestCase):
         """
 
         rendered = loader.render_template(
-            template, template_vars={"greeting": "Hi"}, template_internal_vars=TemplateRenderTests.unittest_template_internal_vars
+            template, template_vars={"greeting": "Hi"}, template_internal_vars=self.unittest_template_internal_vars
         )
 
         expected = """
@@ -1003,7 +990,7 @@ class TemplateRenderTests(TestCase):
             "name": "stranger"
         }
         """
-        self.assertEqual(expected, rendered)
+        assert rendered == expected
 
     def test_render_template_with_globbing(self):
         def key_globber(e):
@@ -1036,9 +1023,7 @@ class TemplateRenderTests(TestCase):
         template_source = loader.TemplateSource("", "track.json", source=source, fileglobber=key_globber)
         template_source.load_template_from_string(template)
 
-        rendered = loader.render_template(
-            template_source.assembled_source, template_internal_vars=TemplateRenderTests.unittest_template_internal_vars
-        )
+        rendered = loader.render_template(template_source.assembled_source, template_internal_vars=self.unittest_template_internal_vars)
 
         expected = """
         {
@@ -1063,7 +1048,7 @@ class TemplateRenderTests(TestCase):
         }
         """
         rendered = loader.render_template(
-            template, template_vars={"clients": 8}, template_internal_vars=TemplateRenderTests.unittest_template_internal_vars
+            template, template_vars={"clients": 8}, template_internal_vars=self.unittest_template_internal_vars
         )
 
         expected = """
@@ -1076,10 +1061,10 @@ class TemplateRenderTests(TestCase):
         self.assertEqualIgnoreWhitespace(expected, rendered)
 
     def assertEqualIgnoreWhitespace(self, expected, actual):
-        self.assertEqual(strip_ws(expected), strip_ws(actual))
+        assert strip_ws(expected) == strip_ws(actual)
 
 
-class CompleteTrackParamsTests(TestCase):
+class TestCompleteTrackParams:
     assembled_source = textwrap.dedent(
         """{% import "rally.helpers" as rally with context %}
         "key1": "value1",
@@ -1091,15 +1076,15 @@ class CompleteTrackParamsTests(TestCase):
 
     def test_check_complete_track_params_contains_all_track_params(self):
         complete_track_params = loader.CompleteTrackParams()
-        loader.register_all_params_in_track(CompleteTrackParamsTests.assembled_source, complete_track_params)
+        loader.register_all_params_in_track(self.assembled_source, complete_track_params)
 
-        self.assertEqual(["value2", "value3"], complete_track_params.sorted_track_defined_params)
+        assert complete_track_params.sorted_track_defined_params == ["value2", "value3"]
 
     def test_check_complete_track_params_does_not_fail_with_no_track_params(self):
         complete_track_params = loader.CompleteTrackParams()
         loader.register_all_params_in_track("{}", complete_track_params)
 
-        self.assertEqual([], complete_track_params.sorted_track_defined_params)
+        assert complete_track_params.sorted_track_defined_params == []
 
     def test_unused_user_defined_track_params(self):
         track_params = {"number_of_repliacs": 1, "enable_source": True, "number_of_shards": 5}  # deliberate typo  # unknown parameter
@@ -1116,7 +1101,7 @@ class CompleteTrackParamsTests(TestCase):
             ]
         )
 
-        self.assertEqual(["enable_source", "number_of_repliacs"], sorted(complete_track_params.unused_user_defined_track_params()))
+        assert sorted(complete_track_params.unused_user_defined_track_params()) == ["enable_source", "number_of_repliacs"]
 
     def test_unused_user_defined_track_params_doesnt_fail_with_detaults(self):
         complete_track_params = loader.CompleteTrackParams()
@@ -1131,10 +1116,10 @@ class CompleteTrackParamsTests(TestCase):
             ]
         )
 
-        self.assertEqual([], sorted(complete_track_params.unused_user_defined_track_params()))
+        assert sorted(complete_track_params.unused_user_defined_track_params()) == []
 
 
-class TrackPostProcessingTests(TestCase):
+class TestTrackPostProcessing:
     track_with_params_as_string = textwrap.dedent(
         """{
         "indices": [
@@ -1370,22 +1355,21 @@ class TrackPostProcessingTests(TestCase):
         cfg = config.Config()
         cfg.add(config.Scope.application, "track", "test.mode.enabled", True)
 
-        self.assertEqual(
+        expected = self.as_track(
+            expected_post_processed,
+            complete_track_params=complete_track_params,
+            index_body=index_body,
+        )
+        actual = loader.TestModeTrackProcessor(cfg).on_after_load_track(
             self.as_track(
-                expected_post_processed,
+                track_specification,
                 complete_track_params=complete_track_params,
                 index_body=index_body,
-            ),
-            loader.TestModeTrackProcessor(cfg).on_after_load_track(
-                self.as_track(
-                    track_specification,
-                    complete_track_params=complete_track_params,
-                    index_body=index_body,
-                )
-            ),
+            )
         )
+        assert actual == expected
 
-        self.assertEqual(["number_of_replicas", "number_of_shards"], complete_track_params.sorted_track_defined_params)
+        assert complete_track_params.sorted_track_defined_params == ["number_of_replicas", "number_of_shards"]
 
     def as_track(self, track_specification, track_params=None, complete_track_params=None, index_body=None):
         reader = loader.TrackSpecificationReader(
@@ -1396,7 +1380,7 @@ class TrackPostProcessingTests(TestCase):
         return reader("unittest", track_specification, "/mappings")
 
 
-class TrackPathTests(TestCase):
+class TestTrackPath:
     @mock.patch("os.path.exists")
     def test_sets_absolute_path(self, path_exists):
         path_exists.return_value = True
@@ -1430,11 +1414,11 @@ class TrackPathTests(TestCase):
 
         loader.set_absolute_data_path(cfg, t)
 
-        self.assertEqual("/data/unittest/docs/documents.json", t.corpora[0].documents[0].document_file)
-        self.assertEqual("/data/unittest/docs/documents.json.bz2", t.corpora[0].documents[0].document_archive)
+        assert t.corpora[0].documents[0].document_file == "/data/unittest/docs/documents.json"
+        assert t.corpora[0].documents[0].document_archive == "/data/unittest/docs/documents.json.bz2"
 
 
-class TrackFilterTests(TestCase):
+class TestTrackFilter:
     def filter(self, track_specification, include_tasks=None, exclude_tasks=None):
         cfg = config.Config()
         cfg.add(config.Scope.application, "track", "include.tasks", include_tasks)
@@ -1444,14 +1428,14 @@ class TrackFilterTests(TestCase):
         return processor.on_after_load_track(track_specification)
 
     def test_rejects_invalid_syntax(self):
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as exc:
             self.filter(track_specification=None, include_tasks=["valid", "a:b:c"])
-        self.assertEqual("Invalid format for filtered tasks: [a:b:c]", ctx.exception.args[0])
+        assert exc.value.args[0] == "Invalid format for filtered tasks: [a:b:c]"
 
     def test_rejects_unknown_filter_type(self):
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as exc:
             self.filter(track_specification=None, include_tasks=["valid", "op-type:index"])
-        self.assertEqual("Invalid format for filtered tasks: [op-type:index]. Expected [type] but got [op-type].", ctx.exception.args[0])
+        assert exc.value.args[0] == "Invalid format for filtered tasks: [op-type:index]. Expected [type] but got [op-type]."
 
     def test_filters_tasks(self):
         track_specification = {
@@ -1554,7 +1538,7 @@ class TrackFilterTests(TestCase):
         }
         reader = loader.TrackSpecificationReader()
         full_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(7, len(full_track.challenges[0].schedule))
+        assert len(full_track.challenges[0].schedule) == 7
 
         filtered = self.filter(
             full_track,
@@ -1568,12 +1552,12 @@ class TrackFilterTests(TestCase):
         )
 
         schedule = filtered.challenges[0].schedule
-        self.assertEqual(5, len(schedule))
-        self.assertEqual(["index-3", "match-all-parallel"], [t.name for t in schedule[0].tasks])
-        self.assertEqual("match-all-serial", schedule[1].name)
-        self.assertEqual("cluster-stats", schedule[2].name)
-        self.assertEqual(["query-filtered", "index-4"], [t.name for t in schedule[3].tasks])
-        self.assertEqual("final-cluster-stats", schedule[4].name)
+        assert len(schedule) == 5
+        assert [t.name for t in schedule[0].tasks] == ["index-3", "match-all-parallel"]
+        assert schedule[1].name == "match-all-serial"
+        assert schedule[2].name == "cluster-stats"
+        assert [t.name for t in schedule[3].tasks] == ["query-filtered", "index-4"]
+        assert schedule[4].name == "final-cluster-stats"
 
     def test_filters_exclude_tasks(self):
         track_specification = {
@@ -1656,15 +1640,15 @@ class TrackFilterTests(TestCase):
         }
         reader = loader.TrackSpecificationReader()
         full_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(5, len(full_track.challenges[0].schedule))
+        assert len(full_track.challenges[0].schedule) == 5
 
         filtered = self.filter(full_track, exclude_tasks=["index-3", "type:search", "create-index"])
 
         schedule = filtered.challenges[0].schedule
-        self.assertEqual(3, len(schedule))
-        self.assertEqual(["index-1", "index-2"], [t.name for t in schedule[0].tasks])
-        self.assertEqual("node-stats", schedule[1].name)
-        self.assertEqual("cluster-stats", schedule[2].name)
+        assert len(schedule) == 3
+        assert [t.name for t in schedule[0].tasks] == ["index-1", "index-2"]
+        assert schedule[1].name == "node-stats"
+        assert schedule[2].name == "cluster-stats"
 
     def test_unmatched_exclude_runs_everything(self):
         track_specification = {
@@ -1729,13 +1713,13 @@ class TrackFilterTests(TestCase):
 
         reader = loader.TrackSpecificationReader()
         full_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(5, len(full_track.challenges[0].schedule))
+        assert len(full_track.challenges[0].schedule) == 5
 
         expected_schedule = full_track.challenges[0].schedule.copy()
         filtered = self.filter(full_track, exclude_tasks=["nothing"])
 
         schedule = filtered.challenges[0].schedule
-        self.assertEqual(expected_schedule, schedule)
+        assert schedule == expected_schedule
 
     def test_unmatched_include_runs_nothing(self):
         track_specification = {
@@ -1800,17 +1784,17 @@ class TrackFilterTests(TestCase):
 
         reader = loader.TrackSpecificationReader()
         full_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(5, len(full_track.challenges[0].schedule))
+        assert len(full_track.challenges[0].schedule) == 5
 
         expected_schedule = []
         filtered = self.filter(full_track, include_tasks=["nothing"])
 
         schedule = filtered.challenges[0].schedule
-        self.assertEqual(expected_schedule, schedule)
+        assert schedule == expected_schedule
 
 
 # pylint: disable=too-many-public-methods
-class TrackSpecificationReaderTests(TestCase):
+class TestTrackSpecificationReader:
     def test_description_is_optional(self):
         track_specification = {
             # no description here
@@ -1819,8 +1803,8 @@ class TrackSpecificationReaderTests(TestCase):
         reader = loader.TrackSpecificationReader()
 
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual("unittest", resulting_track.name)
-        self.assertEqual("", resulting_track.description)
+        assert resulting_track.name == "unittest"
+        assert resulting_track.description == ""
 
     def test_can_read_track_info(self):
         track_specification = {
@@ -1838,8 +1822,8 @@ class TrackSpecificationReaderTests(TestCase):
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual("unittest", resulting_track.name)
-        self.assertEqual("description for unit test", resulting_track.description)
+        assert resulting_track.name == "unittest"
+        assert resulting_track.description == "description for unit test"
 
     def test_document_count_mandatory_if_file_present(self):
         track_specification = {
@@ -1862,9 +1846,9 @@ class TrackSpecificationReaderTests(TestCase):
             "challenges": [],
         }
         reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Mandatory element 'document-count' is missing.", ctx.exception.args[0])
+        assert exc.value.args[0] == "Track 'unittest' is invalid. Mandatory element 'document-count' is missing."
 
     def test_parse_with_mixed_warmup_iterations_and_measurement(self):
         track_specification = {
@@ -1918,12 +1902,11 @@ class TrackSpecificationReaderTests(TestCase):
                 }
             )
         )
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' defines 3 warmup "
-            "iterations and a time period of 60 seconds but mixing time periods and iterations is not allowed.",
-            ctx.exception.args[0],
+            "iterations and a time period of 60 seconds but mixing time periods and iterations is not allowed."
         )
 
     def test_parse_with_mixed_iterations_and_ramp_up(self):
@@ -1973,13 +1956,12 @@ class TrackSpecificationReaderTests(TestCase):
                 }
             )
         )
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' "
             "defines a ramp-up time period of 120 seconds as well as 3 warmup iterations and 5 iterations "
-            "but mixing time periods and iterations is not allowed.",
-            ctx.exception.args[0],
+            "but mixing time periods and iterations is not allowed."
         )
 
     def test_parse_missing_challenge_or_challenges(self):
@@ -2014,11 +1996,10 @@ class TrackSpecificationReaderTests(TestCase):
                 }
             )
         )
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
-            "Track 'unittest' is invalid. You must define 'challenge', 'challenges' or 'schedule' but none is specified.",
-            ctx.exception.args[0],
+        assert exc.value.args[0] == (
+            "Track 'unittest' is invalid. You must define 'challenge', 'challenges' or 'schedule' but none is specified."
         )
 
     def test_parse_challenge_and_challenges_are_defined(self):
@@ -2049,12 +2030,11 @@ class TrackSpecificationReaderTests(TestCase):
                 }
             )
         )
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. Multiple out of 'challenge', 'challenges' or 'schedule' are defined but only "
-            "one of them is allowed.",
-            ctx.exception.args[0],
+            "one of them is allowed."
         )
 
     def test_parse_with_mixed_warmup_time_period_and_iterations(self):
@@ -2109,12 +2089,11 @@ class TrackSpecificationReaderTests(TestCase):
                 }
             )
         )
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' defines a warmup time "
-            "period of 20 seconds and 1000 iterations but mixing time periods and iterations is not allowed.",
-            ctx.exception.args[0],
+            "period of 20 seconds and 1000 iterations but mixing time periods and iterations is not allowed."
         )
 
     def test_parse_duplicate_implicit_task_names(self):
@@ -2142,12 +2121,11 @@ class TrackSpecificationReaderTests(TestCase):
             },
         }
         reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. Challenge 'default-challenge' contains multiple tasks with the name 'search'. Please"
-            " use the task's name property to assign a unique name for each task.",
-            ctx.exception.args[0],
+            " use the task's name property to assign a unique name for each task."
         )
 
     def test_parse_duplicate_explicit_task_names(self):
@@ -2177,12 +2155,11 @@ class TrackSpecificationReaderTests(TestCase):
             },
         }
         reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. Challenge 'default-challenge' contains multiple tasks with the name "
-            "'duplicate-task-name'. Please use the task's name property to assign a unique name for each task.",
-            ctx.exception.args[0],
+            "'duplicate-task-name'. Please use the task's name property to assign a unique name for each task."
         )
 
     def test_load_invalid_index_body(self):
@@ -2238,9 +2215,9 @@ class TrackSpecificationReaderTests(TestCase):
                 }
             ),
         )
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Could not load file template for 'definition for index index-historical in body.json'", ctx.exception.args[0])
+        assert exc.value.args[0] == "Could not load file template for 'definition for index index-historical in body.json'"
 
     def test_parse_unique_task_names(self):
         track_specification = {
@@ -2270,15 +2247,15 @@ class TrackSpecificationReaderTests(TestCase):
         }
         reader = loader.TrackSpecificationReader(selected_challenge="default-challenge")
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual("unittest", resulting_track.name)
+        assert resulting_track.name == "unittest"
         challenge = resulting_track.challenges[0]
-        self.assertTrue(challenge.selected)
+        assert challenge.selected
         schedule = challenge.schedule
-        self.assertEqual(2, len(schedule))
-        self.assertEqual("search-one-client", schedule[0].name)
-        self.assertEqual("search", schedule[0].operation.name)
-        self.assertEqual("search-two-clients", schedule[1].name)
-        self.assertEqual("search", schedule[1].operation.name)
+        assert len(schedule) == 2
+        assert schedule[0].name == "search-one-client"
+        assert schedule[0].operation.name == "search"
+        assert schedule[1].name == "search-two-clients"
+        assert schedule[1].operation.name == "search"
 
     def test_parse_indices_valid_track_specification(self):
         track_specification = {
@@ -2372,67 +2349,64 @@ class TrackSpecificationReaderTests(TestCase):
         )
         resulting_track = reader("unittest", track_specification, "/mappings")
         # j2 variables defined in the track -- used for checking mismatching user track params
-        self.assertEqual(["number_of_shards"], complete_track_params.sorted_track_defined_params)
-        self.assertEqual("unittest", resulting_track.name)
-        self.assertEqual("description for unit test", resulting_track.description)
+        assert complete_track_params.sorted_track_defined_params == ["number_of_shards"]
+        assert resulting_track.name == "unittest"
+        assert resulting_track.description == "description for unit test"
         # indices
-        self.assertEqual(1, len(resulting_track.indices))
-        self.assertEqual("index-historical", resulting_track.indices[0].name)
-        self.assertDictEqual(
-            {
-                "settings": {
-                    "number_of_shards": 3,
-                },
-                "mappings": {
-                    "main": "empty-for-test",
-                    "secondary": "empty-for-test",
-                },
+        assert len(resulting_track.indices) == 1
+        assert resulting_track.indices[0].name == "index-historical"
+        assert {
+            "settings": {
+                "number_of_shards": 3,
             },
-            resulting_track.indices[0].body,
-        )
-        self.assertEqual(2, len(resulting_track.indices[0].types))
-        self.assertEqual("main", resulting_track.indices[0].types[0])
-        self.assertEqual("secondary", resulting_track.indices[0].types[1])
+            "mappings": {
+                "main": "empty-for-test",
+                "secondary": "empty-for-test",
+            },
+        } == resulting_track.indices[0].body
+        assert len(resulting_track.indices[0].types) == 2
+        assert resulting_track.indices[0].types[0] == "main"
+        assert resulting_track.indices[0].types[1] == "secondary"
         # corpora
-        self.assertEqual(1, len(resulting_track.corpora))
-        self.assertEqual("test", resulting_track.corpora[0].name)
-        self.assertDictEqual({"test-corpus": True}, resulting_track.corpora[0].meta_data)
-        self.assertEqual(2, len(resulting_track.corpora[0].documents))
+        assert len(resulting_track.corpora) == 1
+        assert resulting_track.corpora[0].name == "test"
+        assert resulting_track.corpora[0].meta_data == {"test-corpus": True}
+        assert len(resulting_track.corpora[0].documents) == 2
 
         docs_primary = resulting_track.corpora[0].documents[0]
-        self.assertEqual(track.Documents.SOURCE_FORMAT_BULK, docs_primary.source_format)
-        self.assertEqual("documents-main.json", docs_primary.document_file)
-        self.assertEqual("documents-main.json.bz2", docs_primary.document_archive)
-        self.assertEqual("https://localhost/data", docs_primary.base_url)
-        self.assertFalse(docs_primary.includes_action_and_meta_data)
-        self.assertEqual(10, docs_primary.number_of_documents)
-        self.assertEqual(100, docs_primary.compressed_size_in_bytes)
-        self.assertEqual(10000, docs_primary.uncompressed_size_in_bytes)
-        self.assertEqual("index-historical", docs_primary.target_index)
-        self.assertEqual("main", docs_primary.target_type)
-        self.assertDictEqual({"test-docs": True, "role": "main"}, docs_primary.meta_data)
+        assert track.Documents.SOURCE_FORMAT_BULK == docs_primary.source_format
+        assert docs_primary.document_file == "documents-main.json"
+        assert docs_primary.document_archive == "documents-main.json.bz2"
+        assert docs_primary.base_url == "https://localhost/data"
+        assert not docs_primary.includes_action_and_meta_data
+        assert docs_primary.number_of_documents == 10
+        assert docs_primary.compressed_size_in_bytes == 100
+        assert docs_primary.uncompressed_size_in_bytes == 10000
+        assert docs_primary.target_index == "index-historical"
+        assert docs_primary.target_type == "main"
+        assert docs_primary.meta_data == {"test-docs": True, "role": "main"}
 
         docs_secondary = resulting_track.corpora[0].documents[1]
-        self.assertEqual(track.Documents.SOURCE_FORMAT_BULK, docs_secondary.source_format)
-        self.assertEqual("documents-secondary.json", docs_secondary.document_file)
-        self.assertEqual("documents-secondary.json.bz2", docs_secondary.document_archive)
-        self.assertEqual("https://localhost/data", docs_secondary.base_url)
-        self.assertTrue(docs_secondary.includes_action_and_meta_data)
-        self.assertEqual(20, docs_secondary.number_of_documents)
-        self.assertEqual(200, docs_secondary.compressed_size_in_bytes)
-        self.assertEqual(20000, docs_secondary.uncompressed_size_in_bytes)
+        assert track.Documents.SOURCE_FORMAT_BULK == docs_secondary.source_format
+        assert docs_secondary.document_file == "documents-secondary.json"
+        assert docs_secondary.document_archive == "documents-secondary.json.bz2"
+        assert docs_secondary.base_url == "https://localhost/data"
+        assert docs_secondary.includes_action_and_meta_data
+        assert docs_secondary.number_of_documents == 20
+        assert docs_secondary.compressed_size_in_bytes == 200
+        assert docs_secondary.uncompressed_size_in_bytes == 20000
         # This is defined by the action-and-meta-data line!
-        self.assertIsNone(docs_secondary.target_index)
-        self.assertIsNone(docs_secondary.target_type)
-        self.assertDictEqual({"test-docs": True, "role": "secondary"}, docs_secondary.meta_data)
+        assert docs_secondary.target_index is None
+        assert docs_secondary.target_type is None
+        assert docs_secondary.meta_data == {"test-docs": True, "role": "secondary"}
 
         # challenges
-        self.assertEqual(1, len(resulting_track.challenges))
-        self.assertEqual("default-challenge", resulting_track.challenges[0].name)
-        self.assertEqual("Default challenge", resulting_track.challenges[0].description)
-        self.assertEqual({"mixed": True, "max-clients": 8}, resulting_track.challenges[0].meta_data)
-        self.assertEqual({"append": True}, resulting_track.challenges[0].schedule[0].operation.meta_data)
-        self.assertEqual({"operation-index": 0}, resulting_track.challenges[0].schedule[0].meta_data)
+        assert len(resulting_track.challenges) == 1
+        assert resulting_track.challenges[0].name == "default-challenge"
+        assert resulting_track.challenges[0].description == "Default challenge"
+        assert resulting_track.challenges[0].meta_data == {"mixed": True, "max-clients": 8}
+        assert resulting_track.challenges[0].schedule[0].operation.meta_data == {"append": True}
+        assert resulting_track.challenges[0].schedule[0].meta_data == {"operation-index": 0}
 
     def test_parse_data_streams_valid_track_specification(self):
         track_specification = {
@@ -2506,62 +2480,62 @@ class TrackSpecificationReaderTests(TestCase):
         reader = loader.TrackSpecificationReader(complete_track_params=complete_track_params)
         resulting_track = reader("unittest", track_specification, "/mappings")
         # j2 variables defined in the track -- used for checking mismatching user track params
-        self.assertEqual("unittest", resulting_track.name)
-        self.assertEqual("description for unit test", resulting_track.description)
+        assert resulting_track.name == "unittest"
+        assert resulting_track.description == "description for unit test"
         # data streams
-        self.assertEqual(1, len(resulting_track.data_streams))
-        self.assertEqual("data-stream-historical", resulting_track.data_streams[0].name)
+        assert len(resulting_track.data_streams) == 1
+        assert resulting_track.data_streams[0].name == "data-stream-historical"
         # corpora
-        self.assertEqual(1, len(resulting_track.corpora))
-        self.assertEqual("test", resulting_track.corpora[0].name)
-        self.assertEqual(3, len(resulting_track.corpora[0].documents))
+        assert len(resulting_track.corpora) == 1
+        assert resulting_track.corpora[0].name == "test"
+        assert len(resulting_track.corpora[0].documents) == 3
 
         docs_primary = resulting_track.corpora[0].documents[0]
-        self.assertEqual(track.Documents.SOURCE_FORMAT_BULK, docs_primary.source_format)
-        self.assertEqual("documents-main.json", docs_primary.document_file)
-        self.assertEqual("documents-main.json.bz2", docs_primary.document_archive)
-        self.assertEqual("https://localhost/data", docs_primary.base_url)
-        self.assertFalse(docs_primary.includes_action_and_meta_data)
-        self.assertEqual(10, docs_primary.number_of_documents)
-        self.assertEqual(100, docs_primary.compressed_size_in_bytes)
-        self.assertEqual(10000, docs_primary.uncompressed_size_in_bytes)
-        self.assertEqual("data-stream-historical", docs_primary.target_data_stream)
-        self.assertIsNone(docs_primary.target_index)
-        self.assertIsNone(docs_primary.target_type)
+        assert track.Documents.SOURCE_FORMAT_BULK == docs_primary.source_format
+        assert docs_primary.document_file == "documents-main.json"
+        assert docs_primary.document_archive == "documents-main.json.bz2"
+        assert docs_primary.base_url == "https://localhost/data"
+        assert not docs_primary.includes_action_and_meta_data
+        assert docs_primary.number_of_documents == 10
+        assert docs_primary.compressed_size_in_bytes == 100
+        assert docs_primary.uncompressed_size_in_bytes == 10000
+        assert docs_primary.target_data_stream == "data-stream-historical"
+        assert docs_primary.target_index is None
+        assert docs_primary.target_type is None
 
         docs_secondary = resulting_track.corpora[0].documents[1]
-        self.assertEqual(track.Documents.SOURCE_FORMAT_BULK, docs_secondary.source_format)
-        self.assertEqual("documents-secondary.json", docs_secondary.document_file)
-        self.assertEqual("documents-secondary.json.bz2", docs_secondary.document_archive)
-        self.assertEqual("https://localhost/data", docs_secondary.base_url)
-        self.assertTrue(docs_secondary.includes_action_and_meta_data)
-        self.assertEqual(20, docs_secondary.number_of_documents)
-        self.assertEqual(200, docs_secondary.compressed_size_in_bytes)
-        self.assertEqual(20000, docs_secondary.uncompressed_size_in_bytes)
+        assert track.Documents.SOURCE_FORMAT_BULK == docs_secondary.source_format
+        assert docs_secondary.document_file == "documents-secondary.json"
+        assert docs_secondary.document_archive == "documents-secondary.json.bz2"
+        assert docs_secondary.base_url == "https://localhost/data"
+        assert docs_secondary.includes_action_and_meta_data
+        assert docs_secondary.number_of_documents == 20
+        assert docs_secondary.compressed_size_in_bytes == 200
+        assert docs_secondary.uncompressed_size_in_bytes == 20000
         # This is defined by the action-and-meta-data line!
-        self.assertIsNone(docs_secondary.target_data_stream)
-        self.assertIsNone(docs_secondary.target_index)
-        self.assertIsNone(docs_secondary.target_type)
+        assert docs_secondary.target_data_stream is None
+        assert docs_secondary.target_index is None
+        assert docs_secondary.target_type is None
 
         docs_tertiary = resulting_track.corpora[0].documents[2]
-        self.assertEqual(track.Documents.SOURCE_FORMAT_BULK, docs_tertiary.source_format)
-        self.assertEqual("documents-main.json", docs_tertiary.document_file)
-        self.assertEqual("documents-main.json.bz2", docs_tertiary.document_archive)
-        self.assertEqual("https://localhost/data", docs_tertiary.base_url)
-        self.assertFalse(docs_tertiary.includes_action_and_meta_data)
-        self.assertEqual(10, docs_tertiary.number_of_documents)
-        self.assertEqual(100, docs_tertiary.compressed_size_in_bytes)
-        self.assertIsNone(docs_tertiary.target_index)
-        self.assertIsNone(docs_tertiary.target_type)
-        self.assertEqual("data-stream-historical", docs_tertiary.target_data_stream)
+        assert track.Documents.SOURCE_FORMAT_BULK == docs_tertiary.source_format
+        assert docs_tertiary.document_file == "documents-main.json"
+        assert docs_tertiary.document_archive == "documents-main.json.bz2"
+        assert docs_tertiary.base_url == "https://localhost/data"
+        assert not docs_tertiary.includes_action_and_meta_data
+        assert docs_tertiary.number_of_documents == 10
+        assert docs_tertiary.compressed_size_in_bytes == 100
+        assert docs_tertiary.target_index is None
+        assert docs_tertiary.target_type is None
+        assert docs_tertiary.target_data_stream == "data-stream-historical"
 
         # challenges
-        self.assertEqual(1, len(resulting_track.challenges))
-        self.assertEqual("default-challenge", resulting_track.challenges[0].name)
-        self.assertEqual("Default challenge", resulting_track.challenges[0].description)
-        self.assertEqual({"mixed": True, "max-clients": 8}, resulting_track.challenges[0].meta_data)
-        self.assertEqual({"append": True}, resulting_track.challenges[0].schedule[0].operation.meta_data)
-        self.assertEqual({"operation-index": 0}, resulting_track.challenges[0].schedule[0].meta_data)
+        assert len(resulting_track.challenges) == 1
+        assert resulting_track.challenges[0].name == "default-challenge"
+        assert resulting_track.challenges[0].description == "Default challenge"
+        assert resulting_track.challenges[0].meta_data == {"mixed": True, "max-clients": 8}
+        assert resulting_track.challenges[0].schedule[0].operation.meta_data == {"append": True}
+        assert resulting_track.challenges[0].schedule[0].meta_data == {"operation-index": 0}
 
     def test_parse_valid_without_types(self):
         track_specification = {
@@ -2615,40 +2589,37 @@ class TrackSpecificationReaderTests(TestCase):
             ),
         )
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual("unittest", resulting_track.name)
-        self.assertEqual("description for unit test", resulting_track.description)
+        assert resulting_track.name == "unittest"
+        assert resulting_track.description == "description for unit test"
         # indices
-        self.assertEqual(1, len(resulting_track.indices))
-        self.assertEqual("index-historical", resulting_track.indices[0].name)
-        self.assertDictEqual(
-            {
-                "settings": {
-                    "number_of_shards": 3,
-                },
+        assert len(resulting_track.indices) == 1
+        assert resulting_track.indices[0].name == "index-historical"
+        assert resulting_track.indices[0].body == {
+            "settings": {
+                "number_of_shards": 3,
             },
-            resulting_track.indices[0].body,
-        )
-        self.assertEqual(0, len(resulting_track.indices[0].types))
+        }
+        assert len(resulting_track.indices[0].types) == 0
         # corpora
-        self.assertEqual(1, len(resulting_track.corpora))
-        self.assertEqual("test", resulting_track.corpora[0].name)
-        self.assertEqual(1, len(resulting_track.corpora[0].documents))
+        assert len(resulting_track.corpora) == 1
+        assert resulting_track.corpora[0].name == "test"
+        assert len(resulting_track.corpora[0].documents) == 1
 
         docs_primary = resulting_track.corpora[0].documents[0]
-        self.assertEqual(track.Documents.SOURCE_FORMAT_BULK, docs_primary.source_format)
-        self.assertEqual("documents-main.json", docs_primary.document_file)
-        self.assertEqual("documents-main.json.bz2", docs_primary.document_archive)
-        self.assertEqual("https://localhost/data", docs_primary.base_url)
-        self.assertFalse(docs_primary.includes_action_and_meta_data)
-        self.assertEqual(10, docs_primary.number_of_documents)
-        self.assertEqual(100, docs_primary.compressed_size_in_bytes)
-        self.assertEqual(10000, docs_primary.uncompressed_size_in_bytes)
-        self.assertEqual("index-historical", docs_primary.target_index)
-        self.assertIsNone(docs_primary.target_type)
-        self.assertIsNone(docs_primary.target_data_stream)
+        assert track.Documents.SOURCE_FORMAT_BULK == docs_primary.source_format
+        assert docs_primary.document_file == "documents-main.json"
+        assert docs_primary.document_archive == "documents-main.json.bz2"
+        assert docs_primary.base_url == "https://localhost/data"
+        assert not docs_primary.includes_action_and_meta_data
+        assert docs_primary.number_of_documents == 10
+        assert docs_primary.compressed_size_in_bytes == 100
+        assert docs_primary.uncompressed_size_in_bytes == 10000
+        assert docs_primary.target_index == "index-historical"
+        assert docs_primary.target_type is None
+        assert docs_primary.target_data_stream is None
 
         # challenges
-        self.assertEqual(1, len(resulting_track.challenges))
+        assert len(resulting_track.challenges) == 1
 
     def test_parse_invalid_data_streams_with_indices(self):
         track_specification = {
@@ -2691,7 +2662,7 @@ class TrackSpecificationReaderTests(TestCase):
         }
         complete_track_params = loader.CompleteTrackParams()
         reader = loader.TrackSpecificationReader(complete_track_params=complete_track_params)
-        with self.assertRaises(loader.TrackSyntaxError):
+        with pytest.raises(loader.TrackSyntaxError):
             reader("unittest", track_specification, "/mapping")
 
     def test_parse_invalid_data_streams_with_target_index(self):
@@ -2730,7 +2701,7 @@ class TrackSpecificationReaderTests(TestCase):
         }
         complete_track_params = loader.CompleteTrackParams()
         reader = loader.TrackSpecificationReader(complete_track_params=complete_track_params)
-        with self.assertRaises(loader.TrackSyntaxError):
+        with pytest.raises(loader.TrackSyntaxError):
             reader("unittest", track_specification, "/mapping")
 
     def test_parse_invalid_data_streams_with_target_type(self):
@@ -2765,7 +2736,7 @@ class TrackSpecificationReaderTests(TestCase):
         }
         complete_track_params = loader.CompleteTrackParams()
         reader = loader.TrackSpecificationReader(complete_track_params=complete_track_params)
-        with self.assertRaises(loader.TrackSyntaxError):
+        with pytest.raises(loader.TrackSyntaxError):
             reader("unittest", track_specification, "/mapping")
 
     def test_parse_invalid_no_data_stream_target(self):
@@ -2806,7 +2777,7 @@ class TrackSpecificationReaderTests(TestCase):
         }
         complete_track_params = loader.CompleteTrackParams()
         reader = loader.TrackSpecificationReader(complete_track_params=complete_track_params)
-        with self.assertRaises(loader.TrackSyntaxError):
+        with pytest.raises(loader.TrackSyntaxError):
             reader("unittest", track_specification, "/mapping")
 
     def test_parse_valid_without_indices(self):
@@ -2855,33 +2826,33 @@ class TrackSpecificationReaderTests(TestCase):
             ),
         )
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual("unittest", resulting_track.name)
-        self.assertEqual("description for unit test", resulting_track.description)
+        assert resulting_track.name == "unittest"
+        assert resulting_track.description == "description for unit test"
         # indices
-        self.assertEqual(0, len(resulting_track.indices))
+        assert len(resulting_track.indices) == 0
         # data streams
-        self.assertEqual(1, len(resulting_track.data_streams))
-        self.assertEqual("historical-data-stream", resulting_track.data_streams[0].name)
+        assert len(resulting_track.data_streams) == 1
+        assert resulting_track.data_streams[0].name == "historical-data-stream"
         # corpora
-        self.assertEqual(1, len(resulting_track.corpora))
-        self.assertEqual("test", resulting_track.corpora[0].name)
-        self.assertEqual(1, len(resulting_track.corpora[0].documents))
+        assert len(resulting_track.corpora) == 1
+        assert resulting_track.corpora[0].name == "test"
+        assert len(resulting_track.corpora[0].documents) == 1
 
         docs_primary = resulting_track.corpora[0].documents[0]
-        self.assertEqual(track.Documents.SOURCE_FORMAT_BULK, docs_primary.source_format)
-        self.assertEqual("documents-main.json", docs_primary.document_file)
-        self.assertEqual("documents-main.json.bz2", docs_primary.document_archive)
-        self.assertEqual("https://localhost/data", docs_primary.base_url)
-        self.assertFalse(docs_primary.includes_action_and_meta_data)
-        self.assertEqual(10, docs_primary.number_of_documents)
-        self.assertEqual(100, docs_primary.compressed_size_in_bytes)
-        self.assertEqual(10000, docs_primary.uncompressed_size_in_bytes)
-        self.assertEqual("historical-data-stream", docs_primary.target_data_stream)
-        self.assertIsNone(docs_primary.target_type)
-        self.assertIsNone(docs_primary.target_index)
+        assert track.Documents.SOURCE_FORMAT_BULK == docs_primary.source_format
+        assert docs_primary.document_file == "documents-main.json"
+        assert docs_primary.document_archive == "documents-main.json.bz2"
+        assert docs_primary.base_url == "https://localhost/data"
+        assert not docs_primary.includes_action_and_meta_data
+        assert docs_primary.number_of_documents == 10
+        assert docs_primary.compressed_size_in_bytes == 100
+        assert docs_primary.uncompressed_size_in_bytes == 10000
+        assert docs_primary.target_data_stream == "historical-data-stream"
+        assert docs_primary.target_type is None
+        assert docs_primary.target_index is None
 
         # challenges
-        self.assertEqual(1, len(resulting_track.challenges))
+        assert len(resulting_track.challenges) == 1
 
     def test_parse_valid_track_specification_with_index_template(self):
         track_specification = {
@@ -2916,23 +2887,20 @@ class TrackSpecificationReaderTests(TestCase):
             ),
         )
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(["index_pattern", "number_of_shards"], complete_track_params.sorted_track_defined_params)
-        self.assertEqual("unittest", resulting_track.name)
-        self.assertEqual("description for unit test", resulting_track.description)
-        self.assertEqual(0, len(resulting_track.indices))
-        self.assertEqual(1, len(resulting_track.templates))
-        self.assertEqual("my-index-template", resulting_track.templates[0].name)
-        self.assertEqual("*", resulting_track.templates[0].pattern)
-        self.assertDictEqual(
-            {
-                "index_patterns": ["*"],
-                "settings": {
-                    "number_of_shards": 1,
-                },
+        assert complete_track_params.sorted_track_defined_params == ["index_pattern", "number_of_shards"]
+        assert resulting_track.name == "unittest"
+        assert resulting_track.description == "description for unit test"
+        assert len(resulting_track.indices) == 0
+        assert len(resulting_track.templates) == 1
+        assert resulting_track.templates[0].name == "my-index-template"
+        assert resulting_track.templates[0].pattern == "*"
+        assert resulting_track.templates[0].content == {
+            "index_patterns": ["*"],
+            "settings": {
+                "number_of_shards": 1,
             },
-            resulting_track.templates[0].content,
-        )
-        self.assertEqual(0, len(resulting_track.challenges))
+        }
+        assert len(resulting_track.challenges) == 0
 
     def test_parse_valid_track_specification_with_composable_template(self):
         track_specification = {
@@ -3009,55 +2977,46 @@ class TrackSpecificationReaderTests(TestCase):
             ),
         )
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(["index_pattern", "number_of_replicas", "number_of_shards"], complete_track_params.sorted_track_defined_params)
-        self.assertEqual("unittest", resulting_track.name)
-        self.assertEqual("description for unit test", resulting_track.description)
-        self.assertEqual(0, len(resulting_track.indices))
-        self.assertEqual(1, len(resulting_track.composable_templates))
-        self.assertEqual(2, len(resulting_track.component_templates))
-        self.assertEqual("my-index-template", resulting_track.composable_templates[0].name)
-        self.assertEqual("*", resulting_track.composable_templates[0].pattern)
-        self.assertEqual("my-component-template-1", resulting_track.component_templates[0].name)
-        self.assertEqual("my-component-template-2", resulting_track.component_templates[1].name)
-        self.assertDictEqual(
-            {
-                "index_patterns": ["logs-*"],
-                "template": {
-                    "settings": {
-                        "number_of_shards": 1,
-                    },
-                },
-                "composed_of": [
-                    "my-component-template-1",
-                    "my-component-template-2",
-                ],
-            },
-            resulting_track.composable_templates[0].content,
-        )
-        self.assertDictEqual(
-            {
-                "template": {
-                    "settings": {
-                        "index.number_of_shards": 2,
-                    },
+        assert ["index_pattern", "number_of_replicas", "number_of_shards"] == complete_track_params.sorted_track_defined_params
+        assert resulting_track.name == "unittest"
+        assert resulting_track.description == "description for unit test"
+        assert len(resulting_track.indices) == 0
+        assert len(resulting_track.composable_templates) == 1
+        assert len(resulting_track.component_templates) == 2
+        assert resulting_track.composable_templates[0].name == "my-index-template"
+        assert resulting_track.composable_templates[0].pattern == "*"
+        assert resulting_track.component_templates[0].name == "my-component-template-1"
+        assert resulting_track.component_templates[1].name == "my-component-template-2"
+        assert resulting_track.composable_templates[0].content == {
+            "index_patterns": ["logs-*"],
+            "template": {
+                "settings": {
+                    "number_of_shards": 1,
                 },
             },
-            resulting_track.component_templates[0].content,
-        )
-        self.assertDictEqual(
-            {
-                "template": {
-                    "settings": {"index.number_of_replicas": 1},
-                    "mappings": {
-                        "properties": {
-                            "@timestamp": {"type": "date"},
-                        },
+            "composed_of": [
+                "my-component-template-1",
+                "my-component-template-2",
+            ],
+        }
+        assert resulting_track.component_templates[0].content == {
+            "template": {
+                "settings": {
+                    "index.number_of_shards": 2,
+                },
+            },
+        }
+        assert resulting_track.component_templates[1].content == {
+            "template": {
+                "settings": {"index.number_of_replicas": 1},
+                "mappings": {
+                    "properties": {
+                        "@timestamp": {"type": "date"},
                     },
                 },
             },
-            resulting_track.component_templates[1].content,
-        )
-        self.assertEqual(0, len(resulting_track.challenges))
+        }
+        assert len(resulting_track.challenges) == 0
 
     def test_parse_invalid_track_specification_with_composable_template(self):
         track_specification = {
@@ -3074,9 +3033,9 @@ class TrackSpecificationReaderTests(TestCase):
         reader = loader.TrackSpecificationReader(
             track_params={"index_pattern": "logs-*", "number_of_replicas": 1}, complete_track_params=complete_track_params
         )
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Mandatory element 'template' is missing.", ctx.exception.args[0])
+        assert exc.value.args[0] == "Track 'unittest' is invalid. Mandatory element 'template' is missing."
 
     def test_unique_challenge_names(self):
         track_specification = {
@@ -3103,9 +3062,9 @@ class TrackSpecificationReaderTests(TestCase):
             ],
         }
         reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual("Track 'unittest' is invalid. Duplicate challenge with name 'test-challenge'.", ctx.exception.args[0])
+        assert exc.value.args[0] == "Track 'unittest' is invalid. Duplicate challenge with name 'test-challenge'."
 
     def test_not_more_than_one_default_challenge_possible(self):
         track_specification = {
@@ -3137,12 +3096,11 @@ class TrackSpecificationReaderTests(TestCase):
             ],
         }
         reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. Both 'default-challenge' and 'another-challenge' are defined as default challenges. "
-            "Please define only one of them as default.",
-            ctx.exception.args[0],
+            "Please define only one of them as default."
         )
 
     def test_at_least_one_default_challenge(self):
@@ -3175,12 +3133,11 @@ class TrackSpecificationReaderTests(TestCase):
             ],
         }
         reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. No default challenge specified. Please edit the track and add \"default\": true "
-            "to one of the challenges challenge, another-challenge.",
-            ctx.exception.args[0],
+            "to one of the challenges challenge, another-challenge."
         )
 
     def test_exactly_one_default_challenge(self):
@@ -3215,11 +3172,11 @@ class TrackSpecificationReaderTests(TestCase):
         }
         reader = loader.TrackSpecificationReader(selected_challenge="another-challenge")
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(2, len(resulting_track.challenges))
-        self.assertEqual("challenge", resulting_track.challenges[0].name)
-        self.assertTrue(resulting_track.challenges[0].default)
-        self.assertFalse(resulting_track.challenges[1].default)
-        self.assertTrue(resulting_track.challenges[1].selected)
+        assert len(resulting_track.challenges) == 2
+        assert resulting_track.challenges[0].name == "challenge"
+        assert resulting_track.challenges[0].default
+        assert not resulting_track.challenges[1].default
+        assert resulting_track.challenges[1].selected
 
     def test_selects_sole_challenge_implicitly_as_default(self):
         track_specification = {
@@ -3242,10 +3199,10 @@ class TrackSpecificationReaderTests(TestCase):
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(1, len(resulting_track.challenges))
-        self.assertEqual("challenge", resulting_track.challenges[0].name)
-        self.assertTrue(resulting_track.challenges[0].default)
-        self.assertTrue(resulting_track.challenges[0].selected)
+        assert len(resulting_track.challenges) == 1
+        assert resulting_track.challenges[0].name == "challenge"
+        assert resulting_track.challenges[0].default
+        assert resulting_track.challenges[0].selected
 
     def test_auto_generates_challenge_from_schedule(self):
         track_specification = {
@@ -3267,10 +3224,10 @@ class TrackSpecificationReaderTests(TestCase):
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(1, len(resulting_track.challenges))
-        self.assertTrue(resulting_track.challenges[0].auto_generated)
-        self.assertTrue(resulting_track.challenges[0].default)
-        self.assertTrue(resulting_track.challenges[0].selected)
+        assert len(resulting_track.challenges) == 1
+        assert resulting_track.challenges[0].auto_generated
+        assert resulting_track.challenges[0].default
+        assert resulting_track.challenges[0].selected
 
     def test_inline_operations(self):
         track_specification = {
@@ -3298,9 +3255,9 @@ class TrackSpecificationReaderTests(TestCase):
         resulting_track = reader("unittest", track_specification, "/mappings")
 
         challenge = resulting_track.challenges[0]
-        self.assertEqual(2, len(challenge.schedule))
-        self.assertEqual(track.OperationType.Bulk.to_hyphenated_string(), challenge.schedule[0].operation.type)
-        self.assertEqual(track.OperationType.ForceMerge.to_hyphenated_string(), challenge.schedule[1].operation.type)
+        assert len(challenge.schedule) == 2
+        assert track.OperationType.Bulk.to_hyphenated_string() == challenge.schedule[0].operation.type
+        assert track.OperationType.ForceMerge.to_hyphenated_string() == challenge.schedule[1].operation.type
 
     def test_supports_target_throughput(self):
         track_specification = {
@@ -3332,9 +3289,9 @@ class TrackSpecificationReaderTests(TestCase):
         resulting_track = reader("unittest", track_specification, "/mappings")
 
         indexing_task = resulting_track.challenges[0].schedule[0]
-        self.assertEqual(10, indexing_task.params["target-throughput"])
-        self.assertEqual(120, indexing_task.warmup_time_period)
-        self.assertEqual(60, indexing_task.ramp_up_time_period)
+        assert indexing_task.params["target-throughput"] == 10
+        assert indexing_task.warmup_time_period == 120
+        assert indexing_task.ramp_up_time_period == 60
 
     def test_supports_target_interval(self):
         track_specification = {
@@ -3364,7 +3321,7 @@ class TrackSpecificationReaderTests(TestCase):
         }
         reader = loader.TrackSpecificationReader()
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(5, resulting_track.challenges[0].schedule[0].params["target-interval"])
+        assert resulting_track.challenges[0].schedule[0].params["target-interval"] == 5
 
     def test_ramp_up_but_no_warmup(self):
         track_specification = {
@@ -3393,12 +3350,11 @@ class TrackSpecificationReaderTests(TestCase):
         }
 
         reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. Operation 'index-append' in challenge 'default-challenge' "
-            "defines a ramp-up time period of 60 seconds but no warmup-time-period.",
-            ctx.exception.args[0],
+            "defines a ramp-up time period of 60 seconds but no warmup-time-period."
         )
 
     def test_warmup_shorter_than_ramp_up(self):
@@ -3429,13 +3385,12 @@ class TrackSpecificationReaderTests(TestCase):
         }
 
         reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. The warmup-time-period of operation 'index-append' in "
             "challenge 'default-challenge' is 59 seconds but must be greater than or equal to the "
-            "ramp-up-time-period of 60 seconds.",
-            ctx.exception.args[0],
+            "ramp-up-time-period of 60 seconds."
         )
 
     def test_parallel_tasks_with_default_values(self):
@@ -3484,29 +3439,29 @@ class TrackSpecificationReaderTests(TestCase):
         parallel_element = resulting_track.challenges[0].schedule[0]
         parallel_tasks = parallel_element.tasks
 
-        self.assertEqual(22, parallel_element.clients)
-        self.assertEqual(3, len(parallel_tasks))
+        assert parallel_element.clients == 22
+        assert len(parallel_tasks) == 3
 
-        self.assertEqual("index-1", parallel_tasks[0].operation.name)
-        self.assertEqual(300, parallel_tasks[0].ramp_up_time_period)
-        self.assertEqual(300, parallel_tasks[0].warmup_time_period)
-        self.assertEqual(36000, parallel_tasks[0].time_period)
-        self.assertEqual(2, parallel_tasks[0].clients)
-        self.assertFalse("target-throughput" in parallel_tasks[0].params)
+        assert parallel_tasks[0].operation.name == "index-1"
+        assert parallel_tasks[0].ramp_up_time_period == 300
+        assert parallel_tasks[0].warmup_time_period == 300
+        assert parallel_tasks[0].time_period == 36000
+        assert parallel_tasks[0].clients == 2
+        assert "target-throughput" not in parallel_tasks[0].params
 
-        self.assertEqual("index-2", parallel_tasks[1].operation.name)
-        self.assertEqual(300, parallel_tasks[1].ramp_up_time_period)
-        self.assertEqual(2400, parallel_tasks[1].warmup_time_period)
-        self.assertEqual(3600, parallel_tasks[1].time_period)
-        self.assertEqual(4, parallel_tasks[1].clients)
-        self.assertFalse("target-throughput" in parallel_tasks[1].params)
+        assert parallel_tasks[1].operation.name == "index-2"
+        assert parallel_tasks[1].ramp_up_time_period == 300
+        assert parallel_tasks[1].warmup_time_period == 2400
+        assert parallel_tasks[1].time_period == 3600
+        assert parallel_tasks[1].clients == 4
+        assert "target-throughput" not in parallel_tasks[1].params
 
-        self.assertEqual("index-3", parallel_tasks[2].operation.name)
-        self.assertEqual(300, parallel_tasks[2].ramp_up_time_period)
-        self.assertEqual(2400, parallel_tasks[2].warmup_time_period)
-        self.assertEqual(36000, parallel_tasks[2].time_period)
-        self.assertEqual(16, parallel_tasks[2].clients)
-        self.assertEqual(10, parallel_tasks[2].params["target-throughput"])
+        assert parallel_tasks[2].operation.name == "index-3"
+        assert parallel_tasks[2].ramp_up_time_period == 300
+        assert parallel_tasks[2].warmup_time_period == 2400
+        assert parallel_tasks[2].time_period == 36000
+        assert parallel_tasks[2].clients == 16
+        assert parallel_tasks[2].params["target-throughput"] == 10
 
     def test_parallel_tasks_with_default_clients_does_not_propagate(self):
         track_specification = {
@@ -3561,10 +3516,10 @@ class TrackSpecificationReaderTests(TestCase):
         parallel_tasks = parallel_element.tasks
 
         # we will only have two clients *in total*
-        self.assertEqual(2, parallel_element.clients)
-        self.assertEqual(4, len(parallel_tasks))
+        assert parallel_element.clients == 2
+        assert len(parallel_tasks) == 4
         for task in parallel_tasks:
-            self.assertEqual(1, task.clients)
+            assert task.clients == 1
 
     def test_parallel_tasks_with_completed_by_set(self):
         track_specification = {
@@ -3609,14 +3564,14 @@ class TrackSpecificationReaderTests(TestCase):
         parallel_tasks = parallel_element.tasks
 
         # we will only have two clients *in total*
-        self.assertEqual(2, parallel_element.clients)
-        self.assertEqual(2, len(parallel_tasks))
+        assert parallel_element.clients == 2
+        assert len(parallel_tasks) == 2
 
-        self.assertEqual("index-1", parallel_tasks[0].operation.name)
-        self.assertFalse(parallel_tasks[0].completes_parent)
+        assert parallel_tasks[0].operation.name == "index-1"
+        assert not parallel_tasks[0].completes_parent
 
-        self.assertEqual("index-2", parallel_tasks[1].operation.name)
-        self.assertTrue(parallel_tasks[1].completes_parent)
+        assert parallel_tasks[1].operation.name == "index-2"
+        assert parallel_tasks[1].completes_parent
 
     def test_parallel_tasks_with_named_task_completed_by_set(self):
         track_specification = {
@@ -3667,14 +3622,14 @@ class TrackSpecificationReaderTests(TestCase):
         parallel_tasks = parallel_element.tasks
 
         # we will only have two clients *in total*
-        self.assertEqual(2, parallel_element.clients)
-        self.assertEqual(2, len(parallel_tasks))
+        assert parallel_element.clients == 2
+        assert len(parallel_tasks) == 2
 
-        self.assertEqual("index-1", parallel_tasks[0].operation.name)
-        self.assertFalse(parallel_tasks[0].completes_parent)
+        assert parallel_tasks[0].operation.name == "index-1"
+        assert not parallel_tasks[0].completes_parent
 
-        self.assertEqual("index-2", parallel_tasks[1].operation.name)
-        self.assertTrue(parallel_tasks[1].completes_parent)
+        assert parallel_tasks[1].operation.name == "index-2"
+        assert parallel_tasks[1].completes_parent
 
     def test_parallel_tasks_with_any_task_completed_by_set(self):
         track_specification = {
@@ -3726,16 +3681,16 @@ class TrackSpecificationReaderTests(TestCase):
         parallel_tasks = parallel_element.tasks
 
         # we will only have two clients *in total*
-        self.assertEqual(2, parallel_element.clients)
-        self.assertEqual(2, len(parallel_tasks))
+        assert parallel_element.clients == 2
+        assert len(parallel_tasks) == 2
 
-        self.assertEqual("index-1", parallel_tasks[0].operation.name)
-        self.assertTrue(parallel_tasks[0].any_completes_parent)
-        self.assertFalse(parallel_tasks[0].completes_parent)
+        assert parallel_tasks[0].operation.name == "index-1"
+        assert parallel_tasks[0].any_completes_parent
+        assert not parallel_tasks[0].completes_parent
 
-        self.assertEqual("index-2", parallel_tasks[1].operation.name)
-        self.assertTrue(parallel_tasks[1].any_completes_parent)
-        self.assertFalse(parallel_tasks[1].completes_parent)
+        assert parallel_tasks[1].operation.name == "index-2"
+        assert parallel_tasks[1].any_completes_parent
+        assert not parallel_tasks[1].completes_parent
 
     def test_parallel_tasks_with_completed_by_set_no_task_matches(self):
         track_specification = {
@@ -3774,12 +3729,11 @@ class TrackSpecificationReaderTests(TestCase):
         }
         reader = loader.TrackSpecificationReader()
 
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. 'parallel' element for challenge 'default-challenge' is marked with 'completed-by' "
-            "with task name 'non-existing-task' but no task with this name exists.",
-            ctx.exception.args[0],
+            "with task name 'non-existing-task' but no task with this name exists."
         )
 
     def test_parallel_tasks_with_completed_by_set_multiple_tasks_match(self):
@@ -3815,12 +3769,11 @@ class TrackSpecificationReaderTests(TestCase):
         }
         reader = loader.TrackSpecificationReader()
 
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. 'parallel' element for challenge 'default-challenge' contains multiple tasks with "
-            "the name 'index-1' marked with 'completed-by' but only task is allowed to match.",
-            ctx.exception.args[0],
+            "the name 'index-1' marked with 'completed-by' but only task is allowed to match."
         )
 
     def test_parallel_tasks_ramp_up_cannot_be_overridden(self):
@@ -3859,12 +3812,11 @@ class TrackSpecificationReaderTests(TestCase):
         }
 
         reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. task 'name-index-1' specifies a different ramp-up-time-period "
-            "than its enclosing 'parallel' element in challenge 'default-challenge'.",
-            ctx.exception.args[0],
+            "than its enclosing 'parallel' element in challenge 'default-challenge'."
         )
 
     def test_parallel_tasks_ramp_up_only_on_parallel(self):
@@ -3896,13 +3848,12 @@ class TrackSpecificationReaderTests(TestCase):
         }
 
         reader = loader.TrackSpecificationReader()
-        with self.assertRaises(loader.TrackSyntaxError) as ctx:
+        with pytest.raises(loader.TrackSyntaxError) as exc:
             reader("unittest", track_specification, "/mappings")
-        self.assertEqual(
+        assert exc.value.args[0] == (
             "Track 'unittest' is invalid. task 'name-index-1' in 'parallel' element of challenge "
             "'default-challenge' specifies a ramp-up-time-period but it is only allowed on the 'parallel' "
-            "element.",
-            ctx.exception.args[0],
+            "element."
         )
 
     def test_propagate_parameters_to_challenge_level(self):
@@ -3949,41 +3900,35 @@ class TrackSpecificationReaderTests(TestCase):
         }
         reader = loader.TrackSpecificationReader(selected_challenge="another-challenge")
         resulting_track = reader("unittest", track_specification, "/mappings")
-        self.assertEqual(2, len(resulting_track.challenges))
-        self.assertEqual("challenge", resulting_track.challenges[0].name)
-        self.assertTrue(resulting_track.challenges[0].default)
-        self.assertDictEqual(
-            {
-                "level": "challenge",
-                "value": 7,
-                "another-value": 17,
-            },
-            resulting_track.challenges[0].parameters,
-        )
+        assert len(resulting_track.challenges) == 2
+        assert resulting_track.challenges[0].name == "challenge"
+        assert resulting_track.challenges[0].default
+        assert resulting_track.challenges[0].parameters == {
+            "level": "challenge",
+            "value": 7,
+            "another-value": 17,
+        }
 
-        self.assertFalse(resulting_track.challenges[1].default)
-        self.assertTrue(resulting_track.challenges[1].selected)
-        self.assertDictEqual(
-            {
-                "level": "track",
-                "value": 7,
-            },
-            resulting_track.challenges[1].parameters,
-        )
+        assert not resulting_track.challenges[1].default
+        assert resulting_track.challenges[1].selected
+        assert resulting_track.challenges[1].parameters == {
+            "level": "track",
+            "value": 7,
+        }
 
 
 class MyMockTrackProcessor(loader.TrackProcessor):
     pass
 
 
-class TrackProcessorRegistryTests(TestCase):
+class TestTrackProcessorRegistry:
     def test_default_track_processors(self):
         cfg = config.Config()
         cfg.add(config.Scope.application, "system", "offline.mode", False)
         tpr = loader.TrackProcessorRegistry(cfg)
         expected_defaults = [loader.TaskFilterTrackProcessor, loader.TestModeTrackProcessor, loader.DefaultTrackPreparator]
         actual_defaults = [proc.__class__ for proc in tpr.processors]
-        self.assertCountEqual(expected_defaults, actual_defaults)
+        assert len(expected_defaults) == len(actual_defaults)
 
     def test_override_default_preparator(self):
         cfg = config.Config()
@@ -3994,7 +3939,7 @@ class TrackProcessorRegistryTests(TestCase):
         tpr.register_track_processor(MyMockTrackProcessor())
         expected_processors = [loader.TaskFilterTrackProcessor, loader.TestModeTrackProcessor, MyMockTrackProcessor]
         actual_processors = [proc.__class__ for proc in tpr.processors]
-        self.assertCountEqual(expected_processors, actual_processors)
+        assert len(expected_processors) == len(actual_processors)
 
     def test_allow_to_specify_default_preparator(self):
         cfg = config.Config()
@@ -4011,4 +3956,4 @@ class TrackProcessorRegistryTests(TestCase):
             loader.DefaultTrackPreparator,
         ]
         actual_processors = [proc.__class__ for proc in tpr.processors]
-        self.assertCountEqual(expected_processors, actual_processors)
+        assert len(expected_processors) == len(actual_processors)

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2426,10 +2426,9 @@ class TestSearchParamSource:
         assert p["opaque-id"] is None
         assert p["headers"] == {"header1": "value1"}
         assert p["request-params"] == {}
-        # Explicitly check in these tests for equality - assertFalse would also succeed if it is `None`.
-        assert p["cache"] == True
-        assert p["response-compression-enabled"] == True
-        assert p["detailed-results"] == False
+        assert p["cache"] is True
+        assert p["response-compression-enabled"] is True
+        assert p["detailed-results"] is False
         assert p["body"] == {
             "query": {
                 "match_all": {},
@@ -2462,9 +2461,9 @@ class TestSearchParamSource:
         assert p["headers"] == {"header1": "value1", "header2": "value2"}
         assert p["opaque-id"] == "12345abcde"
         assert p["request-params"] == {}
-        assert p["cache"] == True
-        assert p["response-compression-enabled"] == True
-        assert p["detailed-results"] == False
+        assert p["cache"] is True
+        assert p["response-compression-enabled"] is True
+        assert p["detailed-results"] is False
         assert p["body"] == {
             "query": {
                 "match_all": {},
@@ -2512,8 +2511,8 @@ class TestSearchParamSource:
         assert p["opaque-id"] is None
         assert p["request-params"] == {"_source_include": "some_field"}
         assert p["cache"] is None
-        assert p["response-compression-enabled"] == True
-        assert p["detailed-results"] == False
+        assert p["response-compression-enabled"] is True
+        assert p["detailed-results"] is False
         assert p["body"] == {
             "query": {
                 "match_all": {},
@@ -2548,10 +2547,9 @@ class TestSearchParamSource:
         assert p["request-timeout"] is None
         assert p["headers"] is None
         assert p["opaque-id"] == "12345abcde"
-        # Explicitly check for equality to `False` - assertFalse would also succeed if it is `None`.
-        assert p["cache"] == False
-        assert p["response-compression-enabled"] == False
-        assert p["detailed-results"] == True
+        assert p["cache"] is False
+        assert p["response-compression-enabled"] is False
+        assert p["detailed-results"] is True
         assert p["body"] == {
             "query": {
                 "match_all": {},
@@ -2584,10 +2582,9 @@ class TestSearchParamSource:
         assert p["headers"] is None
         assert p["opaque-id"] is None
         assert p["request-params"] == {}
-        # Explicitly check for equality to `False` - assertFalse would also succeed if it is `None`.
-        assert p["cache"] == False
-        assert p["response-compression-enabled"] == False
-        assert p["detailed-results"] == False
+        assert p["cache"] is False
+        assert p["response-compression-enabled"] is False
+        assert p["detailed-results"] is False
         assert p["body"] == {
             "query": {
                 "match_all": {},

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2426,6 +2426,7 @@ class TestSearchParamSource:
         assert p["opaque-id"] is None
         assert p["headers"] == {"header1": "value1"}
         assert p["request-params"] == {}
+        # Explicitly check in these tests for equality, `assert not x` succeeds if `x` is None
         assert p["cache"] is True
         assert p["response-compression-enabled"] is True
         assert p["detailed-results"] is False
@@ -2461,6 +2462,7 @@ class TestSearchParamSource:
         assert p["headers"] == {"header1": "value1", "header2": "value2"}
         assert p["opaque-id"] == "12345abcde"
         assert p["request-params"] == {}
+        # Explicitly check in these tests for equality, `assert not x` succeeds if `x` is None
         assert p["cache"] is True
         assert p["response-compression-enabled"] is True
         assert p["detailed-results"] is False
@@ -2510,6 +2512,7 @@ class TestSearchParamSource:
         assert p["headers"] is None
         assert p["opaque-id"] is None
         assert p["request-params"] == {"_source_include": "some_field"}
+        # Explicitly check in these tests for equality, `assert not x` succeeds if `x` is None
         assert p["cache"] is None
         assert p["response-compression-enabled"] is True
         assert p["detailed-results"] is False
@@ -2547,6 +2550,7 @@ class TestSearchParamSource:
         assert p["request-timeout"] is None
         assert p["headers"] is None
         assert p["opaque-id"] == "12345abcde"
+        # Explicitly check in these tests for equality, `assert not x` succeeds if `x` is None
         assert p["cache"] is False
         assert p["response-compression-enabled"] is False
         assert p["detailed-results"] is True
@@ -2582,6 +2586,7 @@ class TestSearchParamSource:
         assert p["headers"] is None
         assert p["opaque-id"] is None
         assert p["request-params"] == {}
+        # Explicitly check in these tests for equality, `assert not x` succeeds if `x` is None
         assert p["cache"] is False
         assert p["response-compression-enabled"] is False
         assert p["detailed-results"] is False

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -15,104 +15,99 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from unittest import TestCase
+import pytest
 
 from esrally import exceptions
 from esrally.track import track
 
 
-class TrackTests(TestCase):
+class TestTrack:
     def test_finds_default_challenge(self):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        self.assertEqual(
-            default_challenge,
+        assert default_challenge == (
             track.Track(
                 name="unittest",
                 description="unittest track",
                 challenges=[another_challenge, default_challenge],
-            ).default_challenge,
+            ).default_challenge
         )
 
     def test_default_challenge_none_if_no_challenges(self):
-        self.assertIsNone(
-            track.Track(name="unittest", description="unittest track", challenges=[]).default_challenge,
-        )
+        assert track.Track(name="unittest", description="unittest track", challenges=[]).default_challenge is None
 
     def test_finds_challenge_by_name(self):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        self.assertEqual(
-            another_challenge,
+        assert another_challenge == (
             track.Track(
                 name="unittest",
                 description="unittest track",
                 challenges=[another_challenge, default_challenge],
-            ).find_challenge_or_default("other"),
+            ).find_challenge_or_default("other")
         )
 
     def test_uses_default_challenge_if_no_name_given(self):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        self.assertEqual(
-            default_challenge,
+        assert default_challenge == (
             track.Track(
                 name="unittest",
                 description="unittest track",
                 challenges=[another_challenge, default_challenge],
-            ).find_challenge_or_default(""),
+            ).find_challenge_or_default("")
         )
 
     def test_does_not_find_unknown_challenge(self):
         default_challenge = track.Challenge("default", description="default challenge", default=True)
         another_challenge = track.Challenge("other", description="non-default challenge", default=False)
 
-        with self.assertRaises(exceptions.InvalidName) as ctx:
+        with pytest.raises(exceptions.InvalidName) as exc:
             track.Track(
                 name="unittest",
                 description="unittest track",
                 challenges=[another_challenge, default_challenge],
             ).find_challenge_or_default("unknown-name")
 
-        self.assertEqual("Unknown challenge [unknown-name] for track [unittest]", ctx.exception.args[0])
+        assert exc.value.args[0] == "Unknown challenge [unknown-name] for track [unittest]"
 
 
-class IndexTests(TestCase):
+class TestIndex:
     def test_matches_exactly(self):
-        self.assertTrue(track.Index("test").matches("test"))
-        self.assertFalse(track.Index("test").matches(" test"))
+        assert track.Index("test").matches("test")
+        assert not track.Index("test").matches(" test")
 
     def test_matches_if_no_pattern_is_defined(self):
-        self.assertTrue(track.Index("test").matches(pattern=None))
+        assert track.Index("test").matches(pattern=None)
 
     def test_matches_if_catch_all_pattern_is_defined(self):
-        self.assertTrue(track.Index("test").matches(pattern="*"))
-        self.assertTrue(track.Index("test").matches(pattern="_all"))
+        assert track.Index("test").matches(pattern="*")
+        assert track.Index("test").matches(pattern="_all")
 
     def test_str(self):
-        self.assertEqual("test", str(track.Index("test")))
+        assert str(track.Index("test")) == "test"
 
 
-class DataStreamTests(TestCase):
+class TestDataStream:
     def test_matches_exactly(self):
-        self.assertTrue(track.DataStream("test").matches("test"))
-        self.assertFalse(track.DataStream("test").matches(" test"))
+        assert track.DataStream("test").matches("test")
+        assert not track.DataStream("test").matches(" test")
 
     def test_matches_if_no_pattern_is_defined(self):
-        self.assertTrue(track.DataStream("test").matches(pattern=None))
+        assert track.DataStream("test").matches(pattern=None)
 
     def test_matches_if_catch_all_pattern_is_defined(self):
-        self.assertTrue(track.DataStream("test").matches(pattern="*"))
-        self.assertTrue(track.DataStream("test").matches(pattern="_all"))
+        assert track.DataStream("test").matches(pattern="*")
+        assert track.DataStream("test").matches(pattern="_all")
 
     def test_str(self):
-        self.assertEqual("test", str(track.DataStream("test")))
+        assert str(track.DataStream("test")) == "test"
 
 
-class DocumentCorpusTests(TestCase):
+class TestDocumentCorpus:
     def test_do_not_filter(self):
         corpus = track.DocumentCorpus(
             "test",
@@ -127,9 +122,9 @@ class DocumentCorpusTests(TestCase):
 
         filtered_corpus = corpus.filter()
 
-        self.assertEqual(corpus.name, filtered_corpus.name)
-        self.assertListEqual(corpus.documents, filtered_corpus.documents)
-        self.assertDictEqual(corpus.meta_data, filtered_corpus.meta_data)
+        assert filtered_corpus.name == corpus.name
+        assert filtered_corpus.documents == corpus.documents
+        assert filtered_corpus.meta_data == corpus.meta_data
 
     def test_filter_documents_by_format(self):
         corpus = track.DocumentCorpus(
@@ -144,10 +139,10 @@ class DocumentCorpusTests(TestCase):
 
         filtered_corpus = corpus.filter(source_format=track.Documents.SOURCE_FORMAT_BULK)
 
-        self.assertEqual("test", filtered_corpus.name)
-        self.assertEqual(2, len(filtered_corpus.documents))
-        self.assertEqual("logs-01", filtered_corpus.documents[0].target_index)
-        self.assertEqual("logs-03", filtered_corpus.documents[1].target_index)
+        assert filtered_corpus.name == "test"
+        assert len(filtered_corpus.documents) == 2
+        assert filtered_corpus.documents[0].target_index == "logs-01"
+        assert filtered_corpus.documents[1].target_index == "logs-03"
 
     def test_filter_documents_by_indices(self):
         corpus = track.DocumentCorpus(
@@ -162,9 +157,9 @@ class DocumentCorpusTests(TestCase):
 
         filtered_corpus = corpus.filter(target_indices=["logs-02"])
 
-        self.assertEqual("test", filtered_corpus.name)
-        self.assertEqual(1, len(filtered_corpus.documents))
-        self.assertEqual("logs-02", filtered_corpus.documents[0].target_index)
+        assert filtered_corpus.name == "test"
+        assert len(filtered_corpus.documents) == 1
+        assert filtered_corpus.documents[0].target_index == "logs-02"
 
     def test_filter_documents_by_data_streams(self):
         corpus = track.DocumentCorpus(
@@ -178,9 +173,9 @@ class DocumentCorpusTests(TestCase):
         )
 
         filtered_corpus = corpus.filter(target_data_streams=["logs-02"])
-        self.assertEqual("test", filtered_corpus.name)
-        self.assertEqual(1, len(filtered_corpus.documents))
-        self.assertEqual("logs-02", filtered_corpus.documents[0].target_data_stream)
+        assert filtered_corpus.name == "test"
+        assert len(filtered_corpus.documents) == 1
+        assert filtered_corpus.documents[0].target_data_stream == "logs-02"
 
     def test_filter_documents_by_format_and_indices(self):
         corpus = track.DocumentCorpus(
@@ -195,10 +190,10 @@ class DocumentCorpusTests(TestCase):
 
         filtered_corpus = corpus.filter(source_format=track.Documents.SOURCE_FORMAT_BULK, target_indices=["logs-01", "logs-02"])
 
-        self.assertEqual("test", filtered_corpus.name)
-        self.assertEqual(2, len(filtered_corpus.documents))
-        self.assertEqual("logs-01", filtered_corpus.documents[0].target_index)
-        self.assertEqual("logs-02", filtered_corpus.documents[1].target_index)
+        assert filtered_corpus.name == "test"
+        assert len(filtered_corpus.documents) == 2
+        assert filtered_corpus.documents[0].target_index == "logs-01"
+        assert filtered_corpus.documents[1].target_index == "logs-02"
 
     def test_union_document_corpus_is_reflexive(self):
         corpus = track.DocumentCorpus(
@@ -210,7 +205,7 @@ class DocumentCorpusTests(TestCase):
                 track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=8, target_index=None),
             ],
         )
-        self.assertTrue(corpus.union(corpus) is corpus)
+        assert corpus.union(corpus) is corpus
 
     def test_union_document_corpora_is_symmetric(self):
         a = track.DocumentCorpus(
@@ -225,8 +220,8 @@ class DocumentCorpusTests(TestCase):
                 track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-02"),
             ],
         )
-        self.assertEqual(b.union(a), a.union(b))
-        self.assertEqual(2, len(a.union(b).documents))
+        assert b.union(a) == a.union(b)
+        assert len(a.union(b).documents) == 2
 
     def test_cannot_union_mixed_document_corpora_by_name(self):
         a = track.DocumentCorpus(
@@ -241,9 +236,9 @@ class DocumentCorpusTests(TestCase):
                 track.Documents(source_format=track.Documents.SOURCE_FORMAT_BULK, number_of_documents=5, target_index="logs-02"),
             ],
         )
-        with self.assertRaises(exceptions.RallyAssertionError) as ae:
+        with pytest.raises(exceptions.RallyAssertionError) as exc:
             a.union(b)
-        self.assertEqual(ae.exception.message, "Corpora names differ: [test] and [other].")
+        assert exc.value.message == "Corpora names differ: [test] and [other]."
 
     def test_cannot_union_mixed_document_corpora_by_meta_data(self):
         a = track.DocumentCorpus(
@@ -260,18 +255,18 @@ class DocumentCorpusTests(TestCase):
             ],
             meta_data={"with-metadata": True},
         )
-        with self.assertRaises(exceptions.RallyAssertionError) as ae:
+        with pytest.raises(exceptions.RallyAssertionError) as exc:
             a.union(b)
-        self.assertEqual(ae.exception.message, "Corpora meta-data differ: [{'with-metadata': False}] and [{'with-metadata': True}].")
+        assert exc.value.message == "Corpora meta-data differ: [{'with-metadata': False}] and [{'with-metadata': True}]."
 
 
-class OperationTypeTests(TestCase):
+class TestOperationType:
     def test_string_hyphenation_is_symmetric(self):
         for op_type in track.OperationType:
-            self.assertEqual(op_type, track.OperationType.from_hyphenated_string(op_type.to_hyphenated_string()))
+            assert track.OperationType.from_hyphenated_string(op_type.to_hyphenated_string()) == op_type
 
 
-class TaskFilterTests(TestCase):
+class TestTaskFilter:
     def create_index_task(self):
         return track.Task(
             "create-index-task",
@@ -286,21 +281,21 @@ class TaskFilterTests(TestCase):
 
     def test_task_name_filter(self):
         f = track.TaskNameFilter("create-index-task")
-        self.assertTrue(f.matches(self.create_index_task()))
-        self.assertFalse(f.matches(self.search_task()))
+        assert f.matches(self.create_index_task())
+        assert not f.matches(self.search_task())
 
     def test_task_op_type_filter(self):
         f = track.TaskOpTypeFilter(track.OperationType.CreateIndex.to_hyphenated_string())
-        self.assertTrue(f.matches(self.create_index_task()))
-        self.assertFalse(f.matches(self.search_task()))
+        assert f.matches(self.create_index_task())
+        assert not f.matches(self.search_task())
 
     def test_task_tag_filter(self):
         f = track.TaskTagFilter(tag_name="write-op")
-        self.assertTrue(f.matches(self.create_index_task()))
-        self.assertFalse(f.matches(self.search_task()))
+        assert f.matches(self.create_index_task())
+        assert not f.matches(self.search_task())
 
 
-class TaskTests(TestCase):
+class TestTask:
     def task(self, schedule=None, target_throughput=None, target_interval=None, ignore_response_error_level=None):
         op = track.Operation("bulk-index", track.OperationType.Bulk.to_hyphenated_string())
         params = {}
@@ -314,64 +309,62 @@ class TaskTests(TestCase):
 
     def test_unthrottled_task(self):
         task = self.task()
-        self.assertIsNone(task.target_throughput)
+        assert task.target_throughput is None
 
     def test_target_interval_zero_treated_as_unthrottled(self):
         task = self.task(target_interval=0)
-        self.assertIsNone(task.target_throughput)
+        assert task.target_throughput is None
 
     def test_valid_throughput_with_unit(self):
         task = self.task(target_throughput="5 MB/s")
-        self.assertEqual(track.Throughput(5.0, "MB/s"), task.target_throughput)
+        assert track.Throughput(5.0, "MB/s") == task.target_throughput
 
     def test_valid_throughput_numeric(self):
         task = self.task(target_throughput=3.2)
-        self.assertEqual(track.Throughput(3.2, "ops/s"), task.target_throughput)
+        assert track.Throughput(3.2, "ops/s") == task.target_throughput
 
     def test_invalid_throughput_format_is_rejected(self):
         task = self.task(target_throughput="3.2 docs")
-        with self.assertRaises(exceptions.InvalidSyntax) as e:
+        with pytest.raises(exceptions.InvalidSyntax) as exc:
             # pylint: disable=pointless-statement
             task.target_throughput
-        self.assertEqual("Task [test] specifies invalid target throughput [3.2 docs].", e.exception.args[0])
+        assert exc.value.args[0] == "Task [test] specifies invalid target throughput [3.2 docs]."
 
     def test_invalid_throughput_type_is_rejected(self):
         task = self.task(target_throughput=True)
-        with self.assertRaises(exceptions.InvalidSyntax) as e:
+        with pytest.raises(exceptions.InvalidSyntax) as exc:
             # pylint: disable=pointless-statement
             task.target_throughput
-        self.assertEqual("Target throughput [True] for task [test] must be string or numeric.", e.exception.args[0])
+        assert exc.value.args[0] == "Target throughput [True] for task [test] must be string or numeric."
 
     def test_interval_and_throughput_is_rejected(self):
         task = self.task(target_throughput=1, target_interval=1)
-        with self.assertRaises(exceptions.InvalidSyntax) as e:
+        with pytest.raises(exceptions.InvalidSyntax) as exc:
             # pylint: disable=pointless-statement
             task.target_throughput
-        self.assertEqual(
-            "Task [test] specifies target-interval [1] and target-throughput [1] but only one of them is allowed.", e.exception.args[0]
-        )
+        assert exc.value.args[0] == "Task [test] specifies target-interval [1] and target-throughput [1] but only one of them is allowed."
 
     def test_invalid_ignore_response_error_level_is_rejected(self):
         task = self.task(ignore_response_error_level="invalid-value")
-        with self.assertRaises(exceptions.InvalidSyntax) as e:
+        with pytest.raises(exceptions.InvalidSyntax) as exc:
             # pylint: disable=pointless-statement
             task.ignore_response_error_level
-        self.assertEqual(
-            "Task [test] specifies ignore-response-error-level to [invalid-value] but the only allowed values are [non-fatal].",
-            e.exception.args[0],
+        assert (
+            exc.value.args[0]
+            == "Task [test] specifies ignore-response-error-level to [invalid-value] but the only allowed values are [non-fatal]."
         )
 
     def test_task_continues_with_global_continue(self):
         task = self.task()
         effective_on_error = task.error_behavior(default_error_behavior="continue")
-        self.assertEqual(effective_on_error, "continue")
+        assert effective_on_error == "continue"
 
     def test_task_continues_with_global_abort_and_task_override(self):
         task = self.task(ignore_response_error_level="non-fatal")
         effective_on_error = task.error_behavior(default_error_behavior="abort")
-        self.assertEqual(effective_on_error, "continue")
+        assert effective_on_error == "continue"
 
     def test_task_aborts_with_global_abort(self):
         task = self.task()
         effective_on_error = task.error_behavior(default_error_behavior="abort")
-        self.assertEqual(effective_on_error, "abort")
+        assert effective_on_error == "abort"


### PR DESCRIPTION
I'm doing this folder by folder, the other example being https://github.com/elastic/rally/pull/1387. I've used unittest2pytest and reversed the yoga conditions as `assert a = 0` is invalid syntax. I find the result much clearer.