### PR TITLE
Add 'root' attribute to Track class

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1122,6 +1122,7 @@ class TrackSpecificationReader:
 
     def __init__(self, track_params=None, complete_track_params=None, selected_challenge=None, source=io.FileSource):
         self.name = None
+        self.base_path = None
         self.track_params = track_params if track_params else {}
         self.complete_track_params = complete_track_params
         self.selected_challenge = selected_challenge

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1036,7 +1036,7 @@ class TrackFileReader:
                 )
             )
 
-        current_track = self.read_track(track_name, track_spec, mapping_dir)
+        current_track = self.read_track(track_name, track_spec, mapping_dir, track_spec_file)
 
         unused_user_defined_track_params = self.complete_track_params.unused_user_defined_track_params()
         if len(unused_user_defined_track_params) > 0:
@@ -1128,8 +1128,9 @@ class TrackSpecificationReader:
         self.source = source
         self.logger = logging.getLogger(__name__)
 
-    def __call__(self, track_name, track_specification, mapping_dir):
+    def __call__(self, track_name, track_specification, mapping_dir, spec_file=None):
         self.name = track_name
+        self.base_path = os.path.dirname(os.path.abspath(spec_file)) if spec_file else None
         description = self._r(track_specification, "description", mandatory=False, default_value="")
 
         meta_data = self._r(track_specification, "meta", mandatory=False)
@@ -1168,6 +1169,7 @@ class TrackSpecificationReader:
             composable_templates=composable_templates,
             component_templates=component_templates,
             corpora=corpora,
+            root=self.base_path,
         )
 
     def _error(self, msg):

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -434,6 +434,7 @@ class Track:
         component_templates=None,
         corpora=None,
         has_plugins=False,
+        root=None,
     ):
         """
 
@@ -449,6 +450,7 @@ class Track:
         :param templates: A list of index templates for this track. May be None.
         :param corpora: A list of document corpus definitions for this track. May be None.
         :param has_plugins: True iff the track also defines plugins (e.g. custom runners or parameter sources).
+        :param root: The absolute path to the directory containing the track file(s).
         """
         self.name = name
         self.meta_data = meta_data if meta_data else {}
@@ -461,6 +463,7 @@ class Track:
         self.composable_templates = composable_templates if composable_templates else []
         self.component_templates = component_templates if component_templates else []
         self.has_plugins = has_plugins
+        self.root = root
 
     @property
     def default_challenge(self):


### PR DESCRIPTION
This change adds a `root` attribute to the Track class, in order to provide an absolute path to original track files to any consumers, such as custom parameter sources.