### PR TITLE
Fix ijson deprecation warning

### DIFF
--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1373,7 +1373,7 @@ class TestAsyncExecutor:
         task_start = time.perf_counter()
         es.new_request_context.return_value = self.StaticRequestTiming(task_start=task_start)
 
-        es.bulk = mock.AsyncMock(return_value=io.StringIO('{"errors": false, "took": 8}'))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(b'{"errors": false, "took": 8}'))
 
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
         test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)
@@ -1636,7 +1636,7 @@ class TestAsyncExecutor:
     @pytest.mark.asyncio
     async def test_cancel_execute_schedule(self, es):
         es.init_request_context.return_value = {"request_start": 0, "request_end": 10}
-        es.bulk = mock.AsyncMock(return_value=io.StringIO('{"errors": false, "took": 8}'))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(b'{"errors": false, "took": 8}'))
 
         params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
         test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -379,7 +379,7 @@ class TestAssertingRunner:
 
 class TestSelectiveJsonParser:
     def doc_as_text(self, doc):
-        return io.StringIO(json.dumps(doc))
+        return io.BytesIO(json.dumps(doc).encode())
 
     def test_parse_all_expected(self):
         doc = self.doc_as_text(
@@ -474,7 +474,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -503,7 +503,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -543,7 +543,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -582,7 +582,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -631,7 +631,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
         bulk = runner.BulkIndex()
 
         bulk_params = {
@@ -668,7 +668,7 @@ class TestBulkIndexRunner:
             "errors": False,
             "took": 8,
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
         bulk = runner.BulkIndex()
 
         bulk_params = {
@@ -710,7 +710,7 @@ class TestBulkIndexRunner:
             ],
         }
 
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -782,7 +782,7 @@ class TestBulkIndexRunner:
             ],
         }
 
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
 
         bulk = runner.BulkIndex()
 
@@ -878,7 +878,7 @@ class TestBulkIndexRunner:
                 },
             ],
         }
-        es.bulk = mock.AsyncMock(return_value=io.StringIO(json.dumps(bulk_response)))
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
         bulk = runner.BulkIndex()
 
         bulk_params = {
@@ -1621,7 +1621,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
 
         query_runner = runner.Query()
 
@@ -1669,7 +1669,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
 
         query_runner = runner.Query()
 
@@ -1723,7 +1723,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
 
         query_runner = runner.Query()
         params = {
@@ -1779,7 +1779,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
 
         query_runner = runner.Query()
         params = {
@@ -1829,7 +1829,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
 
         query_runner = runner.Query()
 
@@ -1886,7 +1886,7 @@ class TestQueryRunner:
                 ],
             },
         }
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
 
         query_runner = runner.Query()
 
@@ -1941,7 +1941,7 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
 
         query_runner = runner.Query()
 
@@ -1997,8 +1997,8 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -2060,8 +2060,8 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -2118,8 +2118,8 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -2198,12 +2198,12 @@ class TestQueryRunner:
 
         es.perform_request = mock.AsyncMock(
             side_effect=[
-                io.StringIO(json.dumps(search_response)),
-                io.StringIO(json.dumps(scroll_response)),
+                io.BytesIO(json.dumps(search_response).encode()),
+                io.BytesIO(json.dumps(scroll_response).encode()),
             ]
         )
 
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -2252,7 +2252,7 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
         es.clear_scroll = mock.AsyncMock(side_effect=elasticsearch.ConnectionTimeout())
 
         query_runner = runner.Query()
@@ -2317,11 +2317,11 @@ class TestQueryRunner:
 
         es.perform_request = mock.AsyncMock(
             side_effect=[
-                io.StringIO(json.dumps(search_response)),
-                io.StringIO(json.dumps(scroll_response)),
+                io.BytesIO(json.dumps(search_response).encode()),
+                io.BytesIO(json.dumps(scroll_response).encode()),
             ]
         )
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -2371,8 +2371,8 @@ class TestQueryRunner:
             },
         }
 
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(search_response)))
-        es.clear_scroll = mock.AsyncMock(return_value=io.StringIO('{"acknowledged": true}'))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(search_response).encode()))
+        es.clear_scroll = mock.AsyncMock(return_value=io.BytesIO(b'{"acknowledged": true}'))
 
         query_runner = runner.Query()
 
@@ -5234,7 +5234,7 @@ class TestSqlRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_fetch_one_page(self, es):
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(self.default_response).encode()))
 
         sql_runner = runner.Sql()
         params = {
@@ -5257,7 +5257,7 @@ class TestSqlRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_fetch_all_pages(self, es):
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(self.default_response).encode()))
 
         sql_runner = runner.Sql()
         params = {"operation-type": "sql", "body": {"query": "SELECT first_name FROM emp"}, "pages": 3}
@@ -5279,7 +5279,10 @@ class TestSqlRunner:
     @pytest.mark.asyncio
     async def test_failure_on_too_few_pages(self, es):
         es.perform_request = mock.AsyncMock(
-            side_effect=[io.StringIO(json.dumps(self.default_response)), io.StringIO(json.dumps({"rows": [["John"]]}))]
+            side_effect=[
+                io.BytesIO(json.dumps(self.default_response).encode()),
+                io.BytesIO(json.dumps({"rows": [["John"]]}).encode()),
+            ]
         )
 
         sql_runner = runner.Sql()
@@ -5344,7 +5347,7 @@ class TestDownsampleRunner:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_index_downsample(self, es):
-        es.perform_request = mock.AsyncMock(return_value=io.StringIO(json.dumps(self.default_response)))
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(self.default_response).encode()))
 
         sql_runner = runner.Downsample()
         params = {
@@ -6326,7 +6329,7 @@ class TestComposite:
                 # raw-request
                 None,
                 # search
-                io.StringIO(
+                io.BytesIO(
                     json.dumps(
                         {
                             "hits": {
@@ -6336,7 +6339,7 @@ class TestComposite:
                                 },
                             },
                         },
-                    ),
+                    ).encode()
                 ),
             ]
         )
@@ -6397,7 +6400,7 @@ class TestComposite:
         es.perform_request = mock.AsyncMock(
             side_effect=[
                 # search
-                io.StringIO(
+                io.BytesIO(
                     json.dumps(
                         {
                             "hits": {
@@ -6407,7 +6410,7 @@ class TestComposite:
                                 },
                             }
                         }
-                    )
+                    ).encode()
                 )
             ]
         )


### PR DESCRIPTION
Like the json module from the standard library, ijson expect bytes. While the signature of `parse()` is type hinted correctly, types are not enforced and many tests were passing a StringIO instance incorrectly. This produced deprecation warnings locally (but not on CI for unknown reasons).

This closes #1533. As you can see in #1533, the original warning was not helpful. I had an eureka moment today: I modified the ijson code to use a higher [stacklevel](https://docs.python.org/3/library/warnings.html#warnings.warn) so that the warning would warn about Rally code, not ijson code. Turns out the problem was in tests. I could not resist taking 20 minutes to fix the issue at that point. Sorry.

I also reported the issue upstream: https://github.com/ICRAR/ijson/issues/79