### PR TITLE
Run unit and integration tests in separate tox environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,17 +111,19 @@ precommit: lint
 
 # checks min and max python versions
 it: check-venv python-caches-clean tox-env-clean
-	. $(VENV_ACTIVATE_FILE); tox -e py38
-	. $(VENV_ACTIVATE_FILE); tox -e py310
+	. $(VENV_ACTIVATE_FILE); tox -e py38-unit
+	. $(VENV_ACTIVATE_FILE); tox -e py38-it
+	. $(VENV_ACTIVATE_FILE); tox -e py310-unit
+	. $(VENV_ACTIVATE_FILE); tox -e py310-it
 
 it38: check-venv python-caches-clean tox-env-clean
-	. $(VENV_ACTIVATE_FILE); tox -e py38
+	. $(VENV_ACTIVATE_FILE); tox -e py38-it
 
 it39: check-venv python-caches-clean tox-env-clean
-	. $(VENV_ACTIVATE_FILE); tox -e py39
+	. $(VENV_ACTIVATE_FILE); tox -e py39-it
 
 it310: check-venv python-caches-clean tox-env-clean
-	. $(VENV_ACTIVATE_FILE); tox -e py310
+	. $(VENV_ACTIVATE_FILE); tox -e py310-it
 
 check-all: lint test it
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@
 ###############################################################################
 [tox]
 envlist =
-    py38, py39, py310
+    py{38,39,310}-unit
+    py{38,39,310}-it
 platform =
     linux|darwin
 
@@ -40,8 +41,8 @@ setenv =
     # applications behave identically, we also set LANG explicitly.
     LANG=C
 commands =
-    pytest --junitxml=junit-{envname}.xml
-    pytest -s it --junitxml=junit-{envname}-it.xml
+    unit: pytest --junitxml=junit-{envname}.xml
+    it: pytest -s it --junitxml=junit-{envname}.xml
 
 whitelist_externals =
     pytest


### PR DESCRIPTION
This will facilitate parallelizing CI jobs in the future. At the moment, it's essentially a no-op; the various `it` targets in the `Makefile` will run all of the same tests as before.