### PR TITLE
Remove buggy indices.exists() calls from code

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1631,13 +1631,11 @@ Properties
 
 If you want it to delete all data streams that have been declared in the ``data-streams`` section, you can specify the following properties:
 
-* ``only-if-exists`` (optional, defaults to ``true``): Defines whether a data stream should only be deleted if it exists.
 * ``request-params`` (optional): A structure containing any request parameters that are allowed by the delete index API. Rally will not attempt to serialize the parameters and pass them as is. Always use "true" / "false" strings for boolean parameters (see example below).
 
 If you want it to delete one specific data stream (pattern) instead, you can specify the following properties:
 
 * ``data-stream`` (mandatory): One or more names of the data streams that should be deleted. If only one data stream should be deleted, you can use a string otherwise this needs to be a list of strings.
-* ``only-if-exists`` (optional, defaults to ``true``): Defines whether a data stream should only be deleted if it exists.
 * ``request-params`` (optional): A structure containing any request parameters that are allowed by the delete data stream API. Rally will not attempt to serialize the parameters and pass them as is. Always use "true" / "false" strings for boolean parameters (see example below).
 
 **Examples**
@@ -1654,8 +1652,7 @@ With the following snippet we will delete all ``ds-logs-*`` data streams::
     {
       "name": "delete-data-streams",
       "operation-type": "delete-data-stream",
-      "data-stream": "ds-logs-*",
-      "only-if-exists": false
+      "data-stream": "ds-logs-*"
     }
 
 This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -1631,11 +1631,13 @@ Properties
 
 If you want it to delete all data streams that have been declared in the ``data-streams`` section, you can specify the following properties:
 
+* ``only-if-exists`` (optional, defaults to ``true``): Defines whether a data stream should only be deleted if it exists.
 * ``request-params`` (optional): A structure containing any request parameters that are allowed by the delete index API. Rally will not attempt to serialize the parameters and pass them as is. Always use "true" / "false" strings for boolean parameters (see example below).
 
 If you want it to delete one specific data stream (pattern) instead, you can specify the following properties:
 
 * ``data-stream`` (mandatory): One or more names of the data streams that should be deleted. If only one data stream should be deleted, you can use a string otherwise this needs to be a list of strings.
+* ``only-if-exists`` (optional, defaults to ``true``): Defines whether a data stream should only be deleted if it exists.
 * ``request-params`` (optional): A structure containing any request parameters that are allowed by the delete data stream API. Rally will not attempt to serialize the parameters and pass them as is. Always use "true" / "false" strings for boolean parameters (see example below).
 
 **Examples**
@@ -1652,7 +1654,8 @@ With the following snippet we will delete all ``ds-logs-*`` data streams::
     {
       "name": "delete-data-streams",
       "operation-type": "delete-data-stream",
-      "data-stream": "ds-logs-*"
+      "data-stream": "ds-logs-*",
+      "only-if-exists": false
     }
 
 This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting ``include-in-reporting`` to ``true``.

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1363,18 +1363,14 @@ class DeleteIndex(Runner):
         ops = 0
 
         indices = mandatory(params, "indices", self)
-        only_if_exists = params.get("only-if-exists", False)
         request_params = params.get("request-params", {})
+        ignore_unavailable = not params.get("only-if-exists", False)
+        request_params["ignore_unavailable"] = str(ignore_unavailable).lower()
         prior_destructive_setting = await set_destructive_requires_name(es, False)
         try:
             for index_name in indices:
-                if not only_if_exists:
-                    await es.indices.delete(index=index_name, params=request_params)
-                    ops += 1
-                elif only_if_exists and await es.indices.exists(index=index_name):
-                    self.logger.info("Index [%s] already exists. Deleting it.", index_name)
-                    await es.indices.delete(index=index_name, params=request_params)
-                    ops += 1
+                await es.indices.delete(index=index_name, params=request_params)
+                ops += 1
         finally:
             await set_destructive_requires_name(es, prior_destructive_setting)
         return {

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1392,17 +1392,11 @@ class DeleteDataStream(Runner):
         ops = 0
 
         data_streams = mandatory(params, "data-streams", self)
-        only_if_exists = mandatory(params, "only-if-exists", self)
         request_params = mandatory(params, "request-params", self)
 
         for data_stream in data_streams:
-            if not only_if_exists:
-                await es.indices.delete_data_stream(name=data_stream, ignore=[404], params=request_params)
-                ops += 1
-            elif only_if_exists and await es.indices.exists(index=data_stream):
-                self.logger.info("Data stream [%s] already exists. Deleting it.", data_stream)
-                await es.indices.delete_data_stream(name=data_stream, params=request_params)
-                ops += 1
+            await es.indices.delete_data_stream(name=data_stream, ignore=[404], params=request_params)
+            ops += 1
 
         return {
             "weight": ops,

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1372,6 +1372,9 @@ class DeleteIndex(Runner):
                     await es.indices.delete(index=index_name, params=request_params)
                     ops += 1
                 elif only_if_exists:
+                    # here we use .get() and check for 404 instead of exists due to a bug in some versions
+                    # of elasticsearch-py/elastic-transport with HEAD calls.
+                    # can change back once using elasticsearch-py >= 8.0.0 and elastic-transport >= 8.1.0
                     get_response = await es.indices.get(index=index_name, ignore=[404])
                     if not get_response.get("status") == 404:
                         self.logger.info("Index [%s] already exists. Deleting it.", index_name)
@@ -1406,6 +1409,9 @@ class DeleteDataStream(Runner):
                 await es.indices.delete_data_stream(name=data_stream, ignore=[404], params=request_params)
                 ops += 1
             elif only_if_exists:
+                # here we use .get() and check for 404 instead of exists due to a bug in some versions
+                # of elasticsearch-py/elastic-transport with HEAD calls.
+                # can change back once using elasticsearch-py >= 8.0.0 and elastic-transport >= 8.1.0
                 get_response = await es.indices.get(index=data_stream, ignore=[404])
                 if not get_response.get("status") == 404:
                     self.logger.info("Data stream [%s] already exists. Deleting it.", data_stream)
@@ -1459,10 +1465,15 @@ class DeleteComponentTemplate(Runner):
             if not only_if_exists:
                 await es.cluster.delete_component_template(name=template_name, params=request_params, ignore=[404])
                 ops_count += 1
-            elif only_if_exists and await es.cluster.exists_component_template(name=template_name):
-                self.logger.info("Component Index template [%s] already exists. Deleting it.", template_name)
-                await es.cluster.delete_component_template(name=template_name, params=request_params)
-                ops_count += 1
+            elif only_if_exists:
+                # here we use .get() and check for 404 instead of exists_component_template due to a bug in some versions
+                # of elasticsearch-py/elastic-transport with HEAD calls.
+                # can change back once using elasticsearch-py >= 8.0.0 and elastic-transport >= 8.1.0
+                component_template_exists = await es.cluster.get_component_template(name=template_name, ignore=[404])
+                if not component_template_exists.get("status") == 404:
+                    self.logger.info("Component Index template [%s] already exists. Deleting it.", template_name)
+                    await es.cluster.delete_component_template(name=template_name, params=request_params)
+                    ops_count += 1
         return {
             "weight": ops_count,
             "unit": "ops",
@@ -1509,10 +1520,15 @@ class DeleteComposableTemplate(Runner):
             if not only_if_exists:
                 await es.indices.delete_index_template(name=template_name, params=request_params, ignore=[404])
                 ops_count += 1
-            elif only_if_exists and await es.indices.exists_index_template(name=template_name):
-                self.logger.info("Composable Index template [%s] already exists. Deleting it.", template_name)
-                await es.indices.delete_index_template(name=template_name, params=request_params)
-                ops_count += 1
+            elif only_if_exists:
+                # here we use .get() and check for 404 instead of exists_index_template due to a bug in some versions
+                # of elasticsearch-py/elastic-transport with HEAD calls.
+                # can change back once using elasticsearch-py >= 8.0.0 and elastic-transport >= 8.1.0
+                index_template_exists = await es.indices.get_index_template(name=template_name, ignore=[404])
+                if not index_template_exists.get("status") == 404:
+                    self.logger.info("Composable Index template [%s] already exists. Deleting it.", template_name)
+                    await es.indices.delete_index_template(name=template_name, params=request_params)
+                    ops_count += 1
             # ensure that we do not provide an empty index pattern by accident
             if delete_matching_indices and index_pattern:
                 await es.indices.delete(index=index_pattern)
@@ -1564,10 +1580,15 @@ class DeleteIndexTemplate(Runner):
             if not only_if_exists:
                 await es.indices.delete_template(name=template_name, params=request_params)
                 ops_count += 1
-            elif only_if_exists and await es.indices.exists_template(name=template_name):
-                self.logger.info("Index template [%s] already exists. Deleting it.", template_name)
-                await es.indices.delete_template(name=template_name, params=request_params)
-                ops_count += 1
+            elif only_if_exists:
+                # here we use .get() and check for 404 instead of exists_template due to a bug in some versions
+                # of elasticsearch-py/elastic-transport with HEAD calls.
+                # can change back once using elasticsearch-py >= 8.0.0 and elastic-transport >= 8.1.0
+                template_exists = await es.indices.get_template(name=template_name, ignore=[404])
+                if not template_exists.get("status") == 404:
+                    self.logger.info("Index template [%s] already exists. Deleting it.", template_name)
+                    await es.indices.delete_template(name=template_name, params=request_params)
+                    ops_count += 1
             # ensure that we do not provide an empty index pattern by accident
             if delete_matching_indices and index_pattern:
                 await es.indices.delete(index=index_pattern)

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1406,7 +1406,7 @@ class DeleteDataStream(Runner):
                 await es.indices.delete_data_stream(name=data_stream, ignore=[404], params=request_params)
                 ops += 1
             elif only_if_exists:
-                get_response = await es.indices.get(index=data_stream)
+                get_response = await es.indices.get(index=data_stream, ignore=[404])
                 if not get_response.get("status") == 404:
                     self.logger.info("Data stream [%s] already exists. Deleting it.", data_stream)
                     await es.indices.delete_data_stream(name=data_stream, params=request_params)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2734,7 +2734,7 @@ class TestDeleteIndexRunner:
                 mock.call(body={"transient": {"action.destructive_requires_name": True}}),
             ]
         )
-        es.indices.delete.assert_awaited_with(index="indexB", params={'ignore_unavailable': 'false'})
+        es.indices.delete.assert_awaited_with(index="indexB", params={"ignore_unavailable": "false"})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2907,7 +2907,7 @@ class TestDeleteIndexTemplateRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_deletes_only_existing_index_templates(self, es):
-        es.indices.get_template = mock.AsyncMock(side_effect=[{"status": 404}, {"status": 200}])
+        es.indices.get_template = mock.AsyncMock(side_effect=[False, True])
         es.indices.delete_template = mock.AsyncMock()
         es.indices.delete = mock.AsyncMock()
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2723,7 +2723,7 @@ class TestDeleteIndexRunner:
         result = await r(es, params)
 
         assert result == {
-            "weight": 1,
+            "weight": 2,
             "unit": "ops",
             "success": True,
         }
@@ -2734,7 +2734,7 @@ class TestDeleteIndexRunner:
                 mock.call(body={"transient": {"action.destructive_requires_name": True}}),
             ]
         )
-        es.indices.delete.assert_awaited_once_with(index="indexB", params={})
+        es.indices.delete.assert_awaited_with(index="indexB", params={'ignore_unavailable': 'false'})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2907,7 +2907,7 @@ class TestDeleteIndexTemplateRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_deletes_only_existing_index_templates(self, es):
-        es.indices.exists_template = mock.AsyncMock(side_effect=[False, True])
+        es.indices.get_template = mock.AsyncMock(side_effect=[{"status": 404}, {"status": 200}])
         es.indices.delete_template = mock.AsyncMock()
         es.indices.delete = mock.AsyncMock()
 
@@ -3038,10 +3038,7 @@ class TestDeleteComponentTemplateRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_deletes_only_existing_index_templates(self, es):
-        async def _side_effect(name):
-            return name == "templateB"
-
-        es.cluster.exists_component_template = mock.AsyncMock(side_effect=_side_effect)
+        es.cluster.get_component_template = mock.AsyncMock(side_effect=[{"status": 404}, {"status": 200}])
         es.cluster.delete_component_template = mock.AsyncMock()
 
         r = runner.DeleteComponentTemplate()
@@ -3201,7 +3198,7 @@ class TestDeleteComposableTemplateRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_deletes_only_existing_index_templates(self, es):
-        es.indices.exists_index_template = mock.AsyncMock(side_effect=[False, True])
+        es.indices.get_index_template = mock.AsyncMock(side_effect=[{"status": 404}, {"status": 200}])
         es.indices.delete_index_template = mock.AsyncMock()
 
         r = runner.DeleteComposableTemplate()

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2712,7 +2712,7 @@ class TestDeleteIndexRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_deletes_existing_indices(self, es):
-        es.indices.exists = mock.AsyncMock(side_effect=[False, True])
+        es.indices.get = mock.AsyncMock(side_effect=[{"status": 404}, {"status": 200}])
         es.indices.delete = mock.AsyncMock()
         es.cluster.get_settings = mock.AsyncMock(return_value={"persistent": {}, "transient": {"action.destructive_requires_name": True}})
         es.cluster.put_settings = mock.AsyncMock()
@@ -2723,7 +2723,7 @@ class TestDeleteIndexRunner:
         result = await r(es, params)
 
         assert result == {
-            "weight": 2,
+            "weight": 1,
             "unit": "ops",
             "success": True,
         }
@@ -2734,7 +2734,7 @@ class TestDeleteIndexRunner:
                 mock.call(body={"transient": {"action.destructive_requires_name": True}}),
             ]
         )
-        es.indices.delete.assert_awaited_with(index="indexB", params={"ignore_unavailable": "false"})
+        es.indices.delete.assert_awaited_once_with(index="indexB", params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
@@ -2777,7 +2777,7 @@ class TestDeleteDataStreamRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_deletes_existing_data_streams(self, es):
-        es.indices.exists = mock.AsyncMock(side_effect=[False, True])
+        es.indices.get = mock.AsyncMock(side_effect=[{"status": 404}, {"status": 200}])
         es.indices.delete_data_stream = mock.AsyncMock()
 
         r = runner.DeleteDataStream()
@@ -2787,12 +2787,12 @@ class TestDeleteDataStreamRunner:
         result = await r(es, params)
 
         assert result == {
-            "weight": 2,
+            "weight": 1,
             "unit": "ops",
             "success": True,
         }
 
-        es.indices.delete_data_stream.assert_awaited_with(name="data-stream-B", ignore=[404], params={})
+        es.indices.delete_data_stream.assert_awaited_once_with(name="data-stream-B", params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2787,12 +2787,12 @@ class TestDeleteDataStreamRunner:
         result = await r(es, params)
 
         assert result == {
-            "weight": 1,
+            "weight": 2,
             "unit": "ops",
             "success": True,
         }
 
-        es.indices.delete_data_stream.assert_awaited_once_with(name="data-stream-B", params={})
+        es.indices.delete_data_stream.assert_awaited_with(name="data-stream-B", ignore=[404], params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio


### PR DESCRIPTION
Recently we've had a few errors surface in Rally executions when indices/data-streams are deleted. The errors would be reported as `connection timed out` for the `DELETE /<index>` call, but when inspected (via a packet capture) the server was shown to have responded correctly and in a timely fashion to Rally.

It turns out that in our version of `elasticsearch-py`, `indices.exists()` calls were handled via GET rather than HEAD. It's unclear to me why this causes an issue, but any of the following fixes the issue when targeting very large indices with the `delete-index` operation:
* Reduce the body size of the index (e.g. reduce the number of mappings)
* Set `only-if-exists` to `false` in the operation (to avoid the `exists()` call)
* Change the `exists()` call to a `get()` call.

I'm led to believe the bytes from the body are left in the event loop and not dequeued properly by the client, hence blocking somehow the response from the very next transaction.

This PR changes from using the `exists()` method to using the `get()` method to determine an index's existence.

A test is updated to show the difference in behavior under-the-hood.