### PR TITLE
Encourage users to read tracks documentation

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -18,7 +18,7 @@ By that you are mimicking what Rally does. Fix any errors that show up here and 
 Where does Rally get the benchmark data from?
 ---------------------------------------------
 
-Rally comes with a set of tracks out of the box which we maintain in the `rally-tracks repository on Github <https://github.com/elastic/rally-tracks>`_. This repository contains the track descriptions. The actual data are stored as compressed files in an S3 bucket.
+Rally comes with a set of tracks out of the box which we maintain in the `rally-tracks repository on Github <https://github.com/elastic/rally-tracks>`_. This repository contains the track descriptions. The actual data are stored as compressed files in an S3 bucket. Each track is documented in README files, including parameters and example data.
 
 Will Rally destroy my existing indices?
 ---------------------------------------

--- a/docs/race.rst
+++ b/docs/race.rst
@@ -32,7 +32,7 @@ This will show the following list::
     pmc            Full text benchmark with academic papers from PMC                                                                                                                                  574,199      5.5 GB             21.7 GB              append-no-conflicts      append-no-conflicts,append-no-conflicts-index-only,append-sorted-no-conflicts,append-fast-with-conflicts,indexing-querying
     so             Indexing benchmark using up to questions and answers from StackOverflow                                                                                                            36,062,278   8.9 GB             33.1 GB              append-no-conflicts      append-no-conflicts
 
-The first two columns show the name and a description of each track. A track also specifies one or more challenges which describe the workload to run.
+The first two columns show the name and a description of each track. A track also specifies one or more challenges which describe the workload to run. To get more details about a given track, `refer to the README files in the rally-tracks repository <https://github.com/elastic/rally-tracks/>`_.
 
 Starting a Race
 ---------------


### PR DESCRIPTION
This addresses the following user feedback:

> I think the main thing that made me not look for documentation was the
> message on the repository main page. It gave me the impression I
> shouldn't be there unless I want to create my own tracks.