### PR TITLE
Retry incomplete HTTP downloads

### DIFF
--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -174,9 +174,9 @@ def download_from_bucket(blobstore, url, local_path, expected_size_in_bytes=None
 
 
 def download_http(url, local_path, expected_size_in_bytes=None, progress_indicator=None):
-    with __http().request("GET", url, preload_content=False, retries=10, timeout=urllib3.Timeout(connect=45, read=240)) as r, open(
-        local_path, "wb"
-    ) as out_file:
+    with __http().request(
+        "GET", url, preload_content=False, enforce_content_length=True, retries=10, timeout=urllib3.Timeout(connect=45, read=240)
+    ) as r, open(local_path, "wb") as out_file:
         if r.status > 299:
             raise urllib.error.HTTPError(url, r.status, "", None, None)
         # noinspection PyBroadException


### PR DESCRIPTION
Currently when we did not download enough data, we just abort the
benchmark. Instead, let's ask urllib3 to retry it per our retry policy.

This does not change the existing Rally logic around Content-Length as
it's possible to specify the expected length and I don't want this fix
to change other behavior.

Closes #1504 (it was a good first issue but we hit this a lot recently)