### PR TITLE
When running rally with no options, print help and exit.

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -661,7 +661,6 @@ def create_arg_parser():
     )
 
     for p in [
-        parser,
         list_parser,
         race_parser,
         compare_parser,

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -661,6 +661,7 @@ def create_arg_parser():
     )
 
     for p in [
+        parser,
         list_parser,
         race_parser,
         compare_parser,
@@ -1031,6 +1032,10 @@ def main():
 
     arg_parser = create_arg_parser()
     args = arg_parser.parse_args()
+
+    if args.subcommand is None:
+        arg_parser.print_help()
+        sys.exit(0)
 
     console.init(quiet=args.quiet)
     console.println(BANNER)

--- a/it/basic_test.py
+++ b/it/basic_test.py
@@ -1,0 +1,35 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import it
+from esrally.utils import process
+
+
+@it.rally_in_mem
+def test_run_without_arguments(cfg):
+    cmd = it.esrally_command_line_for(cfg, "")
+    output = process.run_subprocess_with_output(cmd)
+    expected = "usage: esrally [-h] [--version]"
+    assert expected in "\n".join(output)
+
+
+@it.rally_in_mem
+def test_run_with_help(cfg):
+    cmd = it.esrally_command_line_for(cfg, "--help")
+    output = process.run_subprocess_with_output(cmd)
+    expected = "usage: esrally [-h] [--version]"
+    assert expected in "\n".join(output)


### PR DESCRIPTION
### Fixes https://github.com/elastic/rally/issues/1459.

When running `esrally` with no options, print help and exit.

Another option would be to specify `required=True` in `add_subparsers`, to enforce user choosing a subparser. But in that case, the message is less helpful:

```
usage: esrally [-h] [--version] [--quiet] [--offline] {race,list,info,create-track,generate,compare,download,install,start,stop} ...
esrally: error: the following arguments are required: subcommand
```

so I opted for printing help instead:

```
> esrally
usage: esrally [-h] [--version] [--quiet] [--offline] {race,list,info,create-track,generate,compare,download,install,start,stop} ...

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/

 You Know, for Benchmarking Elasticsearch.

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --quiet               Suppress as much as output as possible (default: false).
  --offline             Assume that Rally has no connection to the Internet (default: false).

subcommands:
  {race,list,info,create-track,generate,compare,download,install,start,stop}
    race                Run a benchmark
    list                List configuration options
    info                Show info about a track
    create-track        Create a Rally track from existing data
    generate            Generate artifacts
    compare             Compare two races
    download            Downloads an artifact
    install             Installs an Elasticsearch node locally
    start               Starts an Elasticsearch node locally
    stop                Stops an Elasticsearch node locally

Find out more about Rally at https://esrally.readthedocs.io/en/latest/
```