### PR TITLE
Black all the things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,12 +91,12 @@ tox-env-clean:
 
 lint: check-venv
 	@. $(VENV_ACTIVATE_FILE); find esrally benchmarks scripts tests it setup.py -name "*.py" -exec pylint -j0 -rn --rcfile=$(CURDIR)/.pylintrc \{\} +
-	@. $(VENV_ACTIVATE_FILE); black --check --diff esrally benchmarks scripts tests it setup.py
-	@. $(VENV_ACTIVATE_FILE); isort --check --diff esrally benchmarks scripts tests it setup.py
+	@. $(VENV_ACTIVATE_FILE); black --check --diff .
+	@. $(VENV_ACTIVATE_FILE); isort --check --diff .
 
 format: check-venv
-	@. $(VENV_ACTIVATE_FILE); black esrally benchmarks scripts tests it setup.py
-	@. $(VENV_ACTIVATE_FILE); isort esrally benchmarks scripts tests it setup.py
+	@. $(VENV_ACTIVATE_FILE); black .
+	@. $(VENV_ACTIVATE_FILE); isort .
 
 docs: check-venv
 	@. $(VENV_ACTIVATE_FILE); cd docs && $(MAKE) html

--- a/changelog.py
+++ b/changelog.py
@@ -8,7 +8,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -103,11 +103,13 @@ def main():
     print("### %s\n" % milestone_name)
 
     print_category("Highlights", prs(gh, milestone, with_labels="highlight"))
-    print_category("Enhancements", prs(gh, milestone, with_labels="enhancement", without_labels=[":Docs", "highlight", ":internal", ":misc"]))
+    print_category(
+        "Enhancements", prs(gh, milestone, with_labels="enhancement", without_labels=[":Docs", "highlight", ":internal", ":misc"])
+    )
     print_category("Bug Fixes", prs(gh, milestone, with_labels="bug", without_labels=[":Docs", "highlight", ":internal", ":misc"]))
     print_category("Doc Changes", prs(gh, milestone, with_labels=":Docs", without_labels=["highlight", ":misc"]))
     print_category("Miscellaneous Changes", prs(gh, milestone, with_labels=":misc", without_labels=[":internal"]))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -21,7 +21,7 @@
 import json
 import os
 from datetime import date
-from os.path import join, dirname
+from os.path import dirname, join
 
 from sphinx.config import ConfigError
 
@@ -30,17 +30,15 @@ from sphinx.config import ConfigError
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    "sphinx.ext.ifconfig"
-]
+extensions = ["sphinx.ext.ifconfig"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames. You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
-master_doc = 'index'
+source_suffix = ".rst"
+master_doc = "index"
 language = None
 
 CI_VARS = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".ci", "variables.json")
@@ -51,14 +49,10 @@ def read_min_python_version():
         with open(CI_VARS, "rt") as fp:
             return json.load(fp)["python_versions"]["MIN_PY_VER"]
     except KeyError as e:
-        raise ConfigError(
-            f"Failed building docs as required key [{e}] couldn't be found in the file [{CI_VARS}]."
-        )
+        raise ConfigError(f"Failed building docs as required key [{e}] couldn't be found in the file [{CI_VARS}].")
 
 
-GLOBAL_SUBSTITUTIONS = {
-    "{MIN_PY_VER}": read_min_python_version()
-}
+GLOBAL_SUBSTITUTIONS = {"{MIN_PY_VER}": read_min_python_version()}
 
 
 # inspiration from https://github.com/sphinx-doc/sphinx/issues/4054#issuecomment-329097229
@@ -104,23 +98,23 @@ release = version
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -132,62 +126,57 @@ todo_include_todos = False
 # a list of builtin themes.
 # html_theme = 'alabaster'
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
+
+    html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Rallydoc'
+htmlhelp_basename = "Rallydoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {}
 
 latex_documents = [
-    (master_doc, 'Rally.tex', 'Rally Documentation',
-     'Daniel Mitterdorfer', 'manual'),
+    (master_doc, "Rally.tex", "Rally Documentation", "Daniel Mitterdorfer", "manual"),
 ]
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'esrally', 'Rally Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "esrally", "Rally Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 # -- Options for Texinfo output -------------------------------------------
 texinfo_documents = [
-    (master_doc, 'Rally', 'Rally Documentation',
-     author, 'Rally', 'Macrobenchmarking framework for Elasticsearch.',
-     'Miscellaneous'),
+    (master_doc, "Rally", "Rally Documentation", author, "Rally", "Macrobenchmarking framework for Elasticsearch.", "Miscellaneous"),
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ from sphinx.config import ConfigError
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.ifconfig"]
+extensions = ["sphinx.ext.ifconfig",]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -52,7 +52,7 @@ def read_min_python_version():
         raise ConfigError(f"Failed building docs as required key [{e}] couldn't be found in the file [{CI_VARS}].")
 
 
-GLOBAL_SUBSTITUTIONS = {"{MIN_PY_VER}": read_min_python_version()}
+GLOBAL_SUBSTITUTIONS = {"{MIN_PY_VER}": read_min_python_version(),}
 
 
 # inspiration from https://github.com/sphinx-doc/sphinx/issues/4054#issuecomment-329097229
@@ -164,19 +164,19 @@ htmlhelp_basename = "Rallydoc"
 latex_elements = {}
 
 latex_documents = [
-    (master_doc, "Rally.tex", "Rally Documentation", "Daniel Mitterdorfer", "manual"),
+    (master_doc, "Rally.tex", "Rally Documentation", "Daniel Mitterdorfer", "manual",),
 ]
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "esrally", "Rally Documentation", [author], 1)]
+man_pages = [(master_doc, "esrally", "Rally Documentation", [author], 1,)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
 
 # -- Options for Texinfo output -------------------------------------------
 texinfo_documents = [
-    (master_doc, "Rally", "Rally Documentation", author, "Rally", "Macrobenchmarking framework for Elasticsearch.", "Miscellaneous"),
+    (master_doc, "Rally", "Rally Documentation", author, "Rally", "Macrobenchmarking framework for Elasticsearch.", "Miscellaneous",),
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,9 @@ from sphinx.config import ConfigError
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.ifconfig",]
+extensions = [
+    "sphinx.ext.ifconfig",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -52,7 +54,9 @@ def read_min_python_version():
         raise ConfigError(f"Failed building docs as required key [{e}] couldn't be found in the file [{CI_VARS}].")
 
 
-GLOBAL_SUBSTITUTIONS = {"{MIN_PY_VER}": read_min_python_version(),}
+GLOBAL_SUBSTITUTIONS = {
+    "{MIN_PY_VER}": read_min_python_version(),
+}
 
 
 # inspiration from https://github.com/sphinx-doc/sphinx/issues/4054#issuecomment-329097229
@@ -164,19 +168,41 @@ htmlhelp_basename = "Rallydoc"
 latex_elements = {}
 
 latex_documents = [
-    (master_doc, "Rally.tex", "Rally Documentation", "Daniel Mitterdorfer", "manual",),
+    (
+        master_doc,
+        "Rally.tex",
+        "Rally Documentation",
+        "Daniel Mitterdorfer",
+        "manual",
+    ),
 ]
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "esrally", "Rally Documentation", [author], 1,)]
+man_pages = [
+    (
+        master_doc,
+        "esrally",
+        "Rally Documentation",
+        [author],
+        1,
+    )
+]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
 
 # -- Options for Texinfo output -------------------------------------------
 texinfo_documents = [
-    (master_doc, "Rally", "Rally Documentation", author, "Rally", "Macrobenchmarking framework for Elasticsearch.", "Miscellaneous",),
+    (
+        master_doc,
+        "Rally",
+        "Rally Documentation",
+        author,
+        "Rally",
+        "Macrobenchmarking framework for Elasticsearch.",
+        "Miscellaneous",
+    ),
 ]

--- a/docs/create_scheduler_plot.py
+++ b/docs/create_scheduler_plot.py
@@ -6,7 +6,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	http://www.apache.org/licenses/LICENSE-2.0
+# 	http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -16,6 +16,7 @@
 # under the License.
 
 import sys
+
 # we don't include matplotlib in setup.py as it's just a development dependency
 try:
     import matplotlib
@@ -58,14 +59,14 @@ def main():
     ax.set_title("Poisson schedule")
     ax.plot(tnp, yn, "o-")
 
-    plt.xlabel('time [s]')
+    plt.xlabel("time [s]")
 
     if len(sys.argv) == 2:
         output_file_path = sys.argv[1]
         print("Saving output to [%s]" % output_file_path)
-        plt.savefig(output_file_path, bbox_inches='tight')
+        plt.savefig(output_file_path, bbox_inches="tight")
     plt.show()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
 line-length = 140
 target-version = ['py38']
+include = '((esrally|benchmarks|scripts|tests|it)/.*\.pyi?$)|setup.py'
 
 [tool.isort]
 profile = 'black'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.black]
 line-length = 140
 target-version = ['py38']
-include = '((esrally|benchmarks|scripts|tests|it)/.*\.pyi?$)|setup.py'
 
 [tool.isort]
 profile = 'black'


### PR DESCRIPTION
Running `black .` shouldn't make unintended changes. We can use `pyproject.toml` to keep `black` rules.