### PR TITLE
Use narrower exception to avoid pylint ignore

### DIFF
--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -188,12 +188,11 @@ def download_http(url, local_path, expected_size_in_bytes=None, progress_indicat
     ) as r, open(local_path, "wb") as out_file:
         if r.status > 299:
             raise urllib.error.HTTPError(url, r.status, "", None, None)
-        # noinspection PyBroadException
         try:
-            size_from_content_header = int(r.getheader("Content-Length"))
+            size_from_content_header = int(r.getheader("Content-Length", ""))
             if expected_size_in_bytes is None:
                 expected_size_in_bytes = size_from_content_header
-        except BaseException:
+        except ValueError:
             size_from_content_header = None
 
         chunk_size = 2**16


### PR DESCRIPTION
getheader() cannot throw an exception and now always returns a string so the only possible exception is ValueError.

This is a small thing I noticed when working on #1578.