### PR TITLE
Not every composable template has a top-level `template`

### DIFF
--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -444,10 +444,8 @@ class CreateTemplateParamSource(ABC, ParamSource):
             template_definitions = []
             for template in templates:
                 if not filter_template or template.name == filter_template:
-                    body = template.content
-                    if body and "template" in body:
-                        body = CreateComposableTemplateParamSource._create_or_merge(template.content, ["template", "settings"], settings)
-                        template_definitions.append((template.name, body))
+                    body = self._create_or_merge(template.content, ["template", "settings"], settings)
+                    template_definitions.append((template.name, body))
             if filter_template and not template_definitions:
                 template_names = ", ".join([template.name for template in templates])
                 raise exceptions.InvalidSyntax(

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -441,12 +441,19 @@ class CreateTemplateParamSource(ABC, ParamSource):
         elif templates:
             filter_template = params.get("template")
             settings = params.get("settings")
+            template_definitions = []
             for template in templates:
                 if not filter_template or template.name == filter_template:
                     body = template.content
                     if body and "template" in body:
                         body = CreateComposableTemplateParamSource._create_or_merge(template.content, ["template", "settings"], settings)
-                        self.template_definitions.append((template.name, body))
+                        template_definitions.append((template.name, body))
+            if filter_template and not template_definitions:
+                template_names = ", ".join([template.name for template in templates])
+                raise exceptions.InvalidSyntax(
+                    f"Unknown template: {filter_template}. Available templates: {template_names}."
+                )
+            self.template_definitions.extend(template_definitions)
         else:
             raise exceptions.InvalidSyntax(
                 "Please set the properties 'template' and 'body' for the "

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -448,9 +448,7 @@ class CreateTemplateParamSource(ABC, ParamSource):
                     template_definitions.append((template.name, body))
             if filter_template and not template_definitions:
                 template_names = ", ".join([template.name for template in templates])
-                raise exceptions.InvalidSyntax(
-                    f"Unknown template: {filter_template}. Available templates: {template_names}."
-                )
+                raise exceptions.InvalidSyntax(f"Unknown template: {filter_template}. Available templates: {template_names}.")
             self.template_definitions.extend(template_definitions)
         else:
             raise exceptions.InvalidSyntax(

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2157,9 +2157,7 @@ class TestCreateComposableTemplateParamSource:
                     "template": "t3",
                 },
             )
-        assert exc.value.args[0] == (
-            "Unknown template: t3. Available templates: t1, t2."
-        )
+        assert exc.value.args[0] == ("Unknown template: t3. Available templates: t1, t2.")
 
     def test_create_composable_index_template_from_track_no_template(self):
         tpl = track.IndexTemplate(
@@ -2339,9 +2337,7 @@ class TestCreateComponentTemplateParamSource:
                     "template": "t3",
                 },
             )
-        assert exc.value.args[0] == (
-            "Unknown template: t3. Available templates: t1, t2."
-        )
+        assert exc.value.args[0] == ("Unknown template: t3. Available templates: t1, t2.")
 
 
 class TestDeleteComponentTemplateParamSource:

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2138,6 +2138,29 @@ class TestCreateComposableTemplateParamSource:
             "composed_of": ["ct1", "ct2"],
         }
 
+    def test_create_composable_index_template_from_track_wrong_filter(self):
+        t1 = track.IndexTemplate(
+            name="t1",
+            content={},
+            pattern="",
+        )
+        t2 = track.IndexTemplate(
+            name="t2",
+            content={},
+            pattern="",
+        )
+
+        with pytest.raises(exceptions.InvalidSyntax) as exc:
+            source = params.CreateComposableTemplateParamSource(
+                track=track.Track(name="unit-test", composable_templates=[t1, t2]),
+                params={
+                    "template": "t3",
+                },
+            )
+        assert exc.value.args[0] == (
+            "Unknown template: t3. Available templates: t1, t2."
+        )
+
     def test_create_or_merge(self):
         content = params.CreateComposableTemplateParamSource._create_or_merge(
             {"parent": {}},
@@ -2269,6 +2292,27 @@ class TestCreateComponentTemplateParamSource:
                 },
             }
         }
+
+    def test_create_component_index_template_from_track_wrong_filter(self):
+        t1 = track.ComponentTemplate(
+            name="t1",
+            content={},
+        )
+        t2 = track.ComponentTemplate(
+            name="t2",
+            content={},
+        )
+
+        with pytest.raises(exceptions.InvalidSyntax) as exc:
+            source = params.CreateComponentTemplateParamSource(
+                track=track.Track(name="unit-test", component_templates=[t1, t2]),
+                params={
+                    "template": "t3",
+                },
+            )
+        assert exc.value.args[0] == (
+            "Unknown template: t3. Available templates: t1, t2."
+        )
 
 
 class TestDeleteComponentTemplateParamSource:

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2151,7 +2151,7 @@ class TestCreateComposableTemplateParamSource:
         )
 
         with pytest.raises(exceptions.InvalidSyntax) as exc:
-            source = params.CreateComposableTemplateParamSource(
+            params.CreateComposableTemplateParamSource(
                 track=track.Track(name="unit-test", composable_templates=[t1, t2]),
                 params={
                     "template": "t3",
@@ -2333,7 +2333,7 @@ class TestCreateComponentTemplateParamSource:
         )
 
         with pytest.raises(exceptions.InvalidSyntax) as exc:
-            source = params.CreateComponentTemplateParamSource(
+            params.CreateComponentTemplateParamSource(
                 track=track.Track(name="unit-test", component_templates=[t1, t2]),
                 params={
                     "template": "t3",

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2161,6 +2161,35 @@ class TestCreateComposableTemplateParamSource:
             "Unknown template: t3. Available templates: t1, t2."
         )
 
+    def test_create_composable_index_template_from_track_no_template(self):
+        tpl = track.IndexTemplate(
+            name="default",
+            pattern="*",
+            content={
+                "index_patterns": ["my*"],
+                "composed_of": ["ct1", "ct2"],
+            },
+        )
+
+        source = params.CreateComposableTemplateParamSource(
+            track=track.Track(name="unit-test", composable_templates=[tpl]),
+            params={
+                "settings": {"index.number_of_replicas": 1},
+            },
+        )
+
+        p = source.params()
+
+        assert len(p["templates"]) == 1
+        assert p["request-params"] == {}
+        template, body = p["templates"][0]
+        assert template == "default"
+        assert body == {
+            "index_patterns": ["my*"],
+            "template": {"settings": {"index.number_of_replicas": 1}},
+            "composed_of": ["ct1", "ct2"],
+        }
+
     def test_create_or_merge(self):
         content = params.CreateComposableTemplateParamSource._create_or_merge(
             {"parent": {}},


### PR DESCRIPTION
Fixes https://github.com/elastic/rally/issues/1487