### PR TITLE
Don't load libs path if not using it

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -473,7 +473,7 @@ class TrackPreparationActor(actor.RallyActor):
         # load node-specific config to have correct paths available
         self.cfg = load_local_config(msg.config)
         # this instance of load_track occurs once per host, so install dependencies if necessary
-        load_track(self.cfg, install_dependencies=True)
+        load_track(self.cfg, install_dependencies=False)
         self.send(sender, ReadyForWork())
 
     @actor.no_retry("track preparator")  # pylint: disable=no-value-for-parameter

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -191,7 +191,7 @@ class BenchmarkCoordinator:
             if specified_version < min_es_version:
                 raise exceptions.SystemSetupError(f"Cluster version must be at least [{min_es_version}] but was [{distribution_version}]")
 
-        self.current_track = track.load_track(self.cfg, install_dependencies=False)
+        self.current_track = track.load_track(self.cfg, install_dependencies=True)
         self.track_revision = self.cfg.opts("track", "repository.revision", mandatory=False)
         challenge_name = self.cfg.opts("track", "challenge.name")
         self.current_challenge = self.current_track.find_challenge_or_default(challenge_name)

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -195,21 +195,7 @@ def load_track(cfg, install_dependencies=False):
 
 
 def _install_dependencies(dependencies):
-    def _cleanup():
-        # fully destructive is fine, we only allow one Rally to run at a time and we will rely on the pip cache for download caching
-        console.info("Cleaning track dependency directory...")
-        logging.info("Cleaning track dependency directory [%s]...", paths.libs())
-        shutil.rmtree(paths.libs(), onerror=_trap)
-
-    def _trap(function, path, exc_info):
-        if exc_info[0] == FileNotFoundError:
-            # couldn't delete because it was already clean
-            return
-        logging.exception("Failed to clean up [%s] with [%s]", path, function, exc_info=True)
-        raise exceptions.SystemSetupError(f"Unable to clean [{paths.libs()}]. See Rally log for more information.")
-
     if dependencies:
-        _cleanup()
         log_path = os.path.join(paths.logs(), "dependency.log")
         console.info(f"Installing track dependencies [{', '.join(dependencies)}]")
         try:

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -202,6 +202,9 @@ def _install_dependencies(dependencies):
         shutil.rmtree(paths.libs(), onerror=_trap)
 
     def _trap(function, path, exc_info):
+        if exc_info[0].__name__ == FileNotFoundError.__name__:
+            # couldn't delete because it was already clean
+            return
         logging.exception("Failed to clean up [%s] with [%s]", path, function, exc_info=True)
         raise exceptions.SystemSetupError(f"Unable to clean [{paths.libs()}]. See Rally log for more information.")
 

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -19,7 +19,6 @@ import json
 import logging
 import os
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -238,7 +237,6 @@ def load_track_plugins(
     register_runner=None,
     register_scheduler=None,
     register_track_processor=None,
-    install_dependencies=False,
     force_update=False,
 ):
     """
@@ -249,7 +247,6 @@ def load_track_plugins(
     :param register_runner: An optional function where runners can be registered.
     :param register_scheduler: An optional function where custom schedulers can be registered.
     :param register_track_processor: An optional function where track processors can be registered.
-    :param install_dependencies: If set to ``True``, install declared dependencies from the track.py. Defaults to ``False``.
     :param force_update: If set to ``True`` this ensures that the track is first updated from the remote repository.
                          Defaults to ``False``.
     :return: True iff this track defines plugins and they have been loaded.

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -231,9 +231,7 @@ def _load_single_track(cfg, track_repository, track_name, install_dependencies=F
         tpr = TrackProcessorRegistry(cfg)
         if install_dependencies:
             _install_dependencies(current_track.dependencies)
-        has_plugins = load_track_plugins(
-            cfg, track_name, install_dependencies=install_dependencies, register_track_processor=tpr.register_track_processor
-        )
+        has_plugins = load_track_plugins(cfg, track_name, register_track_processor=tpr.register_track_processor)
         current_track.has_plugins = has_plugins
         for processor in tpr.processors:
             processor.on_after_load_track(current_track)
@@ -276,7 +274,7 @@ def load_track_plugins(
     plugin_reader = TrackPluginReader(track_plugin_path, register_runner, register_scheduler, register_track_processor)
 
     if plugin_reader.can_load():
-        plugin_reader.load(install_dependencies=install_dependencies)
+        plugin_reader.load()
         return True
     else:
         return False
@@ -1126,11 +1124,10 @@ class TrackPluginReader:
     def can_load(self):
         return self.loader.can_load()
 
-    def load(self, install_dependencies):
-        if install_dependencies:
-            # get dependent libraries installed in a prior step. ensure dir exists to make sure loading works correctly.
-            os.makedirs(paths.libs(), exist_ok=True)
-            sys.path.insert(0, paths.libs())
+    def load(self):
+        # get dependent libraries installed in a prior step. ensure dir exists to make sure loading works correctly.
+        os.makedirs(paths.libs(), exist_ok=True)
+        sys.path.insert(0, paths.libs())
         root_module = self.loader.load()
         try:
             # every module needs to have a register() method

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -202,7 +202,7 @@ def _install_dependencies(dependencies):
         shutil.rmtree(paths.libs(), onerror=_trap)
 
     def _trap(function, path, exc_info):
-        if exc_info[0].__name__ == FileNotFoundError.__name__:
+        if exc_info[0] == FileNotFoundError:
             # couldn't delete because it was already clean
             return
         logging.exception("Failed to clean up [%s] with [%s]", path, function, exc_info=True)


### PR DESCRIPTION
This PR fixes an issue where a dependency installed via the Track Dependencies mechanism lingers for `esrally` invocations where it is not needed or wanted. Also fixes #1474 