### PR TITLE
Relax target-hosts check for multi clusters

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -893,7 +893,7 @@ def configure_connection_params(arg_parser, args, cfg):
     cfg.add(config.Scope.applicationOverride, "client", "hosts", target_hosts)
     client_options = opts.ClientOptions(args.client_options, target_hosts=target_hosts)
     cfg.add(config.Scope.applicationOverride, "client", "options", client_options)
-    if list(target_hosts.all_hosts) != list(client_options.all_client_options):
+    if set(target_hosts.all_hosts) != set(client_options.all_client_options):
         arg_parser.error("--target-hosts and --client-options must define the same keys for multi cluster setups.")
 
 

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -104,8 +104,8 @@ def test_cluster():
 @it.random_rally_config
 def test_multi_target_hosts(cfg, test_cluster):
     hosts = '"127.0.0.1:{}"'.format(test_cluster.http_port)
-    target_hosts = '{{"remote":{hosts}, "default":{hosts}'.format(hosts=hosts)
-    client_options = '{{"default": {"max_connections": 50}, "remote": {"max_connections": 100}}}'
+    target_hosts = '{{ "remote":[{hosts}], "default":[{hosts}] }}'.format(hosts=hosts)
+    client_options = '{{ "default": {{"max_connections": 50}}, "remote": {{"max_connections": 100}} }}'
 
     race_params = (
         f"--test-mode --pipeline=benchmark-only --track=geonames --target-hosts=${target_hosts} --client-options=${client_options} "

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import json
 import logging
 import random
 import shlex
@@ -104,29 +103,16 @@ def test_cluster():
 
 @it.random_rally_config
 def test_multi_target_hosts(cfg, test_cluster):
-    hosts = ["127.0.0.1:{}".format(test_cluster.http_port)]
-    target_hosts = {
-        "remote": hosts,
-        "default": hosts,
-    }
-    client_options = {
-        "default": {"max_connections": 50},
-        "remote": {"max_connections": 100},
-    }
+    hosts = '"127.0.0.1:{}"'.format(test_cluster.http_port)
+    target_hosts = '{{"remote":{hosts}, "default":{hosts}'.format(hosts=hosts)
+    client_options = '{{"default": {"max_connections": 50}, "remote": {"max_connections": 100}}}'
 
-    def race_params():
-        target_hosts_str = json.dumps(json.dumps(target_hosts))
-        client_options_str = json.dumps(json.dumps(client_options))
-        return (
-            f"--test-mode --pipeline=benchmark-only --track=geonames "
-            f"--target-hosts=${target_hosts_str} "
-            f"--client-options=${client_options_str} "
-        )
+    race_params = (
+        f"--test-mode --pipeline=benchmark-only --track=geonames --target-hosts=${target_hosts} "
+        f"--client-options=${client_options} "
+    )
 
-    assert it.race(cfg, race_params()) == 0
-
-    target_hosts["extra_cluster"] = [hosts]
-    assert it.race(cfg, race_params()) != 0
+    assert it.race(cfg, race_params) == 0
 
 
 @it.random_rally_config

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -110,11 +110,11 @@ def test_multi_target_hosts(cfg, test_cluster):
         "default": hosts,
     }
     client_options = {
-        "default": {"timeout": random.choice([60, 120])},
-        "remote": {"timeout": random.choice([60, 120])},
+        "default": {"max_connections": 50},
+        "remote": {"max_connections": 100},
     }
 
-    def generate_cmd():
+    def race_params():
         target_hosts_str = json.dumps(json.dumps(target_hosts))
         client_options_str = json.dumps(json.dumps(client_options))
         return (
@@ -123,10 +123,10 @@ def test_multi_target_hosts(cfg, test_cluster):
             f"--client-options=${client_options_str} "
         )
 
-    assert it.race(cfg, generate_cmd()) == 0
+    assert it.race(cfg, race_params()) == 0
 
     target_hosts["extra_cluster"] = [hosts]
-    assert it.race(cfg, generate_cmd()) != 0
+    assert it.race(cfg, race_params()) != 0
 
 
 @it.random_rally_config

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -128,6 +128,7 @@ def test_multi_target_hosts(cfg, test_cluster):
     target_hosts["extra_cluster"] = [hosts]
     assert it.race(cfg, generate_cmd()) != 0
 
+
 @it.random_rally_config
 def test_eventdata_frozen(cfg, test_cluster):
     challenges = ["frozen-data-generation", "frozen-querying"]

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -108,8 +108,7 @@ def test_multi_target_hosts(cfg, test_cluster):
     client_options = '{{"default": {"max_connections": 50}, "remote": {"max_connections": 100}}}'
 
     race_params = (
-        f"--test-mode --pipeline=benchmark-only --track=geonames --target-hosts=${target_hosts} "
-        f"--client-options=${client_options} "
+        f"--test-mode --pipeline=benchmark-only --track=geonames --target-hosts=${target_hosts} --client-options=${client_options} "
     )
 
     assert it.race(cfg, race_params) == 0


### PR DESCRIPTION
This change relaxes the check of the cluster keys of the `client_options` and `target_hosts` parameters. These parameters are dictionaries, and their keys can be in any order.