### PR TITLE
Add raw-request op type for latency charts

### DIFF
--- a/esrally/chart_generator.py
+++ b/esrally/chart_generator.py
@@ -1778,7 +1778,7 @@ class RaceConfig:
                 # We should refactor the chart generator to make this classification logic more flexible so the user can specify
                 # which tasks / or types of operations should be used for which chart types.
                 if (
-                    sub_task.operation.type in ["search", "composite", "eql", "paginated-search", "scroll-search"]
+                    sub_task.operation.type in ["search", "composite", "eql", "paginated-search", "scroll-search", "raw-request"]
                     or "target-throughput" in sub_task.params
                     or "target-interval" in sub_task.params
                 ):


### PR DESCRIPTION
Add the `raw-request` operation type to the chart generator for latency charts.