### PR TITLE
Finish migration to native pytest

### DIFF
--- a/benchmarks/driver/parsing_test.py
+++ b/benchmarks/driver/parsing_test.py
@@ -18,7 +18,6 @@
 import io
 import json
 import re
-from unittest import TestCase
 
 import pytest
 import ujson
@@ -246,33 +245,33 @@ def pit_id_parsing_candidate_runner_parse(response):
     return pit_id
 
 
-class ParsingBenchmarks(TestCase):
+class TestParsingBenchmarks:
     def test_all_candidates(self):
         """
         Quick utility test to ensure all benchmark cases are correct
         """
 
         pit_id = pit_id_parsing_candidate_runner_parse(self.small_page.encode())
-        self.assertEqual("fedcba9876543210", pit_id)
+        assert pit_id == "fedcba9876543210"
 
         sort = sort_parsing_candidate_reverse_and_regexp(self.small_page)
-        self.assertEqual([1609780186, "2"], sort)
+        assert sort == [1609780186, "2"]
 
         sort = sort_parsing_candidate_rfind_and_regexp(self.large_page)
-        self.assertEqual([1609780186, "2"], sort)
+        assert sort == [1609780186, "2"]
 
         sort = sort_parsing_candidate_end_anchor_regexp(self.small_page)
-        self.assertEqual([1609780186, "2"], sort)
+        assert sort == [1609780186, "2"]
 
         sort = sort_parsing_candidate_find_all(self.large_page)
-        self.assertEqual([1609780186, "2"], sort)
+        assert sort == [1609780186, "2"]
 
         pit_id = pit_id_parsing_candidate_regexp(self.large_page)
-        self.assertEqual("fedcba9876543210", pit_id)
+        assert pit_id == "fedcba9876543210"
 
         pit_id, sort = combined_parsing_candidate_json_loads(self.small_page)
-        self.assertEqual([1609780186, "2"], sort)
-        self.assertEqual("fedcba9876543210", pit_id)
+        assert sort == [1609780186, "2"]
+        assert pit_id == "fedcba9876543210"
 
     small_page = """
     {

--- a/benchmarks/driver/parsing_test.py
+++ b/benchmarks/driver/parsing_test.py
@@ -32,7 +32,7 @@ from esrally.driver import runner
     disable_gc=True,
 )
 def test_sort_reverse_and_regexp_small(benchmark):
-    benchmark(sort_parsing_candidate_reverse_and_regexp, ParsingBenchmarks.small_page)
+    benchmark(sort_parsing_candidate_reverse_and_regexp, TestParsingBenchmarks.small_page)
 
 
 @pytest.mark.benchmark(
@@ -42,7 +42,7 @@ def test_sort_reverse_and_regexp_small(benchmark):
     disable_gc=True,
 )
 def test_sort_reverse_and_regexp_large(benchmark):
-    benchmark(sort_parsing_candidate_reverse_and_regexp, ParsingBenchmarks.large_page)
+    benchmark(sort_parsing_candidate_reverse_and_regexp, TestParsingBenchmarks.large_page)
 
 
 def sort_parsing_candidate_reverse_and_regexp(response):
@@ -60,7 +60,7 @@ def sort_parsing_candidate_reverse_and_regexp(response):
     disable_gc=True,
 )
 def test_sort_rfind_and_regexp_small(benchmark):
-    benchmark(sort_parsing_candidate_rfind_and_regexp, ParsingBenchmarks.small_page)
+    benchmark(sort_parsing_candidate_rfind_and_regexp, TestParsingBenchmarks.small_page)
 
 
 @pytest.mark.benchmark(
@@ -70,7 +70,7 @@ def test_sort_rfind_and_regexp_small(benchmark):
     disable_gc=True,
 )
 def test_sort_rfind_and_regexp_large(benchmark):
-    benchmark(sort_parsing_candidate_rfind_and_regexp, ParsingBenchmarks.large_page)
+    benchmark(sort_parsing_candidate_rfind_and_regexp, TestParsingBenchmarks.large_page)
 
 
 def sort_parsing_candidate_rfind_and_regexp(response):
@@ -88,7 +88,7 @@ def sort_parsing_candidate_rfind_and_regexp(response):
     disable_gc=True,
 )
 def test_sort_end_anchor_regexp(benchmark):
-    benchmark(sort_parsing_candidate_end_anchor_regexp, ParsingBenchmarks.small_page)
+    benchmark(sort_parsing_candidate_end_anchor_regexp, TestParsingBenchmarks.small_page)
 
 
 @pytest.mark.benchmark(
@@ -98,7 +98,7 @@ def test_sort_end_anchor_regexp(benchmark):
     disable_gc=True,
 )
 def test_sort_end_anchor_regexp_large(benchmark):
-    benchmark(sort_parsing_candidate_end_anchor_regexp, ParsingBenchmarks.large_page)
+    benchmark(sort_parsing_candidate_end_anchor_regexp, TestParsingBenchmarks.large_page)
 
 
 def sort_parsing_candidate_end_anchor_regexp(response):
@@ -117,7 +117,7 @@ def sort_parsing_candidate_end_anchor_regexp(response):
     disable_gc=True,
 )
 def test_sort_find_all_regexp_small(benchmark):
-    benchmark(sort_parsing_candidate_find_all, ParsingBenchmarks.small_page)
+    benchmark(sort_parsing_candidate_find_all, TestParsingBenchmarks.small_page)
 
 
 @pytest.mark.benchmark(
@@ -127,7 +127,7 @@ def test_sort_find_all_regexp_small(benchmark):
     disable_gc=True,
 )
 def test_sort_find_all_regexp_large(benchmark):
-    benchmark(sort_parsing_candidate_find_all, ParsingBenchmarks.large_page)
+    benchmark(sort_parsing_candidate_find_all, TestParsingBenchmarks.large_page)
 
 
 def sort_parsing_candidate_find_all(response):
@@ -143,7 +143,7 @@ def sort_parsing_candidate_find_all(response):
     disable_gc=True,
 )
 def test_pit_id_regexp_small(benchmark):
-    benchmark(pit_id_parsing_candidate_regexp, ParsingBenchmarks.small_page)
+    benchmark(pit_id_parsing_candidate_regexp, TestParsingBenchmarks.small_page)
 
 
 @pytest.mark.benchmark(
@@ -153,7 +153,7 @@ def test_pit_id_regexp_small(benchmark):
     disable_gc=True,
 )
 def test_pit_id_regexp_large(benchmark):
-    benchmark(pit_id_parsing_candidate_regexp, ParsingBenchmarks.large_page)
+    benchmark(pit_id_parsing_candidate_regexp, TestParsingBenchmarks.large_page)
 
 
 def pit_id_parsing_candidate_regexp(response):
@@ -169,7 +169,7 @@ def pit_id_parsing_candidate_regexp(response):
     disable_gc=True,
 )
 def test_combined_json_small(benchmark):
-    benchmark(combined_parsing_candidate_json_loads, ParsingBenchmarks.small_page)
+    benchmark(combined_parsing_candidate_json_loads, TestParsingBenchmarks.small_page)
 
 
 @pytest.mark.benchmark(
@@ -179,7 +179,7 @@ def test_combined_json_small(benchmark):
     disable_gc=True,
 )
 def test_combined_json_large(benchmark):
-    benchmark(combined_parsing_candidate_json_loads, ParsingBenchmarks.large_page)
+    benchmark(combined_parsing_candidate_json_loads, TestParsingBenchmarks.large_page)
 
 
 def combined_parsing_candidate_json_loads(response):
@@ -196,7 +196,7 @@ def combined_parsing_candidate_json_loads(response):
     disable_gc=True,
 )
 def test_combined_ijson_large(benchmark):
-    benchmark(combined_parsing_candidate_json_loads, ParsingBenchmarks.large_page)
+    benchmark(combined_parsing_candidate_json_loads, TestParsingBenchmarks.large_page)
 
 
 @pytest.mark.benchmark(
@@ -206,7 +206,7 @@ def test_combined_ijson_large(benchmark):
     disable_gc=True,
 )
 def test_combined_ijson_small(benchmark):
-    benchmark(combined_parsing_candidate_json_loads, ParsingBenchmarks.small_page)
+    benchmark(combined_parsing_candidate_json_loads, TestParsingBenchmarks.small_page)
 
 
 def combined_parsing_candidate_ijson_loads(response):
@@ -223,7 +223,7 @@ def combined_parsing_candidate_ijson_loads(response):
     disable_gc=True,
 )
 def test_pit_id_parse_small(benchmark):
-    page = ParsingBenchmarks.small_page.encode()
+    page = TestParsingBenchmarks.small_page.encode()
     benchmark(pit_id_parsing_candidate_runner_parse, page)
 
 
@@ -234,7 +234,7 @@ def test_pit_id_parse_small(benchmark):
     disable_gc=True,
 )
 def test_pit_id_parse_large(benchmark):
-    page = ParsingBenchmarks.large_page.encode()
+    page = TestParsingBenchmarks.large_page.encode()
     benchmark(pit_id_parsing_candidate_runner_parse, page)
 
 

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -16,7 +16,6 @@
 # under the License.
 # pylint: disable=protected-access
 
-import collections
 import datetime
 import json
 import logging

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -26,9 +26,9 @@ import string
 import tempfile
 import unittest.mock as mock
 import uuid
-from unittest import TestCase
 
 import elasticsearch.exceptions
+import pytest
 
 from esrally import config, exceptions, metrics, paths, track
 from esrally.metrics import GlobalStatsCalculator
@@ -110,39 +110,39 @@ class TransportErrors:
         return side_effect_list
 
 
-class ExtractUserTagsTests(TestCase):
+class TestExtractUserTags:
     def test_no_tags_returns_empty_dict(self):
         cfg = config.Config()
-        self.assertEqual(0, len(metrics.extract_user_tags_from_config(cfg)))
+        assert len(metrics.extract_user_tags_from_config(cfg)) == 0
 
     def test_missing_comma_raises_error(self):
         cfg = config.Config()
         cfg.add(config.Scope.application, "race", "user.tag", "invalid")
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             metrics.extract_user_tags_from_config(cfg)
-        self.assertEqual("User tag keys and values have to separated by a ':'. Invalid value [invalid]", ctx.exception.args[0])
+        assert ctx.value.args[0] == "User tag keys and values have to separated by a ':'. Invalid value [invalid]"
 
     def test_missing_value_raises_error(self):
         cfg = config.Config()
         cfg.add(config.Scope.application, "race", "user.tag", "invalid1,invalid2")
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             metrics.extract_user_tags_from_config(cfg)
-        self.assertEqual("User tag keys and values have to separated by a ':'. Invalid value [invalid1,invalid2]", ctx.exception.args[0])
+        assert ctx.value.args[0] == "User tag keys and values have to separated by a ':'. Invalid value [invalid1,invalid2]"
 
     def test_extracts_proper_user_tags(self):
         cfg = config.Config()
         cfg.add(config.Scope.application, "race", "user.tag", "os:Linux,cpu:ARM")
-        self.assertDictEqual({"os": "Linux", "cpu": "ARM"}, metrics.extract_user_tags_from_config(cfg))
+        assert metrics.extract_user_tags_from_config(cfg) == {"os": "Linux", "cpu": "ARM"}
 
 
-class EsClientTests(TestCase):
+class TestEsClient:
     class TransportMock:
         def __init__(self, hosts):
             self.hosts = hosts
 
     class ClientMock:
         def __init__(self, hosts):
-            self.transport = EsClientTests.TransportMock(hosts)
+            self.transport = TestEsClient.TransportMock(hosts)
 
     @mock.patch("esrally.client.EsClientFactory")
     def test_config_opts_parsing(self, client_esclientfactory):
@@ -180,57 +180,53 @@ class EsClientTests(TestCase):
         def raise_connection_error():
             raise elasticsearch.exceptions.ConnectionError("unit-test")
 
-        client = metrics.EsClient(EsClientTests.ClientMock([{"host": "127.0.0.1", "port": "9200"}]))
+        client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9200"}]))
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             client.guarded(raise_connection_error)
-        self.assertEqual(
+        assert ctx.value.args[0] == (
             "Could not connect to your Elasticsearch metrics store. Please check that it is running on host [127.0.0.1] at "
-            "port [9200] or fix the configuration in [%s/rally.ini]." % paths.rally_confdir(),
-            ctx.exception.args[0],
+            f"port [9200] or fix the configuration in [{paths.rally_confdir()}/rally.ini]."
         )
 
     def test_raises_sytem_setup_error_on_authentication_problems(self):
         def raise_authentication_error():
             raise elasticsearch.exceptions.AuthenticationException("unit-test")
 
-        client = metrics.EsClient(EsClientTests.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
+        client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             client.guarded(raise_authentication_error)
-        self.assertEqual(
+        assert ctx.value.args[0] == (
             "The configured user could not authenticate against your Elasticsearch metrics store running on host [127.0.0.1] "
-            "at port [9243] (wrong password?). Please fix the configuration in [%s/rally.ini]." % paths.rally_confdir(),
-            ctx.exception.args[0],
+            f"at port [9243] (wrong password?). Please fix the configuration in [{paths.rally_confdir()}/rally.ini]."
         )
 
     def test_raises_sytem_setup_error_on_authorization_problems(self):
         def raise_authorization_error():
             raise elasticsearch.exceptions.AuthorizationException("unit-test")
 
-        client = metrics.EsClient(EsClientTests.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
+        client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             client.guarded(raise_authorization_error)
-        self.assertEqual(
+        assert ctx.value.args[0] == (
             "The configured user does not have enough privileges to run the operation [raise_authorization_error] against "
             "your Elasticsearch metrics store running on host [127.0.0.1] at port [9243]. Please adjust your x-pack "
-            "configuration or specify a user with enough privileges in the configuration in [%s/rally.ini]." % paths.rally_confdir(),
-            ctx.exception.args[0],
+            f"configuration or specify a user with enough privileges in the configuration in [{paths.rally_confdir()}/rally.ini]."
         )
 
     def test_raises_rally_error_on_unknown_problems(self):
         def raise_unknown_error():
             raise elasticsearch.exceptions.SerializationError("unit-test")
 
-        client = metrics.EsClient(EsClientTests.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
+        client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
 
-        with self.assertRaises(exceptions.RallyError) as ctx:
+        with pytest.raises(exceptions.RallyError) as ctx:
             client.guarded(raise_unknown_error)
-        self.assertEqual(
+        assert ctx.value.args[0] == (
             "An unknown error occurred while running the operation [raise_unknown_error] against your Elasticsearch metrics "
-            "store on host [127.0.0.1] at port [9243].",
-            ctx.exception.args[0],
+            "store on host [127.0.0.1] at port [9243]."
         )
 
     def test_retries_on_various_transport_errors(self):
@@ -243,14 +239,14 @@ class EsClientTests(TestCase):
             # Disable additional randomization time in exponential backoff calls
             mocked_random.return_value = 0
 
-            client = metrics.EsClient(EsClientTests.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
+            client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
 
             logger = logging.getLogger("esrally.metrics")
             with mock.patch.object(logger, "debug") as mocked_debug_logger:
                 test_result = client.guarded(operation)
                 mocked_sleep.assert_has_calls(expected_sleep_calls)
                 mocked_debug_logger.assert_has_calls(expected_logging_calls, any_order=True)
-                self.assertEqual("success", test_result)
+                assert test_result == "success"
 
         max_retry = 10
         all_err_codes = TransportErrors.err_return_codes
@@ -284,25 +280,24 @@ class EsClientTests(TestCase):
         def random_transport_error(rnd_resp_code):
             raise elasticsearch.exceptions.TransportError(rnd_resp_code, TransportErrors.err_return_codes[rnd_resp_code])
 
-        client = metrics.EsClient(EsClientTests.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
+        client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
         rnd_code = random.choice(list(TransportErrors.err_return_codes))
 
-        with self.assertRaises(exceptions.RallyError) as ctx:
+        with pytest.raises(exceptions.RallyError) as ctx:
             client.guarded(random_transport_error, rnd_code)
 
-        self.assertEqual(
+        assert ctx.value.args[0] == (
             "A transport error occurred while running the operation "
             "[random_transport_error] against your Elasticsearch metrics "
-            "store on host [127.0.0.1] at port [9243].",
-            ctx.exception.args[0],
+            "store on host [127.0.0.1] at port [9243]."
         )
 
 
-class EsMetricsTests(TestCase):
+class TestEsMetrics:
     RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
     RACE_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
-    def setUp(self):
+    def setup_method(self, method):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
         self.cfg.add(config.Scope.application, "track", "params", {"shard-count": 3})
@@ -315,12 +310,12 @@ class EsMetricsTests(TestCase):
 
     def test_put_value_without_meta_info(self):
         throughput = 5000
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         self.metrics_store.put_value_cluster_level("indexing_throughput", throughput, "docs/s")
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "race-id": EsMetricsTests.RACE_ID,
+            "race-id": self.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
@@ -341,14 +336,14 @@ class EsMetricsTests(TestCase):
 
     def test_put_value_with_explicit_timestamps(self):
         throughput = 5000
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         self.metrics_store.put_value_cluster_level(
             name="indexing_throughput", value=throughput, unit="docs/s", absolute_time=0, relative_time=10
         )
         expected_doc = {
             "@timestamp": 0,
-            "race-id": EsMetricsTests.RACE_ID,
+            "race-id": self.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time": 10000,
             "environment": "unittest",
@@ -371,7 +366,7 @@ class EsMetricsTests(TestCase):
         throughput = 5000
         # add a user-defined tag
         self.cfg.add(config.Scope.application, "race", "user.tag", "intention:testing,disk_type:hdd")
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         # Ensure we also merge in cluster level meta info
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "source_revision", "abc123")
@@ -384,7 +379,7 @@ class EsMetricsTests(TestCase):
         self.metrics_store.put_value_node_level("node0", "indexing_throughput", throughput, "docs/s")
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "race-id": EsMetricsTests.RACE_ID,
+            "race-id": self.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
@@ -410,7 +405,7 @@ class EsMetricsTests(TestCase):
         self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc])
 
     def test_put_doc_no_meta_data(self):
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         self.metrics_store.put_doc(
             doc={
@@ -422,7 +417,7 @@ class EsMetricsTests(TestCase):
         )
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "race-id": EsMetricsTests.RACE_ID,
+            "race-id": self.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
@@ -443,7 +438,7 @@ class EsMetricsTests(TestCase):
     def test_put_doc_with_metadata(self):
         # add a user-defined tag
         self.cfg.add(config.Scope.application, "race", "user.tag", "intention:testing,disk_type:hdd")
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         # Ensure we also merge in cluster level meta info
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "source_revision", "abc123")
@@ -468,7 +463,7 @@ class EsMetricsTests(TestCase):
         )
         expected_doc = {
             "@timestamp": StaticClock.NOW * 1000,
-            "race-id": EsMetricsTests.RACE_ID,
+            "race-id": self.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "relative-time": 0,
             "environment": "unittest",
@@ -507,13 +502,13 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
                 "bool": {
                     "filter": [
-                        {"term": {"race-id": EsMetricsTests.RACE_ID}},
+                        {"term": {"race-id": self.RACE_ID}},
                         {"term": {"name": "service_time"}},
                         {"term": {"task": "task1"}},
                     ]
@@ -529,20 +524,20 @@ class EsMetricsTests(TestCase):
 
         self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 
-        self.assertEqual(duration, actual_duration)
+        assert actual_duration == duration
 
     def test_get_one_no_hits(self):
         duration = None
         search_result = {"hits": {"total": 0, "hits": []}}
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
                 "bool": {
                     "filter": [
-                        {"term": {"race-id": EsMetricsTests.RACE_ID}},
+                        {"term": {"race-id": self.RACE_ID}},
                         {"term": {"name": "latency"}},
                         {"term": {"task": "task2"}},
                     ]
@@ -558,7 +553,7 @@ class EsMetricsTests(TestCase):
 
         self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 
-        self.assertEqual(duration, actual_duration)
+        assert actual_duration == duration
 
     def test_get_value(self):
         throughput = 5000
@@ -577,7 +572,7 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
@@ -585,7 +580,7 @@ class EsMetricsTests(TestCase):
                     "filter": [
                         {
                             "term": {
-                                "race-id": EsMetricsTests.RACE_ID,
+                                "race-id": self.RACE_ID,
                             },
                         },
                         {
@@ -603,7 +598,7 @@ class EsMetricsTests(TestCase):
 
         self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 
-        self.assertEqual(throughput, actual_throughput)
+        assert actual_throughput == throughput
 
     def test_get_per_node_value(self):
         index_size = 5000
@@ -622,13 +617,13 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
                 "bool": {
                     "filter": [
-                        {"term": {"race-id": EsMetricsTests.RACE_ID}},
+                        {"term": {"race-id": self.RACE_ID}},
                         {"term": {"name": "final_index_size_bytes"}},
                         {"term": {"meta.node_name": "rally-node-3"}},
                     ]
@@ -641,7 +636,7 @@ class EsMetricsTests(TestCase):
 
         self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 
-        self.assertEqual(index_size, actual_index_size)
+        assert actual_index_size == index_size
 
     def test_get_mean(self):
         mean_throughput = 1734
@@ -661,13 +656,13 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
                 "bool": {
                     "filter": [
-                        {"term": {"race-id": EsMetricsTests.RACE_ID}},
+                        {"term": {"race-id": self.RACE_ID}},
                         {"term": {"name": "indexing_throughput"}},
                         {"term": {"operation-type": "bulk"}},
                     ]
@@ -687,7 +682,7 @@ class EsMetricsTests(TestCase):
 
         self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 
-        self.assertEqual(mean_throughput, actual_mean_throughput)
+        assert actual_mean_throughput == mean_throughput
 
     def test_get_median(self):
         median_throughput = 30535
@@ -705,13 +700,13 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
                 "bool": {
                     "filter": [
-                        {"term": {"race-id": EsMetricsTests.RACE_ID}},
+                        {"term": {"race-id": self.RACE_ID}},
                         {"term": {"name": "indexing_throughput"}},
                         {"term": {"operation-type": "bulk"}},
                     ]
@@ -732,11 +727,10 @@ class EsMetricsTests(TestCase):
 
         self.es_mock.search.assert_called_with(index="rally-metrics-2016-01", body=expected_query)
 
-        self.assertEqual(median_throughput, actual_median_throughput)
+        assert actual_median_throughput == median_throughput
 
     def test_get_error_rate_implicit_zero(self):
-        self.assertEqual(
-            0.0,
+        assert (
             self._get_error_rate(
                 buckets=[
                     {
@@ -745,12 +739,12 @@ class EsMetricsTests(TestCase):
                         "doc_count": 0,
                     },
                 ],
-            ),
+            )
+            == 0.0
         )
 
     def test_get_error_rate_explicit_zero(self):
-        self.assertEqual(
-            0.0,
+        assert (
             self._get_error_rate(
                 buckets=[
                     {
@@ -764,12 +758,12 @@ class EsMetricsTests(TestCase):
                         "doc_count": 500,
                     },
                 ]
-            ),
+            )
+            == 0.0
         )
 
     def test_get_error_rate_implicit_one(self):
-        self.assertEqual(
-            1.0,
+        assert (
             self._get_error_rate(
                 buckets=[
                     {
@@ -778,12 +772,12 @@ class EsMetricsTests(TestCase):
                         "doc_count": 123,
                     },
                 ],
-            ),
+            )
+            == 1.0
         )
 
     def test_get_error_rate_explicit_one(self):
-        self.assertEqual(
-            1.0,
+        assert (
             self._get_error_rate(
                 buckets=[
                     {
@@ -797,12 +791,12 @@ class EsMetricsTests(TestCase):
                         "doc_count": 0,
                     },
                 ]
-            ),
+            )
+            == 1.0
         )
 
     def test_get_error_rate_mixed(self):
-        self.assertEqual(
-            0.5,
+        assert (
             self._get_error_rate(
                 buckets=[
                     {
@@ -816,12 +810,12 @@ class EsMetricsTests(TestCase):
                         "doc_count": 500,
                     },
                 ]
-            ),
+            )
+            == 0.5
         )
 
     def test_get_error_rate_additional_unknown_key(self):
-        self.assertEqual(
-            0.25,
+        assert (
             self._get_error_rate(
                 buckets=[
                     {
@@ -840,7 +834,8 @@ class EsMetricsTests(TestCase):
                         "doc_count": 13700,
                     },
                 ]
-            ),
+            )
+            == 0.25
         )
 
     def _get_error_rate(self, buckets):
@@ -852,13 +847,13 @@ class EsMetricsTests(TestCase):
         }
         self.es_mock.search = mock.MagicMock(return_value=search_result)
 
-        self.metrics_store.open(EsMetricsTests.RACE_ID, EsMetricsTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         expected_query = {
             "query": {
                 "bool": {
                     "filter": [
-                        {"term": {"race-id": EsMetricsTests.RACE_ID}},
+                        {"term": {"race-id": self.RACE_ID}},
                         {"term": {"name": "service_time"}},
                         {"term": {"task": "scroll_query"}},
                     ]
@@ -879,7 +874,7 @@ class EsMetricsTests(TestCase):
         return actual_error_rate
 
 
-class EsRaceStoreTests(TestCase):
+class TestEsRaceStore:
     RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
     RACE_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
@@ -890,11 +885,11 @@ class EsRaceStoreTests(TestCase):
         def as_dict(self):
             return self.d
 
-    def setUp(self):
+    def setup_method(self, method):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
-        self.cfg.add(config.Scope.application, "system", "time.start", EsRaceStoreTests.RACE_TIMESTAMP)
-        self.cfg.add(config.Scope.application, "system", "race.id", FileRaceStoreTests.RACE_ID)
+        self.cfg.add(config.Scope.application, "system", "time.start", self.RACE_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "race.id", self.RACE_ID)
         self.race_store = metrics.EsRaceStore(
             self.cfg,
             client_factory_class=MockClientFactory,
@@ -912,7 +907,7 @@ class EsRaceStoreTests(TestCase):
                         "_source": {
                             "rally-version": "0.4.4",
                             "environment": "unittest",
-                            "race-id": EsRaceStoreTests.RACE_ID,
+                            "race-id": self.RACE_ID,
                             "race-timestamp": "20160131T000000Z",
                             "pipeline": "from-sources",
                             "track": "unittest",
@@ -929,8 +924,8 @@ class EsRaceStoreTests(TestCase):
             }
         }
 
-        race = self.race_store.find_by_race_id(race_id=EsRaceStoreTests.RACE_ID)
-        self.assertEqual(race.race_id, EsRaceStoreTests.RACE_ID)
+        race = self.race_store.find_by_race_id(race_id=self.RACE_ID)
+        assert race.race_id == self.RACE_ID
 
     def test_does_not_find_missing_race_by_race_id(self):
         self.es_mock.search.return_value = {
@@ -943,7 +938,7 @@ class EsRaceStoreTests(TestCase):
             },
         }
 
-        with self.assertRaisesRegex(exceptions.NotFound, r"No race with race id \[.*\]"):
+        with pytest.raises(exceptions.NotFound, match=r"No race with race id \[.*\]"):
             self.race_store.find_by_race_id(race_id="some invalid race id")
 
     def test_store_race(self):
@@ -959,8 +954,8 @@ class EsRaceStoreTests(TestCase):
             rally_version="0.4.4",
             rally_revision="123abc",
             environment_name="unittest",
-            race_id=EsRaceStoreTests.RACE_ID,
-            race_timestamp=EsRaceStoreTests.RACE_TIMESTAMP,
+            race_id=self.RACE_ID,
+            race_timestamp=self.RACE_TIMESTAMP,
             pipeline="from-sources",
             user_tags={"os": "Linux"},
             track=t,
@@ -974,7 +969,7 @@ class EsRaceStoreTests(TestCase):
             distribution_version="5.0.0",
             distribution_flavor="default",
             revision="aaaeeef",
-            results=EsRaceStoreTests.DictHolder(
+            results=self.DictHolder(
                 {
                     "young_gc_time": 100,
                     "old_gc_time": 5,
@@ -995,7 +990,7 @@ class EsRaceStoreTests(TestCase):
             "rally-version": "0.4.4",
             "rally-revision": "123abc",
             "environment": "unittest",
-            "race-id": EsRaceStoreTests.RACE_ID,
+            "race-id": self.RACE_ID,
             "race-timestamp": "20160131T000000Z",
             "pipeline": "from-sources",
             "user-tags": {"os": "Linux"},
@@ -1028,17 +1023,17 @@ class EsRaceStoreTests(TestCase):
                 ],
             },
         }
-        self.es_mock.index.assert_called_with(index="rally-races-2016-01", id=EsRaceStoreTests.RACE_ID, item=expected_doc)
+        self.es_mock.index.assert_called_with(index="rally-races-2016-01", id=self.RACE_ID, item=expected_doc)
 
 
-class EsResultsStoreTests(TestCase):
+class TestEsResultsStore:
     RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
     RACE_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
-    def setUp(self):
+    def setup_method(self, method):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
-        self.cfg.add(config.Scope.application, "system", "time.start", EsRaceStoreTests.RACE_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "time.start", self.RACE_TIMESTAMP)
         self.results_store = metrics.EsResultsStore(
             self.cfg,
             client_factory_class=MockClientFactory,
@@ -1061,8 +1056,8 @@ class EsResultsStoreTests(TestCase):
             rally_version="0.4.4",
             rally_revision="123abc",
             environment_name="unittest",
-            race_id=EsResultsStoreTests.RACE_ID,
-            race_timestamp=EsResultsStoreTests.RACE_TIMESTAMP,
+            race_id=self.RACE_ID,
+            race_timestamp=self.RACE_TIMESTAMP,
             pipeline="from-sources",
             user_tags={"os": "Linux"},
             track=t,
@@ -1108,7 +1103,7 @@ class EsResultsStoreTests(TestCase):
                 "rally-version": "0.4.4",
                 "rally-revision": "123abc",
                 "environment": "unittest",
-                "race-id": EsResultsStoreTests.RACE_ID,
+                "race-id": self.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
@@ -1132,7 +1127,7 @@ class EsResultsStoreTests(TestCase):
                 "rally-version": "0.4.4",
                 "rally-revision": "123abc",
                 "environment": "unittest",
-                "race-id": EsResultsStoreTests.RACE_ID,
+                "race-id": self.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
@@ -1164,7 +1159,7 @@ class EsResultsStoreTests(TestCase):
                 "rally-version": "0.4.4",
                 "rally-revision": "123abc",
                 "environment": "unittest",
-                "race-id": EsResultsStoreTests.RACE_ID,
+                "race-id": self.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
                 "distribution-flavor": "oss",
                 "distribution-version": "5.0.0",
@@ -1201,8 +1196,8 @@ class EsResultsStoreTests(TestCase):
             rally_version="0.4.4",
             rally_revision=None,
             environment_name="unittest",
-            race_id=EsResultsStoreTests.RACE_ID,
-            race_timestamp=EsResultsStoreTests.RACE_TIMESTAMP,
+            race_id=self.RACE_ID,
+            race_timestamp=self.RACE_TIMESTAMP,
             pipeline="from-sources",
             user_tags={"os": "Linux"},
             track=t,
@@ -1248,7 +1243,7 @@ class EsResultsStoreTests(TestCase):
                 "rally-version": "0.4.4",
                 "rally-revision": None,
                 "environment": "unittest",
-                "race-id": EsResultsStoreTests.RACE_ID,
+                "race-id": self.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
                 "distribution-flavor": None,
                 "distribution-version": None,
@@ -1270,7 +1265,7 @@ class EsResultsStoreTests(TestCase):
                 "rally-version": "0.4.4",
                 "rally-revision": None,
                 "environment": "unittest",
-                "race-id": EsResultsStoreTests.RACE_ID,
+                "race-id": self.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
                 "distribution-flavor": None,
                 "distribution-version": None,
@@ -1300,7 +1295,7 @@ class EsResultsStoreTests(TestCase):
                 "rally-version": "0.4.4",
                 "rally-revision": None,
                 "environment": "unittest",
-                "race-id": EsResultsStoreTests.RACE_ID,
+                "race-id": self.RACE_ID,
                 "race-timestamp": "20160131T000000Z",
                 "distribution-flavor": None,
                 "distribution-version": None,
@@ -1322,25 +1317,25 @@ class EsResultsStoreTests(TestCase):
         self.es_mock.bulk_index.assert_called_with(index="rally-results-2016-01", items=expected_docs)
 
 
-class InMemoryMetricsStoreTests(TestCase):
+class TestInMemoryMetricsStore:
     RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
     RACE_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
-    def setUp(self):
+    def setup_method(self, method):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
         self.cfg.add(config.Scope.application, "track", "params", {})
         self.metrics_store = metrics.InMemoryMetricsStore(self.cfg, clock=StaticClock)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         del self.metrics_store
         del self.cfg
 
     def test_get_one(self):
         duration = StaticClock.NOW
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1352,21 +1347,19 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults"
-        )
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         actual_duration = self.metrics_store.get_one(
             "service_time", task="task1", mapper=lambda doc: doc["relative-time"], sort_key="relative-time", sort_reverse=True
         )
 
-        self.assertEqual(duration * 1000, actual_duration)
+        assert duration * 1000 == actual_duration
 
     def test_get_one_no_hits(self):
         duration = StaticClock.NOW
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1376,21 +1369,19 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults"
-        )
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         actual_duration = self.metrics_store.get_one(
             "service_time", task="task1", mapper=lambda doc: doc["relative-time"], sort_key="relative-time", sort_reverse=True
         )
 
-        self.assertIsNone(actual_duration)
+        assert actual_duration is None
 
     def test_get_value(self):
         throughput = 5000
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1402,17 +1393,15 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults"
-        )
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
-        self.assertEqual(1, self.metrics_store.get_one("indexing_throughput", sample_type=metrics.SampleType.Warmup))
-        self.assertEqual(throughput, self.metrics_store.get_one("indexing_throughput", sample_type=metrics.SampleType.Normal))
+        assert self.metrics_store.get_one("indexing_throughput", sample_type=metrics.SampleType.Warmup) == 1
+        assert self.metrics_store.get_one("indexing_throughput", sample_type=metrics.SampleType.Normal) == throughput
 
     def test_get_percentile(self):
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1423,9 +1412,7 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults"
-        )
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
         self.assert_equal_percentiles("query_latency", [100.0], {100.0: 1000.0})
         self.assert_equal_percentiles("query_latency", [99.0], {99.0: 990.0})
@@ -1436,8 +1423,8 @@ class InMemoryMetricsStoreTests(TestCase):
 
     def test_get_mean(self):
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1448,16 +1435,14 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults"
-        )
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
-        self.assertAlmostEqual(50, self.metrics_store.get_mean("query_latency"))
+        assert round(abs(50 - self.metrics_store.get_mean("query_latency")), 7) == 0
 
     def test_get_median(self):
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1468,24 +1453,20 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults"
-        )
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
-        self.assertAlmostEqual(500.5, self.metrics_store.get_median("query_latency"))
+        assert round(abs(500.5 - self.metrics_store.get_median("query_latency")), 7) == 0
 
     def assert_equal_percentiles(self, name, percentiles, expected_percentiles):
         actual_percentiles = self.metrics_store.get_percentiles(name, percentiles=percentiles)
-        self.assertEqual(len(expected_percentiles), len(actual_percentiles))
+        assert len(expected_percentiles) == len(actual_percentiles)
         for percentile, actual_percentile_value in actual_percentiles.items():
-            self.assertAlmostEqual(
-                expected_percentiles[percentile], actual_percentile_value, places=1, msg=str(percentile) + "th percentile differs"
-            )
+            assert round(abs(expected_percentiles[percentile] - actual_percentile_value), 1) == 0
 
     def test_externalize_and_bulk_add(self):
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1493,23 +1474,23 @@ class InMemoryMetricsStoreTests(TestCase):
         )
         self.metrics_store.put_value_cluster_level("final_index_size", 1000, "GB")
 
-        self.assertEqual(1, len(self.metrics_store.docs))
+        assert len(self.metrics_store.docs) == 1
         memento = self.metrics_store.to_externalizable()
 
         self.metrics_store.close()
         del self.metrics_store
 
         self.metrics_store = metrics.InMemoryMetricsStore(self.cfg, clock=StaticClock)
-        self.assertEqual(0, len(self.metrics_store.docs))
+        assert len(self.metrics_store.docs) == 0
 
         self.metrics_store.bulk_add(memento)
-        self.assertEqual(1, len(self.metrics_store.docs))
-        self.assertEqual(1000, self.metrics_store.get_one("final_index_size"))
+        assert len(self.metrics_store.docs) == 1
+        assert self.metrics_store.get_one("final_index_size") == 1000
 
     def test_meta_data_per_document(self):
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1520,15 +1501,15 @@ class InMemoryMetricsStoreTests(TestCase):
         self.metrics_store.put_value_cluster_level("final_index_size", 1000, "GB", meta_data={"fs-block-size-bytes": 512})
         self.metrics_store.put_value_cluster_level("final_bytes_written", 1, "TB", meta_data={"io-batch-size-kb": 4})
 
-        self.assertEqual(2, len(self.metrics_store.docs))
-        self.assertEqual({"cluster-name": "test", "fs-block-size-bytes": 512}, self.metrics_store.docs[0]["meta"])
+        assert len(self.metrics_store.docs) == 2
+        assert self.metrics_store.docs[0]["meta"] == {"cluster-name": "test", "fs-block-size-bytes": 512}
 
-        self.assertEqual({"cluster-name": "test", "io-batch-size-kb": 4}, self.metrics_store.docs[1]["meta"])
+        assert self.metrics_store.docs[1]["meta"] == {"cluster-name": "test", "io-batch-size-kb": 4}
 
     def test_get_error_rate_zero_without_samples(self):
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1536,16 +1517,14 @@ class InMemoryMetricsStoreTests(TestCase):
         )
         self.metrics_store.close()
 
-        self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults"
-        )
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
-        self.assertEqual(0.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal))
+        assert self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal) == 0.0
 
     def test_get_error_rate_by_sample_type(self):
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1560,17 +1539,15 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults"
-        )
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
-        self.assertEqual(1.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Warmup))
-        self.assertEqual(0.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal))
+        assert self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Warmup) == 1.0
+        assert self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal) == 0.0
 
     def test_get_error_rate_mixed(self):
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-no-conflicts",
             "defaults",
@@ -1594,15 +1571,13 @@ class InMemoryMetricsStoreTests(TestCase):
 
         self.metrics_store.close()
 
-        self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID, InMemoryMetricsStoreTests.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults"
-        )
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append-no-conflicts", "defaults")
 
-        self.assertEqual(0.0, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Warmup))
-        self.assertEqual(0.2, self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal))
+        assert self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Warmup) == 0.0
+        assert self.metrics_store.get_error_rate("term-query", sample_type=metrics.SampleType.Normal) == 0.2
 
 
-class FileRaceStoreTests(TestCase):
+class TestFileRaceStore:
     RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
     RACE_ID = "6ebc6e53-ee20-4b0c-99b4-09697987e9f4"
 
@@ -1613,19 +1588,19 @@ class FileRaceStoreTests(TestCase):
         def as_dict(self):
             return self.d
 
-    def setUp(self):
+    def setup_method(self):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "node", "root.dir", os.path.join(tempfile.gettempdir(), str(uuid.uuid4())))
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
         self.cfg.add(config.Scope.application, "system", "list.races.max_results", 100)
-        self.cfg.add(config.Scope.application, "system", "time.start", FileRaceStoreTests.RACE_TIMESTAMP)
-        self.cfg.add(config.Scope.application, "system", "race.id", FileRaceStoreTests.RACE_ID)
+        self.cfg.add(config.Scope.application, "system", "time.start", self.RACE_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "race.id", self.RACE_ID)
         self.race_store = metrics.FileRaceStore(self.cfg)
 
     def test_race_not_found(self):
-        with self.assertRaisesRegex(exceptions.NotFound, r"No race with race id \[.*\]"):
+        with pytest.raises(exceptions.NotFound, match=r"No race with race id \[.*\]"):
             # did not store anything yet
-            self.race_store.find_by_race_id(FileRaceStoreTests.RACE_ID)
+            self.race_store.find_by_race_id(self.RACE_ID)
 
     def test_store_race(self):
         schedule = [track.Task("index #1", track.Operation("index", track.OperationType.Bulk))]
@@ -1640,8 +1615,8 @@ class FileRaceStoreTests(TestCase):
             rally_version="0.4.4",
             rally_revision="123abc",
             environment_name="unittest",
-            race_id=FileRaceStoreTests.RACE_ID,
-            race_timestamp=FileRaceStoreTests.RACE_TIMESTAMP,
+            race_id=self.RACE_ID,
+            race_timestamp=self.RACE_TIMESTAMP,
             pipeline="from-sources",
             user_tags={"os": "Linux"},
             track=t,
@@ -1655,7 +1630,7 @@ class FileRaceStoreTests(TestCase):
             distribution_version="5.0.0",
             distribution_flavor="default",
             revision="aaaeeef",
-            results=FileRaceStoreTests.DictHolder(
+            results=self.DictHolder(
                 {
                     "young_gc_time": 100,
                     "old_gc_time": 5,
@@ -1677,13 +1652,13 @@ class FileRaceStoreTests(TestCase):
 
         self.race_store.store_race(race)
 
-        retrieved_race = self.race_store.find_by_race_id(race_id=FileRaceStoreTests.RACE_ID)
-        self.assertEqual(race.race_id, retrieved_race.race_id)
-        self.assertEqual(race.race_timestamp, retrieved_race.race_timestamp)
-        self.assertEqual(1, len(self.race_store.list()))
+        retrieved_race = self.race_store.find_by_race_id(race_id=self.RACE_ID)
+        assert race.race_id == retrieved_race.race_id
+        assert race.race_timestamp == retrieved_race.race_timestamp
+        assert len(self.race_store.list()) == 1
 
 
-class StatsCalculatorTests(TestCase):
+class TestStatsCalculator:
     def test_calculate_global_stats(self):
         cfg = config.Config()
         cfg.add(config.Scope.application, "system", "env.name", "unittest")
@@ -1794,28 +1769,48 @@ class StatsCalculatorTests(TestCase):
         del store
 
         opm = stats.metrics("index #1")
-        self.assertEqual(
-            collections.OrderedDict([("min", 500), ("mean", 1125), ("median", 1000), ("max", 2000), ("unit", "docs/s")]), opm["throughput"]
-        )
-        self.assertEqual(collections.OrderedDict([("50_0", 220), ("100_0", 225), ("mean", 215), ("unit", "ms")]), opm["latency"])
-        self.assertEqual(collections.OrderedDict([("50_0", 200), ("100_0", 210), ("mean", 200), ("unit", "ms")]), opm["service_time"])
-        self.assertAlmostEqual(0.3333333333333333, opm["error_rate"])
-        self.assertEqual(709 * 1000, opm["duration"])
+        assert opm["throughput"] == {
+            "min": 500,
+            "mean": 1125,
+            "median": 1000,
+            "max": 2000,
+            "unit": "docs/s",
+        }
+        assert opm["latency"] == {
+            "50_0": 220,
+            "100_0": 225,
+            "mean": 215,
+            "unit": "ms",
+        }
+        assert opm["service_time"] == {
+            "50_0": 200,
+            "100_0": 210,
+            "mean": 200,
+            "unit": "ms",
+        }
+        assert round(abs(0.3333333333333333 - opm["error_rate"]), 7) == 0
+        assert opm["duration"] == 709 * 1000
 
         opm2 = stats.metrics("index #2")
-        self.assertEqual(
-            collections.OrderedDict([("min", None), ("mean", None), ("median", None), ("max", None), ("unit", "docs/s")]),
-            opm2["throughput"],
-        )
+        assert opm2["throughput"] == {
+            "min": None,
+            "mean": None,
+            "median": None,
+            "max": None,
+            "unit": "docs/s",
+        }
 
-        self.assertEqual(1, len(stats.ml_processing_time))
-        self.assertEqual("benchmark_ml_job_1", stats.ml_processing_time[0]["job"])
-        self.assertEqual(2.2, stats.ml_processing_time[0]["min"])
-        self.assertEqual(12.3, stats.ml_processing_time[0]["mean"])
-        self.assertEqual(17.2, stats.ml_processing_time[0]["median"])
-        self.assertEqual(36.0, stats.ml_processing_time[0]["max"])
-        self.assertEqual("ms", stats.ml_processing_time[0]["unit"])
-        self.assertEqual(600 * 1000, opm2["duration"])
+        assert stats.ml_processing_time == [
+            {
+                "job": "benchmark_ml_job_1",
+                "min": 2.2,
+                "mean": 12.3,
+                "median": 17.2,
+                "max": 36.0,
+                "unit": "ms",
+            }
+        ]
+        assert opm2["duration"] == 600 * 1000
 
     def test_calculate_system_stats(self):
         cfg = config.Config()
@@ -1845,17 +1840,14 @@ class StatsCalculatorTests(TestCase):
 
         del store
 
-        self.assertEqual(
-            [
-                {
-                    "node": "rally-node-0",
-                    "name": "index_size",
-                    "value": 2048,
-                    "unit": "bytes",
-                }
-            ],
-            stats.node_metrics,
-        )
+        assert stats.node_metrics == [
+            {
+                "node": "rally-node-0",
+                "name": "index_size",
+                "value": 2048,
+                "unit": "bytes",
+            }
+        ]
 
 
 def select(l, name, operation=None, job=None, node=None):
@@ -1865,17 +1857,17 @@ def select(l, name, operation=None, job=None, node=None):
     return None
 
 
-class GlobalStatsCalculatorTests(TestCase):
+class TestGlobalStatsCalculator:
     RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)
     RACE_ID = "fb26018b-428d-4528-b36b-cf8c54a303ec"
 
-    def setUp(self):
+    def setup_method(self, method):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest")
         self.cfg.add(config.Scope.application, "track", "params", {})
         self.metrics_store = metrics.InMemoryMetricsStore(self.cfg, clock=StaticClock)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         del self.metrics_store
         del self.cfg
 
@@ -1885,8 +1877,8 @@ class GlobalStatsCalculatorTests(TestCase):
         challenge = Challenge(name="append-fast-with-conflicts", schedule=[task], meta_data={})
 
         self.metrics_store.open(
-            InMemoryMetricsStoreTests.RACE_ID,
-            InMemoryMetricsStoreTests.RACE_TIMESTAMP,
+            self.RACE_ID,
+            self.RACE_TIMESTAMP,
             "test",
             "append-fast-with-conflicts",
             "defaults",
@@ -1922,7 +1914,7 @@ class GlobalStatsCalculatorTests(TestCase):
         assert "delete-index" in [op_metric.get("task") for op_metric in result.op_metrics]
 
 
-class GlobalStatsTests(TestCase):
+class TestGlobalStats:
     def test_as_flat_list(self):
         d = {
             "op_metrics": [
@@ -2014,276 +2006,213 @@ class GlobalStatsTests(TestCase):
 
         s = metrics.GlobalStats(d)
         metric_list = s.as_flat_list()
-        self.assertEqual(
-            {
-                "name": "throughput",
-                "task": "index #1",
-                "operation": "index",
-                "value": {
-                    "min": 450,
-                    "mean": 450,
-                    "median": 450,
-                    "max": 452,
-                    "unit": "docs/s",
-                },
-                "meta": {
-                    "clients": 8,
-                    "phase": "idx",
-                },
+        assert select(metric_list, "throughput", operation="index") == {
+            "name": "throughput",
+            "task": "index #1",
+            "operation": "index",
+            "value": {
+                "min": 450,
+                "mean": 450,
+                "median": 450,
+                "max": 452,
+                "unit": "docs/s",
             },
-            select(metric_list, "throughput", operation="index"),
-        )
+            "meta": {
+                "clients": 8,
+                "phase": "idx",
+            },
+        }
 
-        self.assertEqual(
-            {
-                "name": "service_time",
-                "task": "index #1",
-                "operation": "index",
-                "value": {
-                    "50": 341,
-                    "100": 376,
-                },
-                "meta": {
-                    "clients": 8,
-                    "phase": "idx",
-                },
+        assert select(metric_list, "service_time", operation="index") == {
+            "name": "service_time",
+            "task": "index #1",
+            "operation": "index",
+            "value": {
+                "50": 341,
+                "100": 376,
             },
-            select(metric_list, "service_time", operation="index"),
-        )
+            "meta": {
+                "clients": 8,
+                "phase": "idx",
+            },
+        }
 
-        self.assertEqual(
-            {
-                "name": "latency",
-                "task": "index #1",
-                "operation": "index",
-                "value": {
-                    "50": 340,
-                    "100": 376,
-                },
-                "meta": {
-                    "clients": 8,
-                    "phase": "idx",
-                },
+        assert select(metric_list, "latency", operation="index") == {
+            "name": "latency",
+            "task": "index #1",
+            "operation": "index",
+            "value": {
+                "50": 340,
+                "100": 376,
             },
-            select(metric_list, "latency", operation="index"),
-        )
+            "meta": {
+                "clients": 8,
+                "phase": "idx",
+            },
+        }
 
-        self.assertEqual(
-            {
-                "name": "error_rate",
-                "task": "index #1",
-                "operation": "index",
-                "value": {
-                    "single": 0.0,
-                },
-                "meta": {
-                    "clients": 8,
-                    "phase": "idx",
-                },
+        assert select(metric_list, "error_rate", operation="index") == {
+            "name": "error_rate",
+            "task": "index #1",
+            "operation": "index",
+            "value": {
+                "single": 0.0,
             },
-            select(metric_list, "error_rate", operation="index"),
-        )
+            "meta": {
+                "clients": 8,
+                "phase": "idx",
+            },
+        }
 
-        self.assertEqual(
-            {
-                "name": "throughput",
-                "task": "search #2",
-                "operation": "search",
-                "value": {
-                    "min": 9,
-                    "mean": 10,
-                    "median": 10,
-                    "max": 12,
-                    "unit": "ops/s",
-                },
+        assert select(metric_list, "throughput", operation="search") == {
+            "name": "throughput",
+            "task": "search #2",
+            "operation": "search",
+            "value": {
+                "min": 9,
+                "mean": 10,
+                "median": 10,
+                "max": 12,
+                "unit": "ops/s",
             },
-            select(metric_list, "throughput", operation="search"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "service_time",
-                "task": "search #2",
-                "operation": "search",
-                "value": {
-                    "50": 98,
-                    "100": 110,
-                },
+        assert select(metric_list, "service_time", operation="search") == {
+            "name": "service_time",
+            "task": "search #2",
+            "operation": "search",
+            "value": {
+                "50": 98,
+                "100": 110,
             },
-            select(metric_list, "service_time", operation="search"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "latency",
-                "task": "search #2",
-                "operation": "search",
-                "value": {
-                    "50": 99,
-                    "100": 111,
-                },
+        assert select(metric_list, "latency", operation="search") == {
+            "name": "latency",
+            "task": "search #2",
+            "operation": "search",
+            "value": {
+                "50": 99,
+                "100": 111,
             },
-            select(metric_list, "latency", operation="search"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "error_rate",
-                "task": "search #2",
-                "operation": "search",
-                "value": {
-                    "single": 0.1,
-                },
+        assert select(metric_list, "error_rate", operation="search") == {
+            "name": "error_rate",
+            "task": "search #2",
+            "operation": "search",
+            "value": {
+                "single": 0.1,
             },
-            select(metric_list, "error_rate", operation="search"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "ml_processing_time",
-                "job": "job_1",
-                "value": {
-                    "min": 3.3,
-                    "mean": 5.2,
-                    "median": 5.8,
-                    "max": 12.34,
-                },
+        assert select(metric_list, "ml_processing_time", job="job_1") == {
+            "name": "ml_processing_time",
+            "job": "job_1",
+            "value": {
+                "min": 3.3,
+                "mean": 5.2,
+                "median": 5.8,
+                "max": 12.34,
             },
-            select(metric_list, "ml_processing_time", job="job_1"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "ml_processing_time",
-                "job": "job_2",
-                "value": {
-                    "min": 3.55,
-                    "mean": 4.2,
-                    "median": 4.9,
-                    "max": 9.4,
-                },
+        assert select(metric_list, "ml_processing_time", job="job_2") == {
+            "name": "ml_processing_time",
+            "job": "job_2",
+            "value": {
+                "min": 3.55,
+                "mean": 4.2,
+                "median": 4.9,
+                "max": 9.4,
             },
-            select(metric_list, "ml_processing_time", job="job_2"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "young_gc_time",
-                "value": {
-                    "single": 68,
-                },
+        assert select(metric_list, "young_gc_time") == {
+            "name": "young_gc_time",
+            "value": {
+                "single": 68,
             },
-            select(metric_list, "young_gc_time"),
-        )
-        self.assertEqual(
-            {
-                "name": "young_gc_count",
-                "value": {
-                    "single": 7,
-                },
+        }
+        assert select(metric_list, "young_gc_count") == {
+            "name": "young_gc_count",
+            "value": {
+                "single": 7,
             },
-            select(metric_list, "young_gc_count"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "old_gc_time",
-                "value": {
-                    "single": 0,
-                },
+        assert select(metric_list, "old_gc_time") == {
+            "name": "old_gc_time",
+            "value": {
+                "single": 0,
             },
-            select(metric_list, "old_gc_time"),
-        )
-        self.assertEqual(
-            {
-                "name": "old_gc_count",
-                "value": {
-                    "single": 0,
-                },
+        }
+        assert select(metric_list, "old_gc_count") == {
+            "name": "old_gc_count",
+            "value": {
+                "single": 0,
             },
-            select(metric_list, "old_gc_count"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "merge_time",
-                "value": {
-                    "single": 3702,
-                },
+        assert select(metric_list, "merge_time") == {
+            "name": "merge_time",
+            "value": {
+                "single": 3702,
             },
-            select(metric_list, "merge_time"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "merge_time_per_shard",
-                "value": {
-                    "min": 40,
-                    "median": 3702,
-                    "max": 3900,
-                    "unit": "ms",
-                },
+        assert select(metric_list, "merge_time_per_shard") == {
+            "name": "merge_time_per_shard",
+            "value": {
+                "min": 40,
+                "median": 3702,
+                "max": 3900,
+                "unit": "ms",
             },
-            select(metric_list, "merge_time_per_shard"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "merge_count",
-                "value": {
-                    "single": 2,
-                },
+        assert select(metric_list, "merge_count") == {
+            "name": "merge_count",
+            "value": {
+                "single": 2,
             },
-            select(metric_list, "merge_count"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "refresh_time",
-                "value": {
-                    "single": 596,
-                },
+        assert select(metric_list, "refresh_time") == {
+            "name": "refresh_time",
+            "value": {
+                "single": 596,
             },
-            select(metric_list, "refresh_time"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "refresh_time_per_shard",
-                "value": {
-                    "min": 48,
-                    "median": 89,
-                    "max": 204,
-                    "unit": "ms",
-                },
+        assert select(metric_list, "refresh_time_per_shard") == {
+            "name": "refresh_time_per_shard",
+            "value": {
+                "min": 48,
+                "median": 89,
+                "max": 204,
+                "unit": "ms",
             },
-            select(metric_list, "refresh_time_per_shard"),
-        )
+        }
 
-        self.assertEqual(
-            {
-                "name": "refresh_count",
-                "value": {
-                    "single": 10,
-                },
+        assert select(metric_list, "refresh_count") == {
+            "name": "refresh_count",
+            "value": {
+                "single": 10,
             },
-            select(metric_list, "refresh_count"),
-        )
+        }
 
-        self.assertIsNone(select(metric_list, "flush_time"))
-        self.assertIsNone(select(metric_list, "flush_time_per_shard"))
-        self.assertEqual(
-            {
-                "name": "flush_count",
-                "value": {
-                    "single": 0,
-                },
+        assert select(metric_list, "flush_time") is None
+        assert select(metric_list, "flush_time_per_shard") is None
+        assert select(metric_list, "flush_count") == {
+            "name": "flush_count",
+            "value": {
+                "single": 0,
             },
-            select(metric_list, "flush_count"),
-        )
+        }
 
 
-class SystemStatsTests(TestCase):
+class TestSystemStats:
     def test_as_flat_list(self):
         d = {
             "node_metrics": [
@@ -2299,46 +2228,64 @@ class SystemStatsTests(TestCase):
         s = metrics.SystemStats(d)
         metric_list = s.as_flat_list()
 
-        self.assertEqual(
-            {"node": "rally-node-0", "name": "startup_time", "value": {"single": 3.4}},
-            select(metric_list, "startup_time", node="rally-node-0"),
-        )
+        assert select(metric_list, "startup_time", node="rally-node-0") == {
+            "node": "rally-node-0",
+            "name": "startup_time",
+            "value": {
+                "single": 3.4,
+            },
+        }
 
-        self.assertEqual(
-            {"node": "rally-node-1", "name": "startup_time", "value": {"single": 4.2}},
-            select(metric_list, "startup_time", node="rally-node-1"),
-        )
+        assert select(metric_list, "startup_time", node="rally-node-1") == {
+            "node": "rally-node-1",
+            "name": "startup_time",
+            "value": {
+                "single": 4.2,
+            },
+        }
 
-        self.assertEqual(
-            {"node": "rally-node-0", "name": "index_size", "value": {"single": 300 * 1024 * 1024}},
-            select(metric_list, "index_size", node="rally-node-0"),
-        )
+        assert select(metric_list, "index_size", node="rally-node-0") == {
+            "node": "rally-node-0",
+            "name": "index_size",
+            "value": {
+                "single": 300 * 1024 * 1024,
+            },
+        }
 
-        self.assertEqual(
-            {"node": "rally-node-1", "name": "index_size", "value": {"single": 302 * 1024 * 1024}},
-            select(metric_list, "index_size", node="rally-node-1"),
-        )
+        assert select(metric_list, "index_size", node="rally-node-1") == {
+            "node": "rally-node-1",
+            "name": "index_size",
+            "value": {
+                "single": 302 * 1024 * 1024,
+            },
+        }
 
-        self.assertEqual(
-            {"node": "rally-node-0", "name": "bytes_written", "value": {"single": 817 * 1024 * 1024}},
-            select(metric_list, "bytes_written", node="rally-node-0"),
-        )
+        assert select(metric_list, "bytes_written", node="rally-node-0") == {
+            "node": "rally-node-0",
+            "name": "bytes_written",
+            "value": {
+                "single": 817 * 1024 * 1024,
+            },
+        }
 
-        self.assertEqual(
-            {"node": "rally-node-1", "name": "bytes_written", "value": {"single": 833 * 1024 * 1024}},
-            select(metric_list, "bytes_written", node="rally-node-1"),
-        )
+        assert select(metric_list, "bytes_written", node="rally-node-1") == {
+            "node": "rally-node-1",
+            "name": "bytes_written",
+            "value": {
+                "single": 833 * 1024 * 1024,
+            },
+        }
 
 
-class IndexTemplateProviderTests(TestCase):
-    def setUp(self):
+class TestIndexTemplateProvider:
+    def setup_method(self, method):
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "node", "root.dir", os.path.join(tempfile.gettempdir(), str(uuid.uuid4())))
         self.cfg.add(config.Scope.application, "node", "rally.root", paths.rally_root())
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
         self.cfg.add(config.Scope.application, "system", "list.races.max_results", 100)
-        self.cfg.add(config.Scope.application, "system", "time.start", FileRaceStoreTests.RACE_TIMESTAMP)
-        self.cfg.add(config.Scope.application, "system", "race.id", FileRaceStoreTests.RACE_ID)
+        self.cfg.add(config.Scope.application, "system", "time.start", TestFileRaceStore.RACE_TIMESTAMP)
+        self.cfg.add(config.Scope.application, "system", "race.id", TestFileRaceStore.RACE_ID)
 
     def test_primary_and_replica_shard_count_specified_index_template_update(self):
         _datastore_type = "elasticsearch"
@@ -2380,7 +2327,7 @@ class IndexTemplateProviderTests(TestCase):
         for template in templates:
             t = json.loads(template)
             assert t["settings"]["index"]["number_of_shards"] == _datastore_number_of_shards
-            with self.assertRaises(KeyError):
+            with pytest.raises(KeyError):
                 # pylint: disable=unused-variable
                 number_of_replicas = t["settings"]["index"]["number_of_replicas"]
 
@@ -2402,7 +2349,7 @@ class IndexTemplateProviderTests(TestCase):
         for template in templates:
             t = json.loads(template)
             assert t["settings"]["index"]["number_of_replicas"] == _datastore_number_of_replicas
-            with self.assertRaises(KeyError):
+            with pytest.raises(KeyError):
                 # pylint: disable=unused-variable
                 number_of_shards = t["settings"]["index"]["number_of_shards"]
 
@@ -2414,17 +2361,16 @@ class IndexTemplateProviderTests(TestCase):
         self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.number_of_shards", _datastore_number_of_shards)
         _index_template_provider = metrics.IndexTemplateProvider(self.cfg)
 
-        with self.assertRaises(exceptions.SystemSetupError) as ctx:
+        with pytest.raises(exceptions.SystemSetupError) as ctx:
             # pylint: disable=unused-variable
             templates = [
                 _index_template_provider.metrics_template(),
                 _index_template_provider.races_template(),
                 _index_template_provider.results_template(),
             ]
-        self.assertEqual(
+        assert ctx.value.args[0] == (
             "The setting: datastore.number_of_shards must be >= 1. Please check the configuration in "
-            f"{_index_template_provider._config.config_file.location}",
-            ctx.exception.args[0],
+            f"{_index_template_provider._config.config_file.location}"
         )
 
     def test_primary_and_replica_shard_counts_passed_as_strings(self):

--- a/tests/reporter_test.py
+++ b/tests/reporter_test.py
@@ -16,14 +16,14 @@
 # under the License.
 # pylint: disable=protected-access
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from esrally import config, reporter
 from esrally.utils import convert
 
 
-class FormatterTests(TestCase):
-    def setUp(self):
+class TestFormatter:
+    def setup_method(self, method):
         self.empty_header = ["Header"]
         self.empty_data = []
 
@@ -38,32 +38,32 @@ class FormatterTests(TestCase):
     def test_formats_as_markdown(self):
         formatted = reporter.format_as_markdown(self.empty_header, self.empty_data, self.numbers_align)
         # 1 header line, 1 separation line + 0 data lines
-        self.assertEqual(1 + 1 + 0, len(formatted.splitlines()))
+        assert len(formatted.splitlines()) == 1 + 1 + 0
 
         formatted = reporter.format_as_markdown(self.metrics_header, self.metrics_data, self.numbers_align)
         # 1 header line, 1 separation line + 3 data lines
-        self.assertEqual(1 + 1 + 3, len(formatted.splitlines()))
+        assert len(formatted.splitlines()) == 1 + 1 + 3
 
     def test_formats_as_csv(self):
         formatted = reporter.format_as_csv(self.empty_header, self.empty_data)
         # 1 header line, no separation line + 0 data lines
-        self.assertEqual(1 + 0, len(formatted.splitlines()))
+        assert len(formatted.splitlines()) == 1 + 0
 
         formatted = reporter.format_as_csv(self.metrics_header, self.metrics_data)
         # 1 header line, no separation line + 3 data lines
-        self.assertEqual(1 + 3, len(formatted.splitlines()))
+        assert len(formatted.splitlines()) == 1 + 3
 
 
-class ComparisonReporterTests(TestCase):
-    def setUp(self):
+class TestComparisonReporter:
+    def setup_method(self, method):
         config_mock = mock.Mock(config.Config)
         config_mock.opts.return_value = True
         self.reporter = reporter.ComparisonReporter(config_mock)
 
     def test_diff_percent_divide_by_zero(self):
         formatted = self.reporter._diff(0, 0, False, as_percentage=True)
-        self.assertEqual("0.00%", formatted)
+        assert formatted == "0.00%"
 
     def test_diff_percent_ignore_formatter(self):
         formatted = self.reporter._diff(1, 0, False, formatter=convert.factor(100.0), as_percentage=True)
-        self.assertEqual("-100.00%", formatted)
+        assert formatted == "-100.00%"

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -21,7 +21,6 @@ import logging
 import random
 import unittest.mock as mock
 from collections import namedtuple
-from unittest import TestCase
 from unittest.mock import call
 
 import elasticsearch
@@ -111,7 +110,7 @@ class MockTelemetryDevice(telemetry.InternalTelemetryDevice):
         return self.mock_java_opts
 
 
-class TelemetryTests(TestCase):
+class TestTelemetry:
     def test_merges_options_set_by_different_devices(self):
         cfg = config.Config()
         cfg.add(config.Scope.application, "telemetry", "devices", "jfr")
@@ -128,12 +127,10 @@ class TelemetryTests(TestCase):
 
         opts = t.instrument_candidate_java_opts()
 
-        self.assertIsNotNone(opts)
-        self.assertEqual(len(opts), 3)
-        self.assertEqual(["-Xms256M", "-Xmx512M", "-Des.network.host=127.0.0.1"], opts)
+        assert opts == ["-Xms256M", "-Xmx512M", "-Des.network.host=127.0.0.1"]
 
 
-class StartupTimeTests(TestCase):
+class TestStartupTime:
     @mock.patch("esrally.time.StopWatch")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
     def test_store_calculated_metrics(self, metrics_store_put_value, stop_watch):
@@ -227,135 +224,101 @@ class TransportClient:
             return self._response
 
 
-class JfrTests(TestCase):
+class TestJfr:
     def test_sets_options_for_pre_java_9_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(0, 8))
-        java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(
-            [
-                "-XX:+UnlockDiagnosticVMOptions",
-                "-XX:+DebugNonSafepoints",
-                "-XX:+UnlockCommercialFeatures",
-                "-XX:+FlightRecorder",
-                "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath=/var/log/test-recording.jfr",
-                "-XX:StartFlightRecording=defaultrecording=true",
-            ],
-            java_opts,
-        )
+        assert jfr.java_opts("/var/log/test-recording.jfr") == [
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+DebugNonSafepoints",
+            "-XX:+UnlockCommercialFeatures",
+            "-XX:+FlightRecorder",
+            "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath=/var/log/test-recording.jfr",
+            "-XX:StartFlightRecording=defaultrecording=true",
+        ]
 
     def test_sets_options_for_java_9_or_10_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(9, 10))
-        java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(
-            [
-                "-XX:+UnlockDiagnosticVMOptions",
-                "-XX:+DebugNonSafepoints",
-                "-XX:+UnlockCommercialFeatures",
-                "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr",
-            ],
-            java_opts,
-        )
+        assert jfr.java_opts("/var/log/test-recording.jfr") == [
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+DebugNonSafepoints",
+            "-XX:+UnlockCommercialFeatures",
+            "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr",
+        ]
 
     def test_sets_options_for_java_11_or_above_default_recording_template(self):
         jfr = telemetry.FlightRecorder(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(11, 999))
-        java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(
-            [
-                "-XX:+UnlockDiagnosticVMOptions",
-                "-XX:+DebugNonSafepoints",
-                "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr",
-            ],
-            java_opts,
-        )
+        assert jfr.java_opts("/var/log/test-recording.jfr") == [
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+DebugNonSafepoints",
+            "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename=/var/log/test-recording.jfr",
+        ]
 
     def test_sets_options_for_pre_java_9_custom_recording_template(self):
         jfr = telemetry.FlightRecorder(
             telemetry_params={"recording-template": "profile"}, log_root="/var/log", java_major_version=random.randint(0, 8)
         )
-        java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(
-            [
-                "-XX:+UnlockDiagnosticVMOptions",
-                "-XX:+DebugNonSafepoints",
-                "-XX:+UnlockCommercialFeatures",
-                "-XX:+FlightRecorder",
-                "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath=/var/log/test-recording.jfr",
-                "-XX:StartFlightRecording=defaultrecording=true,settings=profile",
-            ],
-            java_opts,
-        )
+        assert jfr.java_opts("/var/log/test-recording.jfr") == [
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+DebugNonSafepoints",
+            "-XX:+UnlockCommercialFeatures",
+            "-XX:+FlightRecorder",
+            "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath=/var/log/test-recording.jfr",
+            "-XX:StartFlightRecording=defaultrecording=true,settings=profile",
+        ]
 
     def test_sets_options_for_java_9_or_10_custom_recording_template(self):
         jfr = telemetry.FlightRecorder(
             telemetry_params={"recording-template": "profile"}, log_root="/var/log", java_major_version=random.randint(9, 10)
         )
-        java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(
-            [
-                "-XX:+UnlockDiagnosticVMOptions",
-                "-XX:+DebugNonSafepoints",
-                "-XX:+UnlockCommercialFeatures",
-                "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
-                "filename=/var/log/test-recording.jfr,settings=profile",
-            ],
-            java_opts,
-        )
+        assert jfr.java_opts("/var/log/test-recording.jfr") == [
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+DebugNonSafepoints",
+            "-XX:+UnlockCommercialFeatures",
+            "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
+            "filename=/var/log/test-recording.jfr,settings=profile",
+        ]
 
     def test_sets_options_for_java_11_or_above_custom_recording_template(self):
         jfr = telemetry.FlightRecorder(
             telemetry_params={"recording-template": "profile"}, log_root="/var/log", java_major_version=random.randint(11, 999)
         )
-        java_opts = jfr.java_opts("/var/log/test-recording.jfr")
-        self.assertEqual(
-            [
-                "-XX:+UnlockDiagnosticVMOptions",
-                "-XX:+DebugNonSafepoints",
-                "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
-                "filename=/var/log/test-recording.jfr,settings=profile",
-            ],
-            java_opts,
-        )
+        assert jfr.java_opts("/var/log/test-recording.jfr") == [
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+DebugNonSafepoints",
+            "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,"
+            "filename=/var/log/test-recording.jfr,settings=profile",
+        ]
 
 
-class GcTests(TestCase):
+class TestGc:
     def test_sets_options_for_pre_java_9(self):
         gc = telemetry.Gc(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(0, 8))
-        gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
-        self.assertEqual(7, len(gc_java_opts))
-        self.assertEqual(
-            [
-                "-Xloggc:/var/log/defaults-node-0.gc.log",
-                "-XX:+PrintGCDetails",
-                "-XX:+PrintGCDateStamps",
-                "-XX:+PrintGCTimeStamps",
-                "-XX:+PrintGCApplicationStoppedTime",
-                "-XX:+PrintGCApplicationConcurrentTime",
-                "-XX:+PrintTenuringDistribution",
-            ],
-            gc_java_opts,
-        )
+        assert gc.java_opts("/var/log/defaults-node-0.gc.log") == [
+            "-Xloggc:/var/log/defaults-node-0.gc.log",
+            "-XX:+PrintGCDetails",
+            "-XX:+PrintGCDateStamps",
+            "-XX:+PrintGCTimeStamps",
+            "-XX:+PrintGCApplicationStoppedTime",
+            "-XX:+PrintGCApplicationConcurrentTime",
+            "-XX:+PrintTenuringDistribution",
+        ]
 
     def test_sets_options_for_java_9_or_above(self):
         gc = telemetry.Gc(telemetry_params={}, log_root="/var/log", java_major_version=random.randint(9, 999))
-        gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
-        self.assertEqual(1, len(gc_java_opts))
-        self.assertEqual(
-            ["-Xlog:gc*=info,safepoint=info,age*=trace:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"],
-            gc_java_opts,
-        )
+        assert gc.java_opts("/var/log/defaults-node-0.gc.log") == [
+            "-Xlog:gc*=info,safepoint=info,age*=trace:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"
+        ]
 
     def test_can_override_options_for_java_9_or_above(self):
         gc = telemetry.Gc(
             telemetry_params={"gc-log-config": "gc,safepoint"}, log_root="/var/log", java_major_version=random.randint(9, 999)
         )
-        gc_java_opts = gc.java_opts("/var/log/defaults-node-0.gc.log")
-        self.assertEqual(1, len(gc_java_opts))
-        self.assertEqual(
-            ["-Xlog:gc,safepoint:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"], gc_java_opts
-        )
+        assert gc.java_opts("/var/log/defaults-node-0.gc.log") == [
+            "-Xlog:gc,safepoint:file=/var/log/defaults-node-0.gc.log:utctime,uptimemillis,level,tags:filecount=0"
+        ]
 
 
-class HeapdumpTests(TestCase):
+class TestHeapdump:
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_generates_heap_dump(self, run_subprocess_with_logging):
         run_subprocess_with_logging.return_value = 0
@@ -367,7 +330,7 @@ class HeapdumpTests(TestCase):
         run_subprocess_with_logging.assert_called_with("jmap -dump:format=b,file=/var/log/heap_at_exit_1234.hprof 1234")
 
 
-class SegmentStatsTests(TestCase):
+class TestSegmentStats:
     @mock.patch("elasticsearch.Elasticsearch")
     @mock.patch("builtins.open", new_callable=mock.mock_open)
     def test_generates_log_file(self, file_mock, es):
@@ -392,14 +355,14 @@ class SegmentStatsTests(TestCase):
         )
 
 
-class CcrStatsTests(TestCase):
+class TestCcrStats:
     def test_negative_sample_interval_forbidden(self):
         clients = {"default": Client(), "cluster_b": Client()}
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {"ccr-stats-sample-interval": -1 * random.random()}
-        with self.assertRaisesRegex(
-            exceptions.SystemSetupError, r"The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was .*\."
+        with pytest.raises(
+            exceptions.SystemSetupError, match=r"The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was .*\."
         ):
             telemetry.CcrStats(telemetry_params, clients, metrics_store)
 
@@ -413,25 +376,28 @@ class CcrStatsTests(TestCase):
                 "wrong_cluster_name": ["follower"],
             },
         }
-        with self.assertRaisesRegex(
+        client_keys = ",".join(sorted(clients.keys()))
+        with pytest.raises(
             exceptions.SystemSetupError,
-            r"The telemetry parameter 'ccr-stats-indices' must be a JSON Object with keys matching "
-            r"the cluster names \[{}] specified in --target-hosts "
-            r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys()))),
+            match=(
+                r"The telemetry parameter 'ccr-stats-indices' must be a JSON Object with keys matching "
+                rf"the cluster names \[{client_keys}] specified in --target-hosts "
+                r"but it had \[wrong_cluster_name\]."
+            ),
         ):
             telemetry.CcrStats(telemetry_params, clients, metrics_store)
 
 
-class CcrStatsRecorderTests(TestCase):
+class TestCcrStatsRecorder:
     java_signed_maxlong = (2**63) - 1
 
     def test_raises_exception_on_transport_error(self):
         client = Client(transport_client=TransportClient(response={}, force_error=True))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        with self.assertRaisesRegex(
+        with pytest.raises(
             exceptions.RallyError,
-            r"A transport error occurred while collecting CCR stats from the endpoint "
+            match=r"A transport error occurred while collecting CCR stats from the endpoint "
             r"\[/_ccr/stats\?filter_path=follow_stats\] on "
             r"cluster \[remote\]",
         ):
@@ -439,7 +405,7 @@ class CcrStatsRecorderTests(TestCase):
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_default_ccr_stats(self, metrics_store_put_doc):
-        java_signed_maxlong = CcrStatsRecorderTests.java_signed_maxlong
+        java_signed_maxlong = self.java_signed_maxlong
 
         shard_id = random.randint(0, 999)
         remote_cluster = "leader_cluster"
@@ -533,7 +499,7 @@ class CcrStatsRecorderTests(TestCase):
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_default_ccr_stats_many_shards(self, metrics_store_put_doc):
-        java_signed_maxlong = CcrStatsRecorderTests.java_signed_maxlong
+        java_signed_maxlong = self.java_signed_maxlong
 
         remote_cluster = "leader_cluster"
         leader_index = "leader"
@@ -644,7 +610,7 @@ class CcrStatsRecorderTests(TestCase):
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_filtered_ccr_stats(self, metrics_store_put_doc):
-        java_signed_maxlong = CcrStatsRecorderTests.java_signed_maxlong
+        java_signed_maxlong = self.java_signed_maxlong
 
         remote_cluster = "leader_cluster"
         leader_index1 = "leader1"
@@ -774,7 +740,7 @@ class CcrStatsRecorderTests(TestCase):
         )
 
 
-class RecoveryStatsTests(TestCase):
+class TestRecoveryStats:
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_no_metrics_if_no_pending_recoveries(self, metrics_store_put_doc):
         response = {}
@@ -786,7 +752,7 @@ class RecoveryStatsTests(TestCase):
         )
         recorder.record()
 
-        self.assertEqual(0, metrics_store_put_doc.call_count)
+        assert metrics_store_put_doc.call_count == 0
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_single_shard_stats(self, metrics_store_put_doc):
@@ -1000,7 +966,7 @@ class RecoveryStatsTests(TestCase):
         )
 
 
-class DataStreamStatsTests(TestCase):
+class TestDataStreamStats:
     def test_failure_if_feature_not_implemented_in_version(self):
         # Data Streams aren't available prior to 7.9
         clients = {"default": Client(info={"version": {"number": "7.6.0"}})}
@@ -1008,8 +974,9 @@ class DataStreamStatsTests(TestCase):
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {"data-stream-stats-sample-interval": random.randint(1, 100)}
         t = telemetry.DataStreamStats(telemetry_params, clients, metrics_store)
-        with self.assertRaisesRegex(
-            exceptions.SystemSetupError, r"The data-stream-stats telemetry device can only be used with clusters from version 7.9 onwards"
+        with pytest.raises(
+            exceptions.SystemSetupError,
+            match=r"The data-stream-stats telemetry device can only be used with clusters from version 7.9 onwards",
         ):
             t.on_benchmark_start()
 
@@ -1020,8 +987,9 @@ class DataStreamStatsTests(TestCase):
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {"data-stream-stats-sample-interval": random.randint(1, 100)}
         t = telemetry.DataStreamStats(telemetry_params, clients, metrics_store)
-        with self.assertRaisesRegex(
-            exceptions.SystemSetupError, r"The data-stream-stats telemetry device cannot be used with an OSS distribution of Elasticsearch"
+        with pytest.raises(
+            exceptions.SystemSetupError,
+            match=r"The data-stream-stats telemetry device cannot be used with an OSS distribution of Elasticsearch",
         ):
             t.on_benchmark_start()
 
@@ -1030,14 +998,14 @@ class DataStreamStatsTests(TestCase):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {"data-stream-stats-sample-interval": -1 * random.random()}
-        with self.assertRaisesRegex(
+        with pytest.raises(
             exceptions.SystemSetupError,
-            r"The telemetry parameter 'data-stream-stats-sample-interval' must be greater than zero but was .*\.",
+            match=r"The telemetry parameter 'data-stream-stats-sample-interval' must be greater than zero but was .*\.",
         ):
             telemetry.DataStreamStats(telemetry_params, clients, metrics_store)
 
 
-class DataStreamStatsRecorderTests(TestCase):
+class TestDataStreamStatsRecorder:
     data_streams_stats_response = {
         "_shards": {"total": 4, "successful": 2, "failed": 0},
         "data_stream_count": 2,
@@ -1121,10 +1089,10 @@ class DataStreamStatsRecorderTests(TestCase):
 
         # Given an empty list of 'data_streams' we should only be
         # sending a total of one metric document containing both the `_shards` and overall stats
-        self.assertEqual(1, metrics_store_put_doc.call_count)
+        assert metrics_store_put_doc.call_count == 1
 
 
-class ShardStatsTests(TestCase):
+class TestShardStats:
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_single_shard_stats(self, metrics_store_put_doc):
         node_stats_response = {
@@ -1776,7 +1744,7 @@ class TestSearchableSnapshotsStats:
         metrics_store_put_doc.assert_has_calls(expected_calls, any_order=True)
 
 
-class NodeStatsTests(TestCase):
+class TestNodeStats:
     warning = """You have enabled the node-stats telemetry device with Elasticsearch < 7.2.0. Requests to the
           _nodes/stats Elasticsearch endpoint trigger additional refreshes and WILL SKEW results.
     """
@@ -1792,7 +1760,7 @@ class NodeStatsTests(TestCase):
 
         with mock.patch.object(console, "warn") as mocked_console_warn:
             t.on_benchmark_start()
-        mocked_console_warn.assert_called_once_with(NodeStatsTests.warning, logger=t.logger)
+        mocked_console_warn.assert_called_once_with(self.warning, logger=t.logger)
 
     @mock.patch("esrally.telemetry.NodeStatsRecorder", mock.Mock())
     @mock.patch("esrally.telemetry.SamplerThread", mock.Mock())
@@ -1808,7 +1776,7 @@ class NodeStatsTests(TestCase):
         mocked_console_warn.assert_not_called()
 
 
-class NodeStatsRecorderTests(TestCase):
+class TestNodeStatsRecorder:
     node_stats_response = {
         "cluster_name": "elasticsearch",
         "nodes": {
@@ -2103,32 +2071,30 @@ class NodeStatsRecorderTests(TestCase):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {"node-stats-sample-interval": -1 * random.random()}
-        with self.assertRaisesRegex(
-            exceptions.SystemSetupError, r"The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was .*\."
+        with pytest.raises(
+            exceptions.SystemSetupError,
+            match=r"The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was .*\.",
         ):
             telemetry.NodeStatsRecorder(telemetry_params, cluster_name="default", client=client, metrics_store=metrics_store)
 
     def test_flatten_indices_fields(self):
-        client = Client(nodes=SubClient(stats=NodeStatsRecorderTests.node_stats_response))
+        client = Client(nodes=SubClient(stats=self.node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         flattened_fields = recorder.flatten_stats_fields(
             prefix="indices",
-            stats=NodeStatsRecorderTests.node_stats_response["nodes"]["Zbl_e8EyRXmiR47gbHgPfg"]["indices"],
+            stats=self.node_stats_response["nodes"]["Zbl_e8EyRXmiR47gbHgPfg"]["indices"],
         )
-        self.assertDictEqual(NodeStatsRecorderTests.indices_stats_response_flattened, flattened_fields)
+        assert self.indices_stats_response_flattened == flattened_fields
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     def test_stores_default_nodes_stats(self, metrics_store_put_doc):
-        client = Client(nodes=SubClient(stats=NodeStatsRecorderTests.node_stats_response))
+        client = Client(nodes=SubClient(stats=self.node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        node_name = [
-            NodeStatsRecorderTests.node_stats_response["nodes"][node]["name"]
-            for node in NodeStatsRecorderTests.node_stats_response["nodes"]
-        ][0]
+        node_name = [self.node_stats_response["nodes"][node]["name"] for node in self.node_stats_response["nodes"]][0]
         metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
 
         telemetry_params = {}
@@ -2137,7 +2103,7 @@ class NodeStatsRecorderTests(TestCase):
 
         expected_doc = collections.OrderedDict()
         expected_doc["name"] = "node-stats"
-        expected_doc.update(NodeStatsRecorderTests.default_stats_response_flattened)
+        expected_doc.update(self.default_stats_response_flattened)
 
         metrics_store_put_doc.assert_called_once_with(
             expected_doc, level=MetaInfoScope.node, node_name="rally0", meta_data=metrics_store_meta_data
@@ -2742,21 +2708,22 @@ class NodeStatsRecorderTests(TestCase):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {"node-stats-include-indices-metrics": {"bad": "input"}}
-        with self.assertRaisesRegex(
+        with pytest.raises(
             exceptions.SystemSetupError,
-            "The telemetry parameter 'node-stats-include-indices-metrics' must be a comma-separated string but was <class 'dict'>",
+            match="The telemetry parameter 'node-stats-include-indices-metrics' must be a comma-separated string but was <class 'dict'>",
         ):
             telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
 
 
-class TransformStatsTests(TestCase):
+class TestTransformStats:
     def test_negative_sample_interval_forbidden(self):
         clients = {"default": Client(), "cluster_b": Client()}
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {"transform-stats-sample-interval": -1 * random.random()}
-        with self.assertRaisesRegex(
-            exceptions.SystemSetupError, r"The telemetry parameter 'transform-stats-sample-interval' must be greater than zero but was .*\."
+        with pytest.raises(
+            exceptions.SystemSetupError,
+            match=r"The telemetry parameter 'transform-stats-sample-interval' must be greater than zero but was .*\.",
         ):
             telemetry.TransformStats(telemetry_params, clients, metrics_store)
 
@@ -2765,20 +2732,20 @@ class TransformStatsTests(TestCase):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {"transform-stats-transforms": {"default": ["leader"], "wrong_cluster_name": ["follower"]}}
-        with self.assertRaisesRegex(
+        with pytest.raises(
             exceptions.SystemSetupError,
-            r"The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys matching "
+            match=r"The telemetry parameter 'transform-stats-transforms' must be a JSON Object with keys matching "
             r"the cluster names \[{}] specified in --target-hosts "
             r"but it had \[wrong_cluster_name\].".format(",".join(sorted(clients.keys()))),
         ):
             telemetry.TransformStats(telemetry_params, clients, metrics_store)
 
 
-class TransformStatsRecorderTests(TestCase):
+class TestTransformStatsRecorder:
     transform_stats_response = {}
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         java_signed_maxlong = (2**63) - 1
         transform_id_prefix = "transform_job_"
         count = random.randrange(1, 10)
@@ -2815,11 +2782,11 @@ class TransformStatsRecorderTests(TestCase):
             }
             transforms.append(transform)
 
-        TransformStatsRecorderTests.transform_stats_response = {"count": count, "transforms": transforms}
+        cls.transform_stats_response = {"count": count, "transforms": transforms}
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     def test_stores_default_stats(self, metrics_store_put_value):
-        client = Client(transform=SubClient(transform_stats=TransformStatsRecorderTests.transform_stats_response))
+        client = Client(transform=SubClient(transform_stats=self.transform_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         recorder = telemetry.TransformStatsRecorder(
@@ -2847,7 +2814,7 @@ class TransformStatsRecorderTests(TestCase):
         )
 
 
-class ClusterEnvironmentInfoTests(TestCase):
+class TestClusterEnvironmentInfo:
     @mock.patch("esrally.metrics.EsMetricsStore.add_meta_info")
     def test_stores_cluster_level_metrics_on_attach(self, metrics_store_add_meta_info):
         nodes_info = {"nodes": collections.OrderedDict()}
@@ -2942,10 +2909,10 @@ class ClusterEnvironmentInfoTests(TestCase):
         t = telemetry.Telemetry(cfg, devices=[env_device])
         t.on_benchmark_start()
 
-        self.assertEqual(0, metrics_store_add_meta_info.call_count)
+        assert metrics_store_add_meta_info.call_count == 0
 
 
-class NodeEnvironmentInfoTests(TestCase):
+class TestNodeEnvironmentInfo:
     @mock.patch("esrally.metrics.EsMetricsStore.add_meta_info")
     @mock.patch("esrally.utils.sysstats.os_name")
     @mock.patch("esrally.utils.sysstats.os_version")
@@ -2979,8 +2946,8 @@ class NodeEnvironmentInfoTests(TestCase):
         metrics_store_add_meta_info.assert_has_calls(calls)
 
 
-class ExternalEnvironmentInfoTests(TestCase):
-    def setUp(self):
+class TestExternalEnvironmentInfo:
+    def setup_method(self, method):
         self.cfg = create_config()
 
     @mock.patch("esrally.metrics.EsMetricsStore.add_meta_info")
@@ -3101,10 +3068,10 @@ class ExternalEnvironmentInfoTests(TestCase):
         t = telemetry.Telemetry(self.cfg, devices=[env_device])
         t.on_benchmark_start()
 
-        self.assertEqual(0, metrics_store_add_meta_info.call_count)
+        assert metrics_store_add_meta_info.call_count == 0
 
 
-class DiskIoTests(TestCase):
+class TestDiskIo:
     @mock.patch("esrally.utils.sysstats.process_io_counters")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
     def test_diskio_process_io_counters(self, metrics_store_node_count, process_io_counters):
@@ -3199,7 +3166,7 @@ class DiskIoTests(TestCase):
         )
 
 
-class JvmStatsSummaryTests(TestCase):
+class TestJvmStatsSummary:
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
@@ -3320,7 +3287,7 @@ class JvmStatsSummaryTests(TestCase):
         )
 
 
-class IndexStatsTests(TestCase):
+class TestIndexStats:
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     def test_stores_available_index_stats(self, metrics_store_cluster_value, metrics_store_put_doc):
@@ -3580,7 +3547,7 @@ class IndexStatsTests(TestCase):
         )
 
 
-class MlBucketProcessingTimeTests(TestCase):
+class TestMlBucketProcessingTime:
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("elasticsearch.Elasticsearch")
     def test_error_on_retrieval_does_not_store_metrics(self, es, metrics_store_put_doc):
@@ -3591,7 +3558,7 @@ class MlBucketProcessingTimeTests(TestCase):
         t = telemetry.Telemetry(cfg, devices=[device])
         t.on_benchmark_stop()
 
-        self.assertEqual(0, metrics_store_put_doc.call_count)
+        assert metrics_store_put_doc.call_count == 0
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("elasticsearch.Elasticsearch")
@@ -3609,7 +3576,7 @@ class MlBucketProcessingTimeTests(TestCase):
         t = telemetry.Telemetry(cfg, devices=[device])
         t.on_benchmark_stop()
 
-        self.assertEqual(0, metrics_store_put_doc.call_count)
+        assert metrics_store_put_doc.call_count == 0
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("elasticsearch.Elasticsearch")
@@ -3675,7 +3642,7 @@ class MlBucketProcessingTimeTests(TestCase):
         )
 
 
-class IndexSizeTests(TestCase):
+class TestIndexSize:
     @mock.patch("esrally.utils.io.get_size")
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
     def test_stores_index_size_for_data_paths(self, metrics_store_node_value, get_size):
@@ -3716,24 +3683,24 @@ class IndexSizeTests(TestCase):
         t.detach_from_node(node, running=False)
         t.store_system_metrics(node, metrics_store)
 
-        self.assertEqual(0, run_subprocess.call_count)
-        self.assertEqual(0, metrics_store_cluster_value.call_count)
-        self.assertEqual(0, get_size.call_count)
+        assert run_subprocess.call_count == 0
+        assert metrics_store_cluster_value.call_count == 0
+        assert get_size.call_count == 0
 
 
-class MasterNodeStatsTests(TestCase):
+class TestMasterNodeStats:
     def test_negative_sample_interval_forbidden(self):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         telemetry_params = {"master-node-stats-sample-interval": -1}
-        with self.assertRaisesRegex(
+        with pytest.raises(
             exceptions.SystemSetupError,
-            r"The telemetry parameter 'master-node-stats-sample-interval' must be greater than zero but was .*\.",
+            match=r"The telemetry parameter 'master-node-stats-sample-interval' must be greater than zero but was .*\.",
         ):
             telemetry.MasterNodeStats(telemetry_params, Client(), metrics_store)
 
 
-class MasterNodeStatsRecorderTests(TestCase):
+class TestMasterNodeStatsRecorder:
     master_node_state_response = {
         "master_node": "12345",
     }
@@ -3770,7 +3737,7 @@ class MasterNodeStatsRecorderTests(TestCase):
         )
 
 
-class IngestPipelineStatsTests(TestCase):
+class TestIngestPipelineStats:
 
     ingest_pipeline_stats_start_response = {
         "_nodes": {"total": 1, "successful": 1, "failed": 0},
@@ -3898,8 +3865,8 @@ class IngestPipelineStatsTests(TestCase):
         t.on_benchmark_start()
         t.on_benchmark_stop()
 
-        self.assertEqual(0, metrics_store_cluster_level.call_count)
-        self.assertEqual(0, metrics_store_node_level.call_count)
+        assert metrics_store_cluster_level.call_count == 0
+        assert metrics_store_node_level.call_count == 0
 
     def _assert_node_level_calls(self, metrics_store_node_level, *, value):
         metrics_store_node_level.assert_has_calls(

--- a/tests/test_async_connection.py
+++ b/tests/test_async_connection.py
@@ -16,12 +16,11 @@
 # under the License.
 
 import json
-from unittest import TestCase
 
 from esrally.async_connection import ResponseMatcher
 
 
-class ResponseMatcherTests(TestCase):
+class TestResponseMatcher:
     def test_matches(self):
         matcher = ResponseMatcher(
             responses=[
@@ -49,4 +48,4 @@ class ResponseMatcherTests(TestCase):
 
     def assert_response_type(self, matcher, path, expected_response_type):
         response = json.loads(matcher.response(path))
-        self.assertEqual(response["response-type"], expected_response_type)
+        assert response["response-type"] == expected_response_type

--- a/tests/time_test.py
+++ b/tests/time_test.py
@@ -16,12 +16,11 @@
 # under the License.
 
 import time
-from unittest import TestCase
 
 import esrally.time
 
 
-class TimeTests(TestCase):
+class TestTime:
     def test_split_time_increases(self):
         wait_period_seconds = 0.05
 
@@ -31,11 +30,11 @@ class TimeTests(TestCase):
         for _ in range(3):
             time.sleep(wait_period_seconds)
             split_time = stop_watch.split_time()
-            self.assertLess(prev_split_time, split_time)
+            assert prev_split_time < split_time
             prev_split_time = split_time
         stop_watch.stop()
         total_time = stop_watch.total_time()
-        self.assertLessEqual(prev_split_time, total_time)
+        assert prev_split_time <= total_time
 
     def test_total_time_roughly_in_expected_range(self):
         wait_period_seconds = 0.05
@@ -48,8 +47,8 @@ class TimeTests(TestCase):
 
         interval = stop_watch.total_time()
         # depending on scheduling accuracy we should end up somewhere in that range
-        self.assertGreaterEqual(interval, wait_period_seconds - acceptable_delta_seconds)
-        self.assertLessEqual(interval, wait_period_seconds + acceptable_delta_seconds)
+        assert interval >= wait_period_seconds - acceptable_delta_seconds
+        assert interval <= wait_period_seconds + acceptable_delta_seconds
 
     def test_millis_conversion_roughly_in_expected_range(self):
         wait_period_millis = 50
@@ -62,5 +61,5 @@ class TimeTests(TestCase):
         interval_millis = end - start
 
         # depending on scheduling accuracy we should end up somewhere in that range
-        self.assertGreaterEqual(interval_millis, wait_period_millis - acceptable_delta_millis)
-        self.assertLessEqual(interval_millis, wait_period_millis + acceptable_delta_millis)
+        assert interval_millis >= wait_period_millis - acceptable_delta_millis
+        assert interval_millis <= wait_period_millis + acceptable_delta_millis

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -951,6 +951,10 @@ class TestTemplateSource:
         assert response == expected_response
 
 
+def assert_equal_ignore_whitespace(expected, actual):
+    assert strip_ws(expected) == strip_ws(actual)
+
+
 class TestTemplateRender:
     unittest_template_internal_vars = loader.default_internal_template_vars(clock=StaticClock)
 
@@ -1034,7 +1038,7 @@ class TestTemplateRender:
 
         }
         """
-        self.assertEqualIgnoreWhitespace(expected, rendered)
+        assert_equal_ignore_whitespace(expected, rendered)
 
     def test_render_template_with_variables(self):
         template = """
@@ -1058,10 +1062,7 @@ class TestTemplateRender:
             "dkey2": 100
         }
         """
-        self.assertEqualIgnoreWhitespace(expected, rendered)
-
-    def assertEqualIgnoreWhitespace(self, expected, actual):
-        assert strip_ws(expected) == strip_ws(actual)
+        assert_equal_ignore_whitespace(expected, rendered)
 
 
 class TestCompleteTrackParams:


### PR DESCRIPTION
This is the last PR after https://github.com/elastic/rally/pull/1387, https://github.com/elastic/rally/pull/142, https://github.com/elastic/rally/pull/1426 and #1439. When this and #1439 have been merged, then we won't be using TestCase anymore, which means the test will be much more readable.