### PR TITLE
Make online detection more resilient

### DIFF
--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -261,7 +261,7 @@ def has_internet_connection(probing_url):
         logger.debug("Checking for internet connection against [%s]", probing_url)
         # We do a HTTP request here to respect the HTTP proxy setting. If we'd open a plain socket connection we circumvent the
         # proxy and erroneously conclude we don't have an Internet connection.
-        response = __http().request("GET", probing_url, timeout=2.0, retries=10)
+        response = __http().request("GET", probing_url, timeout=10.0, retries=8)  # wait up to 90s, 9 requests in total
         status = response.status
         logger.debug("Probing result is HTTP status [%s]", str(status))
         return status == 200

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -261,14 +261,14 @@ def has_internet_connection(probing_url):
         logger.debug("Checking for internet connection against [%s]", probing_url)
         # We do a HTTP request here to respect the HTTP proxy setting. If we'd open a plain socket connection we circumvent the
         # proxy and erroneously conclude we don't have an Internet connection.
-        response = __http().request("GET", probing_url, timeout=2.0)
+        response = __http().request("GET", probing_url, timeout=2.0, retries=10)
         status = response.status
         logger.debug("Probing result is HTTP status [%s]", str(status))
         return status == 200
     except KeyboardInterrupt:
         raise
     except BaseException:
-        logger.debug("Could not detect a working Internet connection", exc_info=True)
+        logger.info("Could not detect a working Internet connection", exc_info=True)
         return False
 
 


### PR DESCRIPTION
Rally at a very early startup phase determines whether it has internet
access[^1]. Offline is not a terminal event, it just puts itself in the
offline mode and assumes users have been following the offline
install instructions[^2].

This commit makes the check more resilient to transient network errors,
by increasing retries from the (default 3) to 10. It also logs the error
with the default logging settings, to ease troubleshooting.

[^1]: https://github.com/elastic/rally/blob/1b3e656cf95fe2ee57d291d86cfcddcec09c6c3f/esrally/rally.py#L1054
[^2]: https://esrally.readthedocs.io/en/stable/install.html?highlight=offline#offline-install
