### PR TITLE
Stop trying to test Elasticsearch 6.8.0 on ARM

### DIFF
--- a/it/__init__.py
+++ b/it/__init__.py
@@ -19,6 +19,7 @@ import errno
 import functools
 import json
 import os
+import platform
 import random
 import socket
 import subprocess
@@ -30,7 +31,10 @@ from esrally import client, config, version
 from esrally.utils import process
 
 CONFIG_NAMES = ["in-memory-it", "es-it"]
-DISTRIBUTIONS = ["6.8.0", "8.4.0"]
+DISTRIBUTIONS = ["8.4.0"]
+# There are no ARM distribution artefacts for 6.8.0, which can't be tested on Apple Silicon
+if platform.machine() != "arm64":
+    DISTRIBUTIONS.insert(0, "6.8.0")
 TRACKS = ["geonames", "nyc_taxis", "http_logs", "nested"]
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -198,7 +198,7 @@ class TestCluster:
 
 
 class EsMetricsStore:
-    VERSION = "7.6.0"
+    VERSION = "7.17.0"
 
     def __init__(self):
         self.cluster = TestCluster("in-memory-it")


### PR DESCRIPTION
This will allow developers with Apple Silicon hardware to still run
integration tests.