### PR TITLE
Include a new downsampling operation

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3070,13 +3070,13 @@ Properties
 
 **Example**
 
-Run a downsampling operation aggregating data in the source index (test-source-index) and creating a new target index (test-target-index) applying an aggregation
+Executes a downsampling operation aggregating data in the source index (test-source-index) and creating a new target index (test-target-index) applying an aggregation
 interval of 1 minute on the @timestamp field::
 
     {
-      "name": "downsampling",
+      "name": "downsample",
       "operation": {
-      "operation-type": "downsampling",
+      "operation-type": "downsample",
       "body": {
         "fixed-interval": "1m",
         "source-index": "test-source-index",

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3065,10 +3065,9 @@ Executes a downsampling operation on an index producing a new index whose data i
 Properties
 """"""""""
 
-* ``fixed_interval``: The aggregation interval key defined as in `https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals`.
-* ``source-index``: The index containing data to aggregate which includes a ``@timestamp`` field. Note that this index should be marked read-only prior to the execution of this operation.
-* ``target-index``: Tne new target index created by the downsampling operation and including aggregated data.
-
+* ``fixed_interval`` (optional, defaults to ``1h``): The aggregation interval key defined as in `https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals`.
+* ``source-index`` (optional, defaults to ``tsdb-index``): The index containing data to aggregate which includes a ``@timestamp`` field. Note that this index should be marked read-only prior to the execution of this operation.
+* ``target-index`` (optional, defaults to ``{source-index}-{fixed-interval}``): Tne new target index created by the downsampling operation and including aggregated data.
 
 **Example**
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3056,6 +3056,41 @@ The following meta data is always returned:
 * ``weight``: The number of fetched pages. Should always equal to the ``pages`` parameter.
 * ``unit``: The unit in which to interpret ``weight``. Always "ops".
 
+downsampling
+~~~~~~~~~~~~~~~~~~~
+
+Executes a downsampling operation on an index producing a new index whose data is aggregated on the @timestamp field.
+
+
+Properties
+""""""""""
+
+* ``body`` (mandatory): The ``body`` property must contain the ``fixed_interval`` key defined as in 
+`https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals`
+the ``source-index`` and the ``target-index``. The source index is an existing index which includes a ``@timestamp`` field. Write operations
+to the source index must be disabled. Tne target index is a new index that is created by the downsamplig operation and including aggregated data.
+
+**Example**
+
+Run a downsampling operation aggregating data in the source index (test-source-index) and creating a new target index (test-target-index) applying an aggregation
+interval of 1 minute on the @timestamp field.
+
+  {
+    "name": "downsampling",
+    "operation": {
+    "operation-type": "downsampling",
+    "body": {
+      "fixed-interval": "1m",
+      "source-index": "test-source-index",
+      "target-index": "tsdb-target-index"
+    }
+  }
+
+Meta-data
+"""""""""
+
+The operation returns no meta-data.
+
 field-caps
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3065,27 +3065,24 @@ Executes a downsampling operation on an index producing a new index whose data i
 Properties
 """"""""""
 
-* ``body`` (mandatory): The ``body`` property must contain the ``fixed_interval`` key defined as in 
-`https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals`
-the ``source-index`` and the ``target-index``. The source index is an existing index which includes a ``@timestamp`` field. Write operations
-to the source index must be disabled. Tne target index is a new index that is created by the downsamplig operation and including aggregated data.
+* ``body`` (mandatory): The ``body`` property must contain the ``fixed_interval`` key defined as in `https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals` the ``source-index`` and the ``target-index``. The source index is an existing index which includes a ``@timestamp`` field. Write operations to the source index must be disabled. Tne target index is a new index that is created by the downsamplig operation and including aggregated data.
 
 
 **Example**
 
 Run a downsampling operation aggregating data in the source index (test-source-index) and creating a new target index (test-target-index) applying an aggregation
-interval of 1 minute on the @timestamp field.
+interval of 1 minute on the @timestamp field::
 
-{
-  "name": "downsampling",
-  "operation": {
-  "operation-type": "downsampling",
-  "body": {
-    "fixed-interval": "1m",
-    "source-index": "test-source-index",
-    "target-index": "tsdb-target-index"
-  }
-}
+    {
+      "name": "downsampling",
+      "operation": {
+      "operation-type": "downsampling",
+      "body": {
+        "fixed-interval": "1m",
+        "source-index": "test-source-index",
+        "target-index": "tsdb-target-index"
+      }
+    }
 
 Meta-data
 """""""""

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3056,7 +3056,7 @@ The following meta data is always returned:
 * ``weight``: The number of fetched pages. Should always equal to the ``pages`` parameter.
 * ``unit``: The unit in which to interpret ``weight``. Always "ops".
 
-downsampling
+downsample
 ~~~~~~~~~~~~~~~~~~~
 
 Executes a downsampling operation on an index producing a new index whose data is aggregated on the @timestamp field.

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3065,7 +3065,9 @@ Executes a downsampling operation on an index producing a new index whose data i
 Properties
 """"""""""
 
-* ``body`` (mandatory): The ``body`` property must contain the ``fixed_interval`` key defined as in `https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals` the ``source-index`` and the ``target-index``. The source index is an existing index which includes a ``@timestamp`` field. Write operations to the source index must be disabled. Tne target index is a new index that is created by the downsamplig operation and including aggregated data.
+* ``fixed_interval``: The aggregation interval key defined as in `https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals`.
+* ``source-index``: The read-only index containing data to aggregate which includes a ``@timestamp`` field.
+* ``target-index``: Tne new target index created by the downsamplig operation and including aggregated data.
 
 
 **Example**
@@ -3077,11 +3079,9 @@ interval of 1 minute on the @timestamp field::
       "name": "downsample",
       "operation": {
       "operation-type": "downsample",
-      "body": {
-        "fixed-interval": "1m",
-        "source-index": "test-source-index",
-        "target-index": "tsdb-target-index"
-      }
+      "fixed-interval": "1m",
+      "source-index": "test-source-index",
+      "target-index": "tsdb-target-index"
     }
 
 Meta-data

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3057,7 +3057,7 @@ The following meta data is always returned:
 * ``unit``: The unit in which to interpret ``weight``. Always "ops".
 
 downsample
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
 Executes a downsampling operation on an index producing a new index whose data is aggregated on the @timestamp field.
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3066,7 +3066,7 @@ Properties
 """"""""""
 
 * ``fixed_interval`` (optional, defaults to ``1h``): The aggregation interval key defined as in `https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals`.
-* ``source-index`` (optional, defaults to ``tsdb-index``): The index containing data to aggregate which includes a ``@timestamp`` field. Note that this index should be marked read-only prior to the execution of this operation.
+* ``source-index`` (optional): The index containing data to aggregate which includes a ``@timestamp`` field. Note that this index should be marked read-only prior to the execution of this operation. If there is only one index defined in the ``indices`` of the track definition, that will be used as the default.
 * ``target-index`` (optional, defaults to ``{source-index}-{fixed-interval}``): Tne new target index created by the downsampling operation and including aggregated data.
 
 **Example**

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3066,7 +3066,7 @@ Properties
 """"""""""
 
 * ``fixed_interval``: The aggregation interval key defined as in `https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals`.
-* ``source-index``: The read-only index containing data to aggregate which includes a ``@timestamp`` field.
+* ``source-index``: The index containing data to aggregate which includes a ``@timestamp`` field. Note that this index should be marked read-only prior to the execution of this operation.
 * ``target-index``: Tne new target index created by the downsampling operation and including aggregated data.
 
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3070,21 +3070,22 @@ Properties
 the ``source-index`` and the ``target-index``. The source index is an existing index which includes a ``@timestamp`` field. Write operations
 to the source index must be disabled. Tne target index is a new index that is created by the downsamplig operation and including aggregated data.
 
+
 **Example**
 
 Run a downsampling operation aggregating data in the source index (test-source-index) and creating a new target index (test-target-index) applying an aggregation
 interval of 1 minute on the @timestamp field.
 
-  {
-    "name": "downsampling",
-    "operation": {
-    "operation-type": "downsampling",
-    "body": {
-      "fixed-interval": "1m",
-      "source-index": "test-source-index",
-      "target-index": "tsdb-target-index"
-    }
+{
+  "name": "downsampling",
+  "operation": {
+  "operation-type": "downsampling",
+  "body": {
+    "fixed-interval": "1m",
+    "source-index": "test-source-index",
+    "target-index": "tsdb-target-index"
   }
+}
 
 Meta-data
 """""""""

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3078,10 +3078,11 @@ interval of 1 minute on the @timestamp field::
     {
       "name": "downsample",
       "operation": {
-      "operation-type": "downsample",
-      "fixed-interval": "1m",
-      "source-index": "test-source-index",
-      "target-index": "tsdb-target-index"
+        "operation-type": "downsample",
+        "fixed-interval": "1m",
+        "source-index": "test-source-index",
+        "target-index": "tsdb-target-index"
+      }
     }
 
 Meta-data

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3067,7 +3067,7 @@ Properties
 
 * ``fixed_interval``: The aggregation interval key defined as in `https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals`.
 * ``source-index``: The read-only index containing data to aggregate which includes a ``@timestamp`` field.
-* ``target-index``: Tne new target index created by the downsamplig operation and including aggregated data.
+* ``target-index``: Tne new target index created by the downsampling operation and including aggregated data.
 
 
 **Example**

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2715,7 +2715,7 @@ class Downsampling(Runner):
                 "Add it to your parameter source and try again."
             )
 
-        path = "/" + source_index + "/_rollup/" + target_index
+        path = f"/{source_index}/_rollup/{target_index}"
 
         await es.perform_request(
             method="POST", path=path, body={"fixed_interval": fixed_interval}, params=request_params, headers=request_headers

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2715,7 +2715,7 @@ class Downsampling(Runner):
                 "Add it to your parameter source and try again."
             )
 
-        path = f"/{source_index}/_rollup/{target_index}"
+        path = f"/{source_index}/_downsample/{target_index}"
 
         await es.perform_request(
             method="POST", path=path, body={"fixed_interval": fixed_interval}, params=request_params, headers=request_headers

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1370,6 +1370,7 @@ class DeleteIndex(Runner):
         try:
             for index_name in indices:
                 if not only_if_exists:
+                    request_params["ignore_unavailable"] = "true"
                     await es.indices.delete(index=index_name, params=request_params)
                     ops += 1
                 elif only_if_exists and await es.indices.exists(index=index_name):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -60,7 +60,7 @@ def register_default_runners():
     register_runner(track.OperationType.ClosePointInTime, ClosePointInTime(), async_runner=True)
     register_runner(track.OperationType.Sql, Sql(), async_runner=True)
     register_runner(track.OperationType.FieldCaps, FieldCaps(), async_runner=True)
-    register_runner(track.OperationType.Downsampling, Downsampling(), async_runner=True)
+    register_runner(track.OperationType.Downsample, Downsample(), async_runner=True)
 
     # This is an administrative operation but there is no need for a retry here as we don't issue a request
     register_runner(track.OperationType.Sleep, Sleep(), async_runner=True)
@@ -2684,7 +2684,7 @@ class Sql(Runner):
         return "sql"
 
 
-class Downsampling(Runner):
+class Downsample(Runner):
     """
     Executes a downsampling operation creating the target index and aggregating data in the source index on the @timestamp field.
     """
@@ -2697,21 +2697,21 @@ class Downsampling(Runner):
         fixed_interval = body.get("fixed-interval")
         if fixed_interval is None:
             raise exceptions.DataError(
-                "Parameter source for operation 'downsampling' did not provide the mandatory parameter 'body.fixed-interval'. "
+                "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.fixed-interval'. "
                 "Add it to your parameter source and try again."
             )
 
         source_index = body.get("source-index")
         if source_index is None:
             raise exceptions.DataError(
-                "Parameter source for operation 'downsampling' did not provide the mandatory parameter 'body.source-index'. "
+                "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.source-index'. "
                 "Add it to your parameter source and try again."
             )
 
         target_index = body.get("target-index")
         if target_index is None:
             raise exceptions.DataError(
-                "Parameter source for operation 'downsampling' did not provide the mandatory parameter 'body.target-index'. "
+                "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.target-index'. "
                 "Add it to your parameter source and try again."
             )
 
@@ -2724,7 +2724,7 @@ class Downsampling(Runner):
         return {"weight": 1, "unit": "ops", "success": True}
 
     def __repr__(self, *args, **kwargs):
-        return "downsampling"
+        return "downsample"
 
 
 class FieldCaps(Runner):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1370,7 +1370,6 @@ class DeleteIndex(Runner):
         try:
             for index_name in indices:
                 if not only_if_exists:
-                    request_params["ignore_unavailable"] = "true"
                     await es.indices.delete(index=index_name, params=request_params)
                     ops += 1
                 elif only_if_exists:

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2692,23 +2692,22 @@ class Downsample(Runner):
     async def __call__(self, es, params):
 
         request_params, request_headers = self._transport_request_params(params)
-        body = mandatory(params, "body", self)
 
-        fixed_interval = body.get("fixed-interval")
+        fixed_interval = mandatory(params, "fixed-interval", self)
         if fixed_interval is None:
             raise exceptions.DataError(
                 "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.fixed-interval'. "
                 "Add it to your parameter source and try again."
             )
 
-        source_index = body.get("source-index")
+        source_index = mandatory(params, "source-index", self)
         if source_index is None:
             raise exceptions.DataError(
                 "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.source-index'. "
                 "Add it to your parameter source and try again."
             )
 
-        target_index = body.get("target-index")
+        target_index = mandatory(params, "target-index", self)
         if target_index is None:
             raise exceptions.DataError(
                 "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.target-index'. "

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2696,21 +2696,21 @@ class Downsample(Runner):
         fixed_interval = mandatory(params, "fixed-interval", self)
         if fixed_interval is None:
             raise exceptions.DataError(
-                "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.fixed-interval'. "
+                "Parameter source for operation 'downsample' did not provide the mandatory parameter 'fixed-interval'. "
                 "Add it to your parameter source and try again."
             )
 
         source_index = mandatory(params, "source-index", self)
         if source_index is None:
             raise exceptions.DataError(
-                "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.source-index'. "
+                "Parameter source for operation 'downsample' did not provide the mandatory parameter 'source-index'. "
                 "Add it to your parameter source and try again."
             )
 
         target_index = mandatory(params, "target-index", self)
         if target_index is None:
             raise exceptions.DataError(
-                "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.target-index'. "
+                "Parameter source for operation 'downsample' did not provide the mandatory parameter 'target-index'. "
                 "Add it to your parameter source and try again."
             )
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -60,7 +60,6 @@ def register_default_runners():
     register_runner(track.OperationType.ClosePointInTime, ClosePointInTime(), async_runner=True)
     register_runner(track.OperationType.Sql, Sql(), async_runner=True)
     register_runner(track.OperationType.FieldCaps, FieldCaps(), async_runner=True)
-    register_runner(track.OperationType.Downsample, Downsample(), async_runner=True)
 
     # This is an administrative operation but there is no need for a retry here as we don't issue a request
     register_runner(track.OperationType.Sleep, Sleep(), async_runner=True)
@@ -103,6 +102,7 @@ def register_default_runners():
     register_runner(track.OperationType.TransformStats, Retry(TransformStats()), async_runner=True)
     register_runner(track.OperationType.CreateIlmPolicy, Retry(CreateIlmPolicy()), async_runner=True)
     register_runner(track.OperationType.DeleteIlmPolicy, Retry(DeleteIlmPolicy()), async_runner=True)
+    register_runner(track.OperationType.Downsample, Retry(Downsample()), async_runner=True)
 
 
 def runner_for(operation_type):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -66,6 +66,7 @@ def register_default_runners():
     # these requests should not be retried as they are not idempotent
     register_runner(track.OperationType.CreateSnapshot, CreateSnapshot(), async_runner=True)
     register_runner(track.OperationType.RestoreSnapshot, RestoreSnapshot(), async_runner=True)
+    register_runner(track.OperationType.Downsample, Downsample(), async_runner=True)
     # We treat the following as administrative commands and thus already start to wrap them in a retry.
     register_runner(track.OperationType.ClusterHealth, Retry(ClusterHealth()), async_runner=True)
     register_runner(track.OperationType.PutPipeline, Retry(PutPipeline()), async_runner=True)
@@ -102,7 +103,6 @@ def register_default_runners():
     register_runner(track.OperationType.TransformStats, Retry(TransformStats()), async_runner=True)
     register_runner(track.OperationType.CreateIlmPolicy, Retry(CreateIlmPolicy()), async_runner=True)
     register_runner(track.OperationType.DeleteIlmPolicy, Retry(DeleteIlmPolicy()), async_runner=True)
-    register_runner(track.OperationType.Downsample, Retry(Downsample()), async_runner=True)
 
 
 def runner_for(operation_type):

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -842,7 +842,7 @@ class DownsampleParamSource(ParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
         self._fixed_interval = params.get("fixed-interval", "1h")
-        self._source_index = params.get("source-index", "tsdb-index")
+        self._source_index = params.get_target(track, params)
         self._target_index = params.get("target-index", f"{self._source_index}-{self._fixed_interval}")
 
     def params(self):

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -842,6 +842,7 @@ class DownsampleParamSource(ParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
         self._fixed_interval = params.get("fixed-interval", "1h")
+        params["index"] = params.get("source-index")
         self._source_index = get_target(track, params)
         self._target_index = params.get("target-index", f"{self._source_index}-{self._fixed_interval}")
 

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -842,7 +842,7 @@ class DownsampleParamSource(ParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
         self._fixed_interval = params.get("fixed-interval", "1h")
-        self._source_index = params.get_target(track, params)
+        self._source_index = get_target(track, params)
         self._target_index = params.get("target-index", f"{self._source_index}-{self._fixed_interval}")
 
     def params(self):

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -838,6 +838,19 @@ class ForceMergeParamSource(ParamSource):
         return parsed_params
 
 
+class DownsampleParamSource(ParamSource):
+    def __init__(self, track, params, **kwargs):
+        super().__init__(track, params, **kwargs)
+        self._fixed_interval = params.get("fixed-interval", "1h")
+        self._source_index = params.get("source-index", "tsdb-index")
+        self._target_index = params.get("target-index", f"{self._source_index}-{self._fixed_interval}")
+
+    def params(self):
+        parsed_params = {"fixed-interval": self._fixed_interval, "source-index": self._source_index, "target-index": self._target_index}
+        parsed_params.update(self._client_params())
+        return parsed_params
+
+
 def get_target(track, params):
     if len(track.indices) == 1:
         default_target = track.indices[0].name
@@ -1342,6 +1355,7 @@ register_param_source_for_operation(track.OperationType.CreateComposableTemplate
 register_param_source_for_operation(track.OperationType.DeleteComposableTemplate, DeleteComposableTemplateParamSource)
 register_param_source_for_operation(track.OperationType.Sleep, SleepParamSource)
 register_param_source_for_operation(track.OperationType.ForceMerge, ForceMergeParamSource)
+register_param_source_for_operation(track.OperationType.Downsample, DownsampleParamSource)
 
 # Also register by name, so users can use it too
 register_param_source_for_name("file-reader", BulkIndexParamSource)

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -687,7 +687,7 @@ class OperationType(Enum):
     FieldCaps = 17
     CompositeAgg = 18
     WaitForCurrentSnapshotsCreate = 19
-    Downsampling = 20
+    Downsample = 20
 
     # administrative actions
     ForceMerge = 1001
@@ -853,8 +853,8 @@ class OperationType(Enum):
             return OperationType.Sql
         elif v == "field-caps":
             return OperationType.FieldCaps
-        elif v == "downsampling":
-            return OperationType.Downsampling
+        elif v == "downsample":
+            return OperationType.Downsample
         else:
             raise KeyError(f"No enum value for [{v}]")
 

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -687,6 +687,7 @@ class OperationType(Enum):
     FieldCaps = 17
     CompositeAgg = 18
     WaitForCurrentSnapshotsCreate = 19
+    Downsample = 20
 
     # administrative actions
     ForceMerge = 1001
@@ -725,7 +726,6 @@ class OperationType(Enum):
     TransformStats = 1034
     CreateIlmPolicy = 1035
     DeleteIlmPolicy = 1036
-    Downsample = 1037
 
     @property
     def admin_op(self):

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -687,6 +687,7 @@ class OperationType(Enum):
     FieldCaps = 17
     CompositeAgg = 18
     WaitForCurrentSnapshotsCreate = 19
+    Downsampling = 20
 
     # administrative actions
     ForceMerge = 1001
@@ -852,6 +853,8 @@ class OperationType(Enum):
             return OperationType.Sql
         elif v == "field-caps":
             return OperationType.FieldCaps
+        elif v == "downsampling":
+            return OperationType.Downsampling
         else:
             raise KeyError(f"No enum value for [{v}]")
 

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -687,7 +687,6 @@ class OperationType(Enum):
     FieldCaps = 17
     CompositeAgg = 18
     WaitForCurrentSnapshotsCreate = 19
-    Downsample = 20
 
     # administrative actions
     ForceMerge = 1001
@@ -726,6 +725,7 @@ class OperationType(Enum):
     TransformStats = 1034
     CreateIlmPolicy = 1035
     DeleteIlmPolicy = 1036
+    Downsample = 1037
 
     @property
     def admin_op(self):

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -5301,8 +5301,8 @@ class TestDownsampleRunner:
 
         es.perform_request.assert_awaited_once_with(
             method="POST",
-            path="/source-index/_rollup/target-index",
-            body={"fixed_interval": params.get("body").get("fixed-interval")},
+            path="/source-index/_downsample/target-index",
+            body={"fixed_interval": params.get("fixed-interval")},
             params={},
             headers={},
         )

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -5289,7 +5289,9 @@ class TestDownsampleRunner:
         sql_runner = runner.Downsample()
         params = {
             "operation-type": "downsample",
-            "body": {"fixed-interval": "1d", "source-index": "source-index", "target-index": "target-index"},
+            "fixed-interval": "1d",
+            "source-index": "source-index",
+            "target-index": "target-index",
         }
 
         async with sql_runner:
@@ -5307,22 +5309,9 @@ class TestDownsampleRunner:
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
-    async def test_mandatory_body_param(self, es):
-        sql_runner = runner.Dwnsample()
-        params = {"operation-type": "downsample"}
-
-        with pytest.raises(exceptions.DataError) as exc:
-            await sql_runner(es, params)
-        assert exc.value.args[0] == (
-            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body'. "
-            "Add it to your parameter source and try again."
-        )
-
-    @mock.patch("elasticsearch.Elasticsearch")
-    @pytest.mark.asyncio
     async def test_mandatory_fixed_interval_in_body_param(self, es):
         sql_runner = runner.Downsample()
-        params = {"operation-type": "downsample", "body": {"source-index": "source-index", "target-index": "target-index"}}
+        params = {"operation-type": "downsample", "source-index": "source-index", "target-index": "target-index"}
 
         with pytest.raises(exceptions.DataError) as exc:
             await sql_runner(es, params)
@@ -5335,7 +5324,7 @@ class TestDownsampleRunner:
     @pytest.mark.asyncio
     async def test_mandatory_source_index_in_body_param(self, es):
         sql_runner = runner.Downsample()
-        params = {"operation-type": "downsample", "body": {"fixed-interval": "1d", "target-index": "target-index"}}
+        params = {"operation-type": "downsample", "fixed-interval": "1d", "target-index": "target-index"}
 
         with pytest.raises(exceptions.DataError) as exc:
             await sql_runner(es, params)
@@ -5348,7 +5337,7 @@ class TestDownsampleRunner:
     @pytest.mark.asyncio
     async def test_mandatory_target_index_in_body_param(self, es):
         sql_runner = runner.Downsample()
-        params = {"operation-type": "downsample", "body": {"fixed-interval": "1d", "source-index": "source-index"}}
+        params = {"operation-type": "downsample", "fixed-interval": "1d", "source-index": "source-index"}
 
         with pytest.raises(exceptions.DataError) as exc:
             await sql_runner(es, params)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -5316,7 +5316,7 @@ class TestDownsampleRunner:
         with pytest.raises(exceptions.DataError) as exc:
             await sql_runner(es, params)
         assert exc.value.args[0] == (
-            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.fixed-interval'. "
+            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'fixed-interval'. "
             "Add it to your parameter source and try again."
         )
 
@@ -5329,7 +5329,7 @@ class TestDownsampleRunner:
         with pytest.raises(exceptions.DataError) as exc:
             await sql_runner(es, params)
         assert exc.value.args[0] == (
-            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.source-index'. "
+            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'source-index'. "
             "Add it to your parameter source and try again."
         )
 
@@ -5342,7 +5342,7 @@ class TestDownsampleRunner:
         with pytest.raises(exceptions.DataError) as exc:
             await sql_runner(es, params)
         assert exc.value.args[0] == (
-            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.target-index'. "
+            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'target-index'. "
             "Add it to your parameter source and try again."
         )
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -5278,17 +5278,17 @@ class TestSqlRunner:
         )
 
 
-class TestDownsamplingRunner:
+class TestDownsampleRunner:
     default_response = {}
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
-    async def test_index_downsampling(self, es):
+    async def test_index_downsample(self, es):
         es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
 
-        sql_runner = runner.Downsampling()
+        sql_runner = runner.Downsample()
         params = {
-            "operation-type": "downsampling",
+            "operation-type": "downsample",
             "body": {"fixed-interval": "1d", "source-index": "source-index", "target-index": "target-index"},
         }
 
@@ -5308,52 +5308,52 @@ class TestDownsamplingRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_mandatory_body_param(self, es):
-        sql_runner = runner.Downsampling()
-        params = {"operation-type": "downsampling"}
+        sql_runner = runner.Dwnsample()
+        params = {"operation-type": "downsample"}
 
         with pytest.raises(exceptions.DataError) as exc:
             await sql_runner(es, params)
         assert exc.value.args[0] == (
-            "Parameter source for operation 'downsampling' did not provide the mandatory parameter 'body'. "
+            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body'. "
             "Add it to your parameter source and try again."
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_mandatory_fixed_interval_in_body_param(self, es):
-        sql_runner = runner.Downsampling()
-        params = {"operation-type": "downsampling", "body": {"source-index": "source-index", "downsampling-index": "downsampling-index"}}
+        sql_runner = runner.Downsample()
+        params = {"operation-type": "downsample", "body": {"source-index": "source-index", "target-index": "target-index"}}
 
         with pytest.raises(exceptions.DataError) as exc:
             await sql_runner(es, params)
         assert exc.value.args[0] == (
-            "Parameter source for operation 'downsampling' did not provide the mandatory parameter 'body.fixed-interval'. "
+            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.fixed-interval'. "
             "Add it to your parameter source and try again."
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_mandatory_source_index_in_body_param(self, es):
-        sql_runner = runner.Downsampling()
-        params = {"operation-type": "downsampling", "body": {"fixed-interval": "1d", "target-index": "target-index"}}
+        sql_runner = runner.Downsample()
+        params = {"operation-type": "downsample", "body": {"fixed-interval": "1d", "target-index": "target-index"}}
 
         with pytest.raises(exceptions.DataError) as exc:
             await sql_runner(es, params)
         assert exc.value.args[0] == (
-            "Parameter source for operation 'downsampling' did not provide the mandatory parameter 'body.source-index'. "
+            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.source-index'. "
             "Add it to your parameter source and try again."
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_mandatory_target_index_in_body_param(self, es):
-        sql_runner = runner.Downsampling()
-        params = {"operation-type": "downsampling", "body": {"fixed-interval": "1d", "source-index": "source-index"}}
+        sql_runner = runner.Downsample()
+        params = {"operation-type": "downsample", "body": {"fixed-interval": "1d", "source-index": "source-index"}}
 
         with pytest.raises(exceptions.DataError) as exc:
             await sql_runner(es, params)
         assert exc.value.args[0] == (
-            "Parameter source for operation 'downsampling' did not provide the mandatory parameter 'body.target-index'. "
+            "Parameter source for operation 'downsample' did not provide the mandatory parameter 'body.target-index'. "
             "Add it to your parameter source and try again."
         )
 

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2778,7 +2778,7 @@ class TestDownsampleParamSource:
     def test_downsample_all_params(self):
         source = params.DownsampleParamSource(
             track.Track(name="unit-test"),
-            params={"index": "test-source-index", "target-index": "test-target-index", "fixed-interval": "1m"},
+            params={"source-index": "test-source-index", "target-index": "test-target-index", "fixed-interval": "1m"},
         )
 
         p = source.params()
@@ -2790,7 +2790,7 @@ class TestDownsampleParamSource:
     def test_downsample_target_index_param(self):
         source = params.DownsampleParamSource(
             track.Track(name="unit-test"),
-            params={"index": "tsdb", "fixed-interval": "1m"},
+            params={"source-index": "tsdb", "fixed-interval": "1m"},
         )
 
         p = source.params()

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2787,17 +2787,29 @@ class TestDownsampleParamSource:
         assert p["source-index"] == "test-source-index"
         assert p["target-index"] == "test-target-index"
 
-    def test_downsample_target_index_param(self):
+    def test_downsample_default_index_param(self):
         source = params.DownsampleParamSource(
-            track.Track(name="unit-test"),
-            params={"source-index": "tsdb", "fixed-interval": "1m"},
+            track.Track(name="unit-test", indices=[track.Index(name="test-source-index", body="index.json")]),
+            params={"fixed-interval": "1m", "target-index": "test-target-index"},
         )
 
         p = source.params()
 
         assert p["fixed-interval"] == "1m"
-        assert p["source-index"] == "tsdb"
-        assert p["target-index"] == "tsdb-1m"
+        assert p["source-index"] == "test-source-index"
+        assert p["target-index"] == "test-target-index"
+
+    def test_downsample_source_index_override_default_index_param(self):
+        source = params.DownsampleParamSource(
+            track.Track(name="unit-test", indices=[track.Index(name="test-source-index", body="index.json")]),
+            params={"source-index": "another-index", "fixed-interval": "1m", "target-index": "test-target-index"},
+        )
+
+        p = source.params()
+
+        assert p["fixed-interval"] == "1m"
+        assert p["source-index"] == "another-index"
+        assert p["target-index"] == "test-target-index"
 
     def test_downsample_empty_params(self):
         source = params.DownsampleParamSource(

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2772,3 +2772,41 @@ class TestForceMergeParamSource:
         assert p["request-timeout"] == 30
         assert p["max-num-segments"] == 1
         assert p["mode"] == "polling"
+
+
+class TestDownsampleParamSource:
+    def test_downsample_all_params(self):
+        source = params.DownsampleParamSource(
+            track.Track(name="unit-test"),
+            params={"source-index": "test-source-index", "target-index": "test-target-index", "fixed-interval": "1m"},
+        )
+
+        p = source.params()
+
+        assert p["fixed-interval"] == "1m"
+        assert p["source-index"] == "test-source-index"
+        assert p["target-index"] == "test-target-index"
+
+    def test_downsample_target_index_param(self):
+        source = params.DownsampleParamSource(
+            track.Track(name="unit-test"),
+            params={"source-index": "tsdb", "fixed-interval": "1m"},
+        )
+
+        p = source.params()
+
+        assert p["fixed-interval"] == "1m"
+        assert p["source-index"] == "tsdb"
+        assert p["target-index"] == "tsdb-1m"
+
+    def test_downsample_empty_params(self):
+        source = params.DownsampleParamSource(
+            track.Track(name="unit-test"),
+            params={},
+        )
+
+        p = source.params()
+
+        assert p["fixed-interval"] != ""
+        assert p["source-index"] != ""
+        assert p["target-index"] == f"{p['source-index']}-{p['fixed-interval']}"

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2778,7 +2778,7 @@ class TestDownsampleParamSource:
     def test_downsample_all_params(self):
         source = params.DownsampleParamSource(
             track.Track(name="unit-test"),
-            params={"source-index": "test-source-index", "target-index": "test-target-index", "fixed-interval": "1m"},
+            params={"index": "test-source-index", "target-index": "test-target-index", "fixed-interval": "1m"},
         )
 
         p = source.params()
@@ -2790,7 +2790,7 @@ class TestDownsampleParamSource:
     def test_downsample_target_index_param(self):
         source = params.DownsampleParamSource(
             track.Track(name="unit-test"),
-            params={"source-index": "tsdb", "fixed-interval": "1m"},
+            params={"index": "tsdb", "fixed-interval": "1m"},
         )
 
         p = source.params()

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2807,6 +2807,6 @@ class TestDownsampleParamSource:
 
         p = source.params()
 
-        assert p["fixed-interval"] != ""
+        assert p["fixed-interval"] == "1h"
         assert p["source-index"] != ""
         assert p["target-index"] == f"{p['source-index']}-{p['fixed-interval']}"

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2820,5 +2820,4 @@ class TestDownsampleParamSource:
         p = source.params()
 
         assert p["fixed-interval"] == "1h"
-        assert p["source-index"] != ""
         assert p["target-index"] == f"{p['source-index']}-{p['fixed-interval']}"


### PR DESCRIPTION
The new downsampling operation allows Rally to hit the Elasticsearch  `/<source-index>/_downsample/<target-index>` endpoint to start a downsampling operation on the source index. Expected parameters include:

* `fixed_interval`: the aggregation granularity using the same interval definition used by date histograms
* `source-index`: the index to downsample applying the aggregation
* `target-index`: the index created as a result of the aggregation on the timestamp field

Example: aggregate the index `test-source-index` on the timestamp field using a 1 minute interval and store the result in a new index called `test-target-index`.

```
{
  "name": "downsample",
  "operation": {
    "operation-type": "downsample",
    "fixed-interval": "1m",
    "source-index": "test-source-index",
    "target-index": "test-target-index"
  }
}
```