### PR TITLE
Bump develop dependencies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ templates_path = ["_templates"]
 # source_suffix = ['.rst', '.md']
 source_suffix = ".rst"
 root_doc = "index"
-language = None
+language = "en"
 
 CI_VARS = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".ci", "variables.json")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,19 +90,19 @@ develop = [
     "boto3==1.18.46",
     # tests
     "ujson",
-    "pytest==6.2.5",
-    "pytest-benchmark==3.2.2",
-    "pytest-asyncio==0.18.1",
-    "tox==3.14.0",
-    "sphinx==4.2.0",
+    "pytest==7.1.2",
+    "pytest-benchmark==3.4.1",
+    "pytest-asyncio==0.19.0",
+    "pytest-httpserver==1.0.5",
+    "tox==3.25.0",
+    "sphinx==5.1.1",
     "furo==2022.06.21",
-    "twine==1.15.0",
+    "twine==4.0.1",
     "wheel==0.37.1",
-    "github3.py==1.3.0",
+    "github3.py==3.2.0",
     "pre-commit==2.20.0",
     "pylint==2.6.0",
     "trustme==0.9.0",
-    "pytest-httpserver==1.0.4",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This will fix the pluggy incompatibility between hatchling and pytest.

As noticed here: https://github.com/elastic/rally/pull/1565#issuecomment-1228286217