### PR TITLE
Support refresh-timeout (and other kwargs) for Refresh

### DIFF
--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -6207,3 +6207,22 @@ class TestRemovePrefix:
         suffix = runner.remove_prefix(index_name, "unrelatedprefix")
 
         assert index_name == suffix
+
+class TestRefreshRunner:
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_refresh_with_defaults(self, es):
+        es.indices.refresh = mock.AsyncMock()
+        refresh = runner.Refresh()
+        await refresh(es, params={"index": "_all"})
+
+        es.indices.refresh.assert_awaited_once_with(index="_all")
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @run_async
+    async def test_refresh_request_timeout(self, es):
+        es.indices.refresh = mock.AsyncMock()
+        refresh = runner.Refresh()
+        await refresh(es, params={"index": "_all", "request-timeout": 50000})
+
+        es.indices.refresh.assert_awaited_once_with(index="_all", request_timeout=50000)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -6208,6 +6208,7 @@ class TestRemovePrefix:
 
         assert index_name == suffix
 
+
 class TestRefreshRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async


### PR DESCRIPTION
Add support for `request-timeout` and other kw params
for Refresh. This is something we already document as
supported for all operations and Refresh is missing it.

We also harmonize the variable name to the same
convention used in the runner module.
