### PR TITLE
Migrate Jenkins job definitions and parallelize PR checks

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -85,7 +85,27 @@ function python_common {
   eval "$(pyenv virtualenv-init -)"
 }
 
+function java_common {
+  JAVA_ROOT=$HOME/.java
+
+  export JAVA7_HOME=${JAVA_ROOT}/java7
+  export JAVA8_HOME=${JAVA_ROOT}/java8
+  export JAVA9_HOME=${JAVA_ROOT}/java9
+  export JAVA10_HOME=${JAVA_ROOT}/java10
+  export JAVA11_HOME=${JAVA_ROOT}/java11
+
+  # handle all Javas after that generically
+  for java in ${JAVA_ROOT}/openjdk??
+  do
+    version=${java##*openjdk}
+    export JAVA${version}_HOME=$java
+  done
+
+  export ES_JAVA_HOME=$JAVA17_HOME
+}
+
 function install {
+  java_common
   python_common
   install_python_prereq
   make install

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -24,18 +24,54 @@ set -o pipefail
 # fail on any unset environment variables
 set -u
 
+# based on https://gist.github.com/sj26/88e1c6584397bb7c13bd11108a579746?permalink_comment_id=4155247#gistcomment-4155247
+function retry {
+  local retries=$1
+  shift
+  local cmd=($@)
+  local cmd_string="${@}"
+  local count=0
+
+  # be lenient with non-zero exit codes, to allow retries
+  set +o errexit
+  set +o pipefail
+  until "${cmd[@]}"; do
+    retcode=$?
+    wait=$(( 2 ** count ))
+    count=$(( count + 1))
+    if [[ $count -le $retries ]]; then
+      printf "Command [%s] failed. Retry [%d/%d] in [%d] seconds.\n" "$cmd_string" $count $retries $wait
+      sleep $wait
+    else
+      printf "Exhausted all [%s] retries for command [%s]. Exiting.\n" "$cmd_string" $retries
+      # restore settings to fail immediately on error
+      set -o errexit
+      set -o pipefail
+      return $retcode
+    fi
+  done
+  # restore settings to fail immediately on error
+  set -o errexit
+  set -o pipefail
+  return 0
+}
+
 function update_pyenv {
   # need to have the latest pyenv version to ensure latest patch releases are installable
   cd $HOME/.pyenv/plugins/python-build/../.. && git pull origin master --rebase && cd -
 }
 
-function build {
+function install_python_prereq
+{
+  retry 5 make prereq
+}
+
+function python_common {
   export THESPLOG_FILE="${THESPLOG_FILE:-${RALLY_HOME}/.rally/logs/actor-system-internal.log}"
   # this value is in bytes, the default is 50kB. We increase it to 200kiB.
   export THESPLOG_FILE_MAXSIZE=${THESPLOG_FILE_MAXSIZE:-204800}
   # adjust the default log level from WARNING
   export THESPLOG_THRESHOLD="INFO"
-
   # turn nounset off because some of the following commands fail if nounset is turned on
   set +u
 
@@ -47,11 +83,28 @@ function build {
   # ensure pyenv shims are added to PATH, see https://github.com/pyenv/pyenv/issues/1906
   eval "$(pyenv init --path)"
   eval "$(pyenv virtualenv-init -)"
+}
 
-  make prereq
+function install {
+  python_common
+  install_python_prereq
   make install
+}
+
+function precommit {
+  install
   make precommit
-  make it
+  make unit
+}
+
+function it38 {
+  install
+  make it38
+}
+
+function it310 {
+  install
+  make it310
 }
 
 function license-scan {

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -64,16 +64,4 @@
       - inject:
           properties-content: |
             HOME=$JENKINS_HOME
-            JAVA7_HOME=$HOME/.java/java7
-            JAVA8_HOME=$HOME/.java/java8
-            JAVA9_HOME=$HOME/.java/java9
-            JAVA10_HOME=$HOME/.java/java10
-            JAVA11_HOME=$HOME/.java/java11
-            JAVA12_HOME=$HOME/.java/openjdk12
-            JAVA13_HOME=$HOME/.java/openjdk13
-            JAVA14_HOME=$HOME/.java/openjdk14
-            JAVA15_HOME=$HOME/.java/openjdk15
-            JAVA16_HOME=$HOME/.java/openjdk16
-            JAVA17_HOME=$HOME/.java/openjdk17
-            ES_JAVA_HOME=$JAVA17_HOME
             RALLY_HOME=$WORKSPACE

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,79 @@
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: elasticsearch-ci
+
+##### JOB DEFAULTS
+
+- job:
+    vault:
+      url: "https://secrets.elastic.co:8200"
+      role_name: "elasticsearch-ci"
+    node: "rally"
+    concurrent: true
+    logrotate:
+      daysToKeep: 30
+      numToKeep: 500
+      artifactDaysToKeep: 7
+    parameters:
+      - string:
+          name: branch_specifier
+          default: "refs/heads/master"
+          description: "the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;, &lt;commitId&gt;, etc.)\n"
+    scm:
+      - git:
+          name: origin
+          # master node jenkins user ~/.ssh
+          credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          reference-repo: "/var/lib/jenkins/.git-references/rally.git"
+          branches:
+            - "${branch_specifier}"
+          url: "https://github.com/elastic/rally.git"
+          basedir: ""
+          wipe-workspace: true
+    triggers: []
+    wrappers:
+      - ansicolor
+      - timeout:
+          type: absolute
+          timeout: 80
+          fail: true
+      - timestamps
+    properties:
+      - github:
+          url: https://github.com/elastic/rally/
+    publishers:
+      - email:
+          recipients: infra-root+build@elastic.co
+      - junit:
+          allow-empty-results: true
+          results: 'junit-py*.xml'
+          keep-long-stdio: true
+      - google-cloud-storage:
+          credentials-id: 'elasticsearch-ci-gcs-plugin'
+          uploads:
+            - classic:
+                file-pattern: '.rally/$BUILD_NUMBER.tar.bz2'
+                storage-location: 'gs://elasticsearch-ci-artifacts/jobs/$JOB_NAME'
+                share-publicly: false
+                upload-for-failed-jobs: true
+                show-inline: true
+    builders:
+      - inject:
+          properties-content: |
+            HOME=$JENKINS_HOME
+            JAVA7_HOME=$HOME/.java/java7
+            JAVA8_HOME=$HOME/.java/java8
+            JAVA9_HOME=$HOME/.java/java9
+            JAVA10_HOME=$HOME/.java/java10
+            JAVA11_HOME=$HOME/.java/java11
+            JAVA12_HOME=$HOME/.java/openjdk12
+            JAVA13_HOME=$HOME/.java/openjdk13
+            JAVA14_HOME=$HOME/.java/openjdk14
+            JAVA15_HOME=$HOME/.java/openjdk15
+            JAVA16_HOME=$HOME/.java/openjdk16
+            JAVA17_HOME=$HOME/.java/openjdk17
+            ES_JAVA_HOME=$JAVA17_HOME
+            RALLY_HOME=$WORKSPACE

--- a/.ci/jobs/periodic-it310.yml
+++ b/.ci/jobs/periodic-it310.yml
@@ -1,0 +1,7 @@
+---
+
+jjbb-template: it.yml
+vars:
+  - jobname: periodic
+  - branch: master
+  - py_version: "310"

--- a/.ci/jobs/periodic-it38.yml
+++ b/.ci/jobs/periodic-it38.yml
@@ -1,0 +1,7 @@
+---
+
+jjbb-template: it.yml
+vars:
+  - jobname: periodic
+  - branch: master
+  - py_version: "38"

--- a/.ci/jobs/periodic-precommit.yml
+++ b/.ci/jobs/periodic-precommit.yml
@@ -1,0 +1,6 @@
+---
+
+jjbb-template: precommit.yml
+vars:
+  - jobname: periodic
+  - branch: master

--- a/.ci/jobs/periodic.yml
+++ b/.ci/jobs/periodic.yml
@@ -1,0 +1,5 @@
+---
+
+jjbb-template: periodic.yml
+vars:
+  - branch: master

--- a/.ci/jobs/pull-request-it310.yml
+++ b/.ci/jobs/pull-request-it310.yml
@@ -1,0 +1,5 @@
+---
+
+jjbb-template: pull-request-it.yml
+vars:
+  - py_version: "310"

--- a/.ci/jobs/pull-request-it38.yml
+++ b/.ci/jobs/pull-request-it38.yml
@@ -1,0 +1,5 @@
+---
+
+jjbb-template: pull-request-it.yml
+vars:
+  - py_version: "38"

--- a/.ci/jobs/pull-request-precommit.yml
+++ b/.ci/jobs/pull-request-precommit.yml
@@ -1,0 +1,27 @@
+---
+
+- job:
+    name: "elastic+rally+pull-request+precommit"
+    display-name: "elastic / rally # pull-request+precommit"
+    description: "Precommit (checkstyle + unit) tests for rally pull requests"
+    scm:
+      - git:
+          refspec: "+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*"
+          branches:
+            - "${ghprbActualCommit}"
+    triggers:
+      - github-pull-request:
+          org-list:
+            - elastic
+          allow-whitelist-orgs-as-admins: true
+          trigger-phrase: '.*run\W+rally/precommit.*'
+          github-hooks: true
+          status-context: "rally/precommit"
+          cancel-builds-on-update: true
+          black-list-labels:
+            - '>test-mute'
+    builders:
+      - shell: |
+          #!/usr/local/bin/runbld
+          set -o errexit
+          bash .ci/build.sh precommit

--- a/.ci/jobs/push-it310.yml
+++ b/.ci/jobs/push-it310.yml
@@ -1,0 +1,7 @@
+---
+
+jjbb-template: it.yml
+vars:
+  - jobname: push
+  - branch: master
+  - py_version: "310"

--- a/.ci/jobs/push-it38.yml
+++ b/.ci/jobs/push-it38.yml
@@ -1,0 +1,7 @@
+---
+
+jjbb-template: it.yml
+vars:
+  - jobname: push
+  - branch: master
+  - py_version: "38"

--- a/.ci/jobs/push-precommit.yml
+++ b/.ci/jobs/push-precommit.yml
@@ -1,0 +1,6 @@
+---
+
+jjbb-template: precommit.yml
+vars:
+  - jobname: push
+  - branch: master

--- a/.ci/jobs/push.yml
+++ b/.ci/jobs/push.yml
@@ -1,0 +1,5 @@
+---
+
+jjbb-template: push.yml
+vars:
+  - branch: master

--- a/.ci/jobs/release-docker.yml
+++ b/.ci/jobs/release-docker.yml
@@ -1,0 +1,34 @@
+---
+
+- job:
+    name: "elastic+rally-release-docker+master"
+    display-name: "elastic / rally # master - release docker"
+    description: "Release Docker Artifacts for Rally"
+    parameters:
+      - string:
+          name: branch_specifier
+          default: "refs/heads/master"
+          description: "the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;, &lt;commitId&gt;, etc.)"
+      - string:
+          name: RELEASE_VERSION
+          default: ""
+          description: "The version to release e.g. '1.2.1'."
+    triggers: []
+    builders:
+      - shell: |
+          #!/usr/bin/env bash
+          set -eo pipefail
+          set +x
+          VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+          export VAULT_TOKEN
+          unset VAULT_ROLE_ID VAULT_SECRET_ID
+          # login to docker registry
+          DOCKER_PASSWORD=$(vault read -field token secret/release/docker-hub-rally)
+          unset VAULT_TOKEN
+          source /usr/local/bin/bash_standard_lib.sh
+          retry 5 docker login -u elasticmachine -p $DOCKER_PASSWORD
+          unset DOCKER_PASSWORD
+          set -x
+          export TERM=dumb
+          export LC_ALL=en_US.UTF-8
+          ./release-docker.sh "$RELEASE_VERSION"

--- a/.ci/templates/it.yml
+++ b/.ci/templates/it.yml
@@ -1,0 +1,16 @@
+---
+
+- job:
+    name: "elastic+rally+{jobname}+{branch}-it-python{py_version}"
+    display-name: "elastic / rally # {branch} - {jobname}+it-python{py_version}"
+    description: "Integration tests for elastic/rally (Python {py_version})"
+    concurrent: true
+    scm:
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    builders:
+      - shell: |
+          #!/usr/local/bin/runbld
+          set -o errexit
+          bash .ci/build.sh it{py_version}
+          bash .ci/build.sh archive

--- a/.ci/templates/periodic.yml
+++ b/.ci/templates/periodic.yml
@@ -1,0 +1,23 @@
+---
+
+- job:
+    name: "elastic+rally+{branch}+periodic"
+    display-name: "elastic / rally # {branch} - periodic"
+    description: "CI testing for rally"
+    project-type: multijob
+    concurrent: true
+    node: master
+    triggers:
+      - timed: "H H * * *"
+    parameters:
+      - string:
+          name: branch_specifier
+          default: "refs/heads/{branch}"
+          description: "the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;, &lt;commitId&gt;, etc.)\n"
+    builders:
+      - multijob:
+          name: all CI tests
+          projects:
+            - name: elastic+rally+periodic+{branch}-precommit
+            - name: elastic+rally+periodic+{branch}-it-python38
+            - name: elastic+rally+periodic+{branch}-it-python310

--- a/.ci/templates/precommit.yml
+++ b/.ci/templates/precommit.yml
@@ -1,0 +1,15 @@
+---
+
+- job:
+    name: "elastic+rally+{jobname}+{branch}-precommit"
+    display-name: "elastic / rally # {branch} - {jobname}+precommit"
+    description: "Precommit (checkstyle + unit) tests for elastic/rally"
+    concurrent: true
+    scm:
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    builders:
+      - shell: |
+          #!/usr/local/bin/runbld
+          set -o errexit
+          bash .ci/build.sh precommit

--- a/.ci/templates/pull-request-it.yml
+++ b/.ci/templates/pull-request-it.yml
@@ -1,0 +1,28 @@
+---
+
+- job:
+    name: "elastic+rally+pull-request+it-python{py_version}"
+    display-name: "elastic / rally # pull-request+it-python{py_version}"
+    description: "Integration tests for rally pull requests (Python {py_version})"
+    scm:
+      - git:
+          refspec: "+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*"
+          branches:
+            - "${ghprbActualCommit}"
+    triggers:
+      - github-pull-request:
+          org-list:
+            - elastic
+          allow-whitelist-orgs-as-admins: true
+          trigger-phrase: '.*run\W+rally/it.*'
+          github-hooks: true
+          status-context: "rally/it-python{py_version}"
+          cancel-builds-on-update: true
+          black-list-labels:
+            - '>test-mute'
+    builders:
+      - shell: |
+          #!/usr/local/bin/runbld
+          set -o errexit
+          bash .ci/build.sh it{py_version}
+          bash .ci/build.sh archive

--- a/.ci/templates/push.yml
+++ b/.ci/templates/push.yml
@@ -1,0 +1,23 @@
+---
+
+- job:
+    name: "elastic+rally+push+{branch}"
+    display-name: "elastic / rally # {branch} - push"
+    description: "CI testing for rally"
+    project-type: multijob
+    concurrent: true
+    node: master
+    triggers:
+      - github
+    parameters:
+      - string:
+          name: branch_specifier
+          default: "refs/heads/{branch}"
+          description: "the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;, &lt;commitId&gt;, etc.)\n"
+    builders:
+      - multijob:
+          name: all CI tests
+          projects:
+            - name: elastic+rally+push+{branch}-precommit
+            - name: elastic+rally+push+{branch}-it-python38
+            - name: elastic+rally+push+{branch}-it-python310

--- a/.ci/views/views.yml
+++ b/.ci/views/views.yml
@@ -1,0 +1,4 @@
+- view:
+    name: "rally"
+    view-type: list
+    regex: '^elastic[-+]rally.*$'

--- a/Makefile
+++ b/Makefile
@@ -108,11 +108,13 @@ test: check-venv
 
 precommit: lint
 
+unit: check-venv python-caches-clean tox-env-clean
+	. $(VENV_ACTIVATE_FILE); tox -e py38-unit
+	. $(VENV_ACTIVATE_FILE); tox -e py310-unit
+
 # checks min and max python versions
 it: check-venv python-caches-clean tox-env-clean
-	. $(VENV_ACTIVATE_FILE); tox -e py38-unit
 	. $(VENV_ACTIVATE_FILE); tox -e py38-it
-	. $(VENV_ACTIVATE_FILE); tox -e py310-unit
 	. $(VENV_ACTIVATE_FILE); tox -e py310-it
 
 it38: check-venv python-caches-clean tox-env-clean


### PR DESCRIPTION
This PR does two main things.

First, it brings Rally's Jenkins job definitions into this repository.

Second, it splits the current monolithic PR check into three checks that are run in parallel:

- `elastic / rally # pull-request+precommit` runs unit tests for both Python 3.8 and Python 3.10.
-  `elastic / rally # pull-request+it-python38` runs integration tests (i.e. tests in the `it` directory) using Python 3.8.
- `elastic / rally # pull-request+it-python310` does the same as above, but with Python 3.10.

Unit tests run so much faster than integration tests that creating separate jobs for different Python versions and running them in parallel offers no benefit. However, parallelizing the integration tests in this way reduces the time taken for all PR checks to complete from ~60 minutes today to ~35 minutes. So, we'll get feedback on PRs much faster, which is nice.

Note that this structure preserves our approach of testing against our min and max supported Python versions, but we could 
we could easily test every PR against Python 3.9 as well if we'd like by adding an `it-python39` job. This would not increase the ~35m feedback loop, but would increase infrastructure costs. Happy to do that in a follow-up PR if folks think it's worth it.

@dliappis There are a few subtleties regarding how I tested this locally that would be easier to discuss/demo offline, so I'll reach out. In the meantime, any feedback on the content of the job definitions or overall approach would be great.