### PR TITLE
Use Docker for Elasticsearch source builds

### DIFF
--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -890,7 +890,7 @@ class DockerBuilder:
                 image=container_image.id,
                 user=self.user_name,
                 group_add=[self.group_id],
-                command=f'/bin/bash -c "{command}"',
+                command=f'/bin/bash -c "git config --global --add safe.directory \'*\'; {command}"',
                 volumes=[f"{self.src_dir}:/home/{self.user_name}/elasticsearch"],
                 working_dir=f"/home/{self.user_name}/elasticsearch",
             )

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -890,7 +890,7 @@ class DockerBuilder:
                 image=container_image.id,
                 user=self.user_name,
                 group_add=[self.group_id],
-                command=f'/bin/bash -c "git config --global --add safe.directory \'*\'; {command}"',
+                command=f"/bin/bash -c \"git config --global --add safe.directory '*'; {command}\"",
                 volumes=[f"{self.src_dir}:/home/{self.user_name}/elasticsearch"],
                 working_dir=f"/home/{self.user_name}/elasticsearch",
             )

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -400,6 +400,12 @@ def create_arg_parser():
         help="A comma-separated list of the initial seed host IPs",
         default="",
     )
+    install_parser.add_argument(
+        "--source-build-method",
+        help="Method with which to build Elasticsearch and plugins from source",
+        choices=["docker", "default"],
+        default="default",
+    )
     for p in [race_parser, install_parser]:
         p.add_argument(
             "--cluster-name",
@@ -643,6 +649,12 @@ def create_arg_parser():
         action="store_true",
         default=False,
         help="If any processes is running, it is going to kill them and allow Rally to continue to run.",
+    )
+    race_parser.add_argument(
+        "--source-build-method",
+        help="Method with which to build Elasticsearch and plugins from source",
+        choices=["docker", "default"],
+        default="default",
     )
 
     ###############################################################################
@@ -932,6 +944,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "mechanic", "network.host", args.network_host)
             cfg.add(config.Scope.applicationOverride, "mechanic", "network.http.port", args.http_port)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.method", args.source_build_method)
             cfg.add(config.Scope.applicationOverride, "mechanic", "build.type", args.build_type)
             cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
             cfg.add(config.Scope.applicationOverride, "mechanic", "node.name", args.node_name)
@@ -975,6 +988,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             configure_mechanic_params(args, cfg)
             cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.method", args.source_build_method)
             cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", opts.csv_to_list(args.elasticsearch_plugins))
             cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", opts.to_dict(args.plugin_params))
             cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))

--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -22,6 +22,8 @@ import it
 def test_sources(cfg):
     port = 19200
     it.wait_until_port_is_free(port_number=port)
+
+    # Default sources build method
     assert (
         it.race(
             cfg,
@@ -31,12 +33,35 @@ def test_sources(cfg):
         == 0
     )
 
+    # Default sources build method
     it.wait_until_port_is_free(port_number=port)
     assert (
         it.race(
             cfg,
             f"--pipeline=from-sources --track=geonames --test-mode --target-hosts=127.0.0.1:{port} "
             f'--challenge=append-no-conflicts-index-only --car="4gheap,basic-license,ea"',
+        )
+        == 0
+    )
+
+    # Docker sources build method
+    assert (
+        it.race(
+            cfg,
+            f"--revision=@2022-07-07 --track=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
+            f"--challenge=append-no-conflicts --car=4gheap,basic-license --elasticsearch-plugins=analysis-icu "
+            f"--source-build-method=docker",
+        )
+        == 0
+    )
+
+    # Docker sources build method
+    it.wait_until_port_is_free(port_number=port)
+    assert (
+        it.race(
+            cfg,
+            f"--pipeline=from-sources --track=geonames --test-mode --target-hosts=127.0.0.1:{port} "
+            f'--source-build-method=docker --challenge=append-no-conflicts-index-only --car="4gheap,basic-license,ea"',
         )
         == 0
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     #   aiohttp: Apache 2.0
     "elasticsearch[async]==7.14.0",
     "urllib3==1.26.9",
+    "docker==6.0.0",
     # License: BSD
     "psutil==5.8.0",
     # License: MIT

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -205,7 +205,7 @@ class TestDockerBuilder:
             user=user,
             group_add=[group_id],
             image="test-image",
-            command='/bin/bash -c "git config --global --add safe.directory \'*\'; ./gradlew clean; ./gradlew assemble"',
+            command="/bin/bash -c \"git config --global --add safe.directory '*'; ./gradlew clean; ./gradlew assemble\"",
             volumes=[f"/src:/home/{user}/elasticsearch"],
             working_dir=f"/home/{user}/elasticsearch",
         )
@@ -255,7 +255,7 @@ class TestDockerBuilder:
                     image="test-image",
                     user=builder.user_name,
                     group_add=[builder.group_id],
-                    command='/bin/bash -c "git config --global --add safe.directory \'*\'; test command"',
+                    command="/bin/bash -c \"git config --global --add safe.directory '*'; test command\"",
                     volumes=[f"/src:/home/{builder.user_name}/elasticsearch"],
                     working_dir=f"/home/{builder.user_name}/elasticsearch",
                 ),

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -205,7 +205,7 @@ class TestDockerBuilder:
             user=user,
             group_add=[group_id],
             image="test-image",
-            command='/bin/bash -c "./gradlew clean; ./gradlew assemble"',
+            command='/bin/bash -c "git config --global --add safe.directory \'*\'; ./gradlew clean; ./gradlew assemble"',
             volumes=[f"/src:/home/{user}/elasticsearch"],
             working_dir=f"/home/{user}/elasticsearch",
         )
@@ -255,7 +255,7 @@ class TestDockerBuilder:
                     image="test-image",
                     user=builder.user_name,
                     group_add=[builder.group_id],
-                    command='/bin/bash -c "test command"',
+                    command='/bin/bash -c "git config --global --add safe.directory \'*\'; test command"',
                     volumes=[f"/src:/home/{builder.user_name}/elasticsearch"],
                     working_dir=f"/home/{builder.user_name}/elasticsearch",
                 ),


### PR DESCRIPTION
With this commit we introduce a new a way to build Elasticsearch and
core plugins from source using Docker. This new method is configured via 
the new CLI argument (`--source-build-method`), which allows users to 
specify the desired method. Currently, there are only two options, 
'default', and 'docker'.

Relates https://github.com/elastic/rally/issues/1462


### Sample invocations

  - `esrally race --revision="@2022-07-07" --track=geonames --test-mode  --target-hosts=127.0.0.1:29200 --challenge=append-no-conflicts --car=4gheap,basic-license --elasticsearch-plugins= --runtime-jdk=bundled --kill-running-processes --source-build-method=docker`
  - `esrally install --revision="@2022-07-15" --node-name="rally-node-0" --network-host="127.0.0.1" --http-port=39200 --master-nodes="rally-node-0" --seed-hosts="127.0.0.1:29300" --kill-running-processes --source-build-method=docker`

### Note for reviewers

Apple Silicon equipped Macs can't run ITs:
  - (https://github.com/elastic/rally/pull/1498)
  - https://github.com/elastic/rally/pull/1571


FYI:  The actor system is bugged on MacOS and will hang when running `esrally race --revision=...`, you can work around this by commenting out line `1342` in `.venv/lib/python3.8/site-packages/thespian/system/transport/TCPTransport.py`.
```
#lsock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
```