### PR TITLE
Correctly log how long it took to close transports

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1752,7 +1752,7 @@ class AsyncIoAdapter:
                 for es in c.values():
                     await es.close()
             transport_close_end = time.perf_counter()
-            self.logger.info("Total time to close transports: %f seconds.", (shutdown_asyncgens_end - transport_close_end))
+            self.logger.info("Total time to close transports: %f seconds.", (transport_close_end - shutdown_asyncgens_end))
 
 
 class AsyncProfiler:


### PR DESCRIPTION
The load driver incorrectly logs a negative number when reporting how long it took to shut down transports. Example:

  ```
  2022-07-07 14:49:27,475 ActorAddr-(T|:37235)/PID:2900742 esrally.driver.driver INFO Total time to close transports: -0.000971 seconds.
  ```

This PR fixes this, resulting in logs like this:

```
2022-07-07 14:56:28,700 ActorAddr-(T|:40609)/PID:2902950 esrally.driver.driver INFO Total time to close transports: 0.000797 seconds.
```