### PR TITLE
Replace os.system with subprocess.call

### DIFF
--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -25,7 +25,7 @@ import psutil
 
 
 def run_subprocess(command_line):
-    return os.system(command_line)
+    return subprocess.call(command_line, shell=True)
 
 
 def run_subprocess_with_output(command_line, env_vars=None):

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -21,6 +21,7 @@ import json
 import os
 import random
 import socket
+import subprocess
 import time
 
 import pytest
@@ -79,7 +80,7 @@ def esrally(cfg, command_line):
     This method should be used for rally invocations of the all commands besides race.
     These commands may have different CLI options than race.
     """
-    return os.system(esrally_command_line_for(cfg, command_line))
+    return subprocess.call(esrally_command_line_for(cfg, command_line), shell=True)
 
 
 def race(cfg, command_line):
@@ -98,7 +99,7 @@ def shell_cmd(command_line):
     :return: (int) the exit code
     """
 
-    return os.system(command_line)
+    return subprocess.call(command_line, shell=True)
 
 
 def command_in_docker(command_line, python_version):


### PR DESCRIPTION
See https://docs.python.org/3/library/subprocess.html#replacing-os-system for more details. I think the default semantics are better.

One big advantage is that the exit code is not opaque with `subprocess.call`, which has slowed us down in https://github.com/elastic/rally/issues/1430.