### PR TITLE
Make esrally.utils.git branch agnostic

### DIFF
--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -621,20 +621,20 @@ class SourceRepository:
     def _update(self, revision):
         if self.has_remote() and revision == "latest":
             self.logger.info("Fetching latest sources for %s from origin.", self.name)
-            git.pull(self.src_dir)
+            git.pull(self.src_dir, branch="master")
         elif revision == "current":
             self.logger.info("Skip fetching sources for %s.", self.name)
         elif self.has_remote() and revision.startswith("@"):
             # convert timestamp annotated for Rally to something git understands -> we strip leading and trailing " and the @.
             git_ts_revision = revision[1:]
             self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s.", git_ts_revision, self.name)
-            git.pull_ts(self.src_dir, git_ts_revision)
+            git.pull_ts(self.src_dir, git_ts_revision, branch="master")
         elif self.has_remote():  # assume a git commit hash
             self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
             git.pull_revision(self.src_dir, revision)
         else:
             self.logger.info("Checking out local revision [%s] for %s.", revision, self.name)
-            git.checkout(self.src_dir, revision)
+            git.checkout(self.src_dir, branch=revision)
         if git.is_working_copy(self.src_dir):
             git_revision = git.head_revision(self.src_dir)
             self.logger.info("User-specified revision [%s] for [%s] results in git revision [%s]", revision, self.name, git_revision)

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -62,31 +62,30 @@ def fetch(src, remote="origin"):
 
 
 @probed
-def checkout(src_dir, branch="master"):
+def checkout(src_dir, *, branch):
     if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), branch)):
         raise exceptions.SupplyError("Could not checkout [%s]. Do you have uncommitted changes?" % branch)
 
 
 @probed
-def rebase(src_dir, remote="origin", branch="master"):
-    checkout(src_dir, branch)
+def rebase(src_dir, remote="origin", *, branch):
+    checkout(src_dir, branch=branch)
     if process.run_subprocess_with_logging("git -C {0} rebase {1}/{2}".format(io.escape_path(src_dir), remote, branch)):
         raise exceptions.SupplyError("Could not rebase on branch [%s]" % branch)
 
 
 @probed
-def pull(src_dir, remote="origin", branch="master"):
+def pull(src_dir, remote="origin", *, branch):
     fetch(src_dir, remote)
-    rebase(src_dir, remote, branch)
+    rebase(src_dir, remote, branch=branch)
 
 
 @probed
-def pull_ts(src_dir, ts):
+def pull_ts(src_dir, ts, remote="origin", *, branch):
     fetch(src_dir)
     clean_src = io.escape_path(src_dir)
-    revision = process.run_subprocess_with_output(
-        'git -C {0} rev-list -n 1 --before="{1}" --date=iso8601 origin/master'.format(clean_src, ts)
-    )[0].strip()
+    rev_list_command = f'git -C {clean_src} rev-list -n 1 --before="{ts}" --date=iso8601 {remote}/{branch}'
+    revision = process.run_subprocess_with_output(rev_list_command)[0].strip()
     if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(clean_src, revision)):
         raise exceptions.SupplyError("Could not checkout source tree for timestamped revision [%s]" % ts)
 

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -123,7 +123,7 @@ class RallyRepository:
 
     def checkout(self, revision):
         self.logger.info("Checking out revision [%s] in [%s].", revision, self.repo_dir)
-        git.checkout(self.repo_dir, revision)
+        git.checkout(self.repo_dir, branch=revision)
 
     def correct_revision(self, revision):
         return git.head_revision(self.repo_dir) == revision

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -69,7 +69,7 @@ class TestSourceRepository:
 
         mock_is_working_copy.assert_called_with("/src")
         mock_clone.assert_called_with("/src", "some-github-url")
-        mock_pull.assert_called_with("/src")
+        mock_pull.assert_called_with("/src", branch="master")
         mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
@@ -104,7 +104,7 @@ class TestSourceRepository:
         mock_is_working_copy.assert_called_with("/src")
         assert mock_clone.call_count == 0
         assert mock_pull.call_count == 0
-        mock_checkout.assert_called_with("/src", "67c2f42")
+        mock_checkout.assert_called_with("/src", branch="67c2f42")
         mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
@@ -118,7 +118,7 @@ class TestSourceRepository:
         s.fetch("@2015-01-01-01:00:00")
 
         mock_is_working_copy.assert_called_with("/src")
-        mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00")
+        mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00", branch="master")
         mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.head_revision", autospec=True)

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -88,7 +88,7 @@ class TestGit:
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_checkout_successful(self, run_subprocess_with_logging):
         run_subprocess_with_logging.return_value = 0
-        git.checkout("/src", "feature-branch")
+        git.checkout("/src", branch="feature-branch")
         run_subprocess_with_logging.assert_called_with("git -C /src checkout feature-branch")
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
@@ -96,7 +96,7 @@ class TestGit:
         # first call is to check the git version (0 -> succeeds), the second call is the failing checkout (1 -> fails)
         run_subprocess_with_logging.side_effect = [0, 1]
         with pytest.raises(exceptions.SupplyError) as exc:
-            git.checkout("/src", "feature-branch")
+            git.checkout("/src", branch="feature-branch")
         assert exc.value.args[0] == "Could not checkout [feature-branch]. Do you have uncommitted changes?"
         run_subprocess_with_logging.assert_called_with("git -C /src checkout feature-branch")
 
@@ -136,7 +136,7 @@ class TestGit:
         run_subprocess_with_logging.return_value = 0
         run_subprocess_with_output.return_value = ["3694a07"]
         run_subprocess.side_effect = [False, False]
-        git.pull_ts("/src", "20160101T110000Z")
+        git.pull_ts("/src", "20160101T110000Z", branch="master")
 
         run_subprocess_with_output.assert_called_with('git -C /src rev-list -n 1 --before="20160101T110000Z" --date=iso8601 origin/master')
         run_subprocess.has_calls(

--- a/tests/utils/repo_test.py
+++ b/tests/utils/repo_test.py
@@ -350,4 +350,4 @@ class TestRallyRepository:
 
         r.checkout("abcdef123")
 
-        checkout.assert_called_with("/rally-resources/unit-test", "abcdef123")
+        checkout.assert_called_with("/rally-resources/unit-test", branch="abcdef123")


### PR DESCRIPTION
This will force callers to be explicit with the branch they're using
which in turn will make the gradual transition to main easier.