### PR TITLE
Make git.clone remote kwarg-only

### DIFF
--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -621,17 +621,17 @@ class SourceRepository:
     def _update(self, revision):
         if self.has_remote() and revision == "latest":
             self.logger.info("Fetching latest sources for %s from origin.", self.name)
-            git.pull(self.src_dir, branch="master")
+            git.pull(self.src_dir, remote="origin", branch="master")
         elif revision == "current":
             self.logger.info("Skip fetching sources for %s.", self.name)
         elif self.has_remote() and revision.startswith("@"):
             # convert timestamp annotated for Rally to something git understands -> we strip leading and trailing " and the @.
             git_ts_revision = revision[1:]
             self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s.", git_ts_revision, self.name)
-            git.pull_ts(self.src_dir, git_ts_revision, branch="master")
+            git.pull_ts(self.src_dir, git_ts_revision, remote="origin", branch="master")
         elif self.has_remote():  # assume a git commit hash
             self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
-            git.pull_revision(self.src_dir, revision)
+            git.pull_revision(self.src_dir, remote="origin", revision=revision)
         else:
             self.logger.info("Checking out local revision [%s] for %s.", revision, self.name)
             git.checkout(self.src_dir, branch=revision)

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -612,7 +612,7 @@ class SourceRepository:
         if not git.is_working_copy(self.src_dir):
             if self.has_remote():
                 self.logger.info("Downloading sources for %s from %s to %s.", self.name, self.remote_url, self.src_dir)
-                git.clone(self.src_dir, self.remote_url)
+                git.clone(self.src_dir, remote=self.remote_url)
             elif os.path.isdir(self.src_dir) and may_skip_init:
                 self.logger.info("Skipping repository initialization for %s.", self.name)
             else:

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -56,7 +56,7 @@ def clone(src, *, remote):
 
 
 @probed
-def fetch(src, remote="origin"):
+def fetch(src, *, remote):
     if process.run_subprocess_with_logging("git -C {0} fetch --prune --tags {1}".format(io.escape_path(src), remote)):
         raise exceptions.SupplyError("Could not fetch source tree from [%s]" % remote)
 
@@ -76,13 +76,13 @@ def rebase(src_dir, remote="origin", *, branch):
 
 @probed
 def pull(src_dir, remote="origin", *, branch):
-    fetch(src_dir, remote)
+    fetch(src_dir, remote=remote)
     rebase(src_dir, remote, branch=branch)
 
 
 @probed
 def pull_ts(src_dir, ts, remote="origin", *, branch):
-    fetch(src_dir)
+    fetch(src_dir, remote=remote)
     clean_src = io.escape_path(src_dir)
     rev_list_command = f'git -C {clean_src} rev-list -n 1 --before="{ts}" --date=iso8601 {remote}/{branch}'
     revision = process.run_subprocess_with_output(rev_list_command)[0].strip()
@@ -91,8 +91,8 @@ def pull_ts(src_dir, ts, remote="origin", *, branch):
 
 
 @probed
-def pull_revision(src_dir, revision):
-    fetch(src_dir)
+def pull_revision(src_dir, revision, remote="origin"):
+    fetch(src_dir, remote=remote)
     if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), revision)):
         raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
 

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -75,13 +75,13 @@ def rebase(src_dir, *, remote, branch):
 
 
 @probed
-def pull(src_dir, remote="origin", *, branch):
+def pull(src_dir, *, remote, branch):
     fetch(src_dir, remote=remote)
     rebase(src_dir, remote=remote, branch=branch)
 
 
 @probed
-def pull_ts(src_dir, ts, remote="origin", *, branch):
+def pull_ts(src_dir, ts, *, remote, branch):
     fetch(src_dir, remote=remote)
     clean_src = io.escape_path(src_dir)
     rev_list_command = f'git -C {clean_src} rev-list -n 1 --before="{ts}" --date=iso8601 {remote}/{branch}'
@@ -91,7 +91,7 @@ def pull_ts(src_dir, ts, remote="origin", *, branch):
 
 
 @probed
-def pull_revision(src_dir, revision, remote="origin"):
+def pull_revision(src_dir, *, remote, revision):
     fetch(src_dir, remote=remote)
     if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), revision)):
         raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -68,7 +68,7 @@ def checkout(src_dir, *, branch):
 
 
 @probed
-def rebase(src_dir, remote="origin", *, branch):
+def rebase(src_dir, *, remote, branch):
     checkout(src_dir, branch=branch)
     if process.run_subprocess_with_logging("git -C {0} rebase {1}/{2}".format(io.escape_path(src_dir), remote, branch)):
         raise exceptions.SupplyError("Could not rebase on branch [%s]" % branch)
@@ -77,7 +77,7 @@ def rebase(src_dir, remote="origin", *, branch):
 @probed
 def pull(src_dir, remote="origin", *, branch):
     fetch(src_dir, remote=remote)
-    rebase(src_dir, remote, branch=branch)
+    rebase(src_dir, remote=remote, branch=branch)
 
 
 @probed

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -48,7 +48,7 @@ def is_working_copy(src):
     return os.path.exists(src) and os.path.exists(os.path.join(src, ".git"))
 
 
-def clone(src, remote):
+def clone(src, *, remote):
     io.ensure_dir(src)
     # Don't swallow subprocess output, user might need to enter credentials...
     if process.run_subprocess_with_logging("git clone %s %s" % (remote, io.escape_path(src))):

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -43,7 +43,7 @@ class RallyRepository:
                 git.clone(src=self.repo_dir, remote=self.url)
             else:
                 try:
-                    git.fetch(src=self.repo_dir)
+                    git.fetch(src=self.repo_dir, remote="origin")
                 except exceptions.SupplyError:
                     console.warn("Could not update %s. Continuing with your locally available state." % self.resource_name)
         else:

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -69,7 +69,7 @@ class RallyRepository:
                     git.checkout(self.repo_dir, branch=branch)
                     self.logger.info("Rebasing on [%s] in [%s] for distribution version [%s].", branch, self.repo_dir, distribution_version)
                     try:
-                        git.rebase(self.repo_dir, branch=branch)
+                        git.rebase(self.repo_dir, remote="origin", branch=branch)
                         self.revision = git.head_revision(self.repo_dir)
                     except exceptions.SupplyError:
                         self.logger.exception("Cannot rebase due to local changes in [%s]", self.repo_dir)

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -68,7 +68,7 @@ class TestSourceRepository:
         s.fetch("latest")
 
         mock_is_working_copy.assert_called_with("/src")
-        mock_clone.assert_called_with("/src", "some-github-url")
+        mock_clone.assert_called_with("/src", remote="some-github-url")
         mock_pull.assert_called_with("/src", branch="master")
         mock_head_revision.assert_called_with("/src")
 

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -69,7 +69,7 @@ class TestSourceRepository:
 
         mock_is_working_copy.assert_called_with("/src")
         mock_clone.assert_called_with("/src", remote="some-github-url")
-        mock_pull.assert_called_with("/src", branch="master")
+        mock_pull.assert_called_with("/src", remote="origin", branch="master")
         mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
@@ -118,7 +118,7 @@ class TestSourceRepository:
         s.fetch("@2015-01-01-01:00:00")
 
         mock_is_working_copy.assert_called_with("/src")
-        mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00", branch="master")
+        mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00", remote="origin", branch="master")
         mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
@@ -132,7 +132,7 @@ class TestSourceRepository:
         s.fetch("67c2f42")
 
         mock_is_working_copy.assert_called_with("/src")
-        mock_pull_revision.assert_called_with("/src", "67c2f42")
+        mock_pull_revision.assert_called_with("/src", remote="origin", revision="67c2f42")
         mock_head_revision.assert_called_with("/src")
 
     def test_is_commit_hash(self):

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -136,7 +136,7 @@ class TestGit:
         run_subprocess_with_logging.return_value = 0
         run_subprocess_with_output.return_value = ["3694a07"]
         run_subprocess.side_effect = [False, False]
-        git.pull_ts("/src", "20160101T110000Z", branch="master")
+        git.pull_ts("/src", "20160101T110000Z", remote="origin", branch="master")
 
         run_subprocess_with_output.assert_called_with('git -C /src rev-list -n 1 --before="20160101T110000Z" --date=iso8601 origin/master')
         run_subprocess.has_calls(
@@ -151,7 +151,7 @@ class TestGit:
     def test_pull_revision(self, run_subprocess_with_logging, run_subprocess):
         run_subprocess_with_logging.return_value = 0
         run_subprocess.side_effect = [False, False]
-        git.pull_revision("/src", "3694a07")
+        git.pull_revision("/src", remote="origin", revision="3694a07")
         run_subprocess.has_calls(
             [
                 mock.call("git -C /src fetch --prune --tags --quiet origin"),

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -51,7 +51,7 @@ class TestGit:
         src = "/src"
         remote = "http://github.com/some/project"
 
-        git.clone(src, remote)
+        git.clone(src, remote=remote)
 
         ensure_dir.assert_called_with(src)
         run_subprocess_with_logging.assert_called_with("git clone http://github.com/some/project /src")
@@ -64,7 +64,7 @@ class TestGit:
         remote = "http://github.com/some/project"
 
         with pytest.raises(exceptions.SupplyError) as exc:
-            git.clone(src, remote)
+            git.clone(src, remote=remote)
         assert exc.value.args[0] == "Could not clone from [http://github.com/some/project] to [/src]"
 
         ensure_dir.assert_called_with(src)

--- a/tests/utils/repo_test.py
+++ b/tests/utils/repo_test.py
@@ -108,7 +108,7 @@ class TestRallyRepository:
             offline=False,
         )
 
-        fetch.assert_called_with(src="/rally-resources/unit-test")
+        fetch.assert_called_with(src="/rally-resources/unit-test", remote="origin")
 
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
     @mock.patch("esrally.utils.git.fetch")
@@ -144,7 +144,7 @@ class TestRallyRepository:
         # no exception during the call - we reach this here
         assert r.remote
 
-        fetch.assert_called_with(src="/rally-resources/unit-test")
+        fetch.assert_called_with(src="/rally-resources/unit-test", remote="origin")
 
     @mock.patch("esrally.utils.git.head_revision")
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)

--- a/tests/utils/repo_test.py
+++ b/tests/utils/repo_test.py
@@ -168,7 +168,7 @@ class TestRallyRepository:
         r.update(distribution_version="1.7.3")
 
         branches.assert_called_with("/rally-resources/unit-test", remote=True)
-        rebase.assert_called_with("/rally-resources/unit-test", branch="1")
+        rebase.assert_called_with("/rally-resources/unit-test", remote="origin", branch="1")
         checkout.assert_called_with("/rally-resources/unit-test", branch="1")
 
     @mock.patch("esrally.utils.git.head_revision")


### PR DESCRIPTION
This is the discussed follow-up to https://github.com/elastic/rally/pull/1527.