### PR TITLE
Fix formatting of opts

### DIFF
--- a/esrally/utils/opts.py
+++ b/esrally/utils/opts.py
@@ -212,8 +212,7 @@ class ClientOptions(ConnectOptions):
         default_client_map = kv_to_map([ClientOptions.DEFAULT_CLIENT_OPTIONS])
         if self.argvalue == ClientOptions.DEFAULT_CLIENT_OPTIONS and self.target_hosts is not None:
             # --client-options unset but multi-clusters used in --target-hosts? apply options defaults for all cluster names.
-            self.parsed_options = {cluster_name: default_client_map for cluster_name in
-                                   self.target_hosts.all_hosts.keys()}
+            self.parsed_options = {cluster_name: default_client_map for cluster_name in self.target_hosts.all_hosts.keys()}
         else:
             self.parsed_options = to_dict(self.argvalue, default_parser=ClientOptions.normalize_to_dict)
 

--- a/tests/utils/opts_test.py
+++ b/tests/utils/opts_test.py
@@ -72,7 +72,6 @@ class TestConfigHelperFunction:
         assert opts.kv_to_map(["k:none"]) == {"k": None}
         assert opts.kv_to_map(["k:NONE"]) == {"k": None}
 
-
     def test_to_dict_with_inline_json(self):
         assert opts.to_dict('{"default": ["127.0.0.1:9200","10.17.0.5:19200"]}') == {"default": ["127.0.0.1:9200", "10.17.0.5:19200"]}
 


### PR DESCRIPTION
Not sure why CI missed this via `make precommit` prior to being merged, but https://github.com/elastic/rally/pull/1541 had two incorrectly formatted files (according to Black).