### PR TITLE
Introduce `sql` operation type

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2907,7 +2907,7 @@ the `SQL search API <https://www.elastic.co/guide/en/elasticsearch/reference/cur
 Properties
 """"""""""
 
-* ``body``: The request body passed to the _sql API with the initial request. Must contain the "query" key. Subsequent pagination requests will only include the cursor in the request body.
+* ``body`` (mandatory): The request body passed to the _sql API with the initial request. Must contain the "query" key. Subsequent pagination requests will only include the cursor in the request body.
 * ``pages``: (optional, defaults to 1) Number of pages to retrieve at most for this search. If a query yields fewer results than the specified number of pages it will fail with an exception.
 
 **Example**

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2898,6 +2898,48 @@ Meta-data
 
 This operation returns no meta-data.
 
+sql-query
+~~~~~~~~~~~~~~~~~~~
+
+Executes an SQL query and optionally paginates through subsequent pages. The ``body`` property will directly be passed to
+the `SQL search API <https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-search-api.html>`_.
+
+Properties
+""""""""""
+
+* ``body``: The request body passed to the _sql API with the initial request. Must contain the "query" key. Subsequent pagination requests will only include the cursor in the request body.
+* ``pages``: (optional, defaults to 1) Number of pages to retrieve at most for this search. If a query yields fewer results than the specified number of pages it will fail with an exception.
+
+**Example**
+
+Run an SQL query and fetch the first 10 pages with 100 records each::
+
+    {
+      "operation": {
+        "operation-type": "sql-query",
+        "name": "select-station-names",
+        "body": {
+          "query": "SELECT station.name FROM \"weather-data-2016\"",
+          "page_timeout": "1000ms",
+          "request_timeout": "1000ms",
+          "fetch_size": 100
+        },
+        "pages": 10
+      },
+      "target-throughput": 10,
+      "clients": 2,
+      "warmup-iterations": 50,
+      "iterations": 100
+    }
+
+Meta-data
+"""""""""
+
+The following meta data is always returned:
+
+* ``weight``: The number of fetched pages. Should always equal to the ``pages`` parameter.
+* ``unit``: The unit in which to interpret ``weight``. Always "ops".
+
 Examples
 ========
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2898,7 +2898,7 @@ Meta-data
 
 This operation returns no meta-data.
 
-sql-query
+sql
 ~~~~~~~~~~~~~~~~~~~
 
 Executes an SQL query and optionally paginates through subsequent pages. The ``body`` property will directly be passed to
@@ -2916,7 +2916,7 @@ Run an SQL query and fetch the first 10 pages with 100 records each::
 
     {
       "operation": {
-        "operation-type": "sql-query",
+        "operation-type": "sql",
         "name": "select-station-names",
         "body": {
           "query": "SELECT station.name FROM \"weather-data-2016\"",

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -56,7 +56,7 @@ def register_default_runners():
     register_runner(track.OperationType.DeleteAsyncSearch, DeleteAsyncSearch(), async_runner=True)
     register_runner(track.OperationType.OpenPointInTime, OpenPointInTime(), async_runner=True)
     register_runner(track.OperationType.ClosePointInTime, ClosePointInTime(), async_runner=True)
-    register_runner(track.OperationType.SqlQuery, SqlQuery(), async_runner=True)
+    register_runner(track.OperationType.Sql, Sql(), async_runner=True)
 
     # This is an administrative operation but there is no need for a retry here as we don't issue a request
     register_runner(track.OperationType.Sleep, Sleep(), async_runner=True)
@@ -2438,7 +2438,7 @@ class DeleteIlmPolicy(Runner):
         return "delete-ilm-policy"
 
 
-class SqlQuery(Runner):
+class Sql(Runner):
     """
     Executes an SQL query and optionally paginates through subsequent pages.
     """

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -56,6 +56,7 @@ def register_default_runners():
     register_runner(track.OperationType.DeleteAsyncSearch, DeleteAsyncSearch(), async_runner=True)
     register_runner(track.OperationType.OpenPointInTime, OpenPointInTime(), async_runner=True)
     register_runner(track.OperationType.ClosePointInTime, ClosePointInTime(), async_runner=True)
+    register_runner(track.OperationType.SqlQuery, SqlQuery(), async_runner=True)
 
     # This is an administrative operation but there is no need for a retry here as we don't issue a request
     register_runner(track.OperationType.Sleep, Sleep(), async_runner=True)
@@ -2435,6 +2436,41 @@ class DeleteIlmPolicy(Runner):
 
     def __repr__(self, *args, **kwargs):
         return "delete-ilm-policy"
+
+
+class SqlQuery(Runner):
+    """
+    Executes an SQL query and optionally paginates through subsequent pages.
+    """
+
+    async def __call__(self, es, params):
+        body = mandatory(params, "body", self)
+        mandatory(body, "query", str(self) + ".body")
+        pages = params.get("pages", 1)
+
+        es.return_raw_response()
+
+        r = await es.transport.perform_request("POST", "/_sql", body=body)
+        pages -= 1
+        weight = 1
+
+        cursor = parse(r, ["cursor"]).get("cursor")
+
+        while cursor and pages > 0:
+            r = await es.transport.perform_request("POST", "/_sql", body={"cursor": cursor})
+            pages -= 1
+            weight += 1
+            cursor = parse(r, ["cursor"]).get("cursor")
+
+        if pages > 0:
+            raise exceptions.DataError(
+                "Result set has been exhausted before all pages have been fetched, {} page(s) remaining.".format(pages)
+            )
+
+        return {"weight": weight, "unit": "ops", "success": True}
+
+    def __repr__(self, *args, **kwargs):
+        return "sql"
 
 
 class RequestTiming(Runner, Delegator):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2447,8 +2447,8 @@ class Sql(Runner):
         body = mandatory(params, "body", self)
         if body.get("query") is None:
             raise exceptions.DataError(
-                f"Parameter source for operation 'sql' did not provide the mandatory parameter 'body.query'. "
-                f"Add it to your parameter source and try again."
+                "Parameter source for operation 'sql' did not provide the mandatory parameter 'body.query'. "
+                "Add it to your parameter source and try again."
             )
         pages = params.get("pages", 1)
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2445,7 +2445,11 @@ class Sql(Runner):
 
     async def __call__(self, es, params):
         body = mandatory(params, "body", self)
-        mandatory(body, "query", str(self) + ".body")
+        if body.get("query") is None:
+            raise exceptions.DataError(
+                f"Parameter source for operation 'sql' did not provide the mandatory parameter 'body.query'. "
+                f"Add it to your parameter source and try again."
+            )
         pages = params.get("pages", 1)
 
         es.return_raw_response()

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -672,7 +672,7 @@ class OperationType(Enum):
     ScrollSearch = 13
     OpenPointInTime = 14
     ClosePointInTime = 15
-    SqlQuery = 16
+    Sql = 16
 
     # administrative actions
     ForceMerge = 1001
@@ -830,8 +830,8 @@ class OperationType(Enum):
             return OperationType.CreateIlmPolicy
         elif v == "delete-ilm-policy":
             return OperationType.DeleteIlmPolicy
-        elif v == "sql-query":
-            return OperationType.SqlQuery
+        elif v == "sql":
+            return OperationType.Sql
         else:
             raise KeyError(f"No enum value for [{v}]")
 

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -672,6 +672,7 @@ class OperationType(Enum):
     ScrollSearch = 13
     OpenPointInTime = 14
     ClosePointInTime = 15
+    SqlQuery = 16
 
     # administrative actions
     ForceMerge = 1001
@@ -829,6 +830,8 @@ class OperationType(Enum):
             return OperationType.CreateIlmPolicy
         elif v == "delete-ilm-policy":
             return OperationType.DeleteIlmPolicy
+        elif v == "sql-query":
+            return OperationType.SqlQuery
         else:
             raise KeyError(f"No enum value for [{v}]")
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -5011,7 +5011,7 @@ class TestSqlRunner:
             "Parameter source for operation 'sql' did not provide the mandatory parameter 'body'. "
             "Add it to your parameter source and try again."
         )
-        
+
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
     async def test_mandatory_query_in_body_param(self, es):
@@ -5028,6 +5028,8 @@ class TestSqlRunner:
             "Parameter source for operation 'sql' did not provide the mandatory parameter 'body.query'. "
             "Add it to your parameter source and try again."
         )
+
+
 class TestSubmitAsyncSearch:
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -4913,7 +4913,7 @@ class TestDeleteIlmPolicyRunner:
         es.ilm.delete_lifecycle.assert_awaited_once_with(policy=params["policy-name"], params={})
 
 
-class SqlTests(TestCase):
+class TestSqlRunner:
     default_response = {
         "columns": [{"name": "first_name", "type": "text"}],
         "rows": [
@@ -4942,8 +4942,7 @@ class SqlTests(TestCase):
         async with sql_runner:
             result = await sql_runner(es, params)
 
-        self.assertEqual(1, result["weight"])
-        self.assertEqual("ops", result["unit"])
+        assert result == {"success": True, "weight": 1, "unit": "ops"}
 
         es.transport.perform_request.assert_awaited_once_with("POST", "/_sql", body=params["body"])
 
@@ -4958,8 +4957,7 @@ class SqlTests(TestCase):
         async with sql_runner:
             result = await sql_runner(es, params)
 
-        self.assertEqual(3, result["weight"])
-        self.assertEqual("ops", result["unit"])
+        assert result == {"success": True, "weight": 3, "unit": "ops"}
 
         es.transport.perform_request.assert_has_calls(
             [
@@ -4985,11 +4983,11 @@ class SqlTests(TestCase):
             "pages": 3,
         }
 
-        with self.assertRaises(exceptions.DataError) as ctx:
+        with pytest.raises(exceptions.DataError) as ctx:
             async with sql_runner:
                 await sql_runner(es, params)
 
-        self.assertEqual("Result set has been exhausted before all pages have been fetched, 1 page(s) remaining.", ctx.exception.message)
+        assert ctx.value.message == "Result set has been exhausted before all pages have been fetched, 1 page(s) remaining."
 
         es.transport.perform_request.assert_has_calls(
             [

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -4814,7 +4814,7 @@ class DeleteIlmPolicyRunner(TestCase):
         es.ilm.delete_lifecycle.assert_awaited_once_with(policy=params["policy-name"], params={})
 
 
-class SqlQueryTests(TestCase):
+class SqlTests(TestCase):
     default_response = {
         "columns": [{"name": "first_name", "type": "text"}],
         "rows": [
@@ -4826,10 +4826,10 @@ class SqlQueryTests(TestCase):
 
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async
-    async def test_sql_query(self, es):
+    async def test_fetch_one_page(self, es):
         es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
 
-        sql_runner = runner.SqlQuery()
+        sql_runner = runner.Sql()
         params = {
             "operation-type": "sql",
             "body": {
@@ -4853,7 +4853,7 @@ class SqlQueryTests(TestCase):
     async def test_fetch_all_pages(self, es):
         es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
 
-        sql_runner = runner.SqlQuery()
+        sql_runner = runner.Sql()
         params = {"operation-type": "sql", "body": {"query": "SELECT first_name FROM emp"}, "pages": 3}
 
         async with sql_runner:
@@ -4877,7 +4877,7 @@ class SqlQueryTests(TestCase):
             side_effect=[io.StringIO(json.dumps(self.default_response)), io.StringIO(json.dumps({"rows": [["John"]]}))]
         )
 
-        sql_runner = runner.SqlQuery()
+        sql_runner = runner.Sql()
         params = {
             "operation-type": "sql",
             "body": {

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -4996,7 +4996,38 @@ class TestSqlRunner:
             ]
         )
 
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_mandatory_body_param(self, es):
+        sql_runner = runner.Sql()
+        params = {
+            "operation-type": "sql",
+            "pages": 3,
+        }
 
+        with pytest.raises(exceptions.DataError) as exc:
+            await sql_runner(es, params)
+        assert exc.value.args[0] == (
+            "Parameter source for operation 'sql' did not provide the mandatory parameter 'body'. "
+            "Add it to your parameter source and try again."
+        )
+        
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_mandatory_query_in_body_param(self, es):
+        sql_runner = runner.Sql()
+        params = {
+            "operation-type": "sql",
+            "body": {},
+            "pages": 3,
+        }
+
+        with pytest.raises(exceptions.DataError) as exc:
+            await sql_runner(es, params)
+        assert exc.value.args[0] == (
+            "Parameter source for operation 'sql' did not provide the mandatory parameter 'body.query'. "
+            "Add it to your parameter source and try again."
+        )
 class TestSubmitAsyncSearch:
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async


### PR DESCRIPTION
Addresses #1382 for SQL.

~The operation type is named `sql-query` to avoid naming conflicts with the custom operation type defined in https://github.com/elastic/rally-tracks/blob/master/sql/track.py~ The operation type is named `sql` like the custom operation type defined in https://github.com/elastic/rally-tracks/blob/master/sql/track.py.

The operation performs pagination if the `pages` parameter is set.

Because `json` is the only format that allows cursor extraction from the response body (instead of the response header), the operation does currently not support overriding the `format` parameter.