### PR TITLE
Explicit offline mode

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -1057,10 +1057,9 @@ def main():
     if not args.offline:
         probing_url = cfg.opts("system", "probing.url", default_value="https://github.com", mandatory=False)
         if not net.has_internet_connection(probing_url):
-            console.warn("No Internet connection detected. Automatic download of track data sets etc. is disabled.", logger=logger)
-            cfg.add(config.Scope.applicationOverride, "system", "offline.mode", True)
-        else:
-            logger.info("Detected a working Internet connection.")
+            console.warn("No Internet connection detected. Specify --offline to run without it.", logger=logger)
+            sys.exit(0)
+        logger.info("Detected a working Internet connection.")
 
     result = dispatch_sub_command(arg_parser, args, cfg)
 

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -28,11 +28,16 @@ def run_subprocess(command_line):
     return os.system(command_line)
 
 
-def run_subprocess_with_output(command_line):
+def run_subprocess_with_output(command_line, env_vars=None):
     logger = logging.getLogger(__name__)
     logger.debug("Running subprocess [%s] with output.", command_line)
     command_line_args = shlex.split(command_line)
-    with subprocess.Popen(command_line_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as command_line_process:
+    kwargs = {}
+    if env_vars:
+        cmd_env = os.environ.copy()
+        cmd_env.update(env_vars)
+        kwargs["env"] = cmd_env
+    with subprocess.Popen(command_line_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs) as command_line_process:
         has_output = True
         lines = []
         while has_output:

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -189,7 +189,7 @@ class TestCluster:
 
 
 class EsMetricsStore:
-    VERSION = "7.6.0"
+    VERSION = os.getenv("it_es_version", "7.6.0")
 
     def __init__(self):
         self.cluster = TestCluster("in-memory-it")

--- a/it/basic_test.py
+++ b/it/basic_test.py
@@ -33,3 +33,11 @@ def test_run_with_help(cfg):
     output = process.run_subprocess_with_output(cmd)
     expected = "usage: esrally [-h] [--version]"
     assert expected in "\n".join(output)
+
+
+@it.rally_in_mem
+def test_run_without_http_connection(cfg):
+    cmd = it.esrally_command_line_for(cfg, "list races")
+    output = process.run_subprocess_with_output(cmd, {"http_proxy": "http://non-existent-proxy-server.com"})
+    expected = "No Internet connection detected. Specify --offline"
+    assert expected in "\n".join(output)

--- a/it/proxy_test.py
+++ b/it/proxy_test.py
@@ -81,7 +81,7 @@ def test_anonymous_proxy_no_connection(cfg, http_proxy, fresh_log_file):
     assert process.run_subprocess_with_logging(it.esrally_command_line_for(cfg, "list tracks"), env=env) == 0
     assert_log_line_present(fresh_log_file, f"Connecting via proxy URL [{http_proxy.anonymous_url}] to the Internet")
     # unauthenticated proxy access is prevented
-    assert_log_line_present(fresh_log_file, "No Internet connection detected")
+    assert_log_line_present(fresh_log_file, "No Internet connection detected. Specify --offline")
 
 
 @it.rally_in_mem


### PR DESCRIPTION
### Closes https://github.com/elastic/rally/issues/1468.

In case there's no internet connection, exit and suggest using `--offline` mode, as opposed to falling back to offline mode without asking.

Added an integration test as well.