### PR TITLE
Revert "Add support for assertions on raw requests"

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -371,16 +371,13 @@ class AssertingRunner(Runner, Delegator):
     def equal(self, expected, actual):
         return actual == expected
 
-    def check_assertion(self, op_name, assertion, properties, *, props_expand_keys=True):
+    def check_assertion(self, op_name, assertion, properties):
         path = assertion["property"]
         predicate_name = assertion["condition"]
         expected_value = assertion["value"]
         actual_value = properties
-        if props_expand_keys:
-            for k in path.split("."):
-                actual_value = actual_value[k]
-        else:
-            actual_value = actual_value[path]
+        for k in path.split("."):
+            actual_value = actual_value[k]
         predicate = self.predicates[predicate_name]
         success = predicate(expected_value, actual_value)
         if not success:
@@ -399,10 +396,6 @@ class AssertingRunner(Runner, Delegator):
             if isinstance(return_value, dict):
                 for assertion in params["assertions"]:
                     self.check_assertion(op_name, assertion, return_value)
-            elif isinstance(return_value, BytesIO):
-                for assertion in params["assertions"]:
-                    props = parse(return_value, assertion["property"])
-                    self.check_assertion(op_name, assertion, props, props_expand_keys=False)
             else:
                 self.logger.debug("Skipping assertion check in [%s] as [%s] does not return a dict.", op_name, repr(self.delegate))
         return return_value
@@ -1945,7 +1938,7 @@ class RawRequest(Runner):
             # counter-intuitive, but preserves prior behavior
             headers = None
 
-        return await es.perform_request(
+        await es.perform_request(
             method=params.get("method", "GET"), path=path, headers=headers, body=params.get("body"), params=request_params
         )
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -233,37 +233,6 @@ class TestAssertingRunner:
         assert final_response == response
 
     @pytest.mark.asyncio
-    async def test_asserts_text_equal_succeeds(self):
-        es = None
-        response = io.BytesIO(
-            json.dumps(
-                {
-                    "hits": {
-                        "hits": {
-                            "value": 5,
-                            "relation": "eq",
-                        },
-                    },
-                }
-            ).encode()
-        )
-        delegate = mock.AsyncMock(return_value=response)
-        r = runner.AssertingRunner(delegate)
-        async with r:
-            final_response = await r(
-                es,
-                {
-                    "name": "test-task",
-                    "assertions": [
-                        {"property": "hits.hits.value", "condition": "==", "value": 5},
-                        {"property": "hits.hits.relation", "condition": "==", "value": "eq"},
-                    ],
-                },
-            )
-
-        assert final_response == response
-
-    @pytest.mark.asyncio
     async def test_asserts_equal_fails(self):
         es = None
         response = {
@@ -274,38 +243,6 @@ class TestAssertingRunner:
                 },
             },
         }
-        delegate = mock.AsyncMock(return_value=response)
-        r = runner.AssertingRunner(delegate)
-        with pytest.raises(
-            exceptions.RallyTaskAssertionError, match=r"Expected \[hits.hits.relation\] in \[test-task\] to be == \[eq\] but was \[gte\]."
-        ):
-            async with r:
-                await r(
-                    es,
-                    {
-                        "name": "test-task",
-                        "assertions": [
-                            {"property": "hits.hits.value", "condition": "==", "value": 10000},
-                            {"property": "hits.hits.relation", "condition": "==", "value": "eq"},
-                        ],
-                    },
-                )
-
-    @pytest.mark.asyncio
-    async def test_asserts_text_equal_fails(self):
-        es = None
-        response = io.BytesIO(
-            json.dumps(
-                {
-                    "hits": {
-                        "hits": {
-                            "value": 10000,
-                            "relation": "gte",
-                        },
-                    },
-                }
-            ).encode()
-        )
         delegate = mock.AsyncMock(return_value=response)
         r = runner.AssertingRunner(delegate)
         with pytest.raises(


### PR DESCRIPTION
Reverts elastic/rally#1584

Unfortunately this had a side effect on how we handle metrics for the `raw-request` operation, when there is a `hits` field in the response body it conflicts with our established `meta.hits` `long` mapping in the `rally-metrics-*` index mappings. Reverting for now, tagging reviewers purely FYI