### PR TITLE
Default disk-usage-stats telemetry indices

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -290,9 +290,9 @@ disk-usage-stats
 
 The disk-usage-stats telemetry device runs the `_disk_usage <https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-disk-usage.html>`_ API after the track has completed and adds the disk used of each field to the report.
 
-Required telemetry parameters:
+Supported telemetry parameters:
 
-* ``disk-usage-stats-indices``: Comma separated list of indices who's disk usage to fetch.
+* ``disk-usage-stats-indices`` (default all indices in the track): Comma separated list of indices who's disk usage to fetch.
 
 Example::
 

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -588,7 +588,7 @@ class Driver:
             es[cluster_name] = self.es_client_factory(cluster_hosts, cluster_client_options).create()
         return es
 
-    def prepare_telemetry(self, es, enable):
+    def prepare_telemetry(self, es, enable, index_names):
         enabled_devices = self.config.opts("telemetry", "devices")
         telemetry_params = self.config.opts("telemetry", "params")
         log_root = paths.race_root(self.config)
@@ -612,7 +612,7 @@ class Driver:
                 telemetry.SearchableSnapshotsStats(telemetry_params, es, self.metrics_store),
                 telemetry.DataStreamStats(telemetry_params, es, self.metrics_store),
                 telemetry.IngestPipelineStats(es, self.metrics_store),
-                telemetry.DiskUsageStats(telemetry_params, es_default, self.metrics_store),
+                telemetry.DiskUsageStats(telemetry_params, es_default, self.metrics_store, index_names),
             ]
         else:
             devices = []
@@ -659,7 +659,7 @@ class Driver:
 
         # Avoid issuing any requests to the target cluster when static responses are enabled. The results
         # are not useful and attempts to connect to a non-existing cluster just lead to exception traces in logs.
-        self.prepare_telemetry(es_clients, enable=not uses_static_responses)
+        self.prepare_telemetry(es_clients, enable=not uses_static_responses, index_names=self.track.index_names())
 
         for host in self.config.opts("driver", "load_driver_hosts"):
             host_config = {

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -530,6 +530,9 @@ class Track:
                 return None
         return size
 
+    def index_names(self):
+        return [i.name for i in self.indices]
+
     def __str__(self):
         return self.name
 

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -74,6 +74,17 @@ class TestTrack:
 
         assert exc.value.args[0] == "Unknown challenge [unknown-name] for track [unittest]"
 
+    def test_index_names(self):
+        idx1 = track.Index(name="foo")
+        idx2 = track.Index(name="bar")
+        assert ["foo", "bar"] == (
+            track.Track(
+                name="unittest",
+                description="unittest track",
+                indices=[idx1, idx2],
+            ).index_names()
+        )
+
 
 class TestIndex:
     def test_matches_exactly(self):

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -77,13 +77,8 @@ class TestTrack:
     def test_index_names(self):
         idx1 = track.Index(name="foo")
         idx2 = track.Index(name="bar")
-        assert ["foo", "bar"] == (
-            track.Track(
-                name="unittest",
-                description="unittest track",
-                indices=[idx1, idx2],
-            ).index_names()
-        )
+        track_ = track.Track(name="unittest", description="unittest track", indices=[idx1, idx2])
+        assert track_.index_names() == ["foo", "bar"]
 
 
 class TestIndex:


### PR DESCRIPTION
When I made the `disk-usage-stats` telemetry device in #1428 there
wasn't a way to use have it collect telemetry from the indices defined
in `track.json`. This adds such a way.
