### PR TITLE
Revert "Surface ES startup errors to the Rally CLI console (#1476)"

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -18,13 +18,12 @@ import logging
 import os
 import shlex
 import subprocess
-from textwrap import indent
 
 import psutil
 
 from esrally import exceptions, telemetry, time
 from esrally.mechanic import cluster, java_resolver
-from esrally.utils import console, io, opts, process
+from esrally.utils import io, opts, process
 
 
 class DockerLauncher:
@@ -200,9 +199,13 @@ class ProcessLauncher:
     @staticmethod
     def _run_subprocess(command_line, env):
         command_line_args = shlex.split(command_line)
-        subprocess.run(
-            command_line_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, start_new_session=True, check=True, text=True
-        )
+
+        with subprocess.Popen(
+            command_line_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env, start_new_session=True
+        ) as command_line_process:
+            # wait for it to finish
+            command_line_process.wait()
+        return command_line_process.returncode
 
     @staticmethod
     def _start_process(binary_path, env):
@@ -212,11 +215,11 @@ class ProcessLauncher:
         cmd = [io.escape_path(os.path.join(".", "bin", "elasticsearch"))]
         pid_path = io.escape_path(os.path.join(".", "pid"))
         cmd.extend(["-d", "-p", pid_path])
-        try:
-            ProcessLauncher._run_subprocess(command_line=" ".join(cmd), env=env)
-        except subprocess.CalledProcessError as e:
-            console.error("Daemon startup failed with exit code [%s]. STDERR:\n\n%s\n" % (e.returncode, indent(e.stderr, "\t")))
-            raise e
+        ret = ProcessLauncher._run_subprocess(command_line=" ".join(cmd), env=env)
+        if ret != 0:
+            msg = "Daemon startup failed with exit code [{}]".format(ret)
+            logging.error(msg)
+            raise exceptions.LaunchError(msg)
 
         return wait_for_pidfile(pid_path)
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -6215,7 +6215,7 @@ class TestComposite:
         assert len(timings) == 3
 
         assert timings[0]["operation"] == "initial-call"
-        assert timings[0]["service_time"] == pytest.approx(0.1, abs=0.15)
+        assert timings[0]["service_time"] == pytest.approx(0.1, abs=0.1)
 
         assert timings[1]["operation"] == "stream-a"
         assert timings[1]["service_time"] == pytest.approx(0.2, abs=0.1)

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -97,7 +97,6 @@ class MockPopen:
         # mocking them as their optional functionality is disabled.
         self.returncode = 1
         self.stdout = io.StringIO()
-        self.args = None
 
     def communicate(self, input=None, timeout=None):
         return [b"", b""]


### PR DESCRIPTION
We've had some recent internal CI failures where `esrally start..` hangs indefinitely the CI timeout is reached the job is killed.

Testing locally, I was able to reproduce the issue with:
```
$ esrally install --distribution-version=7.17.2 --node-name="rally-node-0" --network-host="127.0.0.1" --http-port=39200 --master-nodes="rally-node-0" --seed-hosts="127.0.0.1:39300"
$ esrally start --installation-id=b9c1d5a6-e8aa-4d41-ac2a-88c9ae37ba88 --race-id=1 --runtime-jdk=bundled
```

Where `esrally start` hangs indefinitely despite the Elasticsearch process being up and running: 
```
$ curl -k localhost:39200/_cluster/health" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:100   383  100   383    0     0   8704      0 --:--:-- --:--:-- --:--:--  8704
{
  "cluster_name": "default",
  "status": "green",
  "timed_out": false,
  "number_of_nodes": 1,
  "number_of_data_nodes": 1,
  "active_primary_shards": 3,
  "active_shards": 3,
  "relocating_shards": 0,
  "initializing_shards": 0,
  "unassigned_shards": 0,
  "delayed_unassigned_shards": 0,
  "number_of_pending_tasks": 0,
  "number_of_in_flight_fetch": 0,
  "task_max_waiting_in_queue_millis": 0,
  "active_shards_percent_as_number": 100
}
```

I attached `gdb` and can see that it looks like it's just hanging indefinitely on the `_run_subprocess` method:
```
Traceback (most recent call first):
  File "/home/esbench/.pyenv/versions/3.8.13/lib/python3.8/selectors.py", line 415, in select
    fd_event_list = self._selector.poll(timeout)
  File "/home/esbench/.pyenv/versions/3.8.13/lib/python3.8/subprocess.py", line 2380, in _communicate
  File "/home/esbench/.pyenv/versions/3.8.13/lib/python3.8/subprocess.py", line 1284, in communicate
    handle_list += [int(p2cread), int(c2pwrite), int(errwrite)]
  File "/home/esbench/.pyenv/versions/3.8.13/lib/python3.8/subprocess.py", line 495, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/home/esbench/rally/esrally/mechanic/launcher.py", line 459, in _run_subprocess
  File "/home/esbench/rally/esrally/mechanic/launcher.py", line 216, in _start_process
    ProcessLauncher._run_subprocess(command_line=" ".join(cmd), env=env)
  File "/home/esbench/rally/esrally/mechanic/launcher.py", line 676, in _start_node
  File "/home/esbench/rally/esrally/mechanic/launcher.py", line 134, in <listcomp>
    return [self._start_node(node_configuration, node_count_on_host) for node_configuration in node_configurations]
  File "/home/esbench/rally/esrally/mechanic/launcher.py", line 134, in start
    return [self._start_node(node_configuration, node_count_on_host) for node_configuration in node_configurations]
  File "/home/esbench/rally/esrally/mechanic/mechanic.py", line 619, in start
    self.send(sender, NodesStopped())
  File "/home/esbench/rally/esrally/rally.py", line 955, in dispatch_sub_command
    mechanic.start(cfg)
  File "/home/esbench/rally/esrally/rally.py", line 1081, in main
    result = dispatch_sub_command(arg_parser, args, cfg)
  File "/home/esbench/.local/bin/esrally", line 33, in <module>
    sys.exit(load_entry_point('esrally', 'console_scripts', 'esrally')())
```

I was able to narrow it down to [commit `d4c49f2`](https://github.com/elastic/rally/pull/1476), as it's not reproducible in commit `a967387` :
```
6b3f9dd (HEAD -> master, origin/master, origin/HEAD) Fix one remaining default flavor (#1547)
d4c49f2 Surface ES startup errors to the Rally CLI console (#1476)
a967387 Remove Elasticsearch 6.3 logic (#1497)
```

As for exactly _why_ it's hanging, I don't know. I did some quick research and found [some old references to deadlocks related to the stdout/stderr pipe buffers filling up](http://thraxil.org/users/anders/posts/2008/03/13/Subprocess-Hanging-PIPE-is-your-enemy/) when there's large output expected, but I'm not sure this applies to recent versions. However, it definitely appears that any capturing of `stdout` or `stderr` to a pipe is causing the deadlock. Using something like below seems to fix the issue:
```
command_line_args env=env, start_new_session=True, check=True, text=True
```