### PR TITLE
Introduce rally-tracks compatibility testing

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -127,6 +127,11 @@ function it310 {
   make it310
 }
 
+function rally-tracks-compat {
+  install
+  make rally-tracks-compat
+}
+
 function license-scan {
   # turn nounset off because some of the following commands fail if nounset is turned on
   set +u

--- a/.ci/jobs/pull-request-rally-tracks-compat.yml
+++ b/.ci/jobs/pull-request-rally-tracks-compat.yml
@@ -1,0 +1,27 @@
+---
+
+- job:
+    name: "elastic+rally+pull-request+rally-tracks-compat"
+    display-name: "elastic / rally # pull-request+rally-tracks-compat"
+    description: "rally-tracks integration tests using rally built from PR branch"
+    scm:
+      - git:
+          refspec: "+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*"
+          branches:
+            - "${ghprbActualCommit}"
+    triggers:
+      - github-pull-request:
+          org-list:
+            - elastic
+          allow-whitelist-orgs-as-admins: true
+          trigger-phrase: '.*run\W+rally/rally-tracks-compat.*'
+          github-hooks: true
+          status-context: "rally/rally-tracks-compat"
+          cancel-builds-on-update: true
+          black-list-labels:
+            - '>test-mute'
+    builders:
+      - shell: |
+          #!/usr/local/bin/runbld
+          set -o errexit
+          bash .ci/build.sh rally-tracks-compat

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ install-user: venv-create
 install: install-user
 	# Also install development dependencies
 	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .[develop]
-#	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install git+https://github.com/elastic/pytest-rally.git
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install git+https://github.com/elastic/pytest-rally.git
 
 
 clean: nondocs-clean docs-clean

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ install-user: venv-create
 install: install-user
 	# Also install development dependencies
 	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .[develop]
-	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install git+https://github.com/elastic/pytest-rally.git
+#	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install git+https://github.com/elastic/pytest-rally.git
 
 
 clean: nondocs-clean docs-clean

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ it39: check-venv python-caches-clean tox-env-clean
 it310: check-venv python-caches-clean tox-env-clean
 	. $(VENV_ACTIVATE_FILE); tox -e py310-it
 
+rally-tracks-compat: check-venv python-caches-clean tox-env-clean
+	. $(VENV_ACTIVATE_FILE); tox -e rally-tracks-compat
+
 check-all: lint test it
 
 benchmark: check-venv

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,8 @@ install-user: venv-create
 install: install-user
 	# Also install development dependencies
 	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install -e .[develop]
+	. $(VENV_ACTIVATE_FILE); $(PIP_WRAPPER) install git+https://github.com/elastic/pytest-rally.git
+
 
 clean: nondocs-clean docs-clean
 

--- a/it/track_repo_compatibility/conftest.py
+++ b/it/track_repo_compatibility/conftest.py
@@ -23,8 +23,8 @@ import pytest
 
 RALLY_HOME = os.getenv("RALLY_HOME", os.path.expanduser("~"))
 RALLY_CONFIG_DIR = os.path.join(RALLY_HOME, ".rally")
-RALLY_TRACKS_DIR = os.path.join(RALLY_CONFIG_DIR, "benchmarks", "tracks", "default")
-
+TRACK_REPO_PATH = os.path.join(RALLY_CONFIG_DIR, "benchmarks", "tracks", "rally-tracks-compat")
+REMOTE_TRACK_REPO = "https://github.com/elastic/rally-tracks"
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_addoption(parser):
@@ -32,8 +32,8 @@ def pytest_addoption(parser):
     group.addoption(
         "--track-repository",
         action="store",
-        default=RALLY_TRACKS_DIR,
-        help=("Path to a local track repository\n" f"(default: {RALLY_TRACKS_DIR})"),
+        default=TRACK_REPO_PATH,
+        help=("Path to a local track repository\n" f"(default: {TRACK_REPO_PATH})"),
     )
     group.addoption("--track-revision", action="store", default="master", help=("Track repository revision to test\n" "default: `master`"))
     group.addoption(
@@ -49,12 +49,13 @@ def pytest_addoption(parser):
 def pytest_cmdline_main(config):
     repo = config.option.track_repository
     if not os.path.isdir(repo):
-        if repo == RALLY_TRACKS_DIR:
+        # we're using the defaults, so perform an initial clone of rally-tracks
+        if repo == TRACK_REPO_PATH:
             try:
-                # this will perform the initial clone of rally-tracks
-                subprocess.run(shlex.split("esrally list tracks"), text=True, capture_output=True, check=True)
+                subprocess.run(shlex.split(f"git clone {REMOTE_TRACK_REPO} {repo}"), text=True, capture_output=True, check=True)
             except subprocess.CalledProcessError as e:
-                raise AssertionError(f"Unable to list tracks in {repo}: {e.stderr}")
+                raise AssertionError(f"Unable to clone {REMOTE_TRACK_REPO} into {repo}: {e.stderr}")
+        # user has provided a non-default track repository, but it's not a valid path, so we raise an error
         else:
             raise AssertionError(f"Track repository not found: [{repo}]")
 

--- a/it/track_repo_compatibility/conftest.py
+++ b/it/track_repo_compatibility/conftest.py
@@ -19,15 +19,12 @@ import os
 import shlex
 import subprocess
 
-import pytest
-
 RALLY_HOME = os.getenv("RALLY_HOME", os.path.expanduser("~"))
 RALLY_CONFIG_DIR = os.path.join(RALLY_HOME, ".rally")
 TRACK_REPO_PATH = os.path.join(RALLY_CONFIG_DIR, "benchmarks", "tracks", "rally-tracks-compat")
 REMOTE_TRACK_REPO = "https://github.com/elastic/rally-tracks"
 
 
-@pytest.hookimpl(tryfirst=True)
 def pytest_addoption(parser):
     group = parser.getgroup("rally")
     group.addoption(
@@ -51,7 +48,6 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.hookimpl(tryfirst=True)
 def pytest_cmdline_main(config):
     repo = config.option.track_repository
     if not os.path.isdir(repo):
@@ -69,6 +65,5 @@ def pytest_cmdline_main(config):
     config.args.append(os.path.join(repo, test_dir))
 
 
-@pytest.hookimpl
 def pytest_report_header(config):
     return f"rally: track-repository={config.option.track_repository}, track-revision={config.option.track_revision}"

--- a/it/track_repo_compatibility/conftest.py
+++ b/it/track_repo_compatibility/conftest.py
@@ -1,0 +1,55 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+import pytest
+
+RALLY_HOME = os.getenv("RALLY_HOME", os.path.expanduser("~"))
+RALLY_CONFIG_DIR = os.path.join(RALLY_HOME, ".rally")
+RALLY_TRACKS_DIR = os.path.join(RALLY_CONFIG_DIR, "benchmarks", "tracks", "default")
+
+
+@pytest.hookimpl
+def pytest_addoption(parser):
+    group = parser.getgroup("rally")
+    group.addoption(
+        "--track-repository",
+        action="store",
+        default=RALLY_TRACKS_DIR,
+        help=("Path to a local track repository\n" f"(default: {RALLY_TRACKS_DIR})"),
+    )
+    group.addoption("--track-revision", action="store", default="master", help=("Track repository revision to test\n" "default: `master`"))
+    group.addoption(
+        "--track-repository-test-directory",
+        action="store",
+        dest="track_repo_test_dir",
+        default="it",
+        help=("Name of the directory containing the track repo's integration tests\n" "(default: `it`)"),
+    )
+
+
+@pytest.hookimpl
+def pytest_cmdline_main(config):
+    repo = config.option.track_repository
+    test_dir = config.option.track_repo_test_dir
+    config.args.append(os.path.join(repo, test_dir))
+
+
+@pytest.hookimpl
+def pytest_report_header(config):
+    return f"rally: track-repository={config.option.track_repository}, track-revision={config.option.track_revision}"

--- a/it/track_repo_compatibility/conftest.py
+++ b/it/track_repo_compatibility/conftest.py
@@ -26,6 +26,7 @@ RALLY_CONFIG_DIR = os.path.join(RALLY_HOME, ".rally")
 TRACK_REPO_PATH = os.path.join(RALLY_CONFIG_DIR, "benchmarks", "tracks", "rally-tracks-compat")
 REMOTE_TRACK_REPO = "https://github.com/elastic/rally-tracks"
 
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_addoption(parser):
     group = parser.getgroup("rally")
@@ -33,15 +34,20 @@ def pytest_addoption(parser):
         "--track-repository",
         action="store",
         default=TRACK_REPO_PATH,
-        help=("Path to a local track repository\n" f"(default: {TRACK_REPO_PATH})"),
+        help=f"Path to a local track repository\n(default: {TRACK_REPO_PATH})",
     )
-    group.addoption("--track-revision", action="store", default="master", help=("Track repository revision to test\n" "default: `master`"))
+    group.addoption(
+        "--track-revision",
+        action="store",
+        default="master",
+        help="Track repository revision to test\ndefault: `master`",
+    )
     group.addoption(
         "--track-repository-test-directory",
         action="store",
         dest="track_repo_test_dir",
         default="it",
-        help=("Name of the directory containing the track repo's integration tests\n" "(default: `it`)"),
+        help="Name of the directory containing the track repo's integration tests\n(default: `it`)",
     )
 
 

--- a/it/track_repo_compatibility/conftest.py
+++ b/it/track_repo_compatibility/conftest.py
@@ -52,11 +52,11 @@ def pytest_cmdline_main(config):
         if repo == RALLY_TRACKS_DIR:
             try:
                 # this will perform the initial clone of rally-tracks
-                subprocess.run(shlex.split("esrally list tracks"), capture_output=True, check=True)
+                subprocess.run(shlex.split("esrally list tracks"), text=True, capture_output=True, check=True)
             except subprocess.CalledProcessError as e:
-                raise AssertionError(f"Unable to list tracks in {repo}") from e
+                raise AssertionError(f"Unable to list tracks in {repo}: {e.stderr}")
         else:
-            raise AssertionError(f"Directory {repo} does not exist.")
+            raise AssertionError(f"Track repository not found: [{repo}]")
 
     test_dir = config.option.track_repo_test_dir
     config.args.append(os.path.join(repo, test_dir))

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ isolated_build = True
 envlist =
     py{38,39,310}-unit
     py{38,39,310}-it
+    rally-tracks-compat
 platform =
     linux|darwin
 
@@ -47,3 +48,8 @@ commands =
 
 whitelist_externals =
     pytest
+
+[testenv:rally-tracks-compat]
+deps = pytest-rally @ git+https://github.com/elastic/pytest-rally.git
+commands =
+        rally-tracks-compat: pytest it/track_repo_compatibility --junitxml=junit-{envname}.xml

--- a/tox.ini
+++ b/tox.ini
@@ -52,4 +52,4 @@ whitelist_externals =
 [testenv:rally-tracks-compat]
 deps = pytest-rally @ git+https://github.com/elastic/pytest-rally.git
 commands =
-        rally-tracks-compat: pytest it/track_repo_compatibility --junitxml=junit-{envname}.xml
+        rally-tracks-compat: pytest it/track_repo_compatibility --junitxml=junit-{envname}.xml --log-cli-level=INFO


### PR DESCRIPTION
This PR adds the infrastructure necessary to run `rally-tracks` integration tests (see https://github.com/elastic/rally-tracks/pull/289) from within the Rally repository, both locally and--more importantly--as a PR check via CI.

We [modify and extend](https://github.com/elastic/rally/pull/1564/files#diff-64a87f6e18e0f986ce1182a302e810ba67da5432ded7a1e695bcbc54ed995646) the `pytest-rally` plugin so that its behavior and defaults make sense when run from within the Rally repo as opposed to a track repo. This enables Rally developers and CI jobs to test Rally changes against arbitrary revisions of local track repositories, using arbitrary versions of Elasticsearch. 

In the default case, it simply ensures that changes being made to Rally do not break the `master` branch of `rally-tracks`. It does this by executing whatever tests are contained in the `it` subdirectory of `~/.rally/benchmarks/tracks/default`. By default, it uses a build of the main branch of ES from source (i.e. `--revision=current` in Rally terms) as the benchmark candidate.

To run these tests, execute `pytest it/track_repo_compatibility/` from the root of the Rally repo after running `make install`, or run `make rally-tracks-compat` to run them within a `tox` environment.

**Default behavior**

Here's an example of what happens by default, but we'll limit the example to just one test (for brevity of output) and add some extra logging to more clearly see what the `pytest-rally` plugin is doing:

`pytest it/track_repo_compatibility --log-cli-level=INFO -k metricbeat`

```
===================================================================================== test session starts ======================================================================================
platform linux -- Python 3.8.13, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/baamonde/code/elastic/rally/.venv/bin/python3
cachedir: .pytest_cache
benchmark: 3.2.2 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rally: track-repository=/home/baamonde/.rally/benchmarks/tracks/default, track-revision=master
rootdir: /home/baamonde/code/elastic/rally, configfile: pyproject.toml
plugins: benchmark-3.2.2, rally-0.0.1, asyncio-0.18.1, anyio-3.6.1, httpserver-1.0.4
asyncio: mode=strict
collecting ...
------------------------------------------------------------------------------------- live log collection --------------------------------------------------------------------------------------
INFO     pytest_rally.rally:rally.py:110 Running command: [esrally list tracks --track-repository="/home/baamonde/.rally/benchmarks/tracks/default" --track-revision="master" --configuration-name="pytest"]
collected 68 items / 67 deselected / 1 selected

test_all_tracks_and_challenges.py::TestTrackRepository::test_autogenerated[metricbeat-append-no-conflicts]
---------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------
INFO     pytest_rally.elasticsearch:elasticsearch.py:84 Installing Elasticsearch: [esrally install --quiet --http-port=19200 --node=rally-node --master-nodes=rally-node --car=4gheap,trial-license,x-pack-ml --seed-hosts="127.0.0.1:19300" --revision=current]
INFO     pytest_rally.elasticsearch:elasticsearch.py:93 Starting Elasticsearch: [esrally start --runtime-jdk=bundled --installation-id=a14708f6-d2c0-49e1-aaa2-dd60a2acaf9d --race-id=b50f7204-3f70-4724-bb91-3e0050d0e2e0]
---------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------
INFO     pytest_rally.rally:rally.py:144 Running command: [esrally race --track="metricbeat" --challenge="append-no-conflicts" --track-repository="/home/baamonde/.rally/benchmarks/tracks/default" --track-revision="master" --configuration-name="pytest" --enable-assertions --kill-running-processes --on-error="abort" --pipeline="benchmark-only" --target-hosts="127.0.0.1:19200" --test-mode]
PASSED                                                                                                                                                                                   [100%]
-------------------------------------------------------------------------------------- live log teardown ---------------------------------------------------------------------------------------
INFO     pytest_rally.rally:rally.py:91 Removing Rally config from [/home/baamonde/.rally/rally-pytest.ini]
INFO     pytest_rally.elasticsearch:elasticsearch.py:104 Stopping Elasticsearch: [esrally stop --installation-id=a14708f6-d2c0-49e1-aaa2-dd60a2acaf9d]


============================================================================== 1 passed, 67 deselected in 33.14s ===============================================================================

```

You can see that we've applied the defaults for the `--track-repository` and `--track-revision` options in the first few lines of the output:

`rally: track-repository=/home/baamonde/.rally/benchmarks/tracks/default, track-revision=master`

And that these make their way into the `esrally` commands that `pytest-rally` generates:

```
INFO     pytest_rally.rally:rally.py:144 Running command: [esrally race --track="metricbeat" --challenge="append-no-conflicts" --track-repository="/home/baamonde/.rally/benchmarks/tracks/default" --track-revision="master" --configuration-name="pytest" --enable-assertions --kill-running-processes --on-error="abort" --pipeline="benchmark-only" --target-hosts="127.0.0.1:19200" --test-mode]`
```

**Overriding defaults**

For local development, overriding these defaults could be useful. For example, if you're working on changes to *both* Rally and rally-tracks locally, and want to test with a released version of ES, you could do something like this:

```sh
pytest it/track_repo_compatibility/ \
    --log-cli-level=INFO \
    --track-repository=/home/baamonde/code/elastic/rally-tracks \
    --track-revision=ci \
    --distribution-version=8.3.2 \
    -k metricbeat
```

The pytest session header will reflect these changes:

```
rally: track-repository=/home/baamonde/code/elastic/rally-tracks, track-revision=ci
```

The plugin will pass along the `--distribution-version` to install the ES fixture:

```
INFO     pytest_rally.elasticsearch:elasticsearch.py:84 Installing Elasticsearch: [esrally install --quiet --http-port=19200 --node=rally-node --master-nodes=rally-node --car=4gheap,trial-license,x-pack-ml --seed-hosts="127.0.0.1:19300" --distribution-version=8.3.2]
```

And race commands will provide the correct `--track-repository` and `--track-revision`:

```
INFO     pytest_rally.rally:rally.py:144 Running command: [esrally race --track="metricbeat" --challenge="append-no-conflicts" --track-repository="/home/baamonde/code/elastic/rally-tracks" --track-revision="ci" --configuration-name="pytest" --enable-assertions --kill-running-processes --on-error="abort" --pipeline="benchmark-only" --target-hosts="127.0.0.1:19200" --test-mode]
```