### PR TITLE
remove template key requirement from composable template param source

### DIFF
--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -443,8 +443,7 @@ class CreateTemplateParamSource(ABC, ParamSource):
             settings = params.get("settings")
             for template in templates:
                 if not filter_template or template.name == filter_template:
-                    body = template.content
-                    if body and "template" in body:
+                    if template.content:
                         body = CreateComposableTemplateParamSource._create_or_merge(template.content, ["template", "settings"], settings)
                         self.template_definitions.append((template.name, body))
         else:


### PR DESCRIPTION
According to the API, `template` is not a required key in the create request. This assumption caused valid composable templates to get skipped when using the native `create-composable-template` task.