### PR TITLE
Prepare switch to Elasticsearch Python client 8.2.0

### DIFF
--- a/esrally/client.py
+++ b/esrally/client.py
@@ -237,6 +237,7 @@ class EsClientFactory:
 
         class RallySyncElasticsearch(elasticsearch.Elasticsearch):
             def perform_request(self, *args, **kwargs):
+                kwargs["url"] = kwargs.pop("path")
                 return self.transport.perform_request(*args, **kwargs)
 
         return RallySyncElasticsearch(hosts=self.hosts, ssl_context=self.ssl_context, **self.client_options)
@@ -285,6 +286,7 @@ class EsClientFactory:
 
         class RallyAsyncElasticsearch(elasticsearch.AsyncElasticsearch, RequestContextHolder):
             def perform_request(self, *args, **kwargs):
+                kwargs["url"] = kwargs.pop("path")
                 return self.transport.perform_request(*args, **kwargs)
 
         return RallyAsyncElasticsearch(

--- a/esrally/client.py
+++ b/esrally/client.py
@@ -235,7 +235,11 @@ class EsClientFactory:
         # pylint: disable=import-outside-toplevel
         import elasticsearch
 
-        return elasticsearch.Elasticsearch(hosts=self.hosts, ssl_context=self.ssl_context, **self.client_options)
+        class RallySyncElasticsearch(elasticsearch.Elasticsearch):
+            def perform_request(self, *args, **kwargs):
+                return self.transport.perform_request(*args, **kwargs)
+
+        return RallySyncElasticsearch(hosts=self.hosts, ssl_context=self.ssl_context, **self.client_options)
 
     def create_async(self):
         # pylint: disable=import-outside-toplevel
@@ -280,7 +284,8 @@ class EsClientFactory:
                 self._verified_elasticsearch = True
 
         class RallyAsyncElasticsearch(elasticsearch.AsyncElasticsearch, RequestContextHolder):
-            pass
+            def perform_request(self, *args, **kwargs):
+                return self.transport.perform_request(*args, **kwargs)
 
         return RallyAsyncElasticsearch(
             hosts=self.hosts,

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1533,7 +1533,7 @@ class CreateMlDatafeed(Runner):
         datafeed_id = mandatory(params, "datafeed-id", self)
         body = mandatory(params, "body", self)
         try:
-            await es.xpack.ml.put_datafeed(datafeed_id=datafeed_id, body=body)
+            await es.ml.put_datafeed(datafeed_id=datafeed_id, body=body)
         except elasticsearch.TransportError as e:
             # fallback to old path
             if e.status_code == 400:
@@ -1562,7 +1562,7 @@ class DeleteMlDatafeed(Runner):
         force = params.get("force", False)
         try:
             # we don't want to fail if a datafeed does not exist, thus we ignore 404s.
-            await es.xpack.ml.delete_datafeed(datafeed_id=datafeed_id, force=force, ignore=[404])
+            await es.ml.delete_datafeed(datafeed_id=datafeed_id, force=force, ignore=[404])
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
@@ -1593,7 +1593,7 @@ class StartMlDatafeed(Runner):
         end = params.get("end")
         timeout = params.get("timeout")
         try:
-            await es.xpack.ml.start_datafeed(datafeed_id=datafeed_id, body=body, start=start, end=end, timeout=timeout)
+            await es.ml.start_datafeed(datafeed_id=datafeed_id, body=body, start=start, end=end, timeout=timeout)
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
@@ -1622,7 +1622,7 @@ class StopMlDatafeed(Runner):
         force = params.get("force", False)
         timeout = params.get("timeout")
         try:
-            await es.xpack.ml.stop_datafeed(datafeed_id=datafeed_id, force=force, timeout=timeout)
+            await es.ml.stop_datafeed(datafeed_id=datafeed_id, force=force, timeout=timeout)
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
@@ -1651,7 +1651,7 @@ class CreateMlJob(Runner):
         job_id = mandatory(params, "job-id", self)
         body = mandatory(params, "body", self)
         try:
-            await es.xpack.ml.put_job(job_id=job_id, body=body)
+            await es.ml.put_job(job_id=job_id, body=body)
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
@@ -1680,7 +1680,7 @@ class DeleteMlJob(Runner):
         force = params.get("force", False)
         # we don't want to fail if a job does not exist, thus we ignore 404s.
         try:
-            await es.xpack.ml.delete_job(job_id=job_id, force=force, ignore=[404])
+            await es.ml.delete_job(job_id=job_id, force=force, ignore=[404])
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
@@ -1707,7 +1707,7 @@ class OpenMlJob(Runner):
 
         job_id = mandatory(params, "job-id", self)
         try:
-            await es.xpack.ml.open_job(job_id=job_id)
+            await es.ml.open_job(job_id=job_id)
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
@@ -1735,7 +1735,7 @@ class CloseMlJob(Runner):
         force = params.get("force", False)
         timeout = params.get("timeout")
         try:
-            await es.xpack.ml.close_job(job_id=job_id, force=force, timeout=timeout)
+            await es.ml.close_job(job_id=job_id, force=force, timeout=timeout)
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -950,7 +950,7 @@ class Query(Runner):
                         took = props.get("took", 0)
                         all_results_collected = (size is not None and hits < size) or hits == 0
                     else:
-                        r = await es.transport.perform_request(
+                        r = await es.perform_request(
                             "GET", "/_search/scroll", body={"scroll_id": scroll_id, "scroll": "10s"}, params=request_params, headers=headers
                         )
                         props = parse(r, ["timed_out", "took"], ["hits.hits"])
@@ -1007,7 +1007,7 @@ class Query(Runner):
             components.append(doc_type)
         components.append("_search")
         path = "/".join(components)
-        return await es.transport.perform_request("GET", "/" + path, params=params, body=body, headers=headers)
+        return await es.perform_request("GET", "/" + path, params=params, body=body, headers=headers)
 
     def _query_headers(self, params):
         # reduces overhead due to decompression of very large responses
@@ -1308,7 +1308,7 @@ class DeleteComponentTemplate(Runner):
             from elasticsearch.client import _make_path
 
             # currently not supported by client and hence custom request
-            return await es.transport.perform_request("HEAD", _make_path("_component_template", name))
+            return await es.perform_request("HEAD", _make_path("_component_template", name))
 
         ops_count = 0
         for template_name in template_names:
@@ -1537,7 +1537,7 @@ class CreateMlDatafeed(Runner):
         except elasticsearch.TransportError as e:
             # fallback to old path
             if e.status_code == 400:
-                await es.transport.perform_request(
+                await es.perform_request(
                     "PUT",
                     f"/_xpack/ml/datafeeds/{datafeed_id}",
                     body=body,
@@ -1566,7 +1566,7 @@ class DeleteMlDatafeed(Runner):
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
-                await es.transport.perform_request(
+                await es.perform_request(
                     "DELETE",
                     f"/_xpack/ml/datafeeds/{datafeed_id}",
                     params={"force": escape(force), "ignore": 404},
@@ -1597,7 +1597,7 @@ class StartMlDatafeed(Runner):
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
-                await es.transport.perform_request(
+                await es.perform_request(
                     "POST",
                     f"/_xpack/ml/datafeeds/{datafeed_id}/_start",
                     body=body,
@@ -1631,7 +1631,7 @@ class StopMlDatafeed(Runner):
                 }
                 if timeout:
                     request_params["timeout"] = escape(timeout)
-                await es.transport.perform_request("POST", f"/_xpack/ml/datafeeds/{datafeed_id}/_stop", params=request_params)
+                await es.perform_request("POST", f"/_xpack/ml/datafeeds/{datafeed_id}/_stop", params=request_params)
             else:
                 raise e
 
@@ -1655,7 +1655,7 @@ class CreateMlJob(Runner):
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
-                await es.transport.perform_request(
+                await es.perform_request(
                     "PUT",
                     f"/_xpack/ml/anomaly_detectors/{job_id}",
                     body=body,
@@ -1684,7 +1684,7 @@ class DeleteMlJob(Runner):
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
-                await es.transport.perform_request(
+                await es.perform_request(
                     "DELETE",
                     f"/_xpack/ml/anomaly_detectors/{job_id}",
                     params={"force": escape(force), "ignore": 404},
@@ -1711,7 +1711,7 @@ class OpenMlJob(Runner):
         except elasticsearch.TransportError as e:
             # fallback to old path (ES < 7)
             if e.status_code == 400:
-                await es.transport.perform_request(
+                await es.perform_request(
                     "POST",
                     f"/_xpack/ml/anomaly_detectors/{job_id}/_open",
                 )
@@ -1745,7 +1745,7 @@ class CloseMlJob(Runner):
                 if timeout:
                     request_params["timeout"] = escape(timeout)
 
-                await es.transport.perform_request(
+                await es.perform_request(
                     "POST",
                     f"/_xpack/ml/anomaly_detectors/{job_id}/_close",
                     params=request_params,
@@ -1770,7 +1770,7 @@ class RawRequest(Runner):
             # counter-intuitive, but preserves prior behavior
             headers = None
 
-        await es.transport.perform_request(
+        await es.perform_request(
             method=params.get("method", "GET"), url=path, headers=headers, body=params.get("body"), params=request_params
         )
 
@@ -2462,7 +2462,7 @@ class Sql(Runner):
 
         es.return_raw_response()
 
-        r = await es.transport.perform_request("POST", "/_sql", body=body)
+        r = await es.perform_request("POST", "/_sql", body=body)
         pages -= 1
         weight = 1
 
@@ -2474,7 +2474,7 @@ class Sql(Runner):
                     "Result set has been exhausted before all pages have been fetched, {} page(s) remaining.".format(pages)
                 )
 
-            r = await es.transport.perform_request("POST", "/_sql", body={"cursor": cursor})
+            r = await es.perform_request("POST", "/_sql", body={"cursor": cursor})
             pages -= 1
             weight += 1
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -60,13 +60,13 @@ class EsClient:
         return self.guarded(self._client.indices.put_template, name=name, body=template)
 
     def template_exists(self, name):
-        return self.guarded(self._client.indices.exists_template, name)
+        return self.guarded(self._client.indices.exists_template, name=name)
 
     def delete_template(self, name):
-        self.guarded(self._client.indices.delete_template, name)
+        self.guarded(self._client.indices.delete_template, name=name)
 
     def get_index(self, name):
-        return self.guarded(self._client.indices.get, name)
+        return self.guarded(self._client.indices.get, name=name)
 
     def create_index(self, index):
         # ignore 400 cause by IndexAlreadyExistsException when creating an index

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -460,9 +460,7 @@ class CcrStatsRecorder:
         try:
             ccr_stats_api_endpoint = "/_ccr/stats"
             filter_path = "follow_stats"
-            stats = self.client.transport.perform_request(
-                "GET", ccr_stats_api_endpoint, params={"human": "false", "filter_path": filter_path}
-            )
+            stats = self.client.perform_request("GET", ccr_stats_api_endpoint, params={"human": "false", "filter_path": filter_path})
         except elasticsearch.TransportError:
             msg = "A transport error occurred while collecting CCR stats from the endpoint [{}?filter_path={}] on cluster [{}]".format(
                 ccr_stats_api_endpoint, filter_path, self.cluster_name
@@ -1233,7 +1231,7 @@ class SearchableSnapshotsStatsRecorder:
             # we don't use the existing client support (searchable_snapshots.stats())
             # as the API is deliberately undocumented and might change:
             # https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-stats.html
-            stats = self.client.transport.perform_request("GET", stats_api_endpoint, params={"level": level})
+            stats = self.client.perform_request("GET", stats_api_endpoint, params={"level": level})
         except elasticsearch.NotFoundError as e:
             if "No searchable snapshots indices found" in e.info.get("error").get("reason"):
                 self.logger.info(
@@ -2276,7 +2274,7 @@ class DiskUsageStats(TelemetryDevice):
         for index in self.indices.split(","):
             self.logger.debug("Gathering disk usage for [%s]", index)
             try:
-                response = self.client.transport.perform_request("POST", f"/{index}/_disk_usage", params={"run_expensive_tasks": "true"})
+                response = self.client.perform_request("POST", f"/{index}/_disk_usage", params={"run_expensive_tasks": "true"})
             except elasticsearch.RequestError:
                 msg = f"A transport error occurred while collecting disk usage for {index}"
                 self.logger.exception(msg)

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -460,7 +460,9 @@ class CcrStatsRecorder:
         try:
             ccr_stats_api_endpoint = "/_ccr/stats"
             filter_path = "follow_stats"
-            stats = self.client.perform_request("GET", ccr_stats_api_endpoint, params={"human": "false", "filter_path": filter_path})
+            stats = self.client.perform_request(
+                method="GET", path=ccr_stats_api_endpoint, params={"human": "false", "filter_path": filter_path}
+            )
         except elasticsearch.TransportError:
             msg = "A transport error occurred while collecting CCR stats from the endpoint [{}?filter_path={}] on cluster [{}]".format(
                 ccr_stats_api_endpoint, filter_path, self.cluster_name
@@ -1231,7 +1233,7 @@ class SearchableSnapshotsStatsRecorder:
             # we don't use the existing client support (searchable_snapshots.stats())
             # as the API is deliberately undocumented and might change:
             # https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-stats.html
-            stats = self.client.perform_request("GET", stats_api_endpoint, params={"level": level})
+            stats = self.client.perform_request(method="GET", path=stats_api_endpoint, params={"level": level})
         except elasticsearch.NotFoundError as e:
             if "No searchable snapshots indices found" in e.info.get("error").get("reason"):
                 self.logger.info(
@@ -2274,7 +2276,7 @@ class DiskUsageStats(TelemetryDevice):
         for index in self.indices.split(","):
             self.logger.debug("Gathering disk usage for [%s]", index)
             try:
-                response = self.client.perform_request("POST", f"/{index}/_disk_usage", params={"run_expensive_tasks": "true"})
+                response = self.client.perform_request(method="POST", path=f"/{index}/_disk_usage", params={"run_expensive_tasks": "true"})
             except elasticsearch.RequestError:
                 msg = f"A transport error occurred while collecting disk usage for {index}"
                 self.logger.exception(msg)

--- a/esrally/tracker/index.py
+++ b/esrally/tracker/index.py
@@ -65,7 +65,7 @@ def extract_index_mapping_and_settings(client, index_pattern):
     results = {}
     logger = logging.getLogger(__name__)
     # the response might contain multiple indices if a wildcard was provided
-    response = client.indices.get(index_pattern)
+    response = client.indices.get(index=index_pattern)
     for index, details in response.items():
         valid, reason = is_valid(index)
         if valid:

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1528,7 +1528,7 @@ class TestAsyncExecutor:
         es.init_request_context.return_value = {"request_start": 0, "request_end": 10}
         # as this method is called several times we need to return a fresh instance every time as the previous
         # one has been "consumed".
-        es.transport.perform_request.side_effect = perform_request
+        es.perform_request.side_effect = perform_request
 
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
         test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -3187,19 +3187,19 @@ class TestCreateMlDatafeed:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_create_ml_datafeed(self, es):
-        es.xpack.ml.put_datafeed = mock.AsyncMock()
+        es.ml.put_datafeed = mock.AsyncMock()
 
         params = {"datafeed-id": "some-data-feed", "body": {"job_id": "total-requests", "indices": ["server-metrics"]}}
 
         r = runner.CreateMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.put_datafeed.assert_awaited_once_with(datafeed_id=params["datafeed-id"], body=params["body"])
+        es.ml.put_datafeed.assert_awaited_once_with(datafeed_id=params["datafeed-id"], body=params["body"])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_create_ml_datafeed_fallback(self, es):
-        es.xpack.ml.put_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
+        es.ml.put_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
         es.transport.perform_request = mock.AsyncMock()
         datafeed_id = "some-data-feed"
         body = {"job_id": "total-requests", "indices": ["server-metrics"]}
@@ -3215,7 +3215,7 @@ class TestDeleteMlDatafeed:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_delete_ml_datafeed(self, es):
-        es.xpack.ml.delete_datafeed = mock.AsyncMock()
+        es.ml.delete_datafeed = mock.AsyncMock()
 
         datafeed_id = "some-data-feed"
         params = {"datafeed-id": datafeed_id}
@@ -3223,12 +3223,13 @@ class TestDeleteMlDatafeed:
         r = runner.DeleteMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.delete_datafeed.assert_awaited_once_with(datafeed_id=datafeed_id, force=False, ignore=[404])
+        es.ml.delete_datafeed.assert_awaited_once_with(datafeed_id=datafeed_id, force=False, ignore=[404])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_delete_ml_datafeed_fallback(self, es):
-        es.xpack.ml.delete_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
+        es.ml.delete_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
+
         es.transport.perform_request = mock.AsyncMock()
         datafeed_id = "some-data-feed"
         params = {
@@ -3247,20 +3248,20 @@ class TestStartMlDatafeed:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_start_ml_datafeed_with_body(self, es):
-        es.xpack.ml.start_datafeed = mock.AsyncMock()
+        es.ml.start_datafeed = mock.AsyncMock()
         params = {"datafeed-id": "some-data-feed", "body": {"end": "now"}}
 
         r = runner.StartMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.start_datafeed.assert_awaited_once_with(
+        es.ml.start_datafeed.assert_awaited_once_with(
             datafeed_id=params["datafeed-id"], body=params["body"], start=None, end=None, timeout=None
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_start_ml_datafeed_with_body_fallback(self, es):
-        es.xpack.ml.start_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
+        es.ml.start_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
         es.transport.perform_request = mock.AsyncMock()
         body = {"end": "now"}
         params = {"datafeed-id": "some-data-feed", "body": body}
@@ -3273,7 +3274,7 @@ class TestStartMlDatafeed:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_start_ml_datafeed_with_params(self, es):
-        es.xpack.ml.start_datafeed = mock.AsyncMock()
+        es.ml.start_datafeed = mock.AsyncMock()
         params = {
             "datafeed-id": "some-data-feed",
             "start": "2017-01-01T01:00:00Z",
@@ -3284,7 +3285,7 @@ class TestStartMlDatafeed:
         r = runner.StartMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.start_datafeed.assert_awaited_once_with(
+        es.ml.start_datafeed.assert_awaited_once_with(
             datafeed_id=params["datafeed-id"], body=None, start=params["start"], end=params["end"], timeout=params["timeout"]
         )
 
@@ -3293,7 +3294,7 @@ class TestStopMlDatafeed:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_stop_ml_datafeed(self, es):
-        es.xpack.ml.stop_datafeed = mock.AsyncMock()
+        es.ml.stop_datafeed = mock.AsyncMock()
         params = {
             "datafeed-id": "some-data-feed",
             "force": random.choice([False, True]),
@@ -3303,14 +3304,12 @@ class TestStopMlDatafeed:
         r = runner.StopMlDatafeed()
         await r(es, params)
 
-        es.xpack.ml.stop_datafeed.assert_awaited_once_with(
-            datafeed_id=params["datafeed-id"], force=params["force"], timeout=params["timeout"]
-        )
+        es.ml.stop_datafeed.assert_awaited_once_with(datafeed_id=params["datafeed-id"], force=params["force"], timeout=params["timeout"])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_stop_ml_datafeed_fallback(self, es):
-        es.xpack.ml.stop_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
+        es.ml.stop_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
         es.transport.perform_request = mock.AsyncMock()
 
         params = {
@@ -3333,7 +3332,7 @@ class TestCreateMlJob:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_create_ml_job(self, es):
-        es.xpack.ml.put_job = mock.AsyncMock()
+        es.ml.put_job = mock.AsyncMock()
 
         params = {
             "job-id": "an-ml-job",
@@ -3356,12 +3355,12 @@ class TestCreateMlJob:
         r = runner.CreateMlJob()
         await r(es, params)
 
-        es.xpack.ml.put_job.assert_awaited_once_with(job_id=params["job-id"], body=params["body"])
+        es.ml.put_job.assert_awaited_once_with(job_id=params["job-id"], body=params["body"])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_create_ml_job_fallback(self, es):
-        es.xpack.ml.put_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
+        es.ml.put_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
         es.transport.perform_request = mock.AsyncMock()
 
         body = {
@@ -3390,7 +3389,7 @@ class TestDeleteMlJob:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_delete_ml_job(self, es):
-        es.xpack.ml.delete_job = mock.AsyncMock()
+        es.ml.delete_job = mock.AsyncMock()
 
         job_id = "an-ml-job"
         params = {"job-id": job_id}
@@ -3398,12 +3397,12 @@ class TestDeleteMlJob:
         r = runner.DeleteMlJob()
         await r(es, params)
 
-        es.xpack.ml.delete_job.assert_awaited_once_with(job_id=job_id, force=False, ignore=[404])
+        es.ml.delete_job.assert_awaited_once_with(job_id=job_id, force=False, ignore=[404])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_delete_ml_job_fallback(self, es):
-        es.xpack.ml.delete_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
+        es.ml.delete_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
         es.transport.perform_request = mock.AsyncMock()
 
         job_id = "an-ml-job"
@@ -3421,7 +3420,7 @@ class TestOpenMlJob:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_open_ml_job(self, es):
-        es.xpack.ml.open_job = mock.AsyncMock()
+        es.ml.open_job = mock.AsyncMock()
 
         job_id = "an-ml-job"
         params = {"job-id": job_id}
@@ -3429,12 +3428,12 @@ class TestOpenMlJob:
         r = runner.OpenMlJob()
         await r(es, params)
 
-        es.xpack.ml.open_job.assert_awaited_once_with(job_id=job_id)
+        es.ml.open_job.assert_awaited_once_with(job_id=job_id)
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_open_ml_job_fallback(self, es):
-        es.xpack.ml.open_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
+        es.ml.open_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
         es.transport.perform_request = mock.AsyncMock()
 
         job_id = "an-ml-job"
@@ -3450,7 +3449,7 @@ class TestCloseMlJob:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_close_ml_job(self, es):
-        es.xpack.ml.close_job = mock.AsyncMock()
+        es.ml.close_job = mock.AsyncMock()
         params = {
             "job-id": "an-ml-job",
             "force": random.choice([False, True]),
@@ -3460,12 +3459,12 @@ class TestCloseMlJob:
         r = runner.CloseMlJob()
         await r(es, params)
 
-        es.xpack.ml.close_job.assert_awaited_once_with(job_id=params["job-id"], force=params["force"], timeout=params["timeout"])
+        es.ml.close_job.assert_awaited_once_with(job_id=params["job-id"], force=params["force"], timeout=params["timeout"])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_close_ml_job_fallback(self, es):
-        es.xpack.ml.close_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
+        es.ml.close_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
         es.transport.perform_request = mock.AsyncMock()
 
         params = {

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1496,7 +1496,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1525,7 +1525,7 @@ class TestQueryRunner:
             "took": 5,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "GET", "/_all/_search", params={"request_cache": "true"}, body=params["body"], headers=None
         )
         es.clear_scroll.assert_not_called()
@@ -1544,7 +1544,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1572,7 +1572,7 @@ class TestQueryRunner:
             "took": 5,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "GET",
             "/_all/_search",
             params={"request_timeout": 3.0, "request_cache": "true"},
@@ -1598,7 +1598,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
 
         query_runner = runner.Query()
         params = {
@@ -1625,7 +1625,7 @@ class TestQueryRunner:
             "took": 62,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "GET",
             "/_all/_search",
             params={
@@ -1654,7 +1654,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
 
         query_runner = runner.Query()
         params = {
@@ -1679,7 +1679,7 @@ class TestQueryRunner:
         assert "took" not in result
         assert "error-type" not in result
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "GET",
             "/_all/_search",
             params={
@@ -1704,7 +1704,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1733,7 +1733,7 @@ class TestQueryRunner:
             "took": 5,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "GET",
             "/_all/_search",
             params={
@@ -1761,7 +1761,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1790,7 +1790,7 @@ class TestQueryRunner:
             "took": 5,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "GET",
             "/unittest/_search",
             params={},
@@ -1816,7 +1816,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
 
         query_runner = runner.Query()
 
@@ -1846,7 +1846,7 @@ class TestQueryRunner:
             "took": 5,
         }
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "GET",
             "/unittest/type/_search",
             body=params["body"],
@@ -1872,7 +1872,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
         es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
 
         query_runner = runner.Query()
@@ -1904,7 +1904,7 @@ class TestQueryRunner:
         }
         assert "error-type" not in results
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "GET",
             "/unittest/_search",
             params={
@@ -1935,7 +1935,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
         es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
 
         query_runner = runner.Query()
@@ -1967,7 +1967,7 @@ class TestQueryRunner:
         }
         assert "error-type" not in results
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "GET",
             "/unittest/_search",
             params={"sort": "_doc", "scroll": "10s", "size": 100},
@@ -1993,7 +1993,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
         es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
 
         query_runner = runner.Query()
@@ -2024,7 +2024,7 @@ class TestQueryRunner:
         }
         assert "error-type" not in results
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "GET",
             "/_all/_search",
             params={
@@ -2071,7 +2071,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 io.StringIO(json.dumps(search_response)),
                 io.StringIO(json.dumps(scroll_response)),
@@ -2127,7 +2127,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
         es.clear_scroll = mock.AsyncMock(side_effect=elasticsearch.ConnectionTimeout())
 
         query_runner = runner.Query()
@@ -2190,7 +2190,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 io.StringIO(json.dumps(search_response)),
                 io.StringIO(json.dumps(scroll_response)),
@@ -2246,7 +2246,7 @@ class TestQueryRunner:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
         es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
 
         query_runner = runner.Query()
@@ -2980,7 +2980,7 @@ class TestDeleteComponentTemplateRunner:
             if http_method == "HEAD":
                 return path == "/_component_template/templateB"
 
-        es.transport.perform_request = mock.AsyncMock(side_effect=_side_effect)
+        es.perform_request = mock.AsyncMock(side_effect=_side_effect)
         es.cluster.delete_component_template = mock.AsyncMock()
 
         r = runner.DeleteComponentTemplate()
@@ -3200,7 +3200,7 @@ class TestCreateMlDatafeed:
     @pytest.mark.asyncio
     async def test_create_ml_datafeed_fallback(self, es):
         es.ml.put_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         datafeed_id = "some-data-feed"
         body = {"job_id": "total-requests", "indices": ["server-metrics"]}
         params = {"datafeed-id": datafeed_id, "body": body}
@@ -3208,7 +3208,7 @@ class TestCreateMlDatafeed:
         r = runner.CreateMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with("PUT", f"/_xpack/ml/datafeeds/{datafeed_id}", body=body)
+        es.perform_request.assert_awaited_once_with("PUT", f"/_xpack/ml/datafeeds/{datafeed_id}", body=body)
 
 
 class TestDeleteMlDatafeed:
@@ -3230,7 +3230,7 @@ class TestDeleteMlDatafeed:
     async def test_delete_ml_datafeed_fallback(self, es):
         es.ml.delete_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
 
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         datafeed_id = "some-data-feed"
         params = {
             "datafeed-id": datafeed_id,
@@ -3239,7 +3239,7 @@ class TestDeleteMlDatafeed:
         r = runner.DeleteMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "DELETE", f"/_xpack/ml/datafeeds/{datafeed_id}", params={"force": "false", "ignore": 404}
         )
 
@@ -3262,14 +3262,14 @@ class TestStartMlDatafeed:
     @pytest.mark.asyncio
     async def test_start_ml_datafeed_with_body_fallback(self, es):
         es.ml.start_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         body = {"end": "now"}
         params = {"datafeed-id": "some-data-feed", "body": body}
 
         r = runner.StartMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with("POST", f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_start", body=body)
+        es.perform_request.assert_awaited_once_with("POST", f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_start", body=body)
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
@@ -3310,7 +3310,7 @@ class TestStopMlDatafeed:
     @pytest.mark.asyncio
     async def test_stop_ml_datafeed_fallback(self, es):
         es.ml.stop_datafeed = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
 
         params = {
             "datafeed-id": "some-data-feed",
@@ -3321,7 +3321,7 @@ class TestStopMlDatafeed:
         r = runner.StopMlDatafeed()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "POST",
             f"/_xpack/ml/datafeeds/{params['datafeed-id']}/_stop",
             params={"force": str(params["force"]).lower(), "timeout": params["timeout"]},
@@ -3361,7 +3361,7 @@ class TestCreateMlJob:
     @pytest.mark.asyncio
     async def test_create_ml_job_fallback(self, es):
         es.ml.put_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
 
         body = {
             "description": "Total sum of requests",
@@ -3382,7 +3382,7 @@ class TestCreateMlJob:
         r = runner.CreateMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with("PUT", f"/_xpack/ml/anomaly_detectors/{params['job-id']}", body=body)
+        es.perform_request.assert_awaited_once_with("PUT", f"/_xpack/ml/anomaly_detectors/{params['job-id']}", body=body)
 
 
 class TestDeleteMlJob:
@@ -3403,7 +3403,7 @@ class TestDeleteMlJob:
     @pytest.mark.asyncio
     async def test_delete_ml_job_fallback(self, es):
         es.ml.delete_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
 
         job_id = "an-ml-job"
         params = {"job-id": job_id}
@@ -3411,7 +3411,7 @@ class TestDeleteMlJob:
         r = runner.DeleteMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "DELETE", f"/_xpack/ml/anomaly_detectors/{params['job-id']}", params={"force": "false", "ignore": 404}
         )
 
@@ -3434,7 +3434,7 @@ class TestOpenMlJob:
     @pytest.mark.asyncio
     async def test_open_ml_job_fallback(self, es):
         es.ml.open_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
 
         job_id = "an-ml-job"
         params = {"job-id": job_id}
@@ -3442,7 +3442,7 @@ class TestOpenMlJob:
         r = runner.OpenMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with("POST", f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_open")
+        es.perform_request.assert_awaited_once_with("POST", f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_open")
 
 
 class TestCloseMlJob:
@@ -3465,7 +3465,7 @@ class TestCloseMlJob:
     @pytest.mark.asyncio
     async def test_close_ml_job_fallback(self, es):
         es.ml.close_job = mock.AsyncMock(side_effect=elasticsearch.TransportError(400, "Bad Request"))
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
 
         params = {
             "job-id": "an-ml-job",
@@ -3476,7 +3476,7 @@ class TestCloseMlJob:
         r = runner.CloseMlJob()
         await r(es, params)
 
-        es.transport.perform_request.assert_awaited_once_with(
+        es.perform_request.assert_awaited_once_with(
             "POST",
             f"/_xpack/ml/anomaly_detectors/{params['job-id']}/_close",
             params={"force": str(params["force"]).lower(), "timeout": params["timeout"]},
@@ -3487,7 +3487,7 @@ class TestRawRequestRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_raises_missing_slash(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {"path": "_cat/count"}
@@ -3503,18 +3503,18 @@ class TestRawRequestRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_issue_request_with_defaults(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {"path": "/_cat/count"}
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(method="GET", url="/_cat/count", headers=None, body=None, params={})
+        es.perform_request.assert_called_once_with(method="GET", url="/_cat/count", headers=None, body=None, params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_issue_delete_index(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {
@@ -3527,14 +3527,14 @@ class TestRawRequestRunner:
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(
+        es.perform_request.assert_called_once_with(
             method="DELETE", url="/twitter", headers=None, body=None, params={"ignore": [400, 404], "pretty": "true"}
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_issue_create_index(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {
@@ -3550,14 +3550,14 @@ class TestRawRequestRunner:
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(
+        es.perform_request.assert_called_once_with(
             method="POST", url="/twitter", headers=None, body={"settings": {"index": {"number_of_replicas": 0}}}, params={}
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_issue_msearch(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {
@@ -3572,7 +3572,7 @@ class TestRawRequestRunner:
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(
+        es.perform_request.assert_called_once_with(
             method="GET",
             url="/_msearch",
             headers={"Content-Type": "application/x-ndjson"},
@@ -3588,7 +3588,7 @@ class TestRawRequestRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_raw_with_timeout_and_opaqueid(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
         r = runner.RawRequest()
 
         params = {
@@ -3605,7 +3605,7 @@ class TestRawRequestRunner:
         }
         await r(es, params)
 
-        es.transport.perform_request.assert_called_once_with(
+        es.perform_request.assert_called_once_with(
             method="GET",
             url="/_msearch",
             headers={"Content-Type": "application/x-ndjson", "x-opaque-id": "test-id1"},
@@ -4947,7 +4947,7 @@ class TestSqlRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_fetch_one_page(self, es):
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
 
         sql_runner = runner.Sql()
         params = {
@@ -4965,12 +4965,12 @@ class TestSqlRunner:
 
         assert result == {"success": True, "weight": 1, "unit": "ops"}
 
-        es.transport.perform_request.assert_awaited_once_with("POST", "/_sql", body=params["body"])
+        es.perform_request.assert_awaited_once_with("POST", "/_sql", body=params["body"])
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_fetch_all_pages(self, es):
-        es.transport.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
 
         sql_runner = runner.Sql()
         params = {"operation-type": "sql", "body": {"query": "SELECT first_name FROM emp"}, "pages": 3}
@@ -4980,7 +4980,7 @@ class TestSqlRunner:
 
         assert result == {"success": True, "weight": 3, "unit": "ops"}
 
-        es.transport.perform_request.assert_has_calls(
+        es.perform_request.assert_has_calls(
             [
                 mock.call("POST", "/_sql", body=params["body"]),
                 mock.call("POST", "/_sql", body={"cursor": self.default_response["cursor"]}),
@@ -4991,7 +4991,7 @@ class TestSqlRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_failure_on_too_few_pages(self, es):
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[io.StringIO(json.dumps(self.default_response)), io.StringIO(json.dumps({"rows": [["John"]]}))]
         )
 
@@ -5010,7 +5010,7 @@ class TestSqlRunner:
 
         assert ctx.value.message == "Result set has been exhausted before all pages have been fetched, 1 page(s) remaining."
 
-        es.transport.perform_request.assert_has_calls(
+        es.perform_request.assert_has_calls(
             [
                 mock.call("POST", "/_sql", body=params["body"]),
                 mock.call("POST", "/_sql", body={"cursor": self.default_response["cursor"]}),
@@ -5234,7 +5234,7 @@ class TestQueryWithSearchAfterScroll:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 io.BytesIO(json.dumps(page_1).encode()),
                 io.BytesIO(json.dumps(page_2).encode()),
@@ -5249,7 +5249,7 @@ class TestQueryWithSearchAfterScroll:
             # make sure pit_id is updated afterward
             assert runner.CompositeContext.get(pit_op) == "fedcba9876543211"
 
-        es.transport.perform_request.assert_has_awaits(
+        es.perform_request.assert_has_awaits(
             [
                 mock.call(
                     "GET",
@@ -5344,7 +5344,7 @@ class TestQueryWithSearchAfterScroll:
             },
         }
 
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 io.BytesIO(json.dumps(page_1).encode()),
                 io.BytesIO(json.dumps(page_2).encode()),
@@ -5353,7 +5353,7 @@ class TestQueryWithSearchAfterScroll:
         r = runner.Query()
         await r(es, params)
 
-        es.transport.perform_request.assert_has_awaits(
+        es.perform_request.assert_has_awaits(
             [
                 mock.call(
                     "GET",
@@ -5542,7 +5542,7 @@ class TestComposite:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_execute_multiple_streams(self, es):
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 # raw-request
                 None,
@@ -5605,7 +5605,7 @@ class TestComposite:
         r = runner.Composite()
         await r(es, params)
 
-        es.transport.perform_request.assert_has_awaits(
+        es.perform_request.assert_has_awaits(
             [
                 mock.call(method="GET", url="/", headers=None, body={}, params={}),
                 mock.call("GET", "/test/_search", params={}, body={"query": {"match_all": {}}}, headers=None),
@@ -5615,7 +5615,7 @@ class TestComposite:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_propagates_violated_assertions(self, es):
-        es.transport.perform_request = mock.AsyncMock(
+        es.perform_request = mock.AsyncMock(
             side_effect=[
                 # search
                 io.StringIO(
@@ -5664,7 +5664,7 @@ class TestComposite:
         with pytest.raises(exceptions.RallyTaskAssertionError, match=r"Expected \[hits\] to be > \[0\] but was \[0\]."):
             await r(es, params)
 
-        es.transport.perform_request.assert_has_awaits(
+        es.perform_request.assert_has_awaits(
             [
                 mock.call(
                     "GET",
@@ -5683,7 +5683,7 @@ class TestComposite:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_executes_tasks_in_specified_order(self, es):
-        es.transport.perform_request = mock.AsyncMock()
+        es.perform_request = mock.AsyncMock()
 
         params = {
             "requests": [

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -162,6 +162,9 @@ class Client:
     def info(self):
         return self._info()
 
+    def perform_request(self, *args, **kwargs):
+        return self.transport.perform_request(*args, **kwargs)
+
 
 class SubClient:
     def __init__(self, stats=None, info=None, recovery=None, transform_stats=None, data_streams_stats=None, state=None):

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -4250,9 +4250,9 @@ class TestDiskUsageStats:
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
         t.on_benchmark_stop()
-        assert tc.args == [
-            ("POST", "/foo/_disk_usage"),
-            ("POST", "/bar/_disk_usage"),
+        assert tc.kwargs == [
+            {"method": "POST", "path": "/foo/_disk_usage", "params": {"run_expensive_tasks": "true"}},
+            {"method": "POST", "path": "/bar/_disk_usage", "params": {"run_expensive_tasks": "true"}},
         ]
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -4265,9 +4265,9 @@ class TestDiskUsageStats:
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
         t.on_benchmark_stop()
-        assert tc.args == [
-            ("POST", "/foo/_disk_usage"),
-            ("POST", "/bar/_disk_usage"),
+        assert tc.kwargs == [
+            {"method": "POST", "path": "/foo/_disk_usage", "params": {"run_expensive_tasks": "true"}},
+            {"method": "POST", "path": "/bar/_disk_usage", "params": {"run_expensive_tasks": "true"}},
         ]
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -4282,7 +4282,10 @@ class TestDiskUsageStats:
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
         t.on_benchmark_stop()
-        assert tc.args == [("POST", "/foo/_disk_usage"), ("POST", "/bar/_disk_usage")]
+        assert tc.kwargs == [
+            {"method": "POST", "path": "/foo/_disk_usage", "params": {"run_expensive_tasks": "true"}},
+            {"method": "POST", "path": "/bar/_disk_usage", "params": {"run_expensive_tasks": "true"}},
+        ]
 
     @mock.patch("elasticsearch.Elasticsearch")
     def test_uses_indices_param_if_specified_instead_of_data_stream_names(self, es):
@@ -4296,7 +4299,10 @@ class TestDiskUsageStats:
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
         t.on_benchmark_stop()
-        assert tc.args == [("POST", "/foo/_disk_usage"), ("POST", "/bar/_disk_usage")]
+        assert tc.kwargs == [
+            {"method": "POST", "path": "/foo/_disk_usage", "params": {"run_expensive_tasks": "true"}},
+            {"method": "POST", "path": "/bar/_disk_usage", "params": {"run_expensive_tasks": "true"}},
+        ]
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     def test_error_on_retrieval_does_not_store_metrics(self, metrics_store_cluster_level):


### PR DESCRIPTION
For compatibility with version 8.x of the Elasticsearch Python client. #1510 does it all in one go but I can't review that given the number of lines and the different concerns. This pull request contains self-sufficient commits for mechanical changes to reduce the scope of #1510. I'll be happy to fix the conflicts.

 * Switch from `es.xpack.ml` to `es.ml` (already possible with 7.14)
 * Switch from `es.transport.perform_request` to `es.perform_request` (required an adapter method)
 * Call Elasticsearch Python client with keyword arguments (and automatically convert path to url in `perform_request` calls)