### PR TITLE
Add `use-create` option to fail dups

### DIFF
--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1355,6 +1355,7 @@ class TestBulkDataGenerator:
             on_conflict=None,
             recency=None,
             pipeline=None,
+            use_create=False,
             original_params={"my-custom-parameter": "foo", "my-custom-parameter-2": True},
             create_reader=self.create_test_reader([["1", "2", "3", "4", "5"], ["6", "7", "8"]]),
         )
@@ -1426,6 +1427,7 @@ class TestBulkDataGenerator:
             on_conflict=None,
             recency=None,
             pipeline=None,
+            use_create=False,
             original_params={"my-custom-parameter": "foo", "my-custom-parameter-2": True},
             create_reader=self.create_test_reader([["1", "2", "3", "4", "5"]]),
         )
@@ -1489,6 +1491,7 @@ class TestBulkDataGenerator:
             on_conflict=None,
             recency=None,
             pipeline=None,
+            use_create=False,
             original_params={"body": "foo", "custom-param": "bar"},
             create_reader=self.create_test_reader([["1", "2", "3"]]),
         )


### PR DESCRIPTION
This adds an option to the `bulk` operation to force using
Elasticsearch's `create` operation instead of `index` operation. We
already were sending this operation when indexing into data streams. But
this gives us the option when indexing into regular indices as well.

<!--
Thank you for your interest in and contributing to Rally! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

* Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
* Have you followed the [contributor guidelines](https://github.com/elastic/rally/blob/master/CONTRIBUTING.md)?
* Have you run `make check-all` successfully?
* Did you choose a [descriptive title and description](https://chris.beams.io/posts/git-commit/) for your PR?
* (Only for maintainers) Did you apply appropriate labels and a milestone?
