### PR TITLE
[docs] Mention that create-snapshot is an administrative operation

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2377,6 +2377,8 @@ Properties
     It's not recommended to rely on ``wait-for-completion=true``. Instead you should keep the default value (``False``) and use an additional ``wait-for-snapshot-create`` operation in the next step.
     This is mandatory on `Elastic Cloud <https://www.elastic.co/cloud>`_ or environments where Elasticsearch is connected via intermediate network components, such as proxies, that may terminate the blocking connection after a timeout.
 
+This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.
+
 Meta-data
 """""""""
 


### PR DESCRIPTION
Docs are currently missing that create-snapshot is an administrative operation.