### PR TITLE
Upgrade ES client to 8.2.0

### DIFF
--- a/esrally/client.py
+++ b/esrally/client.py
@@ -523,12 +523,12 @@ class EsClientFactory:
         import esrally.async_connection
 
         class LazyJSONSerializer(JSONSerializer):
-            def loads(self, s):
+            def loads(self, data):
                 meta = RallyAsyncElasticsearch.request_context.get()
                 if "raw_response" in meta:
-                    return io.BytesIO(s)
+                    return io.BytesIO(data)
                 else:
-                    return super().loads(s)
+                    return super().loads(data)
 
         async def on_request_start(session, trace_config_ctx, params):
             RallyAsyncElasticsearch.on_request_start()

--- a/esrally/client.py
+++ b/esrally/client.py
@@ -17,14 +17,41 @@
 
 import contextvars
 import logging
+import re
 import time
+import warnings
+from datetime import date, datetime
+from typing import Any, Iterable, Mapping, Optional
 
 import certifi
+import elastic_transport
 import urllib3
+from elastic_transport import (
+    ApiResponse,
+    BinaryApiResponse,
+    HeadApiResponse,
+    ListApiResponse,
+    ObjectApiResponse,
+    TextApiResponse,
+)
+from elastic_transport.client_utils import DEFAULT, percent_encode
+from elasticsearch.compat import warn_stacklevel
+from elasticsearch.exceptions import (
+    HTTP_EXCEPTIONS,
+    ApiError,
+    ElasticsearchWarning,
+    UnsupportedProductError,
+)
 from urllib3.connection import is_ipaddress
 
 from esrally import doc_link, exceptions
-from esrally.utils import console, convert
+from esrally.utils import console, convert, versions
+
+_WARNING_RE = re.compile(r"\"([^\"]*)\"")
+# TODO: get versionstr dynamically
+_COMPAT_MIMETYPE_TEMPLATE = "application/vnd.elasticsearch+%s; compatible-with=" + str("8.2.0".partition(".")[0])
+_COMPAT_MIMETYPE_RE = re.compile(r"application/(json|x-ndjson|vnd\.mapbox-vector-tile)")
+_COMPAT_MIMETYPE_SUB = _COMPAT_MIMETYPE_TEMPLATE % (r"\g<1>",)
 
 
 class RequestContextManager:
@@ -112,13 +139,22 @@ class RequestContextHolder:
 
 class EsClientFactory:
     """
-    Abstracts how the Elasticsearch client is created. Intended for testing.
+    Abstracts how the Elasticsearch client is created and customizes the client for backwards
+    compatibility guarantees that are broader than the library's defaults.
     """
 
-    def __init__(self, hosts, client_options):
-        self.hosts = hosts
+    def __init__(self, hosts, client_options, distribution_version=None):
+        # We need to pass a list of connection strings to the client as of elasticsearch-py 8.0
+        def host_string(host):
+            protocol = "https" if client_options.get("use_ssl") else "http"
+            return f"{protocol}://{host['host']}:{host['port']}"
+
+        self.hosts = [host_string(h) for h in hosts]
         self.client_options = dict(client_options)
         self.ssl_context = None
+        # This attribute is necessary for the backwards-compatibility logic contained in
+        # RallySyncElasticsearch.perform_request() and RallyAsyncElasticsearch.perform_request().
+        self.distribution_version = distribution_version
         self.logger = logging.getLogger(__name__)
 
         masked_client_options = dict(client_options)
@@ -134,13 +170,15 @@ class EsClientFactory:
             import ssl
 
             self.logger.info("SSL support: on")
-            self.client_options["scheme"] = "https"
 
             self.ssl_context = ssl.create_default_context(
                 ssl.Purpose.SERVER_AUTH, cafile=self.client_options.pop("ca_certs", certifi.where())
             )
 
-            if not self.client_options.pop("verify_certs", True):
+            # We call get() here instead of pop() in order to pass verify_certs through as a kwarg
+            # to the elasticsearch.Elasticsearch constructor. Setting the ssl_context's verify_mode to
+            # ssl.CERT_NONE is insufficient with version 8.0+ of elasticsearch-py.
+            if not self.client_options.get("verify_certs", True):
                 self.logger.info("SSL certificate verification: off")
                 # order matters to avoid ValueError: check_hostname needs a SSL context with either CERT_OPTIONAL or CERT_REQUIRED
                 self.ssl_context.check_hostname = False
@@ -189,11 +227,10 @@ class EsClientFactory:
                 self.ssl_context.load_cert_chain(certfile=client_cert, keyfile=client_key)
         else:
             self.logger.info("SSL support: off")
-            self.client_options["scheme"] = "http"
 
         if self._is_set(self.client_options, "basic_auth_user") and self._is_set(self.client_options, "basic_auth_password"):
             self.logger.info("HTTP basic authentication: on")
-            self.client_options["http_auth"] = (self.client_options.pop("basic_auth_user"), self.client_options.pop("basic_auth_password"))
+            self.client_options["basic_auth"] = (self.client_options.pop("basic_auth_user"), self.client_options.pop("basic_auth_password"))
         else:
             self.logger.info("HTTP basic authentication: off")
 
@@ -235,7 +272,245 @@ class EsClientFactory:
         # pylint: disable=import-outside-toplevel
         import elasticsearch
 
-        return elasticsearch.Elasticsearch(hosts=self.hosts, ssl_context=self.ssl_context, **self.client_options)
+        distro = self.distribution_version
+
+        # This reproduces the product verification behavior of v7.14.0 of the client:
+        # https://github.com/elastic/elasticsearch-py/blob/v7.14.0/elasticsearch/transport.py#L606
+        #
+        # As of v8.0.0, the client determines whether the server is Elasticsearch by checking
+        # whether HTTP responses contain the `X-elastic-product` header. If they do not, it raises
+        # an `UnsupportedProductException`. This header was only introduced in Elasticsearch 7.14.0,
+        # however, so the client will consider any version of ES prior to 7.14.0 unsupported due to
+        # responses not including it.
+        #
+        # Because Rally needs to support versions of ES >= 6.8.0, we resurrect the previous
+        # logic for determining the authenticity of the server, which does not rely exclusively
+        # on this header.
+        class _ProductChecker:
+            """Class which verifies we're connected to a supported product"""
+
+            # States that can be returned from 'check_product'
+            SUCCESS = True
+            UNSUPPORTED_PRODUCT = 2
+            UNSUPPORTED_DISTRIBUTION = 3
+
+            @classmethod
+            def raise_error(cls, state, meta, body):
+                # These states mean the product_check() didn't fail so do nothing.
+                if state in (None, True):
+                    return
+
+                if state == cls.UNSUPPORTED_DISTRIBUTION:
+                    message = "The client noticed that the server is not a supported distribution of Elasticsearch"
+                else:  # UNSUPPORTED_PRODUCT
+                    message = "The client noticed that the server is not Elasticsearch and we do not support this unknown product"
+                raise UnsupportedProductError(message, meta=meta, body=body)
+
+            @classmethod
+            def check_product(cls, headers, response):
+                # type: (dict[str, str], dict[str, str]) -> int
+                """Verifies that the server we're talking to is Elasticsearch.
+                Does this by checking HTTP headers and the deserialized
+                response to the 'info' API. Returns one of the states above.
+                """
+                try:
+                    version = response.get("version", {})
+                    version_number = tuple(
+                        int(x) if x is not None else 999
+                        for x in re.search(r"^([0-9]+)\.([0-9]+)(?:\.([0-9]+))?", version["number"]).groups()
+                    )
+                except (KeyError, TypeError, ValueError, AttributeError):
+                    # No valid 'version.number' field, effectively 0.0.0
+                    version = {}
+                    version_number = (0, 0, 0)
+
+                # Check all of the fields and headers for missing/valid values.
+                try:
+                    bad_tagline = response.get("tagline", None) != "You Know, for Search"
+                    bad_build_flavor = version.get("build_flavor", None) != "default"
+                    bad_product_header = headers.get("x-elastic-product", None) != "Elasticsearch"
+                except (AttributeError, TypeError):
+                    bad_tagline = True
+                    bad_build_flavor = True
+                    bad_product_header = True
+
+                # 7.0-7.13 and there's a bad 'tagline' or unsupported 'build_flavor'
+                if (7, 0, 0) <= version_number < (7, 14, 0):
+                    if bad_tagline:
+                        return cls.UNSUPPORTED_PRODUCT
+                    elif bad_build_flavor:
+                        return cls.UNSUPPORTED_DISTRIBUTION
+
+                elif (
+                    # No version or version less than 6.x
+                    version_number < (6, 0, 0)
+                    # 6.x and there's a bad 'tagline'
+                    or ((6, 0, 0) <= version_number < (7, 0, 0) and bad_tagline)
+                    # 7.14+ and there's a bad 'X-Elastic-Product' HTTP header
+                    or ((7, 14, 0) <= version_number and bad_product_header)
+                ):
+                    return cls.UNSUPPORTED_PRODUCT
+
+                return True
+
+        class RallySyncElasticsearch(elasticsearch.Elasticsearch):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._verified_elasticsearch = None
+
+                if distro is not None:
+                    self.distribution_version = versions.Version.from_string(distro)
+                else:
+                    self.distribution_version = None
+
+            def perform_request(
+                self,
+                method: str,
+                path: str,
+                *,
+                params: Optional[Mapping[str, Any]] = None,
+                headers: Optional[Mapping[str, str]] = None,
+                body: Optional[Any] = None,
+            ) -> ApiResponse[Any]:
+
+                if body is not None:
+                    if headers is None:
+                        headers = {"content-type": "application/json", "accept": "application/json"}
+                    else:
+                        if headers.get("content-type") is None:
+                            headers["content-type"] = "application/json"
+                            headers["accept"] = "application/json"
+
+                if headers:
+                    request_headers = self._headers.copy()
+                    request_headers.update(headers)
+                else:
+                    request_headers = self._headers
+
+                if self._verified_elasticsearch is None:
+                    info = self.transport.perform_request(method="GET", target="/", headers=request_headers)
+                    info_meta = info.meta
+                    info_body = info.body
+
+                    self._verified_elasticsearch = _ProductChecker.check_product(info_meta.headers, info_body)
+
+                    if self._verified_elasticsearch is not True:
+                        _ProductChecker.raise_error(self._verified_elasticsearch, info_meta, info_body)
+
+                def mimetype_header_to_compat(header: str) -> None:
+                    # Converts all parts of a Accept/Content-Type headers
+                    # from application/X -> application/vnd.elasticsearch+X
+                    nonlocal request_headers
+                    mimetype = request_headers.get(header, None)
+                    if mimetype:
+                        request_headers[header] = _COMPAT_MIMETYPE_RE.sub(_COMPAT_MIMETYPE_SUB, mimetype)
+
+                # Custom behavior for backwards compatibility with versions of ES that do not
+                # recognize the compatible-with header.
+                if self.distribution_version is not None and self.distribution_version >= versions.Version.from_string("8.0.0"):
+                    mimetype_header_to_compat("Accept")
+                    mimetype_header_to_compat("Content-Type")
+
+                def _escape(value: Any) -> str:
+                    """
+                    Escape a single value of a URL string or a query parameter. If it is a list
+                    or tuple, turn it into a comma-separated string first.
+                    """
+
+                    # make sequences into comma-separated stings
+                    if isinstance(value, (list, tuple)):
+                        value = ",".join([_escape(item) for item in value])
+
+                    # dates and datetimes into isoformat
+                    elif isinstance(value, (date, datetime)):
+                        value = value.isoformat()
+
+                    # make bools into true/false strings
+                    elif isinstance(value, bool):
+                        value = str(value).lower()
+
+                    elif isinstance(value, bytes):
+                        return value.decode("utf-8", "surrogatepass")
+
+                    if not isinstance(value, str):
+                        return str(value)
+                    return value
+
+                def _quote(value: Any) -> str:
+                    return percent_encode(_escape(value), ",*")
+
+                def _quote_query(query: Mapping[str, Any]) -> str:
+                    return "&".join([f"{k}={_quote(v)}" for k, v in query.items()])
+
+                if params:
+                    target = f"{path}?{_quote_query(params)}"
+                else:
+                    target = path
+
+                meta, resp_body = self.transport.perform_request(
+                    method,
+                    target,
+                    headers=request_headers,
+                    body=body,
+                    request_timeout=self._request_timeout,
+                    max_retries=self._max_retries,
+                    retry_on_status=self._retry_on_status,
+                    retry_on_timeout=self._retry_on_timeout,
+                    client_meta=self._client_meta,
+                )
+
+                # HEAD with a 404 is returned as a normal response
+                # since this is used as an 'exists' functionality.
+                if not (method == "HEAD" and meta.status == 404) and (
+                    not 200 <= meta.status < 299
+                    and (self._ignore_status is DEFAULT or self._ignore_status is None or meta.status not in self._ignore_status)
+                ):
+                    message = str(resp_body)
+
+                    # If the response is an error response try parsing
+                    # the raw Elasticsearch error before raising.
+                    if isinstance(resp_body, dict):
+                        try:
+                            error = resp_body.get("error", message)
+                            if isinstance(error, dict) and "type" in error:
+                                error = error["type"]
+                            message = error
+                        except (ValueError, KeyError, TypeError):
+                            pass
+
+                    raise HTTP_EXCEPTIONS.get(meta.status, ApiError)(message=message, meta=meta, body=resp_body)
+
+                # 'Warning' headers should be reraised as 'ElasticsearchWarning'
+                if "warning" in meta.headers:
+                    warning_header = (meta.headers.get("warning") or "").strip()
+                    warning_messages: Iterable[str] = _WARNING_RE.findall(warning_header) or (warning_header,)
+                    stacklevel = warn_stacklevel()
+                    for warning_message in warning_messages:
+                        warnings.warn(
+                            warning_message,
+                            category=ElasticsearchWarning,
+                            stacklevel=stacklevel,
+                        )
+
+                if method == "HEAD":
+                    response = HeadApiResponse(meta=meta)
+                elif isinstance(resp_body, dict):
+                    response = ObjectApiResponse(body=resp_body, meta=meta)  # type: ignore[assignment]
+                elif isinstance(resp_body, list):
+                    response = ListApiResponse(body=resp_body, meta=meta)  # type: ignore[assignment]
+                elif isinstance(resp_body, str):
+                    response = TextApiResponse(  # type: ignore[assignment]
+                        body=resp_body,
+                        meta=meta,
+                    )
+                elif isinstance(resp_body, bytes):
+                    response = BinaryApiResponse(body=resp_body, meta=meta)  # type: ignore[assignment]
+                else:
+                    response = ApiResponse(body=resp_body, meta=meta)  # type: ignore[assignment]
+
+                return response
+
+        return RallySyncElasticsearch(hosts=self.hosts, ssl_context=self.ssl_context, **self.client_options)
 
     def create_async(self):
         # pylint: disable=import-outside-toplevel
@@ -271,22 +546,186 @@ class EsClientFactory:
         self.client_options["serializer"] = LazyJSONSerializer()
         self.client_options["trace_config"] = trace_config
 
-        class VerifiedAsyncTransport(elasticsearch.AsyncTransport):
+        client_options = self.client_options
+        distro = self.distribution_version
+
+        class RallyAsyncTransport(elastic_transport.AsyncTransport):
+            def __init__(self, *args, **kwargs):
+                # We need to pass a trace config to the session that's created in
+                # async_connection.RallyAiohttphttpnode, which is a subclass of
+                # elastic_transport.AiohttpHttpNode.
+                #
+                # Its constructor only accepts an elastic_transport.NodeConfig object.
+                # Because we do not fully control creation of these objects , we need to
+                # pass the trace_config by adding it to the NodeConfig's `extras`, which
+                # can contain arbitrary metadata.
+                client_options.update({"trace_config": [trace_config]})
+                node_configs = args[0]
+                for conf in node_configs:
+                    extras = conf._extras
+                    extras.update({"_rally_client_options": client_options})
+                    conf._extras = extras
+                original_args = args
+                new_args = (node_configs, *original_args[1:])
+
+                super().__init__(*new_args, node_class=esrally.async_connection.RallyAiohttpHttpNode, **kwargs)
+
+        class RallyAsyncElasticsearch(elasticsearch.AsyncElasticsearch, RequestContextHolder):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 # skip verification at this point; we've already verified this earlier with the synchronous client.
                 # The async client is used in the hot code path and we use customized overrides (such as that we don't
                 # parse response bodies in some cases for performance reasons, e.g. when using the bulk API).
                 self._verified_elasticsearch = True
+                if distro is not None:
+                    self.distribution_version = versions.Version.from_string(distro)
+                else:
+                    self.distribution_version = None
 
-        class RallyAsyncElasticsearch(elasticsearch.AsyncElasticsearch, RequestContextHolder):
-            pass
+            async def perform_request(
+                self,
+                method: str,
+                path: str,
+                *,
+                params: Optional[Mapping[str, Any]] = None,
+                headers: Optional[Mapping[str, str]] = None,
+                body: Optional[Any] = None,
+            ) -> ApiResponse[Any]:
+
+                if body is not None:
+                    if headers is None:
+                        headers = {"content-type": "application/json", "accept": "application/json"}
+                    else:
+                        if headers.get("content-type") is None:
+                            headers["content-type"] = "application/json"
+                            headers["accept"] = "application/json"
+
+                if headers:
+                    request_headers = self._headers.copy()
+                    request_headers.update(headers)
+                else:
+                    request_headers = self._headers
+
+                def mimetype_header_to_compat(header: str) -> None:
+                    # Converts all parts of a Accept/Content-Type headers
+                    # from application/X -> application/vnd.elasticsearch+X
+                    nonlocal request_headers
+                    mimetype = request_headers.get(header, None)
+                    if mimetype:
+                        request_headers[header] = _COMPAT_MIMETYPE_RE.sub(_COMPAT_MIMETYPE_SUB, mimetype)
+
+                if self.distribution_version is not None and self.distribution_version >= versions.Version.from_string("8.0.0"):
+                    mimetype_header_to_compat("Accept")
+                    mimetype_header_to_compat("Content-Type")
+
+                def _escape(value: Any) -> str:
+                    """
+                    Escape a single value of a URL string or a query parameter. If it is a list
+                    or tuple, turn it into a comma-separated string first.
+                    """
+
+                    # make sequences into comma-separated stings
+                    if isinstance(value, (list, tuple)):
+                        value = ",".join([_escape(item) for item in value])
+
+                    # dates and datetimes into isoformat
+                    elif isinstance(value, (date, datetime)):
+                        value = value.isoformat()
+
+                    # make bools into true/false strings
+                    elif isinstance(value, bool):
+                        value = str(value).lower()
+
+                    elif isinstance(value, bytes):
+                        return value.decode("utf-8", "surrogatepass")
+
+                    if not isinstance(value, str):
+                        return str(value)
+                    return value
+
+                def _quote(value: Any) -> str:
+                    return percent_encode(_escape(value), ",*")
+
+                def _quote_query(query: Mapping[str, Any]) -> str:
+                    return "&".join([f"{k}={_quote(v)}" for k, v in query.items()])
+
+                if params:
+                    target = f"{path}?{_quote_query(params)}"
+                else:
+                    target = path
+
+                meta, resp_body = await self.transport.perform_request(
+                    method,
+                    target,
+                    headers=request_headers,
+                    body=body,
+                    request_timeout=self._request_timeout,
+                    max_retries=self._max_retries,
+                    retry_on_status=self._retry_on_status,
+                    retry_on_timeout=self._retry_on_timeout,
+                    client_meta=self._client_meta,
+                )
+
+                # HEAD with a 404 is returned as a normal response
+                # since this is used as an 'exists' functionality.
+                if not (method == "HEAD" and meta.status == 404) and (
+                    not 200 <= meta.status < 299
+                    and (self._ignore_status is DEFAULT or self._ignore_status is None or meta.status not in self._ignore_status)
+                ):
+                    message = str(resp_body)
+
+                    # If the response is an error response try parsing
+                    # the raw Elasticsearch error before raising.
+                    if isinstance(resp_body, dict):
+                        try:
+                            error = resp_body.get("error", message)
+                            if isinstance(error, dict) and "type" in error:
+                                error = error["type"]
+                            message = error
+                        except (ValueError, KeyError, TypeError):
+                            pass
+
+                    raise HTTP_EXCEPTIONS.get(meta.status, ApiError)(message=message, meta=meta, body=resp_body)
+
+                # 'Warning' headers should be reraised as 'ElasticsearchWarning'
+                if "warning" in meta.headers:
+                    warning_header = (meta.headers.get("warning") or "").strip()
+                    warning_messages: Iterable[str] = _WARNING_RE.findall(warning_header) or (warning_header,)
+                    stacklevel = warn_stacklevel()
+                    for warning_message in warning_messages:
+                        warnings.warn(
+                            warning_message,
+                            category=ElasticsearchWarning,
+                            stacklevel=stacklevel,
+                        )
+
+                if method == "HEAD":
+                    response = HeadApiResponse(meta=meta)
+                elif isinstance(resp_body, dict):
+                    response = ObjectApiResponse(body=resp_body, meta=meta)  # type: ignore[assignment]
+                elif isinstance(resp_body, list):
+                    response = ListApiResponse(body=resp_body, meta=meta)  # type: ignore[assignment]
+                elif isinstance(resp_body, str):
+                    response = TextApiResponse(  # type: ignore[assignment]
+                        body=resp_body,
+                        meta=meta,
+                    )
+                elif isinstance(resp_body, bytes):
+                    response = BinaryApiResponse(body=resp_body, meta=meta)  # type: ignore[assignment]
+                else:
+                    response = ApiResponse(body=resp_body, meta=meta)  # type: ignore[assignment]
+
+                return response
+
+        # max_connections and trace_config are not valid kwargs, so we pop them
+        max = self.client_options.pop("max_connections")
+        self.client_options.pop("trace_config")
 
         return RallyAsyncElasticsearch(
             hosts=self.hosts,
-            transport_class=VerifiedAsyncTransport,
-            connection_class=esrally.async_connection.AIOHttpConnection,
+            transport_class=RallyAsyncTransport,
             ssl_context=self.ssl_context,
+            maxsize=max,
             **self.client_options,
         )
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -954,8 +954,12 @@ class Query(Runner):
                         took = props.get("took", 0)
                         all_results_collected = (size is not None and hits < size) or hits == 0
                     else:
-                        r = await es.transport.perform_request(
-                            "GET", "/_search/scroll", body={"scroll_id": scroll_id, "scroll": "10s"}, params=request_params, headers=headers
+                        r = await es.perform_request(
+                            method="GET",
+                            path="/_search/scroll",
+                            body={"scroll_id": scroll_id, "scroll": "10s"},
+                            params=request_params,
+                            headers=headers,
                         )
                         props = parse(r, ["timed_out", "took"], ["hits.hits"])
                         timed_out = timed_out or props.get("timed_out", False)
@@ -1011,7 +1015,7 @@ class Query(Runner):
             components.append(doc_type)
         components.append("_search")
         path = "/".join(components)
-        return await es.transport.perform_request("GET", "/" + path, params=params, body=body, headers=headers)
+        return await es.perform_request(method="GET", path=f"/{path}", params=params, body=body, headers=headers)
 
     def _query_headers(self, params):
         # reduces overhead due to decompression of very large responses
@@ -1183,7 +1187,7 @@ class CreateDataStream(Runner):
         data_streams = mandatory(params, "data-streams", self)
         request_params = mandatory(params, "request-params", self)
         for data_stream in data_streams:
-            await es.indices.create_data_stream(data_stream, params=request_params)
+            await es.indices.create_data_stream(name=data_stream, params=request_params)
         return {
             "weight": len(data_streams),
             "unit": "ops",
@@ -1258,11 +1262,11 @@ class DeleteDataStream(Runner):
 
         for data_stream in data_streams:
             if not only_if_exists:
-                await es.indices.delete_data_stream(data_stream, ignore=[404], params=request_params)
+                await es.indices.delete_data_stream(name=data_stream, ignore=[404], params=request_params)
                 ops += 1
             elif only_if_exists and await es.indices.exists(index=data_stream):
                 self.logger.info("Data stream [%s] already exists. Deleting it.", data_stream)
-                await es.indices.delete_data_stream(data_stream, params=request_params)
+                await es.indices.delete_data_stream(name=data_stream, params=request_params)
                 ops += 1
 
         return {
@@ -1307,19 +1311,12 @@ class DeleteComponentTemplate(Runner):
         only_if_exists = mandatory(params, "only-if-exists", self)
         request_params = mandatory(params, "request-params", self)
 
-        async def _exists(name):
-            # pylint: disable=import-outside-toplevel
-            from elasticsearch.client import _make_path
-
-            # currently not supported by client and hence custom request
-            return await es.transport.perform_request("HEAD", _make_path("_component_template", name))
-
         ops_count = 0
         for template_name in template_names:
             if not only_if_exists:
                 await es.cluster.delete_component_template(name=template_name, params=request_params, ignore=[404])
                 ops_count += 1
-            elif only_if_exists and await _exists(template_name):
+            elif only_if_exists and await es.cluster.exists_component_template(name=template_name):
                 self.logger.info("Component Index template [%s] already exists. Deleting it.", template_name)
                 await es.cluster.delete_component_template(name=template_name, params=request_params)
                 ops_count += 1
@@ -1369,7 +1366,7 @@ class DeleteComposableTemplate(Runner):
             if not only_if_exists:
                 await es.indices.delete_index_template(name=template_name, params=request_params, ignore=[404])
                 ops_count += 1
-            elif only_if_exists and await es.indices.exists_index_template(template_name):
+            elif only_if_exists and await es.indices.exists_index_template(name=template_name):
                 self.logger.info("Composable Index template [%s] already exists. Deleting it.", template_name)
                 await es.indices.delete_index_template(name=template_name, params=request_params)
                 ops_count += 1
@@ -1424,7 +1421,7 @@ class DeleteIndexTemplate(Runner):
             if not only_if_exists:
                 await es.indices.delete_template(name=template_name, params=request_params)
                 ops_count += 1
-            elif only_if_exists and await es.indices.exists_template(template_name):
+            elif only_if_exists and await es.indices.exists_template(name=template_name):
                 self.logger.info("Index template [%s] already exists. Deleting it.", template_name)
                 await es.indices.delete_template(name=template_name, params=request_params)
                 ops_count += 1
@@ -1465,7 +1462,7 @@ class ShrinkIndex(Runner):
 
     async def __call__(self, es, params):
         source_index = mandatory(params, "source-index", self)
-        source_indices_get = await es.indices.get(source_index)
+        source_indices_get = await es.indices.get(index=source_index)
         source_indices = list(source_indices_get.keys())
         source_indices_stem = commonprefix(source_indices)
 
@@ -1537,17 +1534,14 @@ class CreateMlDatafeed(Runner):
         datafeed_id = mandatory(params, "datafeed-id", self)
         body = mandatory(params, "body", self)
         try:
-            await es.xpack.ml.put_datafeed(datafeed_id=datafeed_id, body=body)
-        except elasticsearch.TransportError as e:
+            await es.ml.put_datafeed(datafeed_id=datafeed_id, body=body)
+        except elasticsearch.BadRequestError:
             # fallback to old path
-            if e.status_code == 400:
-                await es.transport.perform_request(
-                    "PUT",
-                    f"/_xpack/ml/datafeeds/{datafeed_id}",
-                    body=body,
-                )
-            else:
-                raise e
+            await es.perform_request(
+                method="PUT",
+                path=f"/_xpack/ml/datafeeds/{datafeed_id}",
+                body=body,
+            )
 
     def __repr__(self, *args, **kwargs):
         return "create-ml-datafeed"
@@ -1566,17 +1560,13 @@ class DeleteMlDatafeed(Runner):
         force = params.get("force", False)
         try:
             # we don't want to fail if a datafeed does not exist, thus we ignore 404s.
-            await es.xpack.ml.delete_datafeed(datafeed_id=datafeed_id, force=force, ignore=[404])
-        except elasticsearch.TransportError as e:
-            # fallback to old path (ES < 7)
-            if e.status_code == 400:
-                await es.transport.perform_request(
-                    "DELETE",
-                    f"/_xpack/ml/datafeeds/{datafeed_id}",
-                    params={"force": escape(force), "ignore": 404},
-                )
-            else:
-                raise e
+            await es.ml.delete_datafeed(datafeed_id=datafeed_id, force=force, ignore=[404])
+        except elasticsearch.BadRequestError:
+            await es.perform_request(
+                method="DELETE",
+                path=f"/_xpack/ml/datafeeds/{datafeed_id}",
+                params={"force": escape(force), "ignore": 404},
+            )
 
     def __repr__(self, *args, **kwargs):
         return "delete-ml-datafeed"
@@ -1597,17 +1587,13 @@ class StartMlDatafeed(Runner):
         end = params.get("end")
         timeout = params.get("timeout")
         try:
-            await es.xpack.ml.start_datafeed(datafeed_id=datafeed_id, body=body, start=start, end=end, timeout=timeout)
-        except elasticsearch.TransportError as e:
-            # fallback to old path (ES < 7)
-            if e.status_code == 400:
-                await es.transport.perform_request(
-                    "POST",
-                    f"/_xpack/ml/datafeeds/{datafeed_id}/_start",
-                    body=body,
-                )
-            else:
-                raise e
+            await es.ml.start_datafeed(datafeed_id=datafeed_id, body=body, start=start, end=end, timeout=timeout)
+        except elasticsearch.BadRequestError:
+            await es.perform_request(
+                method="POST",
+                path=f"/_xpack/ml/datafeeds/{datafeed_id}/_start",
+                body=body,
+            )
 
     def __repr__(self, *args, **kwargs):
         return "start-ml-datafeed"
@@ -1626,18 +1612,15 @@ class StopMlDatafeed(Runner):
         force = params.get("force", False)
         timeout = params.get("timeout")
         try:
-            await es.xpack.ml.stop_datafeed(datafeed_id=datafeed_id, force=force, timeout=timeout)
-        except elasticsearch.TransportError as e:
+            await es.ml.stop_datafeed(datafeed_id=datafeed_id, force=force, timeout=timeout)
+        except elasticsearch.BadRequestError:
             # fallback to old path (ES < 7)
-            if e.status_code == 400:
-                request_params = {
-                    "force": escape(force),
-                }
-                if timeout:
-                    request_params["timeout"] = escape(timeout)
-                await es.transport.perform_request("POST", f"/_xpack/ml/datafeeds/{datafeed_id}/_stop", params=request_params)
-            else:
-                raise e
+            request_params = {
+                "force": escape(force),
+            }
+            if timeout:
+                request_params["timeout"] = escape(timeout)
+            await es.perform_request(method="POST", path=f"/_xpack/ml/datafeeds/{datafeed_id}/_stop", params=request_params)
 
     def __repr__(self, *args, **kwargs):
         return "stop-ml-datafeed"
@@ -1655,17 +1638,14 @@ class CreateMlJob(Runner):
         job_id = mandatory(params, "job-id", self)
         body = mandatory(params, "body", self)
         try:
-            await es.xpack.ml.put_job(job_id=job_id, body=body)
-        except elasticsearch.TransportError as e:
+            await es.ml.put_job(job_id=job_id, body=body)
+        except elasticsearch.BadRequestError:
             # fallback to old path (ES < 7)
-            if e.status_code == 400:
-                await es.transport.perform_request(
-                    "PUT",
-                    f"/_xpack/ml/anomaly_detectors/{job_id}",
-                    body=body,
-                )
-            else:
-                raise e
+            await es.perform_request(
+                method="PUT",
+                path=f"/_xpack/ml/anomaly_detectors/{job_id}",
+                body=body,
+            )
 
     def __repr__(self, *args, **kwargs):
         return "create-ml-job"
@@ -1684,17 +1664,14 @@ class DeleteMlJob(Runner):
         force = params.get("force", False)
         # we don't want to fail if a job does not exist, thus we ignore 404s.
         try:
-            await es.xpack.ml.delete_job(job_id=job_id, force=force, ignore=[404])
-        except elasticsearch.TransportError as e:
+            await es.ml.delete_job(job_id=job_id, force=force, ignore=[404])
+        except elasticsearch.BadRequestError:
             # fallback to old path (ES < 7)
-            if e.status_code == 400:
-                await es.transport.perform_request(
-                    "DELETE",
-                    f"/_xpack/ml/anomaly_detectors/{job_id}",
-                    params={"force": escape(force), "ignore": 404},
-                )
-            else:
-                raise e
+            await es.perform_request(
+                method="DELETE",
+                path=f"/_xpack/ml/anomaly_detectors/{job_id}",
+                params={"force": escape(force), "ignore": 404},
+            )
 
     def __repr__(self, *args, **kwargs):
         return "delete-ml-job"
@@ -1711,16 +1688,13 @@ class OpenMlJob(Runner):
 
         job_id = mandatory(params, "job-id", self)
         try:
-            await es.xpack.ml.open_job(job_id=job_id)
-        except elasticsearch.TransportError as e:
+            await es.ml.open_job(job_id=job_id)
+        except elasticsearch.BadRequestError:
             # fallback to old path (ES < 7)
-            if e.status_code == 400:
-                await es.transport.perform_request(
-                    "POST",
-                    f"/_xpack/ml/anomaly_detectors/{job_id}/_open",
-                )
-            else:
-                raise e
+            await es.perform_request(
+                method="POST",
+                path=f"/_xpack/ml/anomaly_detectors/{job_id}/_open",
+            )
 
     def __repr__(self, *args, **kwargs):
         return "open-ml-job"
@@ -1739,23 +1713,20 @@ class CloseMlJob(Runner):
         force = params.get("force", False)
         timeout = params.get("timeout")
         try:
-            await es.xpack.ml.close_job(job_id=job_id, force=force, timeout=timeout)
-        except elasticsearch.TransportError as e:
+            await es.ml.close_job(job_id=job_id, force=force, timeout=timeout)
+        except elasticsearch.BadRequestError:
             # fallback to old path (ES < 7)
-            if e.status_code == 400:
-                request_params = {
-                    "force": escape(force),
-                }
-                if timeout:
-                    request_params["timeout"] = escape(timeout)
+            request_params = {
+                "force": escape(force),
+            }
+            if timeout:
+                request_params["timeout"] = escape(timeout)
 
-                await es.transport.perform_request(
-                    "POST",
-                    f"/_xpack/ml/anomaly_detectors/{job_id}/_close",
-                    params=request_params,
-                )
-            else:
-                raise e
+            await es.perform_request(
+                method="POST",
+                path=f"/_xpack/ml/anomaly_detectors/{job_id}/_close",
+                params=request_params,
+            )
 
     def __repr__(self, *args, **kwargs):
         return "close-ml-job"
@@ -1774,8 +1745,8 @@ class RawRequest(Runner):
             # counter-intuitive, but preserves prior behavior
             headers = None
 
-        await es.transport.perform_request(
-            method=params.get("method", "GET"), url=path, headers=headers, body=params.get("body"), params=request_params
+        await es.perform_request(
+            method=params.get("method", "GET"), path=path, headers=headers, body=params.get("body"), params=request_params
         )
 
     def __repr__(self, *args, **kwargs):
@@ -2466,7 +2437,7 @@ class Sql(Runner):
 
         es.return_raw_response()
 
-        r = await es.transport.perform_request("POST", "/_sql", body=body)
+        r = await es.perform_request(method="POST", path="/_sql", body=body)
         pages -= 1
         weight = 1
 
@@ -2478,7 +2449,7 @@ class Sql(Runner):
                     "Result set has been exhausted before all pages have been fetched, {} page(s) remaining.".format(pages)
                 )
 
-            r = await es.transport.perform_request("POST", "/_sql", body={"cursor": cursor})
+            r = await es.perform_request(method="POST", path="/_sql", body={"cursor": cursor})
             pages -= 1
             weight += 1
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -200,6 +200,7 @@ class Runner:
         # filter Nones
         return dict(filter(lambda kv: kv[1] is not None, full_result.items()))
 
+    # TODO: have this function call options() on the es instance?
     def _transport_request_params(self, params):
         request_params = params.get("request-params", {})
         request_timeout = params.get("request-timeout")
@@ -726,7 +727,7 @@ class NodeStats(Runner):
 
     async def __call__(self, es, params):
         request_timeout = params.get("request-timeout")
-        await es.nodes.stats(metric="_all", request_timeout=request_timeout)
+        await es.options(request_timeout=request_timeout).nodes.stats(metric="_all")
 
     def __repr__(self, *args, **kwargs):
         return "node-stats"
@@ -823,6 +824,9 @@ class Query(Runner):
 
     async def __call__(self, es, params):
         request_params, headers = self._transport_request_params(params)
+        request_timeout = request_params.pop("request_timeout", None)
+        if request_timeout is not None:
+            es.options(request_timeout=request_timeout)
         # Mandatory to ensure it is always provided. This is especially important when this runner is used in a
         # composite context where there is no actual parameter source and the entire request structure must be provided
         # by the composite's parameter source.

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -461,7 +461,7 @@ class CcrStatsRecorder:
             ccr_stats_api_endpoint = "/_ccr/stats"
             filter_path = "follow_stats"
             stats = self.client.transport.perform_request(
-                "GET", ccr_stats_api_endpoint, params={"human": "false", "filter_path": filter_path}
+                method="GET", path=ccr_stats_api_endpoint, params={"human": "false", "filter_path": filter_path}
             )
         except elasticsearch.TransportError:
             msg = "A transport error occurred while collecting CCR stats from the endpoint [{}?filter_path={}] on cluster [{}]".format(
@@ -1233,7 +1233,7 @@ class SearchableSnapshotsStatsRecorder:
             # we don't use the existing client support (searchable_snapshots.stats())
             # as the API is deliberately undocumented and might change:
             # https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-stats.html
-            stats = self.client.transport.perform_request("GET", stats_api_endpoint, params={"level": level})
+            stats = self.client.transport.perform_request(method="GET", path=stats_api_endpoint, params={"level": level})
         except elasticsearch.NotFoundError as e:
             if "No searchable snapshots indices found" in e.info.get("error").get("reason"):
                 self.logger.info(
@@ -2276,7 +2276,9 @@ class DiskUsageStats(TelemetryDevice):
         for index in self.indices.split(","):
             self.logger.debug("Gathering disk usage for [%s]", index)
             try:
-                response = self.client.transport.perform_request("POST", f"/{index}/_disk_usage", params={"run_expensive_tasks": "true"})
+                response = self.client.transport.perform_request(
+                    method="POST", path=f"/{index}/_disk_usage", params={"run_expensive_tasks": "true"}
+                )
             except elasticsearch.RequestError:
                 msg = f"A transport error occurred while collecting disk usage for {index}"
                 self.logger.exception(msg)

--- a/esrally/tracker/index.py
+++ b/esrally/tracker/index.py
@@ -65,7 +65,7 @@ def extract_index_mapping_and_settings(client, index_pattern):
     results = {}
     logger = logging.getLogger(__name__)
     # the response might contain multiple indices if a wildcard was provided
-    response = client.indices.get(index_pattern)
+    response = client.indices.get(index=index_pattern)
     for index, details in response.items():
         valid, reason = is_valid(index)
         if valid:

--- a/esrally/tracker/tracker.py
+++ b/esrally/tracker/tracker.py
@@ -18,7 +18,7 @@
 import logging
 import os
 
-from elasticsearch import ElasticsearchException
+from elasticsearch import ApiError, TransportError
 from jinja2 import Environment, FileSystemLoader
 
 from esrally import PROGRAM_NAME
@@ -43,7 +43,7 @@ def extract_mappings_and_corpora(client, output_path, indices_to_extract):
     for index_name in indices_to_extract:
         try:
             indices += index.extract(client, output_path, index_name)
-        except ElasticsearchException:
+        except (ApiError, TransportError):
             logging.getLogger(__name__).exception("Failed to extract index [%s]", index_name)
 
     # That list only contains valid indices (with index patterns already resolved)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ install_requires = [
     # transitive dependencies:
     #   urllib3: MIT
     #   aiohttp: Apache 2.0
-    "elasticsearch[async]==7.14.0",
+    "elasticsearch[async]==8.2.0",
+    "elastic-transport==8.1.2",
     "urllib3==1.26.9",
     # License: BSD
     "psutil==5.8.0",

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -24,6 +24,7 @@ import math
 import random
 import unittest.mock as mock
 
+import elastic_transport
 import elasticsearch
 import pytest
 
@@ -1231,7 +1232,7 @@ class TestForceMergeRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_force_merge_with_polling(self, es):
-        es.indices.forcemerge = mock.AsyncMock(side_effect=elasticsearch.ConnectionTimeout())
+        es.indices.forcemerge = mock.AsyncMock(side_effect=elasticsearch.ConnectionTimeout(message="connection timeout"))
         es.tasks.list = mock.AsyncMock(
             side_effect=[
                 {
@@ -1278,7 +1279,7 @@ class TestForceMergeRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_force_merge_with_polling_and_params(self, es):
-        es.indices.forcemerge = mock.AsyncMock(return_value=elasticsearch.ConnectionTimeout())
+        es.indices.forcemerge = mock.AsyncMock(return_value=elasticsearch.ConnectionTimeout("connection timeout"))
         es.tasks.list = mock.AsyncMock(
             side_effect=[
                 {
@@ -1496,7 +1497,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1525,8 +1526,8 @@ class TestQueryRunner:
             "took": 5,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "GET", "/_all/_search", params={"request_cache": "true"}, body=params["body"], headers=None
+        es.perform_request.assert_awaited_once_with(
+            method="GET", path="/_all/_search", params={"request_cache": "true"}, body=params["body"], headers=None
         )
         es.clear_scroll.assert_not_called()
 
@@ -1544,7 +1545,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1572,10 +1573,11 @@ class TestQueryRunner:
             "took": 5,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "GET",
-            "/_all/_search",
-            params={"request_timeout": 3.0, "request_cache": "true"},
+        es.perform_request.assert_awaited_once_with(
+            method="GET",
+            path="/_all/_search",
+            # params={"request_timeout": 3.0, "request_cache": "true"},
+            params={"request_cache": "true"},
             body=params["body"],
             headers={"header1": "value1", "x-opaque-id": "test-id1"},
         )
@@ -1598,7 +1600,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
 
         query_runner = runner.Query()
         params = {
@@ -1625,9 +1627,9 @@ class TestQueryRunner:
             "took": 62,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "GET",
-            "/_all/_search",
+        es.perform_request.assert_awaited_once_with(
+            method="GET",
+            path="/_all/_search",
             params={
                 "request_cache": "false",
                 "q": "user:kimchy",
@@ -1654,7 +1656,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
 
         query_runner = runner.Query()
         params = {
@@ -1679,9 +1681,9 @@ class TestQueryRunner:
         assert "took" not in result
         assert "error-type" not in result
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "GET",
-            "/_all/_search",
+        es.perform_request.assert_awaited_once_with(
+            method="GET",
+            path="/_all/_search",
             params={
                 "q": "user:kimchy",
             },
@@ -1704,7 +1706,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1733,9 +1735,9 @@ class TestQueryRunner:
             "took": 5,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "GET",
-            "/_all/_search",
+        es.perform_request.assert_awaited_once_with(
+            method="GET",
+            path="/_all/_search",
             params={
                 "request_cache": "true",
             },
@@ -1761,7 +1763,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1790,9 +1792,9 @@ class TestQueryRunner:
             "took": 5,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "GET",
-            "/unittest/_search",
+        es.perform_request.assert_awaited_once_with(
+            method="GET",
+            path="/unittest/_search",
             params={},
             body=params["body"],
             headers={
@@ -1816,7 +1818,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1846,9 +1848,9 @@ class TestQueryRunner:
             "took": 5,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "GET",
-            "/unittest/type/_search",
+        es.perform_request.assert_awaited_once_with(
+            method="GET",
+            path="/unittest/type/_search",
             body=params["body"],
             params={},
             headers=None,
@@ -1872,7 +1874,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
         es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
 
         query_runner = runner.Query()
@@ -1904,9 +1906,9 @@ class TestQueryRunner:
         }
         assert "error-type" not in results
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "GET",
-            "/unittest/_search",
+        es.perform_request.assert_awaited_once_with(
+            method="GET",
+            path="/unittest/_search",
             params={
                 "request_cache": "true",
                 "sort": "_doc",
@@ -1935,7 +1937,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
         es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
 
         query_runner = runner.Query()
@@ -1967,9 +1969,9 @@ class TestQueryRunner:
         }
         assert "error-type" not in results
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "GET",
-            "/unittest/_search",
+        es.perform_request.assert_awaited_once_with(
+            method="GET",
+            path="/unittest/_search",
             params={"sort": "_doc", "scroll": "10s", "size": 100},
             body=params["body"],
             headers={"Accept-Encoding": "identity"},
@@ -1993,7 +1995,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
         es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
 
         query_runner = runner.Query()
@@ -2024,9 +2026,9 @@ class TestQueryRunner:
         }
         assert "error-type" not in results
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "GET",
-            "/_all/_search",
+        es.perform_request.assert_awaited_once_with(
+            method="GET",
+            path="/_all/_search",
             params={
                 "sort": "_doc",
                 "scroll": "10s",
@@ -2071,7 +2073,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 io.StringIO(json.dumps(search_response)),
                 io.StringIO(json.dumps(scroll_response)),
@@ -2127,8 +2129,8 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
-        es.clear_scroll = mock.AsyncMock(side_effect=elasticsearch.ConnectionTimeout())
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.clear_scroll = mock.AsyncMock(side_effect=elasticsearch.ConnectionTimeout(message="connection timeout"))
 
         query_runner = runner.Query()
 
@@ -2190,7 +2192,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 io.StringIO(json.dumps(search_response)),
                 io.StringIO(json.dumps(scroll_response)),
@@ -2246,7 +2248,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
         es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
 
         query_runner = runner.Query()
@@ -2623,8 +2625,8 @@ class TestCreateDataStreamRunner:
 
         es.indices.create_data_stream.assert_has_awaits(
             [
-                mock.call("data-stream-A", params=request_params),
-                mock.call("data-stream-B", params=request_params),
+                mock.call(name="data-stream-A", params=request_params),
+                mock.call(name="data-stream-B", params=request_params),
             ]
         )
 
@@ -2730,7 +2732,7 @@ class TestDeleteDataStreamRunner:
             "success": True,
         }
 
-        es.indices.delete_data_stream.assert_awaited_once_with("data-stream-B", params={})
+        es.indices.delete_data_stream.assert_awaited_once_with(name="data-stream-B", params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
@@ -2756,8 +2758,8 @@ class TestDeleteDataStreamRunner:
 
         es.indices.delete_data_stream.assert_has_awaits(
             [
-                mock.call("data-stream-A", ignore=[404], params=params["request-params"]),
-                mock.call("data-stream-B", ignore=[404], params=params["request-params"]),
+                mock.call(name="data-stream-A", ignore=[404], params=params["request-params"]),
+                mock.call(name="data-stream-B", ignore=[404], params=params["request-params"]),
             ]
         )
         assert es.indices.exists.await_count == 0
@@ -2976,11 +2978,7 @@ class TestDeleteComponentTemplateRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_deletes_only_existing_index_templates(self, es):
-        async def _side_effect(http_method, path):
-            if http_method == "HEAD":
-                return path == "/_component_template/templateB"
-
-        es.transport.perform_request = mock.AsyncMock(side_effect=_side_effect)
+        es.cluster.exists_component_template = mock.AsyncMock(side_effect=[False, True])
         es.cluster.delete_component_template = mock.AsyncMock()
 
         r = runner.DeleteComponentTemplate()
@@ -3187,20 +3185,21 @@ class TestCreateMlDatafeed:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_create_ml_datafeed(self, es):
-        es.xpack.ml.put_datafeed = mock.AsyncMock()
+        es.ml.put_datafeed = mock.AsyncMock()
 
         params = {"datafeed-id": "some-data-feed", "body": {"job_id": "total-requests", "indices": ["server-metrics"]}}
 
         r = runner.CreateMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.put_datafeed.assert_awaited_once_with(datafeed_id=params["datafeed-id"], body=params["body"])
+        es.ml.put_datafeed.assert_awaited_once_with(datafeed_id=params["datafeed-id"], body=params["body"])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_create_ml_datafeed_fallback(self, es):
-        es.xpack.ml.put_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        error_meta = elastic_transport.ApiResponseMeta(status=400, http_version="1.1", headers=None, duration=0, node=None)
+        es.ml.put_datafeed = mock.AsyncMock(side_effect=elasticsearch.BadRequestError(message=400, meta=error_meta, body="Bad Request"))
+        es.perform_request = mock.AsyncMock()
         datafeed_id = "some-data-feed"
         body = {"job_id": "total-requests", "indices": ["server-metrics"]}
         params = {"datafeed-id": datafeed_id, "body": body}
@@ -3208,14 +3207,14 @@ class TestCreateMlDatafeed:
         r = runner.CreateMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with("PUT", f"/_xpack/ml/datafeeds/{datafeed_id}", body=body)
+        es.perform_request.assert_awaited_once_with(method="PUT", path=f"/_xpack/ml/datafeeds/{datafeed_id}", body=body)
 
 
 class TestDeleteMlDatafeed:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_delete_ml_datafeed(self, es):
-        es.xpack.ml.delete_datafeed = mock.AsyncMock()
+        es.ml.delete_datafeed = mock.AsyncMock()
 
         datafeed_id = "some-data-feed"
         params = {"datafeed-id": datafeed_id}
@@ -3223,13 +3222,15 @@ class TestDeleteMlDatafeed:
         r = runner.DeleteMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.delete_datafeed.assert_awaited_once_with(datafeed_id=datafeed_id, force=False, ignore=[404])
+        es.ml.delete_datafeed.assert_awaited_once_with(datafeed_id=datafeed_id, force=False, ignore=[404])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_delete_ml_datafeed_fallback(self, es):
-        es.xpack.ml.delete_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        error_meta = elastic_transport.ApiResponseMeta(status=400, http_version="1.1", headers=None, duration=0, node=None)
+        es.ml.delete_datafeed = mock.AsyncMock(side_effect=elasticsearch.BadRequestError(message=400, meta=error_meta, body="Bad Request"))
+
+        es.perform_request = mock.AsyncMock()
         datafeed_id = "some-data-feed"
         params = {
             "datafeed-id": datafeed_id,
@@ -3238,8 +3239,8 @@ class TestDeleteMlDatafeed:
         r = runner.DeleteMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "DELETE", f"/_xpack/ml/datafeeds/{datafeed_id}", params={"force": "false", "ignore": 404}
+        es.perform_request.assert_awaited_once_with(
+            method="DELETE", path=f"/_xpack/ml/datafeeds/{datafeed_id}", params={"force": "false", "ignore": 404}
         )
 
 
@@ -3247,33 +3248,34 @@ class TestStartMlDatafeed:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_start_ml_datafeed_with_body(self, es):
-        es.xpack.ml.start_datafeed = mock.AsyncMock()
+        es.ml.start_datafeed = mock.AsyncMock()
         params = {"datafeed-id": "some-data-feed", "body": {"end": "now"}}
 
         r = runner.StartMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.start_datafeed.assert_awaited_once_with(
+        es.ml.start_datafeed.assert_awaited_once_with(
             datafeed_id=params["datafeed-id"], body=params["body"], start=None, end=None, timeout=None
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_start_ml_datafeed_with_body_fallback(self, es):
-        es.xpack.ml.start_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        error_meta = elastic_transport.ApiResponseMeta(status=400, http_version="1.1", headers=None, duration=0, node=None)
+        es.ml.start_datafeed = mock.AsyncMock(side_effect=elasticsearch.BadRequestError(message=400, meta=error_meta, body="Bad Request"))
+        es.perform_request = mock.AsyncMock()
         body = {"end": "now"}
         params = {"datafeed-id": "some-data-feed", "body": body}
 
         r = runner.StartMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with("POST", f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_start", body=body)
+        es.perform_request.assert_awaited_once_with(method="POST", path=f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_start", body=body)
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_start_ml_datafeed_with_params(self, es):
-        es.xpack.ml.start_datafeed = mock.AsyncMock()
+        es.ml.start_datafeed = mock.AsyncMock()
         params = {
             "datafeed-id": "some-data-feed",
             "start": "2017-01-01T01:00:00Z",
@@ -3284,7 +3286,7 @@ class TestStartMlDatafeed:
         r = runner.StartMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.start_datafeed.assert_awaited_once_with(
+        es.ml.start_datafeed.assert_awaited_once_with(
             datafeed_id=params["datafeed-id"], body=None, start=params["start"], end=params["end"], timeout=params["timeout"]
         )
 
@@ -3293,7 +3295,7 @@ class TestStopMlDatafeed:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_stop_ml_datafeed(self, es):
-        es.xpack.ml.stop_datafeed = mock.AsyncMock()
+        es.ml.stop_datafeed = mock.AsyncMock()
         params = {
             "datafeed-id": "some-data-feed",
             "force": random.choice([False, True]),
@@ -3303,15 +3305,14 @@ class TestStopMlDatafeed:
         r = runner.StopMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.stop_datafeed.assert_awaited_once_with(
-            datafeed_id=params["datafeed-id"], force=params["force"], timeout=params["timeout"]
-        )
+        es.ml.stop_datafeed.assert_awaited_once_with(datafeed_id=params["datafeed-id"], force=params["force"], timeout=params["timeout"])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_stop_ml_datafeed_fallback(self, es):
-        es.xpack.ml.stop_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        error_meta = elastic_transport.ApiResponseMeta(status=400, http_version="1.1", headers=None, duration=0, node=None)
+        es.ml.stop_datafeed = mock.AsyncMock(side_effect=elasticsearch.BadRequestError(message=400, meta=error_meta, body="Bad Request"))
+        es.perform_request = mock.AsyncMock()
 
         params = {
             "datafeed-id": "some-data-feed",
@@ -3322,9 +3323,9 @@ class TestStopMlDatafeed:
         r = runner.StopMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "POST",
-            f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_stop",
+        es.perform_request.assert_awaited_once_with(
+            method="POST",
+            path=f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_stop",
             params={"force": str(params["force"]).lower(), "timeout": params["timeout"]},
         )
 
@@ -3333,7 +3334,7 @@ class TestCreateMlJob:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_create_ml_job(self, es):
-        es.xpack.ml.put_job = mock.AsyncMock()
+        es.ml.put_job = mock.AsyncMock()
 
         params = {
             "job-id": "an-ml-job",
@@ -3356,13 +3357,14 @@ class TestCreateMlJob:
         r = runner.CreateMlJob()
         await r(es, params)
 
-        es.xpack.ml.put_job.assert_awaited_once_with(job_id=params["job-id"], body=params["body"])
+        es.ml.put_job.assert_awaited_once_with(job_id=params["job-id"], body=params["body"])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_create_ml_job_fallback(self, es):
-        es.xpack.ml.put_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        error_meta = elastic_transport.ApiResponseMeta(status=400, http_version="1.1", headers=None, duration=0, node=None)
+        es.ml.put_job = mock.AsyncMock(side_effect=elasticsearch.BadRequestError(message=400, meta=error_meta, body="Bad Request"))
+        es.perform_request = mock.AsyncMock()
 
         body = {
             "description": "Total sum of requests",
@@ -3383,14 +3385,14 @@ class TestCreateMlJob:
         r = runner.CreateMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with("PUT", f"/_xpack/ml/anomaly_detectors/{params['job-id']}", body=body)
+        es.perform_request.assert_awaited_once_with(method="PUT", path=f"/_xpack/ml/anomaly_detectors/{params['job-id']}", body=body)
 
 
 class TestDeleteMlJob:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_delete_ml_job(self, es):
-        es.xpack.ml.delete_job = mock.AsyncMock()
+        es.ml.delete_job = mock.AsyncMock()
 
         job_id = "an-ml-job"
         params = {"job-id": job_id}
@@ -3398,13 +3400,14 @@ class TestDeleteMlJob:
         r = runner.DeleteMlJob()
         await r(es, params)
 
-        es.xpack.ml.delete_job.assert_awaited_once_with(job_id=job_id, force=False, ignore=[404])
+        es.ml.delete_job.assert_awaited_once_with(job_id=job_id, force=False, ignore=[404])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_delete_ml_job_fallback(self, es):
-        es.xpack.ml.delete_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        error_meta = elastic_transport.ApiResponseMeta(status=400, http_version="1.1", headers=None, duration=0, node=None)
+        es.ml.delete_job = mock.AsyncMock(side_effect=elasticsearch.BadRequestError(message=400, meta=error_meta, body="Bad Request"))
+        es.perform_request = mock.AsyncMock()
 
         job_id = "an-ml-job"
         params = {"job-id": job_id}
@@ -3412,8 +3415,8 @@ class TestDeleteMlJob:
         r = runner.DeleteMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "DELETE", f"/_xpack/ml/anomaly_detectors/{params['job-id']}", params={"force": "false", "ignore": 404}
+        es.perform_request.assert_awaited_once_with(
+            method="DELETE", path=f"/_xpack/ml/anomaly_detectors/{params['job-id']}", params={"force": "false", "ignore": 404}
         )
 
 
@@ -3421,7 +3424,7 @@ class TestOpenMlJob:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_open_ml_job(self, es):
-        es.xpack.ml.open_job = mock.AsyncMock()
+        es.ml.open_job = mock.AsyncMock()
 
         job_id = "an-ml-job"
         params = {"job-id": job_id}
@@ -3429,13 +3432,14 @@ class TestOpenMlJob:
         r = runner.OpenMlJob()
         await r(es, params)
 
-        es.xpack.ml.open_job.assert_awaited_once_with(job_id=job_id)
+        es.ml.open_job.assert_awaited_once_with(job_id=job_id)
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_open_ml_job_fallback(self, es):
-        es.xpack.ml.open_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        error_meta = elastic_transport.ApiResponseMeta(status=400, http_version="1.1", headers=None, duration=0, node=None)
+        es.ml.open_job = mock.AsyncMock(side_effect=elasticsearch.BadRequestError(message=400, meta=error_meta, body="Bad Request"))
+        es.perform_request = mock.AsyncMock()
 
         job_id = "an-ml-job"
         params = {"job-id": job_id}
@@ -3443,14 +3447,14 @@ class TestOpenMlJob:
         r = runner.OpenMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with("POST", f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_open")
+        es.perform_request.assert_awaited_once_with(method="POST", path=f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_open")
 
 
 class TestCloseMlJob:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_close_ml_job(self, es):
-        es.xpack.ml.close_job = mock.AsyncMock()
+        es.ml.close_job = mock.AsyncMock()
         params = {
             "job-id": "an-ml-job",
             "force": random.choice([False, True]),
@@ -3460,13 +3464,14 @@ class TestCloseMlJob:
         r = runner.CloseMlJob()
         await r(es, params)
 
-        es.xpack.ml.close_job.assert_awaited_once_with(job_id=params["job-id"], force=params["force"], timeout=params["timeout"])
+        es.ml.close_job.assert_awaited_once_with(job_id=params["job-id"], force=params["force"], timeout=params["timeout"])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_close_ml_job_fallback(self, es):
-        es.xpack.ml.close_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        error_meta = elastic_transport.ApiResponseMeta(status=400, http_version="1.1", headers=None, duration=0, node=None)
+        es.ml.close_job = mock.AsyncMock(side_effect=elasticsearch.BadRequestError(message=400, meta=error_meta, body="Bad Request"))
+        es.perform_request = mock.AsyncMock()
 
         params = {
             "job-id": "an-ml-job",
@@ -3477,9 +3482,9 @@ class TestCloseMlJob:
         r = runner.CloseMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with(
-            "POST",
-            f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_close",
+        es.perform_request.assert_awaited_once_with(
+            method="POST",
+            path=f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_close",
             params={"force": str(params["force"]).lower(), "timeout": params["timeout"]},
         )
 
@@ -3488,7 +3493,7 @@ class TestRawRequestRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_raises_missing_slash(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {"path": "_cat/count"}
@@ -3504,18 +3509,18 @@ class TestRawRequestRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_issue_request_with_defaults(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {"path": "/_cat/count"}
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(method="GET", url="/_cat/count", headers=None, body=None, params={})
+        es.perform_request.assert_called_once_with(method="GET", path="/_cat/count", headers=None, body=None, params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_issue_delete_index(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {
@@ -3528,14 +3533,14 @@ class TestRawRequestRunner:
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(
-            method="DELETE", url="/twitter", headers=None, body=None, params={"ignore": [400, 404], "pretty": "true"}
+        es.perform_request.assert_called_once_with(
+            method="DELETE", path="/twitter", headers=None, body=None, params={"ignore": [400, 404], "pretty": "true"}
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_issue_create_index(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {
@@ -3551,14 +3556,14 @@ class TestRawRequestRunner:
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(
-            method="POST", url="/twitter", headers=None, body={"settings": {"index": {"number_of_replicas": 0}}}, params={}
+        es.perform_request.assert_called_once_with(
+            method="POST", path="/twitter", headers=None, body={"settings": {"index": {"number_of_replicas": 0}}}, params={}
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_issue_msearch(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {
@@ -3573,9 +3578,9 @@ class TestRawRequestRunner:
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(
+        es.perform_request.assert_called_once_with(
             method="GET",
-            url="/_msearch",
+            path="/_msearch",
             headers={"Content-Type": "application/x-ndjson"},
             body=[
                 {"index": "test"},
@@ -3589,7 +3594,7 @@ class TestRawRequestRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_raw_with_timeout_and_opaqueid(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {
@@ -3606,9 +3611,9 @@ class TestRawRequestRunner:
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(
+        es.perform_request.assert_called_once_with(
             method="GET",
-            url="/_msearch",
+            path="/_msearch",
             headers={"Content-Type": "application/x-ndjson", "x-opaque-id": "test-id1"},
             body=[
                 {"index": "test"},
@@ -4948,7 +4953,7 @@ class TestSqlRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_fetch_one_page(self, es):
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
 
         sql_runner = runner.Sql()
         params = {
@@ -4966,12 +4971,12 @@ class TestSqlRunner:
 
         assert result == {"success": True, "weight": 1, "unit": "ops"}
 
-        es.transport.perform_request.assert_awaited_once_with("POST", "/_sql", body=params["body"])
+        es.perform_request.assert_awaited_once_with(method="POST", path="/_sql", body=params["body"])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_fetch_all_pages(self, es):
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
 
         sql_runner = runner.Sql()
         params = {"operation-type": "sql", "body": {"query": "SELECT first_name FROM emp"}, "pages": 3}
@@ -4981,18 +4986,18 @@ class TestSqlRunner:
 
         assert result == {"success": True, "weight": 3, "unit": "ops"}
 
-        es.transport.perform_request.assert_has_calls(
+        es.perform_request.assert_has_calls(
             [
-                mock.call("POST", "/_sql", body=params["body"]),
-                mock.call("POST", "/_sql", body={"cursor": self.default_response["cursor"]}),
-                mock.call("POST", "/_sql", body={"cursor": self.default_response["cursor"]}),
+                mock.call(method="POST", path="/_sql", body=params["body"]),
+                mock.call(method="POST", path="/_sql", body={"cursor": self.default_response["cursor"]}),
+                mock.call(method="POST", path="/_sql", body={"cursor": self.default_response["cursor"]}),
             ]
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_failure_on_too_few_pages(self, es):
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[io.StringIO(json.dumps(self.default_response)), io.StringIO(json.dumps({"rows": [["John"]]}))]
         )
 
@@ -5011,10 +5016,10 @@ class TestSqlRunner:
 
         assert ctx.value.message == "Result set has been exhausted before all pages have been fetched, 1 page(s) remaining."
 
-        es.transport.perform_request.assert_has_calls(
+        es.perform_request.assert_has_calls(
             [
-                mock.call("POST", "/_sql", body=params["body"]),
-                mock.call("POST", "/_sql", body={"cursor": self.default_response["cursor"]}),
+                mock.call(method="POST", path="/_sql", body=params["body"]),
+                mock.call(method="POST", path="/_sql", body={"cursor": self.default_response["cursor"]}),
             ]
         )
 
@@ -5235,7 +5240,7 @@ class TestQueryWithSearchAfterScroll:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 io.BytesIO(json.dumps(page_1).encode()),
                 io.BytesIO(json.dumps(page_2).encode()),
@@ -5250,11 +5255,11 @@ class TestQueryWithSearchAfterScroll:
             # make sure pit_id is updated afterward
             assert runner.CompositeContext.get(pit_op) == "fedcba9876543211"
 
-        es.transport.perform_request.assert_has_awaits(
+        es.perform_request.assert_has_awaits(
             [
                 mock.call(
-                    "GET",
-                    "/_search",
+                    method="GET",
+                    path="/_search",
                     params={},
                     body={
                         "query": {
@@ -5275,8 +5280,8 @@ class TestQueryWithSearchAfterScroll:
                     headers=None,
                 ),
                 mock.call(
-                    "GET",
-                    "/_search",
+                    method="GET",
+                    path="/_search",
                     params={},
                     body={
                         "query": {
@@ -5345,7 +5350,7 @@ class TestQueryWithSearchAfterScroll:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 io.BytesIO(json.dumps(page_1).encode()),
                 io.BytesIO(json.dumps(page_2).encode()),
@@ -5354,11 +5359,11 @@ class TestQueryWithSearchAfterScroll:
         r = runner.Query()
         await r(es, params)
 
-        es.transport.perform_request.assert_has_awaits(
+        es.perform_request.assert_has_awaits(
             [
                 mock.call(
-                    "GET",
-                    "/test-index-1/_search",
+                    method="GET",
+                    path="/test-index-1/_search",
                     params={},
                     body={
                         "query": {
@@ -5372,8 +5377,8 @@ class TestQueryWithSearchAfterScroll:
                     headers=None,
                 ),
                 mock.call(
-                    "GET",
-                    "/test-index-1/_search",
+                    method="GET",
+                    path="/test-index-1/_search",
                     params={},
                     body={
                         "query": {
@@ -5543,7 +5548,7 @@ class TestComposite:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_execute_multiple_streams(self, es):
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 # raw-request
                 None,
@@ -5606,17 +5611,17 @@ class TestComposite:
         r = runner.Composite()
         await r(es, params)
 
-        es.transport.perform_request.assert_has_awaits(
+        es.perform_request.assert_has_awaits(
             [
-                mock.call(method="GET", url="/", headers=None, body={}, params={}),
-                mock.call("GET", "/test/_search", params={}, body={"query": {"match_all": {}}}, headers=None),
+                mock.call(method="GET", path="/", headers=None, body={}, params={}),
+                mock.call(method="GET", path="/test/_search", params={}, body={"query": {"match_all": {}}}, headers=None),
             ]
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_propagates_violated_assertions(self, es):
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 # search
                 io.StringIO(
@@ -5665,11 +5670,11 @@ class TestComposite:
         with pytest.raises(exceptions.RallyTaskAssertionError, match=r"Expected \[hits\] to be > \[0\] but was \[0\]."):
             await r(es, params)
 
-        es.transport.perform_request.assert_has_awaits(
+        es.perform_request.assert_has_awaits(
             [
                 mock.call(
-                    "GET",
-                    "/test/_search",
+                    method="GET",
+                    path="/test/_search",
                     params={},
                     body={
                         "query": {
@@ -5684,7 +5689,7 @@ class TestComposite:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_executes_tasks_in_specified_order(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
 
         params = {
             "requests": [
@@ -6018,10 +6023,10 @@ class TestRetry:
     async def test_retries_on_timeout_if_wanted_and_raises_if_no_recovery(self):
         delegate = mock.AsyncMock(
             side_effect=[
-                elasticsearch.ConnectionError("N/A", "no route to host"),
-                elasticsearch.ConnectionError("N/A", "no route to host"),
-                elasticsearch.ConnectionError("N/A", "no route to host"),
-                elasticsearch.ConnectionError("N/A", "no route to host"),
+                elasticsearch.ConnectionError(message="no route to host"),
+                elasticsearch.ConnectionError(message="no route to host"),
+                elasticsearch.ConnectionError(message="no route to host"),
+                elasticsearch.ConnectionError(message="no route to host"),
             ]
         )
         es = None
@@ -6045,7 +6050,7 @@ class TestRetry:
 
         delegate = mock.AsyncMock(
             side_effect=[
-                elasticsearch.ConnectionError("N/A", "no route to host"),
+                elasticsearch.ConnectionError(message="no route to host"),
                 failed_return_value,
             ]
         )
@@ -6067,7 +6072,7 @@ class TestRetry:
 
     @pytest.mark.asyncio
     async def test_retries_mixed_timeout_and_application_errors(self):
-        connection_error = elasticsearch.ConnectionError("N/A", "no route to host")
+        connection_error = elasticsearch.ConnectionError(message="no route to host")
         failed_return_value = {"weight": 1, "unit": "ops", "success": False}
         success_return_value = {"weight": 1, "unit": "ops", "success": False}
 

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -190,7 +190,7 @@ class TestEsClient:
 
     def test_raises_sytem_setup_error_on_authentication_problems(self):
         def raise_authentication_error():
-            raise elasticsearch.exceptions.AuthenticationException("unit-test")
+            raise elasticsearch.exceptions.AuthenticationException(meta=None, body=None, message="unit-test")
 
         client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
 
@@ -203,7 +203,7 @@ class TestEsClient:
 
     def test_raises_sytem_setup_error_on_authorization_problems(self):
         def raise_authorization_error():
-            raise elasticsearch.exceptions.AuthorizationException("unit-test")
+            raise elasticsearch.exceptions.AuthorizationException(meta=None, body=None, message="unit-test")
 
         client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
 
@@ -217,14 +217,14 @@ class TestEsClient:
 
     def test_raises_rally_error_on_unknown_problems(self):
         def raise_unknown_error():
-            raise elasticsearch.exceptions.SerializationError("unit-test")
+            raise elasticsearch.exceptions.SerializationError(message="unit-test")
 
         client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
 
         with pytest.raises(exceptions.RallyError) as ctx:
             client.guarded(raise_unknown_error)
         assert ctx.value.args[0] == (
-            "An unknown error occurred while running the operation [raise_unknown_error] against your Elasticsearch metrics "
+            "A transport error occurred while running the operation [raise_unknown_error] against your Elasticsearch metrics "
             "store on host [127.0.0.1] at port [9243]."
         )
 

--- a/tests/tracker/corpus_test.py
+++ b/tests/tracker/corpus_test.py
@@ -31,6 +31,9 @@ def test_extract(client, mo):
     doc = {"field1": "stuff", "field2": "things"}
     doc_data = serialize_doc(doc)
     client.count.return_value = {"count": 1001}
+    # the scan helper calls client.options(), which returns a new client instance
+    # we override this behavior here to facilitate mocking
+    client.options.return_value = client
     client.search.return_value = {
         "_scroll_id": "uohialjrknf",
         "_shards": {


### PR DESCRIPTION
This PR upgrades Rally's Elasticsearch Python client library dependency to `v8.2.0` from `v7.14.0`. The changes are pretty substantial. I've tried to make the commits reasonably-sized and atomic, so I suggest reviewing by commit. Nevertheless, some (especially those touching unit tests) are large and mostly consist of migrating from positional arguments to keyword arguments. 

The most important change is contained in e7d83cc60b890f7a1526958f808535e36f9bd126. The Python client has moved all transport logic into a separate library, https://github.com/elastic/elastic-transport-python. Low-level transport-related details have changed substantially, and our customizations within `esrally/client.py` and `esrally/async_connection.py` have had to change accordingly. It's a large diff, but it should all be transparent to the user.

I've also had to override the client's default behavior for verifying that a given server is authentically Elasticsearch. See the commit message (and comments in the code) for details, but the gist is that the client as of `v8.0.0` does this check exclusively via a header that's only available in ES `7.14.0`+. Previous client versions fell back to other mechanisms for verifying authenticity absent this header. Since Rally must support all versions of ES >= `6.8.0`, I've resurrected this prior behavior.

Otherwise, most changes are fairly mechanical. 

A few notes:

- I've tested this with every maintained track that I have access to. Even so, potential for breakage is very high, and I intend to do more. Please feel free to do the same!
- I've issued a [rally-tracks PR](https://github.com/elastic/rally-tracks/pull/271) and an [eventdata PR ](https://github.com/elastic/rally-eventdata-track/pull/113) to update some runners that currently fail with this PR, and will cause integration tests to fail.
- Same as above, but for a few internal tracks.
- There are some TODOs that you'll see in comments, particularly around exception handling, which has changed considerably. What I have right now works, but I don't consider it robust enough yet. I'm actively working on this. Any thoughts on this in particular would be helpful.
- The [`EsClientFactory` class](url) has gotten a bit too big, so I am happy to reorganize that code.
- There are a handful of additional tests that I have in mind that would be useful to add, but could probably be done in follow-up PRs. But if anything seems glaringly missing, please let me know.

Closes #1350.