### PR TITLE
Fail benchmark if assertion could not run

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -404,7 +404,7 @@ class AssertingRunner(Runner, Delegator):
                     props = parse(return_value, assertion["property"])
                     self.check_assertion(op_name, assertion, props, props_expand_keys=False)
             else:
-                self.logger.debug("Skipping assertion check in [%s] as [%s] does not return a dict.", op_name, repr(self.delegate))
+                raise exceptions.DataError(f"Cannot check assertion in [{op_name}] as [{repr(self.delegate)}] does not return a dict.")
         return return_value
 
     def __repr__(self, *args, **kwargs):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -404,7 +404,7 @@ class AssertingRunner(Runner, Delegator):
                     props = parse(return_value, assertion["property"])
                     self.check_assertion(op_name, assertion, props, props_expand_keys=False)
             else:
-                raise exceptions.DataError(f"Cannot check assertion in [{op_name}] as [{repr(self.delegate)}] does not return a dict.")
+                raise exceptions.DataError(f"Cannot check assertion in [{op_name}] as [{repr(self.delegate)}] did not return a dict.")
         return return_value
 
     def __repr__(self, *args, **kwargs):

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1373,7 +1373,7 @@ class TestAsyncExecutor:
         task_start = time.perf_counter()
         es.new_request_context.return_value = self.StaticRequestTiming(task_start=task_start)
 
-        es.bulk = mock.AsyncMock(return_value=io.StringIO('{"errors": false, "took": 8}'))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(b'{"errors": false, "took": 8}'))
 
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
         test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)
@@ -1636,7 +1636,7 @@ class TestAsyncExecutor:
     @pytest.mark.asyncio
     async def test_cancel_execute_schedule(self, es):
         es.init_request_context.return_value = {"request_start": 0, "request_end": 10}
-        es.bulk = mock.AsyncMock(return_value=io.StringIO('{"errors": false, "took": 8}'))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(b'{"errors": false, "took": 8}'))
 
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
         test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -381,7 +381,7 @@ class TestAssertingRunner:
 
 class TestSelectiveJsonParser:
     def doc_as_text(self, doc):
-        return io.StringIO(json.dumps(doc))
+        return io.BytesIO(json.dumps(doc).encode())
 
     def test_parse_all_expected(self):
         doc = self.doc_as_text(
@@ -476,7 +476,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -505,7 +505,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -545,7 +545,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -584,7 +584,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -633,7 +633,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
         bulk = runner.BulkIndex()
 
         bulk_params = {
@@ -670,7 +670,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
         bulk = runner.BulkIndex()
 
         bulk_params = {
@@ -712,7 +712,7 @@ class TestBulkIndexRunner:
             ],
         }
 
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -784,7 +784,7 @@ class TestBulkIndexRunner:
             ],
         }
 
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -880,7 +880,7 @@ class TestBulkIndexRunner:
                 },
             ],
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
         bulk = runner.BulkIndex()
 
         bulk_params = {
@@ -1623,7 +1623,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
 
         query_runner = runner.Query()
 
@@ -1671,7 +1671,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
 
         query_runner = runner.Query()
 
@@ -1725,7 +1725,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
 
         query_runner = runner.Query()
         params = {
@@ -1781,7 +1781,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
 
         query_runner = runner.Query()
         params = {
@@ -1831,7 +1831,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
 
         query_runner = runner.Query()
 
@@ -1888,7 +1888,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
 
         query_runner = runner.Query()
 
@@ -1943,7 +1943,7 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
 
         query_runner = runner.Query()
 
@@ -1999,8 +1999,8 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -2062,8 +2062,8 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -2120,8 +2120,8 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -2200,12 +2200,12 @@ class TestQueryRunner:
 
         es.perform_request = mock.AsyncMock(
             side_effect=[
-                io.StringIO(json.dumps(search_response)),
-                io.StringIO(json.dumps(scroll_response)),
+                io.BytesIO(json.dumps(search_response).encode()),
+                io.BytesIO(json.dumps(scroll_response).encode()),
             ]
         )
 
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -2254,7 +2254,7 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
         es.clear_scroll = mock.AsyncMock(side_effect=elasticsearch.ConnectionTimeout())
 
         query_runner = runner.Query()
@@ -2319,11 +2319,11 @@ class TestQueryRunner:
 
         es.perform_request = mock.AsyncMock(
             side_effect=[
-                io.StringIO(json.dumps(search_response)),
-                io.StringIO(json.dumps(scroll_response)),
+                io.BytesIO(json.dumps(search_response).encode()),
+                io.BytesIO(json.dumps(scroll_response).encode()),
             ]
         )
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -2373,8 +2373,8 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -5236,7 +5236,7 @@ class TestSqlRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_fetch_one_page(self, es):
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(self.default_response).encode()))
 
         sql_runner = runner.Sql()
         params = {
@@ -5259,7 +5259,7 @@ class TestSqlRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_fetch_all_pages(self, es):
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(self.default_response).encode()))
 
         sql_runner = runner.Sql()
         params = {"operation-type": "sql", "body": {"query": "SELECT first_name FROM emp"}, "pages": 3}
@@ -5281,7 +5281,10 @@ class TestSqlRunner:
     @pytest.mark.asyncio
     async def test_failure_on_too_few_pages(self, es):
         es.perform_request = mock.AsyncMock(
-            side_effect=[io.StringIO(json.dumps(self.default_response)), io.StringIO(json.dumps({"rows": [["John"]]}))]
+            side_effect=[
+                io.BytesIO(json.dumps(self.default_response).encode()),
+                io.BytesIO(json.dumps({"rows": [["John"]]}).encode()),
+            ]
         )
 
         sql_runner = runner.Sql()
@@ -5346,7 +5349,7 @@ class TestDownsampleRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_index_downsample(self, es):
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(self.default_response).encode()))
 
         sql_runner = runner.Downsample()
         params = {
@@ -6328,7 +6331,7 @@ class TestComposite:
                 # raw-request
                 None,
                 # search
-                io.StringIO(
+                io.BytesIO(
                     json.dumps(
                         {
                             "hits": {
@@ -6338,7 +6341,7 @@ class TestComposite:
                                 },
                             },
                         },
-                    ),
+                    ).encode()
                 ),
             ]
         )
@@ -6399,7 +6402,7 @@ class TestComposite:
         es.perform_request = mock.AsyncMock(
             side_effect=[
                 # search
-                io.StringIO(
+                io.BytesIO(
                     json.dumps(
                         {
                             "hits": {
@@ -6409,7 +6412,7 @@ class TestComposite:
                                 },
                             }
                         }
-                    )
+                    ).encode()
                 )
             ]
         )

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -261,7 +261,7 @@ class TestAssertingRunner:
                 )
 
     @pytest.mark.asyncio
-    async def test_skips_asserts_for_non_dicts(self):
+    async def test_raise_asserts_for_non_dicts(self):
         es = None
         response = (1, "ops")
         delegate = mock.AsyncMock(return_value=response)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -331,7 +331,7 @@ class TestAssertingRunner:
         r = runner.AssertingRunner(delegate)
         with pytest.raises(
             exceptions.DataError,
-            match=r"Cannot check assertion in \[test-task\] as \[<AsyncMock id='\d+'>\] does not return a dict.",
+            match=r"Cannot check assertion in \[test-task\] as \[<AsyncMock id='\d+'>\] did not return a dict.",
         ):
             async with r:
                 await r(

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -324,27 +324,29 @@ class TestAssertingRunner:
                 )
 
     @pytest.mark.asyncio
-    async def test_skips_asserts_for_non_dicts(self):
+    async def test_raise_asserts_for_non_dicts(self):
         es = None
         response = (1, "ops")
         delegate = mock.AsyncMock(return_value=response)
         r = runner.AssertingRunner(delegate)
-        async with r:
-            final_response = await r(
-                es,
-                {
-                    "name": "test-task",
-                    "assertions": [
-                        {
-                            "property": "hits.hits.value",
-                            "condition": "==",
-                            "value": 5,
-                        },
-                    ],
-                },
-            )
-        # still passes response as is
-        assert final_response == response
+        with pytest.raises(
+            exceptions.DataError,
+            match=r"Cannot check assertion in \[test-task\] as \[<AsyncMock id='\d+'>\] does not return a dict.",
+        ):
+            async with r:
+                await r(
+                    es,
+                    {
+                        "name": "test-task",
+                        "assertions": [
+                            {
+                                "property": "hits.hits.value",
+                                "condition": "==",
+                                "value": 5,
+                            },
+                        ],
+                    },
+                )
 
     def test_predicates(self):
         r = runner.AssertingRunner(delegate=None)


### PR DESCRIPTION
When you 1/ enable assertions and 2/ have assertions in your track but 3/ the operation is returning an unsupported type, we used to only issue a debug log! I believe that we should instead complain loudly. This is technically breaking but will only report valid issues so I think it makes sense to include in the next minor version of Rally.

This was initially reported by @ywelsch in https://github.com/elastic/rally/issues/1582#issuecomment-1247798560.