### PR TITLE
Add disk usage chart

### DIFF
--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -1082,6 +1082,7 @@ class TimeSeriesCharts:
                 "kibanaSavedObjectMeta": {"searchSourceJSON": '{"query":"*","filter":[]}'},
             },
         }
+
     @staticmethod
     def query(environment, race_config, q, iterations):
         metric = "latency"
@@ -1463,7 +1464,6 @@ def generate_disk_usage(chart_type, race_configs, environment):
             structures.append(chart_type.disk_usage(title, environment, race_config))
 
     return structures
-
 
 
 def generate_gc(chart_type, race_configs, environment):

--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -1055,7 +1055,7 @@ class TimeSeriesCharts:
                         "fields": "message",
                         "template": "{{message}}",
                         "index_pattern": "rally-annotations",
-                        "query_string": f'((NOT _exists_:track) OR track:"{race_config.track}") AND ((NOT _exists_:chart) OR chart:io) '
+                        "query_string": f'((NOT _exists_:track) OR track:"{race_config.track}") AND ((NOT _exists_:chart) OR chart:disk_usage) '
                         f'AND ((NOT _exists_:chart-name) OR chart-name:"{title}") AND environment:"{environment}"',
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
@@ -1077,7 +1077,7 @@ class TimeSeriesCharts:
                 "title": title,
                 "visState": json.dumps(vis_state),
                 "uiStateJSON": "{}",
-                "description": "io",
+                "description": "per field disk usage",
                 "version": 1,
                 "kibanaSavedObjectMeta": {"searchSourceJSON": '{"query":"*","filter":[]}'},
             },

--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -1010,6 +1010,7 @@ class TimeSeriesCharts:
     @staticmethod
     def disk_usage(title, environment, race_config):
         env_filter = TimeSeriesCharts.filter_string(environment, race_config)
+        annotations_query = f'((NOT _exists_:track) OR track:"{race_config.track}") AND ((NOT _exists_:chart) OR chart:disk_usage)'
         vis_state = {
             "title": title,
             "type": "metrics",
@@ -1055,8 +1056,7 @@ class TimeSeriesCharts:
                         "fields": "message",
                         "template": "{{message}}",
                         "index_pattern": "rally-annotations",
-                        "query_string": f'((NOT _exists_:track) OR track:"{race_config.track}") AND ((NOT _exists_:chart) OR chart:disk_usage) '
-                        f'AND ((NOT _exists_:chart-name) OR chart-name:"{title}") AND environment:"{environment}"',
+                        "query_string": annotations_query,
                         "id": str(uuid.uuid4()),
                         "color": "rgba(102,102,102,1)",
                         "time_field": "race-timestamp",


### PR DESCRIPTION
This teaches rally how to build per-field disk usage charts based on the
`disk-usage-stats` telemetry device.
