### PR TITLE
Flexible support of GC collectors in telemetry.

### DIFF
--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1844,28 +1844,25 @@ class JvmStatsSummary(InternalTelemetryDevice):
 
     def on_benchmark_stop(self):
         jvm_stats_at_end = self.jvm_stats()
-        total_old_gen_collection_time = 0
-        total_old_gen_collection_count = 0
-        total_young_gen_collection_time = 0
-        total_young_gen_collection_count = 0
+        total_collection_time = collections.defaultdict(int)
+        total_collection_count = collections.defaultdict(int)
 
         for node_name, jvm_stats_end in jvm_stats_at_end.items():
             if node_name in self.jvm_stats_per_node:
                 jvm_stats_start = self.jvm_stats_per_node[node_name]
-                young_gc_time = max(jvm_stats_end["young_gc_time"] - jvm_stats_start["young_gc_time"], 0)
-                young_gc_count = max(jvm_stats_end["young_gc_count"] - jvm_stats_start["young_gc_count"], 0)
-                old_gc_time = max(jvm_stats_end["old_gc_time"] - jvm_stats_start["old_gc_time"], 0)
-                old_gc_count = max(jvm_stats_end["old_gc_count"] - jvm_stats_start["old_gc_count"], 0)
+                collector_stats_start = jvm_stats_start["collectors"]
+                collector_stats_end = jvm_stats_end["collectors"]
+                for collector_name in collector_stats_start:
+                    gc_time_diff = max(collector_stats_end[collector_name]["gc_time"] - collector_stats_start[collector_name]["gc_time"], 0)
+                    gc_count_diff = max(
+                        collector_stats_end[collector_name]["gc_count"] - collector_stats_start[collector_name]["gc_count"], 0
+                    )
 
-                total_young_gen_collection_time += young_gc_time
-                total_young_gen_collection_count += young_gc_count
-                total_old_gen_collection_time += old_gc_time
-                total_old_gen_collection_count += old_gc_count
+                    total_collection_time[collector_name] += gc_time_diff
+                    total_collection_count[collector_name] += gc_count_diff
 
-                self.metrics_store.put_value_node_level(node_name, "node_young_gen_gc_time", young_gc_time, "ms")
-                self.metrics_store.put_value_node_level(node_name, "node_young_gen_gc_count", young_gc_count)
-                self.metrics_store.put_value_node_level(node_name, "node_old_gen_gc_time", old_gc_time, "ms")
-                self.metrics_store.put_value_node_level(node_name, "node_old_gen_gc_count", old_gc_count)
+                    self.metrics_store.put_value_node_level(node_name, f"node_{collector_name}_gc_time", gc_time_diff, "ms")
+                    self.metrics_store.put_value_node_level(node_name, f"node_{collector_name}_gc_count", gc_count_diff)
 
                 all_pool_stats = {"name": "jvm_memory_pool_stats"}
                 for pool_name, pool_stats in jvm_stats_end["pools"].items():
@@ -1875,10 +1872,10 @@ class JvmStatsSummary(InternalTelemetryDevice):
             else:
                 self.logger.warning("Cannot determine JVM stats for [%s] (not in the cluster at the start of the benchmark).", node_name)
 
-        self.metrics_store.put_value_cluster_level("node_total_young_gen_gc_time", total_young_gen_collection_time, "ms")
-        self.metrics_store.put_value_cluster_level("node_total_young_gen_gc_count", total_young_gen_collection_count)
-        self.metrics_store.put_value_cluster_level("node_total_old_gen_gc_time", total_old_gen_collection_time, "ms")
-        self.metrics_store.put_value_cluster_level("node_total_old_gen_gc_count", total_old_gen_collection_count)
+        for collector_name, value in total_collection_time.items():
+            self.metrics_store.put_value_cluster_level(f"node_total_{collector_name}_gc_time", value, "ms")
+        for collector_name, value in total_collection_count.items():
+            self.metrics_store.put_value_cluster_level(f"node_total_{collector_name}_gc_count", value)
 
         self.jvm_stats_per_node = None
 
@@ -1889,7 +1886,7 @@ class JvmStatsSummary(InternalTelemetryDevice):
         import elasticsearch
 
         try:
-            stats = self.client.nodes.stats(metric="_all")
+            stats = self.client.nodes.stats(metric="jvm")
         except elasticsearch.TransportError:
             self.logger.exception("Could not retrieve GC times.")
             return jvm_stats
@@ -1897,17 +1894,21 @@ class JvmStatsSummary(InternalTelemetryDevice):
         for node in nodes.values():
             node_name = node["name"]
             gc = node["jvm"]["gc"]["collectors"]
-            old_gen_collection_time = gc["old"]["collection_time_in_millis"]
-            old_gen_collection_count = gc["old"]["collection_count"]
-            young_gen_collection_time = gc["young"]["collection_time_in_millis"]
-            young_gen_collection_count = gc["young"]["collection_count"]
             jvm_stats[node_name] = {
-                "young_gc_time": young_gen_collection_time,
-                "young_gc_count": young_gen_collection_count,
-                "old_gc_time": old_gen_collection_time,
-                "old_gc_count": old_gen_collection_count,
                 "pools": {},
+                "collectors": {},
             }
+            for collector_name, collector_stats in gc.items():
+                collection_time = collector_stats.get("collection_time_in_millis", 0)
+                collection_count = collector_stats.get("collection_count", 0)
+                if collector_name in ("young", "old"):
+                    metric_prefix = f"{collector_name}_gen"
+                else:
+                    metric_prefix = collector_name.lower().replace(" ", "_")
+                jvm_stats[node_name]["collectors"][metric_prefix] = {
+                    "gc_time": collection_time,
+                    "gc_count": collection_count,
+                }
             pool_usage = node["jvm"]["mem"]["pools"]
             for pool_name, pool_stats in pool_usage.items():
                 jvm_stats[node_name]["pools"][pool_name] = {"peak": pool_stats["peak_used_in_bytes"]}

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -3263,7 +3263,8 @@ class TestJvmStatsSummary:
                 mock.call("rally0", "node_young_gen_gc_count", 3980),
                 mock.call("rally0", "node_old_gen_gc_time", 1500, "ms"),
                 mock.call("rally0", "node_old_gen_gc_count", 1),
-            ]
+            ],
+            any_order=True,
         )
 
         metrics_store_cluster_level.assert_has_calls(
@@ -3272,7 +3273,8 @@ class TestJvmStatsSummary:
                 mock.call("node_total_young_gen_gc_count", 3980),
                 mock.call("node_total_old_gen_gc_time", 1500, "ms"),
                 mock.call("node_total_old_gen_gc_count", 1),
-            ]
+            ],
+            any_order=True,
         )
 
         metrics_store_put_doc.assert_has_calls(
@@ -3288,6 +3290,92 @@ class TestJvmStatsSummary:
                     node_name="rally0",
                 ),
             ]
+        )
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
+    @mock.patch("esrally.metrics.EsMetricsStore.put_value_node_level")
+    def test_handles_optional_collectors(self, metrics_store_node_level, metrics_store_cluster_level, metrics_store_put_doc):
+        nodes_stats_at_start = {
+            "nodes": {
+                "3zCI85c3RWKuR8MeJ8ajQg": {
+                    "name": "rally0",
+                    "host": "127.0.0.1",
+                    "jvm": {
+                        "mem": {
+                            "heap_used_in_bytes": 457179136,
+                            "heap_used_percent": 2,
+                            "heap_committed_in_bytes": 17179869184,
+                            "heap_max_in_bytes": 17179869184,
+                            "non_heap_used_in_bytes": 154359232,
+                            "non_heap_committed_in_bytes": 159907840,
+                            "pools": {},
+                        },
+                        "gc": {
+                            "collectors": {
+                                "ZGC Cycles": {"collection_count": 4, "collection_time_in_millis": 358},
+                                "ZGC Pauses": {"collection_count": 12, "collection_time_in_millis": 0},
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        client = Client(nodes=SubClient(nodes_stats_at_start))
+        cfg = create_config()
+
+        metrics_store = metrics.EsMetricsStore(cfg)
+        device = telemetry.JvmStatsSummary(client, metrics_store)
+        t = telemetry.Telemetry(cfg, devices=[device])
+        t.on_benchmark_start()
+        # now we'd need to change the node stats response
+        nodes_stats_at_end = {
+            "nodes": {
+                "3zCI85c3RWKuR8MeJ8ajQg": {
+                    "name": "rally0",
+                    "host": "127.0.0.1",
+                    "jvm": {
+                        "mem": {
+                            "heap_used_in_bytes": 457179136,
+                            "heap_used_percent": 2,
+                            "heap_committed_in_bytes": 17179869184,
+                            "heap_max_in_bytes": 17179869184,
+                            "non_heap_used_in_bytes": 154359232,
+                            "non_heap_committed_in_bytes": 159907840,
+                            "pools": {},
+                        },
+                        "gc": {
+                            "collectors": {
+                                "ZGC Cycles": {"collection_count": 4, "collection_time_in_millis": 358},
+                                "ZGC Pauses": {"collection_count": 12, "collection_time_in_millis": 0},
+                            }
+                        },
+                    },
+                }
+            }
+        }
+        client.nodes = SubClient(nodes_stats_at_end)
+        t.on_benchmark_stop()
+
+        metrics_store_node_level.assert_has_calls(
+            [
+                mock.call("rally0", "node_zgc_cycles_gc_time", 0, "ms"),
+                mock.call("rally0", "node_zgc_cycles_gc_count", 0),
+                mock.call("rally0", "node_zgc_pauses_gc_time", 0, "ms"),
+                mock.call("rally0", "node_zgc_pauses_gc_count", 0),
+            ],
+            any_order=True,
+        )
+
+        metrics_store_cluster_level.assert_has_calls(
+            [
+                mock.call("node_total_zgc_cycles_gc_time", 0, "ms"),
+                mock.call("node_total_zgc_cycles_gc_count", 0),
+                mock.call("node_total_zgc_pauses_gc_time", 0, "ms"),
+                mock.call("node_total_zgc_pauses_gc_count", 0),
+            ],
+            any_order=True,
         )
 
 


### PR DESCRIPTION
Support collectors other than `young` and `old` when collecting GC stats in telemetry.

Fixes https://github.com/elastic/rally/issues/1052.