### PR TITLE
Stop leading users away from finding errors in docs

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -215,7 +215,7 @@ This behavior can also be changed, by invoking Rally with the :ref:`--on-error <
 
 	esrally race --track=geonames --on-error=abort
 	
-Errors can also be investigated if you have configured a :doc:`dedicated Elasticsearch metrics store </configuration>`.
+Errors can also be investigated: this is what the next section is about.
 
 Checking Queries and Responses
 ------------------------------

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -215,8 +215,6 @@ This behavior can also be changed, by invoking Rally with the :ref:`--on-error <
 
 	esrally race --track=geonames --on-error=abort
 	
-Errors can also be investigated: this is what the next section is about.
-
 Checking Queries and Responses
 ------------------------------
 


### PR DESCRIPTION
There's a link to the metrics store page below and the first part of the
section does not need a metrics store. This confused me multiple times.