### PR TITLE
Address wrapped templates

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -283,6 +283,7 @@ Each composable template in this list consists of the following properties:
 * ``index-pattern`` (mandatory): Index pattern that matches the composable template. This must match the definition in the template file.
 * ``delete-matching-indices`` (optional, defaults to ``true``): Delete all indices that match the provided index pattern if the template is deleted.
 * ``template`` (mandatory): Composable template file name.
+* ``template-path`` (optional): JSON Path to the template inside the file content.
 
 Example::
 
@@ -307,6 +308,7 @@ Each component template in this list consists of the following properties:
 
 * ``name`` (mandatory): Component template name.
 * ``template`` (mandatory): Component template file name.
+* ``template-path`` (optional): JSON Path to the template inside the file content.
 
 Example::
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -283,7 +283,7 @@ Each composable template in this list consists of the following properties:
 * ``index-pattern`` (mandatory): Index pattern that matches the composable template. This must match the definition in the template file.
 * ``delete-matching-indices`` (optional, defaults to ``true``): Delete all indices that match the provided index pattern if the template is deleted.
 * ``template`` (mandatory): Composable template file name.
-* ``template-path`` (optional): JSON Path to the template inside the file content.
+* ``template-path`` (optional): JSON field inside the file content that contains the template.
 
 Example::
 
@@ -308,7 +308,7 @@ Each component template in this list consists of the following properties:
 
 * ``name`` (mandatory): Component template name.
 * ``template`` (mandatory): Component template file name.
-* ``template-path`` (optional): JSON Path to the template inside the file content.
+* ``template-path`` (optional): JSON field inside the file content that contains the template.
 
 Example::
 

--- a/esrally/resources/track-schema.json
+++ b/esrally/resources/track-schema.json
@@ -293,7 +293,7 @@
           },
           "template-path": {
             "type": "string",
-            "description": "Path to the template inside the file content."
+            "description": "JSON Path to the template inside the file content."
           }
         },
         "required": [

--- a/esrally/resources/track-schema.json
+++ b/esrally/resources/track-schema.json
@@ -258,7 +258,7 @@
           },
           "template-path": {
             "type": "string",
-            "description": "JSON Path to the template inside the file content."
+            "description": "JSON field inside the file content that contains the template."
           }
         },
         "required": [
@@ -293,7 +293,7 @@
           },
           "template-path": {
             "type": "string",
-            "description": "JSON Path to the template inside the file content."
+            "description": "JSON field inside the file content that contains the template."
           }
         },
         "required": [

--- a/esrally/resources/track-schema.json
+++ b/esrally/resources/track-schema.json
@@ -258,7 +258,7 @@
           },
           "template-path": {
             "type": "string",
-            "description": "Path to the template inside the file content."
+            "description": "JSON Path to the template inside the file content."
           }
         },
         "required": [

--- a/esrally/resources/track-schema.json
+++ b/esrally/resources/track-schema.json
@@ -255,6 +255,10 @@
           "template": {
             "type": "string",
             "description": "Component template file name."
+          },
+          "template-path": {
+            "type": "string",
+            "description": "Path to the template inside the file content."
           }
         },
         "required": [
@@ -286,6 +290,10 @@
           "template": {
             "type": "string",
             "description": "Composable template file name."
+          },
+          "template-path": {
+            "type": "string",
+            "description": "Path to the template inside the file content."
           }
         },
         "required": [

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1259,6 +1259,7 @@ class TrackSpecificationReader:
     def _create_component_template(self, tpl_spec, mapping_dir):
         name = self._r(tpl_spec, "name")
         template_file = self._r(tpl_spec, "template")
+        template_path = self._r(tpl_spec, "template-path", mandatory=False)
         template_file = os.path.join(mapping_dir, template_file)
         idx_tmpl_src = TemplateSource(mapping_dir, template_file, self.source)
         with self.source(template_file, "rt") as f:
@@ -1266,11 +1267,15 @@ class TrackSpecificationReader:
             template_content = self._load_template(
                 idx_tmpl_src.assembled_source, f"definition for component template {name} in {template_file}"
             )
+        if template_path:
+            for field in template_path.split("."):
+                template_content = template_content[field]
         return track.ComponentTemplate(name, template_content)
 
     def _create_index_template(self, tpl_spec, mapping_dir):
         name = self._r(tpl_spec, "name")
         template_file = self._r(tpl_spec, "template")
+        template_path = self._r(tpl_spec, "template-path", mandatory=False)
         index_pattern = self._r(tpl_spec, "index-pattern")
         delete_matching_indices = self._r(tpl_spec, "delete-matching-indices", mandatory=False, default_value=True)
         template_file = os.path.join(mapping_dir, template_file)
@@ -1280,6 +1285,9 @@ class TrackSpecificationReader:
             template_content = self._load_template(
                 idx_tmpl_src.assembled_source, "definition for index template {} in {}".format(name, template_file)
             )
+        if template_path:
+            for field in template_path.split("."):
+                template_content = template_content[field]
         return track.IndexTemplate(name, index_pattern, template_content, delete_matching_indices)
 
     def _load_template(self, contents, description):


### PR DESCRIPTION
This allows to use integration assets dumped by `elastic-package` as-is, which enclose an outer meta data layer otherwise rejected when sent to Elastisearch.

