### PR TITLE
Use main branch of Elasticsearch for source builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Rally is developed for Unix and is actively tested on Linux and macOS. Rally sup
 Installing Rally
 ~~~~~~~~~~~~~~~~
 
-**Note**: If you actively develop on Elasticsearch, we recommend that you `install Rally in development mode <https://esrally.readthedocs.io/en/latest/developing.html#installation-instructions-for-development>`_ instead as Elasticsearch is fast moving and Rally always adapts accordingly to the latest master version.
+**Note**: If you actively develop on Elasticsearch, we recommend that you `install Rally in development mode <https://esrally.readthedocs.io/en/latest/developing.html#installation-instructions-for-development>`_ instead as Elasticsearch is fast moving and Rally always adapts accordingly to the latest main version.
 
 Install Python 3.8+ including ``pip3``, git 1.9+ and an `appropriate JDK to run Elasticsearch <https://www.elastic.co/support/matrix#matrix_jvm>`_ Be sure that ``JAVA_HOME`` points to that JDK. Then run the following command, optionally prefixed by ``sudo`` if necessary::
 
@@ -116,7 +116,7 @@ See all details in the `contributor guidelines <https://github.com/elastic/rally
 
 License
 -------
- 
+
 This software is licensed under the Apache License, version 2 ("ALv2"), quoted below.
 
 Copyright 2015-2021 Elasticsearch <https://www.elastic.co>

--- a/docs/car.rst
+++ b/docs/car.rst
@@ -118,7 +118,7 @@ Custom Team Repositories
 
 Rally provides a default team repository that is hosted on `Github <https://github.com/elastic/rally-teams>`_. You can also add your own team repositories although this requires a bit of additional work. First of all, team repositories need to be managed by git. The reason is that Rally can benchmark multiple versions of Elasticsearch and we use git branches in the track repository to determine the best match. The versioning scheme is as follows:
 
-* The `master` branch needs to work with the latest `master` branch of Elasticsearch.
+* The ``master`` branch needs to work with the latest ``main`` branch of Elasticsearch.
 * All other branches need to match the version scheme of Elasticsearch, i.e. ``MAJOR.MINOR.PATCH-SUFFIX`` where all parts except ``MAJOR`` are optional.
 
 Rally implements a branch matching logic similar to the one used for :ref:`track-repositories <track-repositories-branch-logic>`.

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -571,7 +571,7 @@ If you actively develop Elasticsearch and want to benchmark a source build of El
 
 You can specify the revision in different formats:
 
-* ``--revision=latest``: Use the HEAD revision from origin/master.
+* ``--revision=latest``: Use the HEAD revision from origin/main.
 * ``--revision=current``: Use the current revision (i.e. don't alter the local source tree).
 * ``--revision=abc123``: Where ``abc123`` is some git revision hash.
 * ``--revision=@2013-07-27T10:37:00Z``: Determines the revision that is closest to the provided date. Rally logs to which git revision hash the date has been resolved and if you use Elasticsearch as metrics store (instead of the default in-memory one), :doc:`each metric record will contain the git revision hash also in the meta-data section </metrics>`.

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -7,7 +7,7 @@ Prerequisites
 Install the following software packages:
 
 * pyenv installed, Follow the instructions in the output of ``pyenv init`` to setup your shell and then restart it before proceeding. For more details please refer to the pyenv `installation instructions <https://github.com/pyenv/pyenv#installation>`_.
-* JDK version required to build Elasticsearch. Please refer to the `build setup requirements <https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-to-the-elasticsearch-codebase>`_.
+* JDK version required to build Elasticsearch. Please refer to the `build setup requirements <https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-to-the-elasticsearch-codebase>`_.
 * `Docker <https://docs.docker.com/install/>`_ and on Linux additionally `docker-compose <https://docs.docker.com/compose/install/>`_.
 * git
 

--- a/docs/elasticsearch_plugins.rst
+++ b/docs/elasticsearch_plugins.rst
@@ -36,7 +36,7 @@ To see which plugins are available, run ``esrally list elasticsearch-plugins``::
     repository-s3
     store-smb
 
-As the availability of plugins may change from release to release we recommend that you include the ``--distribution-version`` parameter when listing plugins. By default Rally assumes that you want to benchmark the latest master version of Elasticsearch.
+As the availability of plugins may change from release to release we recommend that you include the ``--distribution-version`` parameter when listing plugins. By default Rally assumes that you want to benchmark the latest ``main`` version of Elasticsearch.
 
 Running a benchmark with plugins
 --------------------------------
@@ -90,7 +90,7 @@ To make this work, you need to manually edit Rally's configuration file in ``~/.
 Let's discuss these properties one by one:
 
 * ``plugin.my-plugin.remote.repo.url`` (optional): This is needed to let Rally checkout the source code of the plugin. If this is a private repo, credentials need to be setup properly. If the source code is already locally available you may not need to define this property. The remote's name is assumed to be "origin" and this is not configurable. Also, only git is supported as revision control system.
-* ``plugin.my-plugin.src.subdir`` (mandatory): This is the directory to which the plugin will be checked out relative to ``src.root.dir``. In order to allow to build the plugin alongside Elasticsearch, the plugin needs to reside in a subdirectory of ``elasticsearch-extra`` (see also the `Elasticsearch testing documentation <https://github.com/elastic/elasticsearch/blob/master/TESTING.asciidoc#building-with-extra-plugins>`_.
+* ``plugin.my-plugin.src.subdir`` (mandatory): This is the directory to which the plugin will be checked out relative to ``src.root.dir``. In order to allow to build the plugin alongside Elasticsearch, the plugin needs to reside in a subdirectory of ``elasticsearch-extra`` (see also the `Elasticsearch testing documentation <https://github.com/elastic/elasticsearch/blob/main/TESTING.asciidoc#building-with-extra-plugins>`_.
 * ``plugin.my-plugin.build.command`` (mandatory): The full build command to run in order to build the plugin artifact. Note that this command is run from the Elasticsearch source directory as Rally assumes that you want to build your plugin alongside Elasticsearch (otherwise, see the next section).
 * ``plugin.my-plugin.build.artifact.subdir`` (mandatory): This is the subdirectory relative to ``plugin.my-plugin.src.subdir`` in which the final plugin artifact is located.
 
@@ -104,7 +104,7 @@ In order to run a benchmark with ``my-plugin``, you'd invoke Rally as follows: `
 * If your plugin needs to be configured, create a proper plugin specification (see below).
 
 .. note::
-    Rally can build all `Elasticsearch core plugins <https://github.com/elastic/elasticsearch/tree/master/plugins>`_ out of the box without any further configuration.
+    Rally can build all `Elasticsearch core plugins <https://github.com/elastic/elasticsearch/tree/main/plugins>`_ out of the box without any further configuration.
 
 Plugins based on a released Elasticsearch version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,11 @@
 Migration Guide
 ===============
 
+Migrating to Rally 2.5.1
+------------------------
+
+Elasticsearch is migrating its development branch from ``master`` to ``main``. To account for this, Rally now checkouts the ``main`` branch when :ref:`building from sources<pipelines_from-sources>`. This will happen automatically unless you have made changes in ``~/.rally/benchmarks/src/elasticsearch``.
+
 Migrating to Rally 2.4.0
 ------------------------
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -4,7 +4,10 @@ Migration Guide
 Migrating to Rally 2.5.1
 ------------------------
 
-Elasticsearch is migrating its development branch from ``master`` to ``main``. To account for this, Rally now checkouts the ``main`` branch when :ref:`building from sources<pipelines_from-sources>`. This will happen automatically unless you have made changes in ``~/.rally/benchmarks/src/elasticsearch``.
+Elasticsearch development branch has moved
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Elasticsearch is `migrating its development branch from master to main <https://github.com/elastic/elasticsearch/issues/76950>`_. To account for this, Rally now checkouts the ``main`` branch when :ref:`building from sources<pipelines_from-sources>`. This will happen automatically unless you have made changes in ``~/.rally/benchmarks/src/elasticsearch``.
 
 Migrating to Rally 2.4.0
 ------------------------

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -35,7 +35,7 @@ Custom Track Repositories
 
 Alternatively, you can store Rally tracks also in a dedicated git repository which we call a "track repository". Rally provides a default track repository that is hosted on `Github <https://github.com/elastic/rally-tracks>`_. You can also add your own track repositories although this requires a bit of additional work. First of all, track repositories need to be managed by git. The reason is that Rally can benchmark multiple versions of Elasticsearch and we use git branches in the track repository to determine the best match for each track (based on the command line parameter ``--distribution-version``). The versioning scheme is as follows:
 
-* The ``master`` branch needs to work with the latest ``master`` branch of Elasticsearch.
+* The ``master`` branch needs to work with the latest ``main`` branch of Elasticsearch.
 * All other branches need to match the version scheme of Elasticsearch, i.e. ``MAJOR.MINOR.PATCH-SUFFIX`` where all parts except ``MAJOR`` are optional.
 
 .. _track-repositories-branch-logic:

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -370,7 +370,7 @@ class ElasticsearchSourceSupplier:
         self.template_renderer = template_renderer
 
     def fetch(self):
-        return SourceRepository("Elasticsearch", self.remote_url, self.src_dir).fetch(self.revision)
+        return SourceRepository("Elasticsearch", self.remote_url, self.src_dir, branch="main").fetch(self.revision)
 
     def prepare(self):
         if self.builder:
@@ -442,7 +442,7 @@ class ExternalPluginSourceSupplier:
     def fetch(self):
         # optional (but then source code is assumed to be available locally)
         plugin_remote_url = self.src_config.get("plugin.%s.remote.repo.url" % self.plugin.name)
-        return SourceRepository(self.plugin.name, plugin_remote_url, self.plugin_src_dir).fetch(self.revision)
+        return SourceRepository(self.plugin.name, plugin_remote_url, self.plugin_src_dir, branch="master").fetch(self.revision)
 
     def prepare(self):
         if self.builder:
@@ -476,7 +476,7 @@ class CorePluginSourceSupplier:
 
     def fetch(self):
         # Just retrieve the current revision *number* and assume that Elasticsearch has prepared the source tree.
-        return SourceRepository("Elasticsearch", None, self.es_src_dir).fetch(revision="current")
+        return SourceRepository("Elasticsearch", None, self.es_src_dir, branch="main").fetch(revision="current")
 
     def prepare(self):
         if self.builder:
@@ -594,10 +594,11 @@ class SourceRepository:
     Supplier fetches the benchmark candidate source tree from the remote repository.
     """
 
-    def __init__(self, name, remote_url, src_dir):
+    def __init__(self, name, remote_url, src_dir, *, branch):
         self.name = name
         self.remote_url = remote_url
         self.src_dir = src_dir
+        self.branch = branch
         self.logger = logging.getLogger(__name__)
 
     def fetch(self, revision):
@@ -621,14 +622,14 @@ class SourceRepository:
     def _update(self, revision):
         if self.has_remote() and revision == "latest":
             self.logger.info("Fetching latest sources for %s from origin.", self.name)
-            git.pull(self.src_dir, remote="origin", branch="master")
+            git.pull(self.src_dir, remote="origin", branch=self.branch)
         elif revision == "current":
             self.logger.info("Skip fetching sources for %s.", self.name)
         elif self.has_remote() and revision.startswith("@"):
             # convert timestamp annotated for Rally to something git understands -> we strip leading and trailing " and the @.
             git_ts_revision = revision[1:]
             self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s.", git_ts_revision, self.name)
-            git.pull_ts(self.src_dir, git_ts_revision, remote="origin", branch="master")
+            git.pull_ts(self.src_dir, git_ts_revision, remote="origin", branch=self.branch)
         elif self.has_remote():  # assume a git commit hash
             self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
             git.pull_revision(self.src_dir, remote="origin", revision=revision)

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -181,7 +181,7 @@ class BenchmarkCoordinator:
     def setup(self, sources=False):
         # to load the track we need to know the correct cluster distribution version. Usually, this value should be set
         # but there are rare cases (external pipeline and user did not specify the distribution version) where we need
-        # to derive it ourselves. For source builds we always assume "master"
+        # to derive it ourselves. For source builds we always assume "main"
         if not sources and not self.cfg.exists("mechanic", "distribution.version"):
             distribution_version = mechanic.cluster_distribution_version(self.cfg)
             self.logger.info("Automatically derived distribution version [%s]", distribution_version)

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -311,7 +311,7 @@ def create_arg_parser():
     install_parser.add_argument(
         "--revision",
         help="Define the source code revision for building the benchmark candidate. 'current' uses the source tree as is,"
-        " 'latest' fetches the latest version on master. It is also possible to specify a commit id or a timestamp."
+        " 'latest' fetches the latest version on the main branch. It is also possible to specify a commit id or a timestamp."
         ' The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, '
         'e.g. "@2013-07-27T10:37:00Z" (default: current).',
         default="current",

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -105,7 +105,7 @@ def tracks(cfg):
     different versions, this will be reflected in the output.
 
     :param cfg: The config object.
-    :return: A list of tracks that are available for the provided distribution version or else for the master version.
+    :return: A list of tracks that are available for the provided distribution version or else for the main version.
     """
     repo = track_repo(cfg)
     return [_load_single_track(cfg, repo, track_name) for track_name in repo.track_names]

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -64,12 +64,12 @@ class TestSourceRepository:
         mock_is_working_copy.side_effect = [False, True]
         mock_head_revision.return_value = "HEAD"
 
-        s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src")
+        s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src", branch="main")
         s.fetch("latest")
 
         mock_is_working_copy.assert_called_with("/src")
         mock_clone.assert_called_with("/src", remote="some-github-url")
-        mock_pull.assert_called_with("/src", remote="origin", branch="master")
+        mock_pull.assert_called_with("/src", remote="origin", branch="main")
         mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
@@ -80,7 +80,7 @@ class TestSourceRepository:
         mock_is_working_copy.return_value = True
         mock_head_revision.return_value = "HEAD"
 
-        s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src")
+        s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src", branch="main")
         s.fetch("current")
 
         mock_is_working_copy.assert_called_with("/src")
@@ -98,7 +98,7 @@ class TestSourceRepository:
         mock_head_revision.return_value = "HEAD"
 
         # local only, we dont specify a remote
-        s = supplier.SourceRepository(name="Elasticsearch", remote_url=None, src_dir="/src")
+        s = supplier.SourceRepository(name="Elasticsearch", remote_url=None, src_dir="/src", branch="main")
         s.fetch("67c2f42")
 
         mock_is_working_copy.assert_called_with("/src")
@@ -114,11 +114,11 @@ class TestSourceRepository:
         mock_is_working_copy.return_value = True
         mock_head_revision.return_value = "HEAD"
 
-        s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src")
+        s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src", branch="main")
         s.fetch("@2015-01-01-01:00:00")
 
         mock_is_working_copy.assert_called_with("/src")
-        mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00", remote="origin", branch="master")
+        mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00", remote="origin", branch="main")
         mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
@@ -128,7 +128,7 @@ class TestSourceRepository:
         mock_is_working_copy.return_value = True
         mock_head_revision.return_value = "HEAD"
 
-        s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src")
+        s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src", branch="main")
         s.fetch("67c2f42")
 
         mock_is_working_copy.assert_called_with("/src")


### PR DESCRIPTION
Closes #1528

I did not need explicit code to migrate `~/.rally/benchmarks/src/elasticsearch/` to the main branch since the first thing we do is call `git.pull("origin", "main")` which runs `git fetch origin && git checkout main && git rebase origin/main`.