### PR TITLE
Allow compare to continue for missing disk usage stats

### DIFF
--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -412,7 +412,9 @@ class ComparisonReporter:
         metrics_table.extend(self._report_ingest_pipeline_counts(baseline_stats, contender_stats))
         metrics_table.extend(self._report_ingest_pipeline_times(baseline_stats, contender_stats))
         metrics_table.extend(self._report_ingest_pipeline_failed(baseline_stats, contender_stats))
-        metrics_table.extend(self._report_disk_usage_stats_per_field(baseline_stats, contender_stats))
+        # Skip disk usage stats comparison if the disk_usage_total field does not exist
+        if baseline_stats.disk_usage_total and contender_stats.disk_usage_total:
+            metrics_table.extend(self._report_disk_usage_stats_per_field(baseline_stats, contender_stats))
 
         for t in baseline_stats.tasks():
             if t in contender_stats.tasks():
@@ -648,17 +650,15 @@ class ComparisonReporter:
 
     def _report_disk_usage_stats_per_field(self, baseline_stats, contender_stats):
         best = {}
-        if baseline_stats.disk_usage_total:
-            for index, total, field in total_disk_usage_per_field(baseline_stats):
-                best.setdefault(index, {})[field] = total
-            collated_baseline = collate_disk_usage_stats(baseline_stats)
-        if contender_stats.disk_usage_total:
-            for index, total, field in total_disk_usage_per_field(contender_stats):
-                for_idx = best.setdefault(index, {})
-                prev = for_idx.get(field, 0)
-                if prev < total:
-                    for_idx[field] = total
-            collated_contender = collate_disk_usage_stats(contender_stats)
+        for index, total, field in total_disk_usage_per_field(baseline_stats):
+            best.setdefault(index, {})[field] = total
+        collated_baseline = collate_disk_usage_stats(baseline_stats)
+        for index, total, field in total_disk_usage_per_field(contender_stats):
+            for_idx = best.setdefault(index, {})
+            prev = for_idx.get(field, 0)
+            if prev < total:
+                for_idx[field] = total
+        collated_contender = collate_disk_usage_stats(contender_stats)
         totals = []
         for index, for_idx in best.items():
             for field, total in for_idx.items():

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -648,21 +648,22 @@ class ComparisonReporter:
 
     def _report_disk_usage_stats_per_field(self, baseline_stats, contender_stats):
         best = {}
-        for index, total, field in total_disk_usage_per_field(baseline_stats):
-            best.setdefault(index, {})[field] = total
-        for index, total, field in total_disk_usage_per_field(contender_stats):
-            for_idx = best.setdefault(index, {})
-            prev = for_idx.get(field, 0)
-            if prev < total:
-                for_idx[field] = total
+        if baseline_stats.disk_usage_total:
+            for index, total, field in total_disk_usage_per_field(baseline_stats):
+                best.setdefault(index, {})[field] = total
+            collated_baseline = collate_disk_usage_stats(baseline_stats)
+        if contender_stats.disk_usage_total:
+            for index, total, field in total_disk_usage_per_field(contender_stats):
+                for_idx = best.setdefault(index, {})
+                prev = for_idx.get(field, 0)
+                if prev < total:
+                    for_idx[field] = total
+            collated_contender = collate_disk_usage_stats(contender_stats)
         totals = []
         for index, for_idx in best.items():
             for field, total in for_idx.items():
                 totals.append([index, total, field])
         totals.sort()
-
-        collated_baseline = collate_disk_usage_stats(baseline_stats)
-        collated_contender = collate_disk_usage_stats(contender_stats)
 
         lines = []
         for index, _total, field in totals:


### PR DESCRIPTION
This commit fixes an issue introduced by the [one with the beaker](https://github.com/elastic/rally/pull/1428#issuecomment-1027321314) when running `esrally compare` where disk usage stats are not present for prior benchmarks.

```diff
$ esrally compare --baseline=1ad6f592-14c7-4ffd-8c93-4eef6555eb9d --contender=bfdfe50a-d62f-45df-ac9a-6a1a5295d45f

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/


Comparing baseline
  Race ID: 1ad6f592-14c7-4ffd-8c93-4eef6555eb9d
-  Race timestamp: 2021-08-09 20:00:56
  Challenge: logging-querying
  Car: external
  User tags: env-id=4d577a92-4cf4-4da2-b1dd-948efb4a6d15

with contender
  Race ID: bfdfe50a-d62f-45df-ac9a-6a1a5295d45f
  Race timestamp: 2022-05-04 19:09:41
  Challenge: logging-querying
  Car: external
  User tags: env-id=18de9c61-7975-4aa9-800c-d2a984299268, setup=esbench

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

[ERROR] Cannot compare. 'NoneType' object is not iterable.
```

### rally.log

```sh
2022-05-06 21:26:32,719 -not-actor-/PID:70929 esrally.rally ERROR A fatal error occurred while running subcommand [compare].
Traceback (most recent call last):
  File "/Users/jbryan/dev/src/rally/esrally/rally.py", line 910, in dispatch_sub_command
    reporter.compare(cfg, args.baseline, args.contender)
  File "/Users/jbryan/dev/src/rally/esrally/reporter.py", line 49, in compare
    ComparisonReporter(cfg).report(race_store.find_by_race_id(baseline_id), race_store.find_by_race_id(contender_id))
  File "/Users/jbryan/dev/src/rally/esrally/reporter.py", line 397, in report
    metric_table_plain = self._metrics_table(baseline_stats, contender_stats, plain=True)
  File "/Users/jbryan/dev/src/rally/esrally/reporter.py", line 415, in _metrics_table
    metrics_table.extend(self._report_disk_usage_stats_per_field(baseline_stats, contender_stats))
  File "/Users/jbryan/dev/src/rally/esrally/reporter.py", line 652, in _report_disk_usage_stats_per_field
    for index, total, field in total_disk_usage_per_field(baseline_stats):
  File "/Users/jbryan/dev/src/rally/esrally/reporter.py", line 112, in total_disk_usage_per_field
    for field_stat in stats.disk_usage_total:
TypeError: 'NoneType' object is not iterable
```