### PR TITLE
Correctly retry HTTP downloads after incomplete reads

### DIFF
--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -218,10 +218,8 @@ def download_http(url, local_path, expected_size_in_bytes=None, progress_indicat
         except urllib3.exceptions.ProtocolError as exc:
             if i == HTTP_DOWNLOAD_RETRIES:
                 raise
-            if isinstance(exc.args[1], urllib3.exceptions.IncompleteRead):
-                logger.warning("Retrying after %s", exc)
-                continue
-            raise
+            logger.warning("Retrying after %s", exc)
+            continue
 
 
 def add_url_param_elastic_no_kpi(url):

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -18,6 +18,7 @@ import functools
 import logging
 import os
 import socket
+import time
 import urllib.error
 from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 
@@ -210,7 +211,7 @@ def _download_http(url, local_path, expected_size_in_bytes=None, progress_indica
         return expected_size_in_bytes
 
 
-def download_http(url, local_path, expected_size_in_bytes=None, progress_indicator=None):
+def download_http(url, local_path, expected_size_in_bytes=None, progress_indicator=None, *, sleep=time.sleep):
     logger = logging.getLogger(__name__)
     for i in range(HTTP_DOWNLOAD_RETRIES + 1):
         try:
@@ -219,6 +220,7 @@ def download_http(url, local_path, expected_size_in_bytes=None, progress_indicat
             if i == HTTP_DOWNLOAD_RETRIES:
                 raise
             logger.warning("Retrying after %s", exc)
+            sleep(5)
             continue
 
 

--- a/tests/utils/net_test.py
+++ b/tests/utils/net_test.py
@@ -18,6 +18,8 @@ import random
 from unittest import mock
 
 import pytest
+import urllib3.exceptions
+from werkzeug.wrappers import Response
 
 from esrally.utils import net
 
@@ -115,3 +117,44 @@ class TestNetUtils:
         import google.auth
 
         assert True
+
+
+def test_download_http(httpserver, tmp_path):
+    data = b"x" * 10
+    httpserver.expect_request("/foobar").respond_with_data(data)
+    local_path = str(tmp_path / "file.txt")
+
+    net.download_http(httpserver.url_for("/foobar"), local_path=local_path)
+    with open(local_path, "rb") as f:
+        assert f.read() == data
+
+
+def test_download_http_retry_incomplete_read_retry_failure(httpserver, tmp_path):
+    data = b"x" * 10
+    short_resp = Response(headers={"Content-Length": 100, "foo": "bar"})
+    short_resp.automatically_set_content_length = False
+    short_resp.set_data(data)
+
+    httpserver.expect_request("/foobar").respond_with_response(short_resp)
+    local_path = str(tmp_path / "file.txt")
+
+    with pytest.raises(urllib3.exceptions.ProtocolError):
+        net.download_http(httpserver.url_for("/foobar"), local_path=local_path)
+
+
+def test_download_http_retry_incomplete_read_retry_success(httpserver, tmp_path):
+    data = b"x" * 10
+    short_resp = Response(headers={"Content-Length": 100, "foo": "bar"})
+    short_resp.automatically_set_content_length = False
+    short_resp.set_data(data)
+
+    # missing data for the first 10 tries
+    for _i in range(10):
+        httpserver.expect_ordered_request("/foobar").respond_with_response(short_resp)
+    # finally, good content-length
+    httpserver.expect_ordered_request("/foobar").respond_with_data(data)
+
+    local_path = str(tmp_path / "file.txt")
+    net.download_http(httpserver.url_for("/foobar"), local_path=local_path)
+    with open(local_path, "rb") as f:
+        assert f.read() == data

--- a/tests/utils/net_test.py
+++ b/tests/utils/net_test.py
@@ -124,7 +124,11 @@ def test_download_http(httpserver, tmp_path):
     httpserver.expect_request("/foobar").respond_with_data(data)
     local_path = str(tmp_path / "file.txt")
 
-    net.download_http(httpserver.url_for("/foobar"), local_path=local_path)
+    def raise_error(seconds):
+        # Make sure we don't sleep in the success case
+        raise ValueError()
+
+    net.download_http(httpserver.url_for("/foobar"), local_path=local_path, sleep=raise_error)
     with open(local_path, "rb") as f:
         assert f.read() == data
 
@@ -137,9 +141,15 @@ def test_download_http_retry_incomplete_read_retry_failure(httpserver, tmp_path)
 
     httpserver.expect_request("/foobar").respond_with_response(short_resp)
     local_path = str(tmp_path / "file.txt")
+    retries = 0
+
+    def sleep(seconds):
+        nonlocal retries
+        retries += 1
 
     with pytest.raises(urllib3.exceptions.ProtocolError):
-        net.download_http(httpserver.url_for("/foobar"), local_path=local_path)
+        net.download_http(httpserver.url_for("/foobar"), local_path=local_path, sleep=sleep)
+    assert retries == 10
 
 
 def test_download_http_retry_incomplete_read_retry_success(httpserver, tmp_path):
@@ -155,6 +165,13 @@ def test_download_http_retry_incomplete_read_retry_success(httpserver, tmp_path)
     httpserver.expect_ordered_request("/foobar").respond_with_data(data)
 
     local_path = str(tmp_path / "file.txt")
-    net.download_http(httpserver.url_for("/foobar"), local_path=local_path)
+    retries = 0
+
+    def sleep(seconds):
+        nonlocal retries
+        retries += 1
+
+    net.download_http(httpserver.url_for("/foobar"), local_path=local_path, sleep=sleep)
     with open(local_path, "rb") as f:
         assert f.read() == data
+    assert retries == 10


### PR DESCRIPTION
The [previous change] only helped urllib3 *notice* incomplete reads, but it could not retry given this was a streaming download. This commits implements the actual retries.

[previous change]: https://github.com/elastic/rally/issues/1504