### PR TITLE
Fix use_ssl: True on Python 3.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ tox-env-clean:
 
 lint: check-venv
 	@. $(VENV_ACTIVATE_FILE); find esrally benchmarks scripts tests it setup.py -name "*.py" -exec pylint -j0 -rn --rcfile=$(CURDIR)/.pylintrc \{\} +
-	@. $(VENV_ACTIVATE_FILE); black --check esrally benchmarks scripts tests it setup.py
-	@. $(VENV_ACTIVATE_FILE); isort --check esrally benchmarks scripts tests it setup.py
+	@. $(VENV_ACTIVATE_FILE); black --check --diff esrally benchmarks scripts tests it setup.py
+	@. $(VENV_ACTIVATE_FILE); isort --check --diff esrally benchmarks scripts tests it setup.py
 
 format: check-venv
 	@. $(VENV_ACTIVATE_FILE); black esrally benchmarks scripts tests it setup.py

--- a/esrally/client.py
+++ b/esrally/client.py
@@ -21,6 +21,7 @@ import time
 
 import certifi
 import urllib3
+from urllib3.connection import is_ipaddress
 
 from esrally import doc_link, exceptions
 from esrally.utils import console, convert
@@ -135,17 +136,15 @@ class EsClientFactory:
             self.logger.info("SSL support: on")
             self.client_options["scheme"] = "https"
 
-            # ssl.Purpose.CLIENT_AUTH allows presenting client certs and can only be enabled during instantiation
-            # but can be disabled via the verify_mode property later on.
             self.ssl_context = ssl.create_default_context(
-                ssl.Purpose.CLIENT_AUTH, cafile=self.client_options.pop("ca_certs", certifi.where())
+                ssl.Purpose.SERVER_AUTH, cafile=self.client_options.pop("ca_certs", certifi.where())
             )
 
             if not self.client_options.pop("verify_certs", True):
                 self.logger.info("SSL certificate verification: off")
                 # order matters to avoid ValueError: check_hostname needs a SSL context with either CERT_OPTIONAL or CERT_REQUIRED
-                self.ssl_context.verify_mode = ssl.CERT_NONE
                 self.ssl_context.check_hostname = False
+                self.ssl_context.verify_mode = ssl.CERT_NONE
 
                 self.logger.warning(
                     "User has enabled SSL but disabled certificate verification. This is dangerous but may be ok for a "
@@ -156,8 +155,9 @@ class EsClientFactory:
                 # advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings"
                 urllib3.disable_warnings()
             else:
+                # check_hostname should not be set when host is an IP address
+                self.ssl_context.check_hostname = self._only_hostnames(hosts)
                 self.ssl_context.verify_mode = ssl.CERT_REQUIRED
-                self.ssl_context.check_hostname = True
                 self.logger.info("SSL certificate verification: on")
 
             # When using SSL_context, all SSL related kwargs in client options get ignored
@@ -208,6 +208,22 @@ class EsClientFactory:
 
         if self._is_set(self.client_options, "enable_cleanup_closed"):
             self.client_options["enable_cleanup_closed"] = convert.to_bool(self.client_options.pop("enable_cleanup_closed"))
+
+    @staticmethod
+    def _only_hostnames(hosts):
+        has_ip = False
+        has_hostname = False
+        for host in hosts:
+            is_ip = is_ipaddress(host["host"])
+            if is_ip:
+                has_ip = True
+            else:
+                has_hostname = True
+
+        if has_ip and has_hostname:
+            raise exceptions.SystemSetupError("Cannot verify certs with mixed IP addresses and hostnames")
+
+        return has_hostname
 
     def _is_set(self, client_opts, k):
         try:

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,8 @@ develop_require = [
     "pylint==2.6.0",
     "black==22.3.0",
     "isort==5.8.0",
+    "trustme==0.9.0",
+    "pytest-httpserver==1.0.4",
 ]
 
 python_version_classifiers = ["Programming Language :: Python :: {}.{}".format(major, minor) for major, minor in supported_python_versions]

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import asyncio
+import contextlib
 import logging
 import os
 import random
@@ -23,10 +24,12 @@ import ssl
 from copy import deepcopy
 from unittest import mock
 
-import elasticsearch
 import pytest
+import trustme
 import urllib3.exceptions
+from pytest_httpserver import HTTPServer
 
+import elasticsearch
 from esrally import client, doc_link, exceptions
 from esrally.async_connection import AIOHttpConnection
 from esrally.utils import console
@@ -37,7 +40,7 @@ class TestEsClientFactory:
     cwd = os.path.dirname(__file__)
 
     def test_create_http_connection(self):
-        hosts = [{"host": "127.0.0.1", "port": 9200}]
+        hosts = [{"host": "localhost", "port": 9200}]
         client_options = {}
         # make a copy so we can verify later that the factory did not modify it
         original_client_options = dict(client_options)
@@ -53,7 +56,7 @@ class TestEsClientFactory:
 
     @mock.patch.object(ssl.SSLContext, "load_cert_chain")
     def test_create_https_connection_verify_server(self, mocked_load_cert_chain):
-        hosts = [{"host": "127.0.0.1", "port": 9200}]
+        hosts = [{"host": "localhost", "port": 9200}]
         client_options = {
             "use_ssl": True,
             "verify_certs": True,
@@ -91,7 +94,7 @@ class TestEsClientFactory:
 
     @mock.patch.object(ssl.SSLContext, "load_cert_chain")
     def test_create_https_connection_verify_self_signed_server_and_client_certificate(self, mocked_load_cert_chain):
-        hosts = [{"host": "127.0.0.1", "port": 9200}]
+        hosts = [{"host": "localhost", "port": 9200}]
         client_options = {
             "use_ssl": True,
             "verify_certs": True,
@@ -135,7 +138,7 @@ class TestEsClientFactory:
 
     @mock.patch.object(ssl.SSLContext, "load_cert_chain")
     def test_create_https_connection_only_verify_self_signed_server_certificate(self, mocked_load_cert_chain):
-        hosts = [{"host": "127.0.0.1", "port": 9200}]
+        hosts = [{"host": "localhost", "port": 9200}]
         client_options = {
             "use_ssl": True,
             "verify_certs": True,
@@ -172,7 +175,7 @@ class TestEsClientFactory:
         assert client_options == original_client_options
 
     def test_raises_error_when_only_one_of_client_cert_and_client_key_defined(self):
-        hosts = [{"host": "127.0.0.1", "port": 9200}]
+        hosts = [{"host": "localhost", "port": 9200}]
         client_options = {
             "use_ssl": True,
             "verify_certs": True,
@@ -206,7 +209,7 @@ class TestEsClientFactory:
 
     @mock.patch.object(ssl.SSLContext, "load_cert_chain")
     def test_create_https_connection_unverified_certificate(self, mocked_load_cert_chain):
-        hosts = [{"host": "127.0.0.1", "port": 9200}]
+        hosts = [{"host": "localhost", "port": 9200}]
         client_options = {
             "use_ssl": True,
             "verify_certs": False,
@@ -246,7 +249,7 @@ class TestEsClientFactory:
 
     @mock.patch.object(ssl.SSLContext, "load_cert_chain")
     def test_create_https_connection_unverified_certificate_present_client_certificates(self, mocked_load_cert_chain):
-        hosts = [{"host": "127.0.0.1", "port": 9200}]
+        hosts = [{"host": "localhost", "port": 9200}]
         client_options = {
             "use_ssl": True,
             "verify_certs": False,
@@ -287,6 +290,107 @@ class TestEsClientFactory:
         assert "client_key" not in f.client_options
 
         assert client_options == original_client_options
+
+    def test_raises_error_when_verify_ssl_with_mixed_hosts(self):
+        hosts = [{"host": "127.0.0.1", "port": 9200}, {"host": "localhost", "port": 9200}]
+        client_options = {
+            "use_ssl": True,
+            "verify_certs": True,
+            "http_auth": ("user", "password"),
+        }
+
+        with pytest.raises(
+            exceptions.SystemSetupError,
+            match="Cannot verify certs with mixed IP addresses and hostnames",
+        ):
+            client.EsClientFactory(hosts, client_options)
+
+    def test_check_hostname_false_when_host_is_ip(self):
+        hosts = [{"host": "127.0.0.1", "port": 9200}]
+        client_options = {
+            "use_ssl": True,
+            "verify_certs": True,
+            "http_auth": ("user", "password"),
+        }
+
+        f = client.EsClientFactory(hosts, client_options)
+        assert f.hosts == hosts
+        assert f.ssl_context.check_hostname is False
+        assert f.ssl_context.verify_mode == ssl.CERT_REQUIRED
+
+
+@contextlib.contextmanager
+def _build_server(tmpdir, host):
+    ca = trustme.CA()
+    ca_cert_path = str(tmpdir / "ca.pem")
+    ca.cert_pem.write_to_path(ca_cert_path)
+
+    server_cert = ca.issue_cert(host)
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    server_crt = server_cert.cert_chain_pems[0]
+    server_key = server_cert.private_key_pem
+    with server_crt.tempfile() as crt_file, server_key.tempfile() as key_file:
+        context.load_cert_chain(crt_file, key_file)
+
+    server = HTTPServer(ssl_context=context)
+    # Fake what the client expects from Elasticsearch
+    server.expect_request("/").respond_with_json(
+        headers={
+            "x-elastic-product": "Elasticsearch",
+        },
+        response_json={
+            "version": {
+                "number": "8.0.0",
+            }
+        },
+    )
+    server.start()
+
+    yield server, ca, ca_cert_path
+
+    server.clear()
+    if server.is_running():
+        server.stop()
+
+
+class TestEsClientAgainstHTTPSServer:
+    def test_ip_address(self, tmp_path_factory: pytest.TempPathFactory):
+        tmpdir = tmp_path_factory.mktemp("certs")
+        with _build_server(tmpdir, "127.0.0.1") as cfg:
+            server, ca, ca_cert_path = cfg
+            hosts = [{"host": "127.0.0.1", "port": server.port}]
+            client_options = {
+                "use_ssl": True,
+                "verify_certs": True,
+                "ca_certs": ca_cert_path,
+            }
+            f = client.EsClientFactory(hosts, client_options)
+            es = f.create()
+            assert es.info() == {"version": {"number": "8.0.0"}}
+
+    def test_client_cert(self, tmp_path_factory: pytest.TempPathFactory):
+        tmpdir = tmp_path_factory.mktemp("certs")
+        with _build_server(tmpdir, "localhost") as cfg:
+            server, ca, ca_cert_path = cfg
+            client_cert = ca.issue_cert("localhost")
+            client_cert_path = str(tmpdir / "client.pem")
+            client_key_path = str(tmpdir / "client.key")
+            client_cert.cert_chain_pems[0].write_to_path(client_cert_path)
+            client_cert.private_key_pem.write_to_path(client_key_path)
+
+            hosts = [
+                {"host": "localhost", "port": server.port},
+            ]
+            client_options = {
+                "use_ssl": True,
+                "verify_certs": True,
+                "ca_certs": ca_cert_path,
+                "client_cert": client_cert_path,
+                "client_key": client_key_path,
+            }
+            f = client.EsClientFactory(hosts, client_options)
+            es = f.create()
+            assert es.info() == {"version": {"number": "8.0.0"}}
 
 
 class TestRequestContextManager:

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -24,12 +24,12 @@ import ssl
 from copy import deepcopy
 from unittest import mock
 
+import elasticsearch
 import pytest
 import trustme
 import urllib3.exceptions
 from pytest_httpserver import HTTPServer
 
-import elasticsearch
 from esrally import client, doc_link, exceptions
 from esrally.async_connection import AIOHttpConnection
 from esrally.utils import console

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -357,7 +357,7 @@ class TestEsClientAgainstHTTPSServer:
     def test_ip_address(self, tmp_path_factory: pytest.TempPathFactory):
         tmpdir = tmp_path_factory.mktemp("certs")
         with _build_server(tmpdir, "127.0.0.1") as cfg:
-            server, ca, ca_cert_path = cfg
+            server, _ca, ca_cert_path = cfg
             hosts = [{"host": "127.0.0.1", "port": server.port}]
             client_options = {
                 "use_ssl": True,


### PR DESCRIPTION
Rally is a client, so its purpose is to authenticate servers. We
also add tests for the IP and client certs cases to make sure this
change does not break them.

Closes #1484 

I also tested this end-to-end with a variation of https://gist.github.com/dliappis/97d013ab6e0e3250fdd6cbfba8e58a5c updated to use Elasticsearch 8.2.0:

```bash
cat >.env <<'EOF'
CERTS_DIR=/usr/share/elasticsearch/config/certificates
ELASTIC_PASSWORD=PleaseChangeMe
EOF

cat >instances.yml <<EOF
instances:
  - name: es01
    dns:
      - es01
      - localhost
    ip:
      - 127.0.0.1

  - name: es02
    dns:
      - es02
      - localhost
    ip:
      - 127.0.0.1
EOF

cat >docker-compose.yml <<'EOF'
version: '2.2'

services:
  es01:
    container_name: es01
    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0
    environment:
      - node.name=es01
      - discovery.seed_hosts=es02
      - cluster.initial_master_nodes=es01,es02
      - ELASTIC_PASSWORD=$ELASTIC_PASSWORD
      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
      - xpack.license.self_generated.type=trial
      - xpack.security.enabled=true
      - xpack.security.http.ssl.enabled=true
      - xpack.security.http.ssl.client_authentication=required
      - xpack.security.http.ssl.certificate_authorities=$CERTS_DIR/ca/ca.crt
      - xpack.security.http.ssl.certificate=$CERTS_DIR/es01/es01.crt
      - xpack.security.http.ssl.key=$CERTS_DIR/es01/es01.key
      - xpack.security.transport.ssl.enabled=true
      - xpack.security.transport.ssl.verification_mode=certificate
      - xpack.security.transport.ssl.certificate_authorities=$CERTS_DIR/ca/ca.crt
      - xpack.security.transport.ssl.certificate=$CERTS_DIR/es01/es01.crt
      - xpack.security.transport.ssl.key=$CERTS_DIR/es01/es01.key
    volumes:
      - esdata_01:/usr/share/elasticsearch/data
      - ./certs:$CERTS_DIR
    ports:
      - 9200:9200
    healthcheck:
      test: curl --cacert $CERTS_DIR/ca/ca.crt -s https://localhost:9200 >/dev/null; if [[ $$? == 52 ]]; then echo 0; else echo 1; fi
      interval: 30s
      timeout: 10s
      retries: 5

  es02:
    container_name: es02
    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0
    environment:
      - node.name=es02
      - cluster.initial_master_nodes=es01,es02
      - discovery.seed_hosts=es01
      - ELASTIC_PASSWORD=$ELASTIC_PASSWORD
      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
      - xpack.license.self_generated.type=trial
      - xpack.security.enabled=true
      - xpack.security.http.ssl.enabled=true
      - xpack.security.http.ssl.client_authentication=required
      - xpack.security.http.ssl.certificate_authorities=$CERTS_DIR/ca/ca.crt
      - xpack.security.http.ssl.certificate=$CERTS_DIR/es02/es02.crt
      - xpack.security.http.ssl.key=$CERTS_DIR/es02/es02.key
      - xpack.security.transport.ssl.enabled=true
      - xpack.security.transport.ssl.verification_mode=certificate
      - xpack.security.transport.ssl.certificate_authorities=$CERTS_DIR/ca/ca.crt
      - xpack.security.transport.ssl.certificate=$CERTS_DIR/es02/es02.crt
      - xpack.security.transport.ssl.key=$CERTS_DIR/es02/es02.key
    volumes:
      - esdata_02:/usr/share/elasticsearch/data
      - ./certs:$CERTS_DIR

  wait_until_ready:
    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0
    command: /usr/bin/true
    depends_on: {"es01": {"condition": "service_healthy"}}

volumes: {"esdata_01": {"driver": "local"}, "esdata_02": {"driver": "local"}}
EOF

cat >create-certs.yml <<'EOF'
version: '2.2'

services:
  create_certs:
    container_name: create_certs
    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0
    command: >
      bash -c '
        if [[ ! -d config/certificates/certs ]]; then
          mkdir config/certificates/certs;
        fi;
        if [[ ! -f config/certificates/certs/bundle.zip ]]; then
          echo "certgen!"
          bin/elasticsearch-certgen --silent --in config/certificates/instances.yml --out config/certificates/certs/bundle.zip;
          echo "unzip!"
          unzip config/certificates/certs/bundle.zip -d config/certificates/certs;
        fi;
        chgrp -R 0 config/certificates/certs
      '
    user: ${UID:-1000}
    working_dir: /usr/share/elasticsearch
    volumes: ['.:/usr/share/elasticsearch/config/certificates']
EOF

# Create certs under certs/
docker-compose -f create-certs.yml up
# Start ES with x-pack security enabled requiring full verification of client certs
docker-compose up -d


echo "sleep"
sleep 60

# Confirm things are working as expected with curl
curl --cacert certs/ca/ca.crt --cert certs/es01/es01.crt --key certs/es01/es01.key https://elastic:PleaseChangeMe@127.0.0.1:9200

# Run a race both with hostname and IP
esrally race --track=pmc --target-hosts=localhost:9200 --pipeline=benchmark-only --client-options="use_ssl:true,verify_certs:true,client_cert:'$PWD/certs/es01/es01.crt',client_key:'$PWD/certs/es01/es01.key',ca_certs:'$PWD/certs/ca/ca.crt',basic_auth_user:'elastic',basic_auth_password:'PleaseChangeMe'" --test-mode
esrally race --track=pmc --target-hosts=127.0.0.1:9200 --pipeline=benchmark-only --client-options="use_ssl:true,verify_certs:true,client_cert:'$PWD/certs/es01/es01.crt',client_key:'$PWD/certs/es01/es01.key',ca_certs:'$PWD/certs/ca/ca.crt',basic_auth_user:'elastic',basic_auth_password:'PleaseChangeMe'" --test-mode
```
