### PR TITLE
Refactor `pull_revision` to `pull`

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -596,6 +596,7 @@ You can specify the revision in different formats:
 * ``--revision=current``: Use the current revision (i.e. don't alter the local source tree).
 * ``--revision=abc123``: Where ``abc123`` is some git revision hash.
 * ``--revision=@2013-07-27T10:37:00Z``: Determines the revision that is closest to the provided date. Rally logs to which git revision hash the date has been resolved and if you use Elasticsearch as metrics store (instead of the default in-memory one), :doc:`each metric record will contain the git revision hash also in the meta-data section </metrics>`.
+* ``--revision=my-branch-name``: Where ``my-branch-name`` is the name of an existing branch name. If you are using a :ref:`remote source repository <configuration_source>`, Rally will rebase your local checkout on the latest commit from the specified branch.
 
 Supported date format: If you specify a date, it has to be ISO-8601 conformant and must start with an ``@`` sign to make it easier for Rally to determine that you actually mean a date.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -41,6 +41,8 @@ This section contains more details about the source tree.
 * ``cache`` (default: true): Enables Rally's internal :ref:`source artifact <pipelines_from-sources>` cache (``elasticsearch*.tar.gz`` and optionally ``*.zip`` files for plugins). Artifacts are cached based on their git revision.
 * ``cache.days`` (default: 7): The number of days for which an artifact should be kept in the source artifact cache.
 
+.. _configuration_source:
+
 benchmarks
 ~~~~~~~~~~
 

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -704,9 +704,9 @@ class SourceRepository:
             git_ts_revision = revision[1:]
             self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s.", git_ts_revision, self.name)
             git.pull_ts(self.src_dir, git_ts_revision, remote="origin", branch=self.branch)
-        elif self.has_remote():  # assume a git commit hash
+        elif self.has_remote():  # we have either a commit hash or branch name
             self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
-            git.pull_revision(self.src_dir, remote="origin", revision=revision)
+            git.pull(self.src_dir, remote="origin", branch=revision)
         else:
             self.logger.info("Checking out local revision [%s] for %s.", revision, self.name)
             git.checkout(self.src_dir, branch=revision)

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -92,7 +92,7 @@ def pull_ts(src_dir, ts, *, remote, branch):
 
 @probed
 def pull_revision(src_dir, *, remote, revision):
-    fetch(src_dir, remote=remote)
+    pull(src_dir, remote=remote, branch=revision)
     if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), revision)):
         raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
 

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -91,13 +91,6 @@ def pull_ts(src_dir, ts, *, remote, branch):
 
 
 @probed
-def pull_revision(src_dir, *, remote, revision):
-    pull(src_dir, remote=remote, branch=revision)
-    if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), revision)):
-        raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
-
-
-@probed
 def head_revision(src_dir):
     return process.run_subprocess_with_output("git -C {0} rev-parse --short HEAD".format(io.escape_path(src_dir)))[0].strip()
 

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -124,9 +124,9 @@ class TestSourceRepository:
         mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
-    @mock.patch("esrally.utils.git.pull_revision", autospec=True)
+    @mock.patch("esrally.utils.git.pull", autospec=True)
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
-    def test_checkout_revision(self, mock_is_working_copy, mock_pull_revision, mock_head_revision):
+    def test_checkout_revision(self, mock_is_working_copy, mock_pull, mock_head_revision):
         mock_is_working_copy.return_value = True
         mock_head_revision.return_value = "HEAD"
 
@@ -134,7 +134,7 @@ class TestSourceRepository:
         s.fetch("67c2f42")
 
         mock_is_working_copy.assert_called_with("/src")
-        mock_pull_revision.assert_called_with("/src", remote="origin", revision="67c2f42")
+        mock_pull.assert_called_with("/src", remote="origin", branch="67c2f42")
         mock_head_revision.assert_called_with("/src")
 
     def test_is_commit_hash(self):

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -139,23 +139,15 @@ class TestGit:
         git.pull_ts("/src", "20160101T110000Z", remote="origin", branch="master")
 
         run_subprocess_with_output.assert_called_with('git -C /src rev-list -n 1 --before="20160101T110000Z" --date=iso8601 origin/master')
-        run_subprocess.has_calls(
-            [
-                mock.call("git -C /src fetch --prune --tags --quiet origin"),
-                mock.call("git -C /src checkout 3694a07"),
-            ]
-        )
 
-    @mock.patch("esrally.utils.process.run_subprocess")
-    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_pull_revision(self, run_subprocess_with_logging, run_subprocess):
-        run_subprocess_with_logging.return_value = 0
-        run_subprocess.side_effect = [False, False]
-        git.pull_revision("/src", remote="origin", revision="3694a07")
-        run_subprocess.has_calls(
+        run_subprocess_with_logging.assert_has_calls(
             [
-                mock.call("git -C /src fetch --prune --tags --quiet origin"),
-                mock.call("git -C /src checkout --quiet 3694a07"),
+                # git version comes from the @probed decorator on 'git.pull_ts'
+                mock.call("git -C /src --version", level=10),
+                # git version comes from the @probed decorator on 'git.fetch'
+                mock.call("git -C /src --version", level=10),
+                mock.call("git -C /src fetch --prune --tags origin"),
+                mock.call("git -C /src checkout 3694a07"),
             ]
         )
 


### PR DESCRIPTION
The method name `pull_revision` is not consistent with its behaviour, it
only fetches a specific revision from the remote source, and does not 
'pull' it into the local checkout.

This commit makes the behaviour of the method consistent with its name,
by removing the `pull_revision` method, and instead replacing with with
a call to `pull`.