### PR TITLE
Add "revisions" chart type to chart generator

### DIFF
--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -1513,13 +1513,12 @@ def generate_merge_count(chart_type, race_configs, environment):
 def generate_revisions(chart_type, race_configs, environment):
     structures = []
     for race_config in race_configs:
-        if "revisions" in race_config.charts:
-            title = chart_type.format_title(
-                environment, race_config.track, es_license=race_config.es_license, suffix=f"{race_config.label}-revisions"
-            )
-            chart = chart_type.revisions_table(title, environment, race_config)
-            if chart is not None:
-                structures.append(chart)
+        title = chart_type.format_title(
+            environment, race_config.track, es_license=race_config.es_license, suffix=f"{race_config.label}-revisions"
+        )
+        chart = chart_type.revisions_table(title, environment, race_config)
+        if chart is not None:
+            structures.append(chart)
 
     return structures
 

--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -1356,7 +1356,7 @@ class TimeSeriesCharts:
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": json.dumps(
                         {
-                            "index": "13969350-badf-11ea-af86-7d06bde52cfd",
+                            "index": "rally-races-*",
                             "query": {
                                 "query_string": {
                                     "query": f'environment:"{environment}"'

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ develop_require = [
     "wheel==0.33.6",
     "github3.py==1.3.0",
     "pylint==2.6.0",
-    "black==22.1.0",
+    "black==22.3.0",
     "isort==5.8.0",
 ]
 


### PR DESCRIPTION
Adds the ability to generate dashboards with a revisions table. E.g. given the race config

```
[
  {
    "track": "sql",
    "placement": 1,
    "flavors": [
      {
        "name": "default",
        "licenses": [
          {
            "name": "trial",
            "configurations": [
              {
                "name": "sql-1node",
                "label": "sql",
                "charts": [
                  "query",
                  "gc",
                  "io",
                  "revisions"
                ],
                "challenge": "sql",
                "car": "4gheap",
                "x-pack": [
                  "security"
                ]
              }
            ]
          }
        ]
      }
    ]
  }
]
```

the command `esrally generate charts --configuration-name=nightly --chart-spec-path=../night-rally/night_rally/resources/race-configs-group-2.json --chart-type=time-series --output-path=../nightly-sql.ndjson` will produce a dashboard with the following table:

<img width="888" alt="image" src="https://user-images.githubusercontent.com/1016746/156387649-f2e62f95-634a-4060-bc8b-37d024a5ded3.png">

The `BarCharts` chart type could in theory use the same implementation for the revisions table. But since bar charts are used for comparing releases, the revision table is not particularly helpful in these dashboards.