### PR TITLE
Introduce field-caps operation-type

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2972,7 +2972,7 @@ Retrieve `the capabilities of fields among indices <https://www.elastic.co/guide
 Properties
 """"""""""
 
-* ``index`` (optional, defaults to ``_all``): An `index pattern <https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#api-multi-index>`_ that defines which indices should be targeted by this operation.
+* ``index`` (optional, defaults to ``_all``): An `index pattern <https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html>`_ that defines which indices should be targeted by this operation.
 * ``fields`` (optional, default to ``*``): Comma-separated list of fields to retrieve capabilities for.
 * ``index_filter`` (optional): An index_filter to limit this operation to target only indices that match this index_filter
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2533,12 +2533,16 @@ Properties
 
 The ``composite`` operation only supports the following operation-types:
 
+* ``open-point-in-time``
+* ``close-point-in-time``
+* ``search``
+* ``paginated-search``
 * ``raw-request``
 * ``sleep``
-* ``search``
 * ``submit-async-search``
 * ``get-async-search``
 * ``delete-async-search``
+* ``field-caps``
 
 **Examples**
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2978,7 +2978,7 @@ Properties
 
 **Example**
 
-Retrieve the capabilities of fields starting with `message` of the `log-*` indices::
+Retrieve the capabilities of fields starting with ``message`` of the ``log-*`` indices::
 
     {
       "operation": {

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2972,7 +2972,7 @@ Retrieve `the capabilities of fields among indices <https://www.elastic.co/guide
 Properties
 """"""""""
 
-* ``index`` (optional, defaults to `_all`): An `index pattern <https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html>`_ that defines which indices should be targeted by this operation.
+* ``index`` (optional, defaults to ``_all``): An `index pattern <https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#api-multi-index>`_ that defines which indices should be targeted by this operation.
 * ``fields`` (optional, default to ``*``): Comma-separated list of fields to retrieve capabilities for.
 * ``index_filter`` (optional): An index_filter to limit this operation to target only indices that match this index_filter
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2973,7 +2973,7 @@ Properties
 """"""""""
 
 * ``index`` (optional, defaults to `_all`): An `index pattern <https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html>`_ that defines which indices should be targeted by this operation.
-* ``fields`` (optional, default to `*`): Comma-separated list of fields to retrieve capabilities for.
+* ``fields`` (optional, default to ``*``): Comma-separated list of fields to retrieve capabilities for.
 * ``index_filter`` (optional): An index_filter to limit this operation to target only indices that match this index_filter
 
 **Example**

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2964,6 +2964,41 @@ The following meta data is always returned:
 * ``weight``: The number of fetched pages. Should always equal to the ``pages`` parameter.
 * ``unit``: The unit in which to interpret ``weight``. Always "ops".
 
+field-caps
+~~~~~~~~~~~~~~~~~~~
+
+Retrieve `the capabilities of fields among indices. <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-field-caps.html>`_.
+
+Properties
+""""""""""
+
+* ``index`` (optional, defaults to `_all`): An `index pattern <https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html>`_ that defines which indices should be targeted by this operation.
+* ``fields`` (optional, default to `*`): Comma-separated list of fields to retrieve capabilities for.
+* ``index_filter`` (optional): An index_filter to limit this operation to target only indices that match this index_filter
+
+**Example**
+
+Retrieve the capabilities of fields starting with `message` of the `log-*` indices::
+
+    {
+      "operation": {
+        "operation-type": "field-caps",
+        "name": "field-caps-logs-indices",
+        "index": "log-*",
+        "fields": "message*"
+      },
+      "target-throughput": 10,
+      "clients": 2,
+      "warmup-iterations": 50,
+      "iterations": 100
+    }
+
+
+Meta-data
+"""""""""
+
+The operation returns no meta-data.
+
 
 .. _track_dependencies:
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2967,7 +2967,7 @@ The following meta data is always returned:
 field-caps
 ~~~~~~~~~~~~~~~~~~~
 
-Retrieve `the capabilities of fields among indices. <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-field-caps.html>`_.
+Retrieve `the capabilities of fields among indices <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-field-caps.html>`_.
 
 Properties
 """"""""""

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -57,6 +57,8 @@ def register_default_runners():
     register_runner(track.OperationType.OpenPointInTime, OpenPointInTime(), async_runner=True)
     register_runner(track.OperationType.ClosePointInTime, ClosePointInTime(), async_runner=True)
     register_runner(track.OperationType.Sql, Sql(), async_runner=True)
+    register_runner(track.OperationType.FieldCaps, FieldCaps(), async_runner=True)
+
 
     # This is an administrative operation but there is no need for a retry here as we don't issue a request
     register_runner(track.OperationType.Sleep, Sleep(), async_runner=True)
@@ -2481,6 +2483,25 @@ class Sql(Runner):
     def __repr__(self, *args, **kwargs):
         return "sql"
 
+
+class FieldCaps(Runner):
+    """
+    Retrieve `the capabilities of fields among indices.
+    <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-field-caps.html>` _.
+    """
+
+    async def __call__(self, es, params):
+        index = params.get("index", "_all")
+        fields = params.get("fields", "*")
+        body = params.get("body", {})
+        index_filter = params.get("index_filter")
+        if index_filter:
+            body["index_filter"] = index_filter
+        request_params = params.get("request-params")
+        await es.field_caps(index=index, body=body, fields=fields, params=request_params)
+
+    def __repr__(self, *args, **kwargs):
+        return "field-caps"
 
 class RequestTiming(Runner, Delegator):
     def __init__(self, delegate):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2499,8 +2499,9 @@ class FieldCaps(Runner):
             body["index_filter"] = index_filter
         request_params = params.get("request-params")
         await es.field_caps(index=index, body=body, fields=fields, params=request_params)
-        
+
         return {"weight": 1, "unit": "ops", "success": True}
+
     def __repr__(self, *args, **kwargs):
         return "field-caps"
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2344,6 +2344,7 @@ class Composite(Runner):
             "submit-async-search",
             "get-async-search",
             "delete-async-search",
+            "field-caps",
         ]
 
     async def run_stream(self, es, stream, connection_limit):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2499,7 +2499,8 @@ class FieldCaps(Runner):
             body["index_filter"] = index_filter
         request_params = params.get("request-params")
         await es.field_caps(index=index, body=body, fields=fields, params=request_params)
-
+        
+        return {"weight": 1, "unit": "ops", "success": True}
     def __repr__(self, *args, **kwargs):
         return "field-caps"
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -59,7 +59,6 @@ def register_default_runners():
     register_runner(track.OperationType.Sql, Sql(), async_runner=True)
     register_runner(track.OperationType.FieldCaps, FieldCaps(), async_runner=True)
 
-
     # This is an administrative operation but there is no need for a retry here as we don't issue a request
     register_runner(track.OperationType.Sleep, Sleep(), async_runner=True)
     # these requests should not be retried as they are not idempotent
@@ -2502,6 +2501,7 @@ class FieldCaps(Runner):
 
     def __repr__(self, *args, **kwargs):
         return "field-caps"
+
 
 class RequestTiming(Runner, Delegator):
     def __init__(self, delegate):

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -684,6 +684,7 @@ class OperationType(Enum):
     OpenPointInTime = 14
     ClosePointInTime = 15
     Sql = 16
+    FieldCaps = 17
 
     # administrative actions
     ForceMerge = 1001

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -844,6 +844,8 @@ class OperationType(Enum):
             return OperationType.DeleteIlmPolicy
         elif v == "sql":
             return OperationType.Sql
+        elif v == "field-caps":
+            return OperationType.FieldCaps
         else:
             raise KeyError(f"No enum value for [{v}]")
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -5874,7 +5874,8 @@ class TestComposite:
 
         assert exc.value.args[0] == (
             "Unsupported operation-type [bulk]. Use one of [open-point-in-time, close-point-in-time, "
-            "search, paginated-search, raw-request, sleep, submit-async-search, get-async-search, delete-async-search]."
+            "search, paginated-search, raw-request, sleep, submit-async-search, get-async-search, "
+            "delete-async-search, field-caps]."
         )
 
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -6228,6 +6228,7 @@ class TestRefreshRunner:
 
         es.indices.refresh.assert_awaited_once_with(index="_all", request_timeout=50000)
 
+
 class TestFieldCapsRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @run_async

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -6236,7 +6236,8 @@ class TestFieldCapsRunner:
     async def test_field_caps_without_index_filter(self, es):
         es.field_caps = mock.AsyncMock()
         field_caps = runner.FieldCaps()
-        await field_caps(es, params={"index": "log-*"})
+        result = await field_caps(es, params={"index": "log-*"})
+        assert result == {"weight": 1, "unit": "ops", "success": True}
 
         es.field_caps.assert_awaited_once_with(index="log-*", fields="*", body={}, params=None)
 
@@ -6246,7 +6247,8 @@ class TestFieldCapsRunner:
         es.field_caps = mock.AsyncMock()
         field_caps = runner.FieldCaps()
         index_filter = {"range": {"@timestamp": {"gte": "2022"}}}
-        await field_caps(es, params={"fields": "time-*", "index_filter": index_filter})
+        result = await field_caps(es, params={"fields": "time-*", "index_filter": index_filter})
+        assert result == {"weight": 1, "unit": "ops", "success": True}
 
         expected_body = {"index_filter": index_filter}
         es.field_caps.assert_awaited_once_with(index="_all", fields="time-*", body=expected_body, params=None)


### PR DESCRIPTION
The field-caps API can be found at https://www.elastic.co/guide/en/elasticsearch/reference/current/search-field-caps.html.