### PR TITLE
Fix multi-cluster attribute check for wrapped runners

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1626,6 +1626,9 @@ delete-data-stream
 
 With the operation ``delete-data-stream`` you can execute the `delete data stream API <https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-data-stream.html>`_. It supports two modes: it deletes either all data streams that are specified in the track's ``data-streams`` section or it deletes one specific data stream (pattern) defined by this operation.
 
+.. note::
+    This operation is multi-cluster aware, and will run against all clusters specified via the ``--target-hosts`` parameter. See more on multiple cluster support in the :ref:`Advanced topics section <command_line_reference_advanced_topics>`.
+
 Properties
 """"""""""
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1626,9 +1626,6 @@ delete-data-stream
 
 With the operation ``delete-data-stream`` you can execute the `delete data stream API <https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-data-stream.html>`_. It supports two modes: it deletes either all data streams that are specified in the track's ``data-streams`` section or it deletes one specific data stream (pattern) defined by this operation.
 
-.. note::
-    This operation is multi-cluster aware, and will run against all clusters specified via the ``--target-hosts`` parameter. See more on multiple cluster support in the :ref:`Advanced topics section <command_line_reference_advanced_topics>`.
-
 Properties
 """"""""""
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -122,7 +122,7 @@ def enable_assertions(enabled):
 
 def register_runner(operation_type, runner, **kwargs):
     def is_multi_cluster(runner):
-        if getattr(runner, "multi_cluster", False):
+        if hasattr(runner, "multi_cluster"):
             return True
         if hasattr(runner, "delegate"):
             return hasattr(runner.delegate, "multi_cluster")
@@ -137,6 +137,7 @@ def register_runner(operation_type, runner, **kwargs):
         raise exceptions.RallyAssertionError(
             "Runner [{}] must be implemented as async runner and registered with async_runner=True.".format(str(runner))
         )
+
     if is_multi_cluster(runner):
         if "__aenter__" in dir(runner) and "__aexit__" in dir(runner):
             if logger.isEnabledFor(logging.DEBUG):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -121,17 +121,22 @@ def enable_assertions(enabled):
 
 
 def register_runner(operation_type, runner, **kwargs):
+    def is_multi_cluster(runner):
+        if getattr(runner, "multi_cluster", False):
+            return True
+        if hasattr(runner, "delegate"):
+            if getattr(runner.delegate, "multi_cluster", False):
+                return True
+
     logger = logging.getLogger(__name__)
     async_runner = kwargs.get("async_runner", False)
     if isinstance(operation_type, track.OperationType):
         operation_type = operation_type.to_hyphenated_string()
-
     if not async_runner:
         raise exceptions.RallyAssertionError(
             "Runner [{}] must be implemented as async runner and registered with async_runner=True.".format(str(runner))
         )
-
-    if getattr(runner, "multi_cluster", False):
+    if is_multi_cluster(runner):
         if "__aenter__" in dir(runner) and "__aexit__" in dir(runner):
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("Registering runner object [%s] for [%s].", str(runner), str(operation_type))
@@ -1392,21 +1397,23 @@ class DeleteDataStream(Runner):
     Execute the `delete data stream API <https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-data-stream.html>`_.
     """
 
-    async def __call__(self, es, params):
+    multi_cluster = True
+
+    async def __call__(self, multi_es, params):
         ops = 0
+        for es in multi_es.values():
+            data_streams = mandatory(params, "data-streams", self)
+            only_if_exists = mandatory(params, "only-if-exists", self)
+            request_params = mandatory(params, "request-params", self)
 
-        data_streams = mandatory(params, "data-streams", self)
-        only_if_exists = mandatory(params, "only-if-exists", self)
-        request_params = mandatory(params, "request-params", self)
-
-        for data_stream in data_streams:
-            if not only_if_exists:
-                await es.indices.delete_data_stream(name=data_stream, ignore=[404], params=request_params)
-                ops += 1
-            elif only_if_exists and await es.indices.exists(index=data_stream):
-                self.logger.info("Data stream [%s] already exists. Deleting it.", data_stream)
-                await es.indices.delete_data_stream(name=data_stream, params=request_params)
-                ops += 1
+            for data_stream in data_streams:
+                if not only_if_exists:
+                    await es.indices.delete_data_stream(name=data_stream, ignore=[404], params=request_params)
+                    ops += 1
+                elif only_if_exists and await es.indices.exists(index=data_stream):
+                    self.logger.info("Data stream [%s] already exists. Deleting it.", data_stream)
+                    await es.indices.delete_data_stream(name=data_stream, params=request_params)
+                    ops += 1
 
         return {
             "weight": ops,

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -121,13 +121,6 @@ def enable_assertions(enabled):
 
 
 def register_runner(operation_type, runner, **kwargs):
-    def is_multi_cluster(runner):
-        if hasattr(runner, "multi_cluster"):
-            return True
-        if hasattr(runner, "delegate"):
-            return hasattr(runner.delegate, "multi_cluster")
-        return False
-
     logger = logging.getLogger(__name__)
     async_runner = kwargs.get("async_runner", False)
     if isinstance(operation_type, track.OperationType):
@@ -138,7 +131,7 @@ def register_runner(operation_type, runner, **kwargs):
             "Runner [{}] must be implemented as async runner and registered with async_runner=True.".format(str(runner))
         )
 
-    if is_multi_cluster(runner):
+    if hasattr(unwrap(runner), "multi_cluster"):
         if "__aenter__" in dir(runner) and "__aexit__" in dir(runner):
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("Registering runner object [%s] for [%s].", str(runner), str(operation_type))

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -121,6 +121,13 @@ def enable_assertions(enabled):
 
 
 def register_runner(operation_type, runner, **kwargs):
+    def is_multi_cluster(runner):
+        if getattr(runner, "multi_cluster", False):
+            return True
+        if hasattr(runner, "delegate"):
+            return hasattr(runner.delegate, "multi_cluster")
+        return False
+
     logger = logging.getLogger(__name__)
     async_runner = kwargs.get("async_runner", False)
     if isinstance(operation_type, track.OperationType):
@@ -130,8 +137,7 @@ def register_runner(operation_type, runner, **kwargs):
         raise exceptions.RallyAssertionError(
             "Runner [{}] must be implemented as async runner and registered with async_runner=True.".format(str(runner))
         )
-
-    if getattr(runner, "multi_cluster", False):
+    if is_multi_cluster(runner):
         if "__aenter__" in dir(runner) and "__aexit__" in dir(runner):
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("Registering runner object [%s] for [%s].", str(runner), str(operation_type))

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -45,59 +45,6 @@ class TestRegisterRunner:
     def teardown_method(self, method):
         runner.remove_runner("unit_test")
 
-    @mock.patch("esrally.driver.runner._single_cluster_runner")
-    @mock.patch("esrally.driver.runner._multi_cluster_runner")
-    @pytest.mark.asyncio
-    async def test_register_retryable_runner_with_multi_cluster_attribute(self, multi_cluster_runner, single_cluster_runner):
-        class Delegate:
-            multi_cluster = True
-
-            async def __call__(self, *args):
-                return args
-
-            def __repr__(self):
-                return "Delegate"
-
-        delegate = Delegate()
-        es = None
-        params = {}
-
-        single_cluster_runner.return_value = runner.MultiClientRunner(delegate, "deletegate", es, False)
-        multi_cluster_runner.return_value = runner.MultiClientRunner(delegate, "deletegate", es, False)
-
-        runner.register_runner(operation_type="unit_test", runner=runner.Retry(delegate), async_runner=True)
-        retrier = runner.Retry(delegate)
-
-        await retrier(es, params)
-
-        multi_cluster_runner.assert_called()
-        single_cluster_runner.assert_not_called()
-
-    @mock.patch("esrally.driver.runner._single_cluster_runner")
-    @mock.patch("esrally.driver.runner._multi_cluster_runner")
-    @pytest.mark.asyncio
-    async def test_register_retryable_runner_with_no_multi_cluster_attribute(self, multi_cluster_runner, single_cluster_runner):
-        class Delegate:
-            async def __call__(self, *args):
-                return args
-
-            def __repr__(self):
-                return "Delegate"
-
-        delegate = Delegate()
-        es = None
-        params = {}
-
-        single_cluster_runner.return_value = runner.MultiClientRunner(delegate, "deletegate", es, False)
-        multi_cluster_runner.return_value = runner.MultiClientRunner(delegate, "deletegate", es, False)
-
-        runner.register_runner(operation_type="unit_test", runner=runner.Retry(delegate), async_runner=True)
-        retrier = runner.Retry(delegate)
-
-        await retrier(es, params)
-        multi_cluster_runner.assert_not_called()
-        single_cluster_runner.assert_called()
-
     @pytest.mark.asyncio
     async def test_runner_function_should_be_wrapped(self):
         async def runner_function(*args):
@@ -2765,48 +2712,31 @@ class TestDeleteIndexRunner:
 
 
 class TestDeleteDataStreamRunner:
-    @pytest.fixture
     @mock.patch("elasticsearch.Elasticsearch")
-    def setup_es_clients(self, es):
-        remote_es = es
-        default_es = copy.deepcopy(es)
-
-        multi_es = {
-            "remote-cluster": remote_es,
-            "default": default_es,
-        }
-        return multi_es
-
     @pytest.mark.asyncio
-    async def test_deletes_existing_data_streams(self, setup_es_clients):
-        setup_es_clients["default"].indices.exists = mock.AsyncMock(side_effect=[False, True])
-        setup_es_clients["default"].indices.delete_data_stream = mock.AsyncMock()
-
-        setup_es_clients["remote-cluster"].indices.exists = mock.AsyncMock(side_effect=[False, True])
-        setup_es_clients["remote-cluster"].indices.delete_data_stream = mock.AsyncMock()
+    async def test_deletes_existing_data_streams(self, es):
+        es.indices.exists = mock.AsyncMock(side_effect=[False, True])
+        es.indices.delete_data_stream = mock.AsyncMock()
 
         r = runner.DeleteDataStream()
 
         params = {"data-streams": ["data-stream-A", "data-stream-B"], "only-if-exists": True, "request-params": {}}
 
-        result = await r(setup_es_clients, params)
+        result = await r(es, params)
 
         assert result == {
-            "weight": 2,
+            "weight": 1,
             "unit": "ops",
             "success": True,
         }
 
-        setup_es_clients["default"].indices.delete_data_stream.assert_awaited_once_with(name="data-stream-B", params={})
-        setup_es_clients["remote-cluster"].indices.delete_data_stream.assert_awaited_once_with(name="data-stream-B", params={})
+        es.indices.delete_data_stream.assert_awaited_once_with(name="data-stream-B", params={})
 
+    @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
-    async def test_deletes_all_data_streams(self, setup_es_clients):
-        setup_es_clients["default"].indices.delete_data_stream = mock.AsyncMock()
-        setup_es_clients["default"].indices.exists = mock.AsyncMock()
-
-        setup_es_clients["remote-cluster"].indices.delete_data_stream = mock.AsyncMock()
-        setup_es_clients["remote-cluster"].indices.exists = mock.AsyncMock()
+    async def test_deletes_all_data_streams(self, es):
+        es.indices.delete_data_stream = mock.AsyncMock()
+        es.indices.exists = mock.AsyncMock()
 
         r = runner.DeleteDataStream()
 
@@ -2816,29 +2746,21 @@ class TestDeleteDataStreamRunner:
             "request-params": {"ignore_unavailable": "true", "expand_wildcards": "none"},
         }
 
-        result = await r(setup_es_clients, params)
+        result = await r(es, params)
 
         assert result == {
-            "weight": 4,
+            "weight": 2,
             "unit": "ops",
             "success": True,
         }
 
-        setup_es_clients["default"].indices.delete_data_stream.assert_has_awaits(
+        es.indices.delete_data_stream.assert_has_awaits(
             [
                 mock.call(name="data-stream-A", ignore=[404], params=params["request-params"]),
                 mock.call(name="data-stream-B", ignore=[404], params=params["request-params"]),
             ]
         )
-        setup_es_clients["default"].indices.delete_data_stream.assert_has_awaits(
-            [
-                mock.call(name="data-stream-A", ignore=[404], params=params["request-params"]),
-                mock.call(name="data-stream-B", ignore=[404], params=params["request-params"]),
-            ]
-        )
-
-        assert setup_es_clients["default"].indices.exists.await_count == 0
-        assert setup_es_clients["remote-cluster"].indices.exists.await_count == 0
+        assert es.indices.exists.await_count == 0
 
 
 class TestCreateIndexTemplateRunner:


### PR DESCRIPTION
During testing for https://github.com/elastic/rally-tracks/pull/293 I discovered that that the `DeleteDataStream` runner was not multi-cluster aware, and that our previous attribute check would miss any wrapped (i.e. with `Retry()`) multi-cluster aware runner.

With this commit we make the DeleteDataStream runner multi-cluster aware
by default, and fix an existing bug where the multi-cluster attribute of
wrapped runners were not checked properly.