### PR TITLE
Revert "Fix use_ssl: True on Python 3.10"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ tox-env-clean:
 
 lint: check-venv
 	@. $(VENV_ACTIVATE_FILE); find esrally benchmarks scripts tests it setup.py -name "*.py" -exec pylint -j0 -rn --rcfile=$(CURDIR)/.pylintrc \{\} +
-	@. $(VENV_ACTIVATE_FILE); black --check --diff esrally benchmarks scripts tests it setup.py
-	@. $(VENV_ACTIVATE_FILE); isort --check --diff esrally benchmarks scripts tests it setup.py
+	@. $(VENV_ACTIVATE_FILE); black --check esrally benchmarks scripts tests it setup.py
+	@. $(VENV_ACTIVATE_FILE); isort --check esrally benchmarks scripts tests it setup.py
 
 format: check-venv
 	@. $(VENV_ACTIVATE_FILE); black esrally benchmarks scripts tests it setup.py

--- a/setup.py
+++ b/setup.py
@@ -104,8 +104,6 @@ develop_require = [
     "pylint==2.6.0",
     "black==22.3.0",
     "isort==5.8.0",
-    "trustme==0.9.0",
-    "pytest-httpserver==1.0.4",
 ]
 
 python_version_classifiers = ["Programming Language :: Python :: {}.{}".format(major, minor) for major, minor in supported_python_versions]


### PR DESCRIPTION
Reverts elastic/rally#1493 while we work to fix this error in python 3.8:

```
  File "/var/lib/jenkins/src/rally/esrally/metrics.py", line 35, in <module>

    from esrally import client, config, exceptions, paths, time, version

  File "/var/lib/jenkins/src/rally/esrally/client.py", line 24, in <module>

    from urllib3.connection import is_ipaddress

ImportError: cannot import name 'is_ipaddress' from 'urllib3.connection' (/var/lib/jenkins/.local/lib/python3.8/site-packages/urllib3-1.25.8-py3.8.egg/urllib3/connection.py)
```

YOLOing this PR for timing's sake, reviewers for notice.