### PR TITLE
create-notice: update links for repos that switched to main

### DIFF
--- a/create-notice.sh
+++ b/create-notice.sh
@@ -42,8 +42,8 @@ function main {
     # link to a URL providing the MPL-covered source code
     printf "The source code can be obtained at https://github.com/certifi/python-certifi\n" >> "${OUTPUT_FILE}"
     add_license "certifi" "https://raw.githubusercontent.com/certifi/python-certifi/master/LICENSE"
-    add_license "elasticsearch" "https://raw.githubusercontent.com/elastic/elasticsearch-py/master/LICENSE"
-    add_license "jinja2" "https://raw.githubusercontent.com/pallets/jinja/master/LICENSE.rst"
+    add_license "elasticsearch" "https://raw.githubusercontent.com/elastic/elasticsearch-py/main/LICENSE"
+    add_license "jinja2" "https://raw.githubusercontent.com/pallets/jinja/main/LICENSE.rst"
     add_license "jsonschema" "https://raw.githubusercontent.com/Julian/jsonschema/main/COPYING"
     add_license "psutil" "https://raw.githubusercontent.com/giampaolo/psutil/master/LICENSE"
     add_license "py-cpuinfo" "https://raw.githubusercontent.com/workhorsy/py-cpuinfo/master/LICENSE"
@@ -52,19 +52,19 @@ function main {
     add_license "boto3" "https://raw.githubusercontent.com/boto/boto3/develop/LICENSE"
     add_license "yappi" "https://raw.githubusercontent.com/sumerc/yappi/master/LICENSE"
     add_license "ijson" "https://raw.githubusercontent.com/ICRAR/ijson/master/LICENSE.txt"
-    add_license "google-resumable-media" "https://raw.githubusercontent.com/googleapis/google-resumable-media-python/master/LICENSE"
-    add_license "google-auth" "https://raw.githubusercontent.com/googleapis/google-auth-library-python/master/LICENSE"
+    add_license "google-resumable-media" "https://raw.githubusercontent.com/googleapis/google-resumable-media-python/main/LICENSE"
+    add_license "google-auth" "https://raw.githubusercontent.com/googleapis/google-auth-library-python/main/LICENSE"
 
     # transitive dependencies
     # Jinja2 dependencies
-    add_license "Markupsafe" "https://raw.githubusercontent.com/pallets/markupsafe/master/LICENSE.rst"
+    add_license "Markupsafe" "https://raw.githubusercontent.com/pallets/markupsafe/main/LICENSE.rst"
     # elasticsearch dependencies
-    add_license "urllib3" "https://raw.githubusercontent.com/urllib3/urllib3/master/LICENSE.txt"
+    add_license "urllib3" "https://raw.githubusercontent.com/urllib3/urllib3/main/LICENSE.txt"
     #elasticsearch[async] dependencies
     add_license "aiohttp" "https://raw.githubusercontent.com/aio-libs/aiohttp/master/LICENSE.txt"
     #aiohttp dependencies
     add_license "async_timeout" "https://raw.githubusercontent.com/aio-libs/async-timeout/master/LICENSE"
-    add_license "attrs" "https://raw.githubusercontent.com/python-attrs/attrs/master/LICENSE"
+    add_license "attrs" "https://raw.githubusercontent.com/python-attrs/attrs/main/LICENSE"
     add_license "chardet" "https://raw.githubusercontent.com/chardet/chardet/master/LICENSE"
     add_license "multidict" "https://raw.githubusercontent.com/aio-libs/multidict/master/LICENSE"
     add_license "yarl" "https://raw.githubusercontent.com/aio-libs/yarl/master/LICENSE"
@@ -76,7 +76,7 @@ function main {
     add_license "jmespath" "https://raw.githubusercontent.com/jmespath/jmespath.py/develop/LICENSE.txt"
     add_license "botocore" "https://raw.githubusercontent.com/boto/botocore/develop/LICENSE.txt"
     # google-resumable-media dependencies
-    add_license "google-crc32c": "https://raw.githubusercontent.com/googleapis/python-crc32c/master/LICENSE"
+    add_license "google-crc32c": "https://raw.githubusercontent.com/googleapis/python-crc32c/main/LICENSE"
 }
 
 main


### PR DESCRIPTION
While the old links still work, I think it makes sense to update to the new versions?