### PR TITLE
Support checking out remote branches

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -596,7 +596,7 @@ You can specify the revision in different formats:
 * ``--revision=current``: Use the current revision (i.e. don't alter the local source tree).
 * ``--revision=abc123``: Where ``abc123`` is some git revision hash.
 * ``--revision=@2013-07-27T10:37:00Z``: Determines the revision that is closest to the provided date. Rally logs to which git revision hash the date has been resolved and if you use Elasticsearch as metrics store (instead of the default in-memory one), :doc:`each metric record will contain the git revision hash also in the meta-data section </metrics>`.
-* ``--revision=my-branch-name``: Where ``my-branch-name`` is the name of an existing branch name. If you are using a :ref:`remote source repository <configuration_source>`, Rally will fetch and checkout the remote branch.
+* ``--revision=my-branch-name``: Where ``my-branch-name`` is the name of an existing branch name. If you are using a :ref:`remote source repository <configuration_source>`, Rally will rebase your local checkout on the latest commit from the specified branch.
 
 Supported date format: If you specify a date, it has to be ISO-8601 conformant and must start with an ``@`` sign to make it easier for Rally to determine that you actually mean a date.
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -595,6 +595,7 @@ You can specify the revision in different formats:
 * ``--revision=latest``: Use the HEAD revision from origin/main.
 * ``--revision=current``: Use the current revision (i.e. don't alter the local source tree).
 * ``--revision=abc123``: Where ``abc123`` is some git revision hash.
+* ``--revision=v8.4.0``: Where ``v8.4.0`` is some git tag.
 * ``--revision=@2013-07-27T10:37:00Z``: Determines the revision that is closest to the provided date. Rally logs to which git revision hash the date has been resolved and if you use Elasticsearch as metrics store (instead of the default in-memory one), :doc:`each metric record will contain the git revision hash also in the meta-data section </metrics>`.
 * ``--revision=my-branch-name``: Where ``my-branch-name`` is the name of an existing branch name. If you are using a :ref:`remote source repository <configuration_source>`, Rally will fetch and checkout the remote branch.
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -596,7 +596,7 @@ You can specify the revision in different formats:
 * ``--revision=current``: Use the current revision (i.e. don't alter the local source tree).
 * ``--revision=abc123``: Where ``abc123`` is some git revision hash.
 * ``--revision=@2013-07-27T10:37:00Z``: Determines the revision that is closest to the provided date. Rally logs to which git revision hash the date has been resolved and if you use Elasticsearch as metrics store (instead of the default in-memory one), :doc:`each metric record will contain the git revision hash also in the meta-data section </metrics>`.
-* ``--revision=my-branch-name``: Where ``my-branch-name`` is the name of an existing branch name. If you are using a :ref:`remote source repository <configuration_source>`, Rally will rebase your local checkout on the latest commit from the specified branch.
+* ``--revision=my-branch-name``: Where ``my-branch-name`` is the name of an existing branch name. If you are using a :ref:`remote source repository <configuration_source>`, Rally will fetch and checkout the remote branch.
 
 Supported date format: If you specify a date, it has to be ISO-8601 conformant and must start with an ``@`` sign to make it easier for Rally to determine that you actually mean a date.
 

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -705,12 +705,13 @@ class SourceRepository:
             self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s.", git_ts_revision, self.name)
             git.pull_ts(self.src_dir, git_ts_revision, remote="origin", branch=self.branch)
         elif self.has_remote():  # we can have either a commit hash, branch name, or tag
-            if git.is_branch(self.src_dir, remote="origin", identifier=revision):
+            git.fetch(self.src_dir, remote="origin")
+            if git.is_branch(self.src_dir, identifier=revision):
                 self.logger.info("Fetching from remote and checking out branch [%s] for %s.", revision, self.name)
-                git.checkout_remote(self.src_dir, remote="origin", branch=revision)
+                git.checkout_branch(self.src_dir, remote="origin", branch=revision)
             else:  # tag or commit hash
                 self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
-                git.pull_revision(self.src_dir, remote="origin", revision=revision)
+                git.checkout_revision(self.src_dir, revision=revision)
         else:
             self.logger.info("Checking out local revision [%s] for %s.", revision, self.name)
             git.checkout(self.src_dir, branch=revision)

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -704,12 +704,11 @@ class SourceRepository:
             git_ts_revision = revision[1:]
             self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s.", git_ts_revision, self.name)
             git.pull_ts(self.src_dir, git_ts_revision, remote="origin", branch=self.branch)
-        elif self.has_remote():  # we can have either a commit hash or branch name
-            if git.is_branch(src_dir=self.src_dir, identifier=revision):
+        elif self.has_remote():  # we can have either a commit hash, branch name, or tag
+            if git.is_branch(self.src_dir, remote="origin", identifier=revision):
                 self.logger.info("Fetching from remote and checking out branch [%s] for %s.", revision, self.name)
-                git.fetch(self.src_dir, remote="origin")
                 git.checkout_remote(self.src_dir, remote="origin", branch=revision)
-            else:
+            else:  # tag or commit hash
                 self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
                 git.pull_revision(self.src_dir, remote="origin", revision=revision)
         else:

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -201,7 +201,7 @@ def _supply_requirements(sources, distribution, plugins, revisions, distribution
                 except KeyError:
                     # maybe we can use the catch-all revision (only if it's not a git revision)
                     plugin_revision = revisions.get("all")
-                    if not plugin_revision or SourceRepository.is_commit_hash(plugin_revision):
+                    if not plugin_revision or SourceRepository.is_branch(plugin_revision):
                         raise exceptions.SystemSetupError("No revision specified for plugin [%s]." % plugin.name)
                     logging.getLogger(__name__).info(
                         "Revision for [%s] is not explicitly defined. Using catch-all revision [%s].", plugin.name, plugin_revision
@@ -680,6 +680,14 @@ class SourceRepository:
         self._try_init(may_skip_init=revision == "current")
         return self._update(revision)
 
+    @classmethod
+    def is_branch(cls, identifier, src_dir=None):
+        # if we don't have a src dir (i.e. git repo) to run actual git commands in, then just check if the identifier is shorthand
+        if not src_dir:
+            return identifier == "latest" or identifier == "current" or identifier.startswith("@")
+
+        return git.is_branch(src_dir, identifier)
+
     def has_remote(self):
         return self.remote_url is not None
 
@@ -704,9 +712,14 @@ class SourceRepository:
             git_ts_revision = revision[1:]
             self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s.", git_ts_revision, self.name)
             git.pull_ts(self.src_dir, git_ts_revision, remote="origin", branch=self.branch)
-        elif self.has_remote():  # we have either a commit hash or branch name
-            self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
-            git.pull(self.src_dir, remote="origin", branch=revision)
+        elif self.has_remote():  # we can have either a commit hash or branch name
+            if self.is_branch(identifier=revision, src_dir=self.src_dir):
+                self.logger.info("Fetching from remote and checking out branch [%s] for %s.", revision, self.name)
+                git.fetch(self.src_dir, remote="origin")
+                git.checkout_remote(self.src_dir, remote="origin", branch=revision)
+            else:
+                self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
+                git.pull_revision(self.src_dir, remote="origin", revision=revision)
         else:
             self.logger.info("Checking out local revision [%s] for %s.", revision, self.name)
             git.checkout(self.src_dir, branch=revision)
@@ -717,10 +730,6 @@ class SourceRepository:
         else:
             self.logger.info("Skipping git revision resolution for %s (%s is not a git repository).", self.name, self.src_dir)
             return None
-
-    @classmethod
-    def is_commit_hash(cls, revision):
-        return revision != "latest" and revision != "current" and not revision.startswith("@")
 
 
 class Builder:

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -704,15 +704,14 @@ class SourceRepository:
             git_ts_revision = revision[1:]
             self.logger.info("Fetching from remote and checking out revision with timestamp [%s] for %s.", git_ts_revision, self.name)
             git.pull_ts(self.src_dir, git_ts_revision, remote="origin", branch=self.branch)
-        elif self.has_remote():
-            # we can have either a commit hash or branch name
-            if self.is_commit_hash(revision):
-                self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
-                git.pull_revision(self.src_dir, remote="origin", revision=revision)
-            else:
+        elif self.has_remote():  # we can have either a commit hash or branch name
+            if git.is_branch(src_dir=self.src_dir, identifier=revision):
                 self.logger.info("Fetching from remote and checking out branch [%s] for %s.", revision, self.name)
                 git.fetch(self.src_dir, remote="origin")
                 git.checkout_remote(self.src_dir, remote="origin", branch=revision)
+            else:
+                self.logger.info("Fetching from remote and checking out revision [%s] for %s.", revision, self.name)
+                git.pull_revision(self.src_dir, remote="origin", revision=revision)
         else:
             self.logger.info("Checking out local revision [%s] for %s.", revision, self.name)
             git.checkout(self.src_dir, branch=revision)
@@ -726,8 +725,7 @@ class SourceRepository:
 
     @classmethod
     def is_commit_hash(cls, revision):
-        sha1_pattern = re.compile("[0-9a-f]{5,40}")
-        return re.match(sha1_pattern, revision)
+        return revision != "latest" and revision != "current" and not revision.startswith("@")
 
 
 class Builder:

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -110,13 +110,6 @@ def pull(src_dir, *, remote, branch):
 
 
 @probed
-def pull_revision(src_dir, *, remote, revision):
-    fetch(src_dir, remote=remote)
-    if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), revision)):
-        raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
-
-
-@probed
 def pull_ts(src_dir, ts, *, remote, branch):
     fetch(src_dir, remote=remote)
     clean_src = io.escape_path(src_dir)
@@ -124,6 +117,13 @@ def pull_ts(src_dir, ts, *, remote, branch):
     revision = process.run_subprocess_with_output(rev_list_command)[0].strip()
     if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(clean_src, revision)):
         raise exceptions.SupplyError("Could not checkout source tree for timestamped revision [%s]" % ts)
+
+
+@probed
+def pull_revision(src_dir, *, remote, revision):
+    fetch(src_dir, remote=remote)
+    if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), revision)):
+        raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
 
 
 @probed

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -48,14 +48,6 @@ def is_working_copy(src):
     return os.path.exists(src) and os.path.exists(os.path.join(src, ".git"))
 
 
-def is_branch(src_dir, identifier):
-    name_rev_command = f"git -C {io.escape_path(src_dir)} name-rev {identifier}"
-    # git name-rev returns the symbolic name for a given revision
-    # for branches the symbolic name is the name
-    _, symbolic_name = process.run_subprocess_with_output(name_rev_command)[0].split()
-    return identifier == symbolic_name
-
-
 def clone(src, *, remote):
     io.ensure_dir(src)
     # Don't swallow subprocess output, user might need to enter credentials...

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -17,7 +17,6 @@
 
 import logging
 import os
-from itertools import groupby
 
 from esrally import exceptions
 from esrally.utils import io, process
@@ -50,25 +49,11 @@ def is_working_copy(src):
 
 
 def is_branch(src_dir, identifier):
-    def all_equal(iterable):
-        "Returns True if all the elements are equal to each other"
-        g = groupby(iterable)
-        return next(g, True) and not next(g, False)
-
     name_rev_command = f"git -C {io.escape_path(src_dir)} name-rev {identifier}"
-
     # git name-rev returns the symbolic name for a given revision
-    #
-    # for example, if the identifier is a branch:
-    #        $ git name-rev test-branch
-    #          test-branch test-branch
-    #
-    # and if the identifier is a commit hash:
-    #       $ git name-rev e9ff502b0c3
-    #         e9ff502b0c3 test-branch~6
-
-    names = process.run_subprocess_with_output(name_rev_command)[0].split()
-    return all_equal(names)
+    # for branches the symbolic name is the name
+    _, symbolic_name = process.run_subprocess_with_output(name_rev_command)[0].split()
+    return identifier == symbolic_name
 
 
 def clone(src, *, remote):

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -49,8 +49,7 @@ def is_working_copy(src):
 
 
 @probed
-def is_branch(src_dir, remote, identifier):
-    fetch(src_dir, remote=remote)
+def is_branch(src_dir, identifier):
     show_ref_cmd = f"git -C {src_dir} show-ref {identifier}"
 
     # if we get an non-zero exit code, we know that the identifier is not a branch (local or remote)
@@ -85,7 +84,7 @@ def checkout(src_dir, *, branch):
 
 
 @probed
-def checkout_remote(src_dir, remote, branch):
+def checkout_branch(src_dir, remote, branch):
     if process.run_subprocess_with_logging("git -C {0} checkout {1}/{2}".format(io.escape_path(src_dir), remote, branch)):
         raise exceptions.SupplyError("Could not checkout [%s]. Do you have uncommitted changes?" % branch)
 
@@ -114,8 +113,7 @@ def pull_ts(src_dir, ts, *, remote, branch):
 
 
 @probed
-def pull_revision(src_dir, *, remote, revision):
-    fetch(src_dir, remote=remote)
+def checkout_revision(src_dir, *, revision):
     if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), revision)):
         raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
 

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -48,6 +48,14 @@ def is_working_copy(src):
     return os.path.exists(src) and os.path.exists(os.path.join(src, ".git"))
 
 
+def is_branch(src_dir, identifier):
+    name_rev_command = f"git -C {io.escape_path(src_dir)} name-rev {identifier}"
+    # git name-rev returns the symbolic name for a given revision
+    # for branches the symbolic name is the name
+    _, symbolic_name = process.run_subprocess_with_output(name_rev_command)[0].split()
+    return identifier == symbolic_name
+
+
 def clone(src, *, remote):
     io.ensure_dir(src)
     # Don't swallow subprocess output, user might need to enter credentials...

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -123,27 +123,34 @@ class TestSourceRepository:
         mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00", remote="origin", branch="main")
         mock_head_revision.assert_called_with("/src")
 
+    @mock.patch("esrally.utils.git.is_branch", autospec=True)
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
-    @mock.patch("esrally.utils.git.pull", autospec=True)
+    @mock.patch("esrally.utils.git.pull_revision", autospec=True)
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
-    def test_checkout_revision(self, mock_is_working_copy, mock_pull, mock_head_revision):
+    def test_checkout_revision(self, mock_is_working_copy, mock_pull_revision, mock_head_revision, mock_is_branch):
         mock_is_working_copy.return_value = True
+        mock_is_branch.return_value = False
         mock_head_revision.return_value = "HEAD"
 
         s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src", branch="main")
         s.fetch("67c2f42")
 
         mock_is_working_copy.assert_called_with("/src")
-        mock_pull.assert_called_with("/src", remote="origin", branch="67c2f42")
+        mock_pull_revision.assert_called_with("/src", remote="origin", revision="67c2f42")
         mock_head_revision.assert_called_with("/src")
 
-    def test_is_commit_hash(self):
-        assert supplier.SourceRepository.is_commit_hash("67c2f42")
+    @mock.patch("esrally.utils.git.is_branch")
+    def test_branch(self, mocked_is_branch):
+        branch = "test-branch"
+        src = "/src"
+        supplier.SourceRepository.is_branch(branch, src)
 
-    def test_is_not_commit_hash(self):
-        assert not supplier.SourceRepository.is_commit_hash("latest")
-        assert not supplier.SourceRepository.is_commit_hash("current")
-        assert not supplier.SourceRepository.is_commit_hash("@2015-01-01-01:00:00")
+        mocked_is_branch.assert_called_with(src, branch)
+
+    def test_is_branch_shorthand(self):
+        assert supplier.SourceRepository.is_branch(identifier="latest") is True
+        assert supplier.SourceRepository.is_branch(identifier="current") is True
+        assert supplier.SourceRepository.is_branch(identifier="@2015-01-01-01:00:00") is True
 
 
 class TestBuilder:

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -123,20 +123,22 @@ class TestSourceRepository:
         mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00", remote="origin", branch="main")
         mock_head_revision.assert_called_with("/src")
 
+    @mock.patch("esrally.utils.git.fetch", autospec=True)
     @mock.patch("esrally.utils.git.is_branch", autospec=True)
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
-    @mock.patch("esrally.utils.git.pull_revision", autospec=True)
+    @mock.patch("esrally.utils.git.checkout_revision", autospec=True)
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
-    def test_checkout_revision(self, mock_is_working_copy, mock_pull_revision, mock_head_revision, mock_is_branch):
+    def test_checkout_revision(self, mock_is_working_copy, mock_checkout_revision, mock_head_revision, mock_is_branch, mock_fetch):
         mock_is_working_copy.return_value = True
         mock_is_branch.return_value = False
         mock_head_revision.return_value = "HEAD"
+        mock_fetch.return_value = None
 
         s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src", branch="main")
         s.fetch("67c2f42")
 
         mock_is_working_copy.assert_called_with("/src")
-        mock_pull_revision.assert_called_with("/src", remote="origin", revision="67c2f42")
+        mock_checkout_revision.assert_called_with("/src", revision="67c2f42")
         mock_head_revision.assert_called_with("/src")
 
     def test_is_commit_hash(self):

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -139,18 +139,13 @@ class TestSourceRepository:
         mock_pull_revision.assert_called_with("/src", remote="origin", revision="67c2f42")
         mock_head_revision.assert_called_with("/src")
 
-    @mock.patch("esrally.utils.git.is_branch")
-    def test_branch(self, mocked_is_branch):
-        branch = "test-branch"
-        src = "/src"
-        supplier.SourceRepository.is_branch(branch, src)
+    def test_is_commit_hash(self):
+        assert supplier.SourceRepository.is_commit_hash("67c2f42")
 
-        mocked_is_branch.assert_called_with(src, branch)
-
-    def test_is_branch_shorthand(self):
-        assert supplier.SourceRepository.is_branch(identifier="latest") is True
-        assert supplier.SourceRepository.is_branch(identifier="current") is True
-        assert supplier.SourceRepository.is_branch(identifier="@2015-01-01-01:00:00") is True
+    def test_is_not_commit_hash(self):
+        assert not supplier.SourceRepository.is_commit_hash("latest")
+        assert not supplier.SourceRepository.is_commit_hash("current")
+        assert not supplier.SourceRepository.is_commit_hash("@2015-01-01-01:00:00")
 
 
 class TestBuilder:

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -123,13 +123,11 @@ class TestSourceRepository:
         mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00", remote="origin", branch="main")
         mock_head_revision.assert_called_with("/src")
 
-    @mock.patch("esrally.utils.git.is_branch", autospec=True)
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
     @mock.patch("esrally.utils.git.pull_revision", autospec=True)
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
-    def test_checkout_revision(self, mock_is_working_copy, mock_pull_revision, mock_head_revision, mock_is_branch):
+    def test_checkout_revision(self, mock_is_working_copy, mock_pull_revision, mock_head_revision):
         mock_is_working_copy.return_value = True
-        mock_is_branch.return_value = False
         mock_head_revision.return_value = "HEAD"
 
         s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src", branch="main")
@@ -140,12 +138,23 @@ class TestSourceRepository:
         mock_head_revision.assert_called_with("/src")
 
     def test_is_commit_hash(self):
+        assert supplier.SourceRepository.is_commit_hash("6aa52")
+        assert supplier.SourceRepository.is_commit_hash("b65fb")
         assert supplier.SourceRepository.is_commit_hash("67c2f42")
+        assert supplier.SourceRepository.is_commit_hash("a0b8cdc1840")
+        assert supplier.SourceRepository.is_commit_hash("6aa5288e60f")
+        assert supplier.SourceRepository.is_commit_hash("6aa5288e60f7c66cc443805de1e266f2d5ec918e")
+        assert supplier.SourceRepository.is_commit_hash("b65fb17a48328dc91c66facda3f6b41e6f5a8efb")
 
     def test_is_not_commit_hash(self):
         assert not supplier.SourceRepository.is_commit_hash("latest")
         assert not supplier.SourceRepository.is_commit_hash("current")
         assert not supplier.SourceRepository.is_commit_hash("@2015-01-01-01:00:00")
+        assert not supplier.SourceRepository.is_commit_hash("my-test-branch")
+        assert not supplier.SourceRepository.is_commit_hash("testbranch")
+        assert not supplier.SourceRepository.is_commit_hash("remotes/origin/1.7")
+        assert not supplier.SourceRepository.is_commit_hash("remotes/origin/2017-11-17-remove-log-message-newline")
+        assert not supplier.SourceRepository.is_commit_hash("remotes/upstream/Adding-unit-to-the-max-value-of-http.max_content_length")
 
 
 class TestBuilder:

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -123,11 +123,13 @@ class TestSourceRepository:
         mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00", remote="origin", branch="main")
         mock_head_revision.assert_called_with("/src")
 
+    @mock.patch("esrally.utils.git.is_branch", autospec=True)
     @mock.patch("esrally.utils.git.head_revision", autospec=True)
     @mock.patch("esrally.utils.git.pull_revision", autospec=True)
     @mock.patch("esrally.utils.git.is_working_copy", autospec=True)
-    def test_checkout_revision(self, mock_is_working_copy, mock_pull_revision, mock_head_revision):
+    def test_checkout_revision(self, mock_is_working_copy, mock_pull_revision, mock_head_revision, mock_is_branch):
         mock_is_working_copy.return_value = True
+        mock_is_branch.return_value = False
         mock_head_revision.return_value = "HEAD"
 
         s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src", branch="main")
@@ -138,23 +140,12 @@ class TestSourceRepository:
         mock_head_revision.assert_called_with("/src")
 
     def test_is_commit_hash(self):
-        assert supplier.SourceRepository.is_commit_hash("6aa52")
-        assert supplier.SourceRepository.is_commit_hash("b65fb")
         assert supplier.SourceRepository.is_commit_hash("67c2f42")
-        assert supplier.SourceRepository.is_commit_hash("a0b8cdc1840")
-        assert supplier.SourceRepository.is_commit_hash("6aa5288e60f")
-        assert supplier.SourceRepository.is_commit_hash("6aa5288e60f7c66cc443805de1e266f2d5ec918e")
-        assert supplier.SourceRepository.is_commit_hash("b65fb17a48328dc91c66facda3f6b41e6f5a8efb")
 
     def test_is_not_commit_hash(self):
         assert not supplier.SourceRepository.is_commit_hash("latest")
         assert not supplier.SourceRepository.is_commit_hash("current")
         assert not supplier.SourceRepository.is_commit_hash("@2015-01-01-01:00:00")
-        assert not supplier.SourceRepository.is_commit_hash("my-test-branch")
-        assert not supplier.SourceRepository.is_commit_hash("testbranch")
-        assert not supplier.SourceRepository.is_commit_hash("remotes/origin/1.7")
-        assert not supplier.SourceRepository.is_commit_hash("remotes/origin/2017-11-17-remove-log-message-newline")
-        assert not supplier.SourceRepository.is_commit_hash("remotes/upstream/Adding-unit-to-the-max-value-of-http.max_content_length")
 
 
 class TestBuilder:

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -70,7 +70,7 @@ class TestGit:
         run_subprocess_with_logging.return_value = 0
         src = "/src"
         branch = "3694a07"
-        # True, True is for @Probed on is_branch, and fetch
+        # True, True is for @probed on is_branch, and fetch
         mock_exit_status_as_bool.side_effect = [True, True, False]
 
         assert not git.is_branch(src, remote="origin", identifier=branch)

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -41,18 +41,18 @@ class TestGit:
 
         # only remote
         run_subprocess_with_output.return_value = ["6aa5288e60f7c66cc443805de1e266f2d5ec918e refs/remotes/origin/test-branch"]
-        assert git.is_branch(src, remote="origin", identifier=branch)
+        assert git.is_branch(src, identifier=branch)
 
         # only local
         run_subprocess_with_output.return_value = ["6aa5288e60f7c66cc443805de1e266f2d5ec918e refs/heads/test-branch"]
-        assert git.is_branch(src, remote="origin", identifier=branch)
+        assert git.is_branch(src, identifier=branch)
 
         # both remote, and local
         run_subprocess_with_output.return_value = [
             "30b52a48011d54cc591cc3427f01bfe1b6fd1e73 refs/heads/test-branch",
             "636134644da20d96020c818e7eb6afa5bec15e8a refs/remotes/origin/test-branch",
         ]
-        assert git.is_branch(src, remote="origin", identifier=branch)
+        assert git.is_branch(src, identifier=branch)
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     @mock.patch("esrally.utils.process.run_subprocess_with_output")
@@ -62,7 +62,7 @@ class TestGit:
         branch = "3694a07"
         run_subprocess_with_output.return_value = ["30b52a48011d54cc591cc3427f01bfe1b6fd1e73 refs/tags/v7.12.0"]
 
-        assert not git.is_branch(src, remote="origin", identifier=branch)
+        assert not git.is_branch(src, identifier=branch)
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     @mock.patch("esrally.utils.process.exit_status_as_bool")
@@ -70,10 +70,10 @@ class TestGit:
         run_subprocess_with_logging.return_value = 0
         src = "/src"
         branch = "3694a07"
-        # True, True is for @probed on is_branch, and fetch
-        mock_exit_status_as_bool.side_effect = [True, True, False]
+        # True is for @probed on is_branch
+        mock_exit_status_as_bool.side_effect = [True, False]
 
-        assert not git.is_branch(src, remote="origin", identifier=branch)
+        assert not git.is_branch(src, identifier=branch)
 
     @mock.patch("esrally.utils.process.run_subprocess_with_output")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
@@ -196,17 +196,14 @@ class TestGit:
 
     @mock.patch("esrally.utils.process.run_subprocess")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_pull_revision(self, run_subprocess_with_logging, run_subprocess):
+    def test_checkout_revision(self, run_subprocess_with_logging, run_subprocess):
         run_subprocess_with_logging.return_value = 0
         run_subprocess.side_effect = [False, False]
-        git.pull_revision("/src", remote="origin", revision="3694a07")
+        git.checkout_revision("/src", revision="3694a07")
         run_subprocess_with_logging.assert_has_calls(
             [
-                # git version comes from the @probed decorator on 'git.pull_revision'
+                # git version comes from the @probed decorator on 'git.checkout_revision'
                 mock.call("git -C /src --version", level=10),
-                # git version comes from the @probed decorator on 'git.fetch'
-                mock.call("git -C /src --version", level=10),
-                mock.call("git -C /src fetch --prune --tags origin"),
                 mock.call("git -C /src checkout 3694a07"),
             ]
         )

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -33,22 +33,6 @@ class TestGit:
         assert git.is_working_copy(os.path.dirname(test_dir))
 
     @mock.patch("esrally.utils.process.run_subprocess_with_output")
-    def test_is_branch(self, run_subprocess_with_output):
-        src = "/src"
-        branch = "test-branch"
-        run_subprocess_with_output.return_value = ["test-branch test-branch"]
-
-        assert git.is_branch(src, branch) is True
-
-    @mock.patch("esrally.utils.process.run_subprocess_with_output")
-    def test_is_not_branch(self, run_subprocess_with_output):
-        src = "/src"
-        branch = "3694a07"
-        run_subprocess_with_output.return_value = ["3694a07 test-branch~2"]
-
-        assert git.is_branch(src, branch) is False
-
-    @mock.patch("esrally.utils.process.run_subprocess_with_output")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_git_version_too_old(self, run_subprocess_with_logging, run_subprocess):
         # any non-zero return value will do

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -33,6 +33,22 @@ class TestGit:
         assert git.is_working_copy(os.path.dirname(test_dir))
 
     @mock.patch("esrally.utils.process.run_subprocess_with_output")
+    def test_is_branch(self, run_subprocess_with_output):
+        src = "/src"
+        branch = "test-branch"
+        run_subprocess_with_output.return_value = ["test-branch test-branch"]
+
+        assert git.is_branch(src, branch) is True
+
+    @mock.patch("esrally.utils.process.run_subprocess_with_output")
+    def test_is_not_branch(self, run_subprocess_with_output):
+        src = "/src"
+        branch = "3694a07"
+        run_subprocess_with_output.return_value = ["3694a07 test-branch~2"]
+
+        assert git.is_branch(src, branch) is False
+
+    @mock.patch("esrally.utils.process.run_subprocess_with_output")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_git_version_too_old(self, run_subprocess_with_logging, run_subprocess):
         # any non-zero return value will do


### PR DESCRIPTION
Unfortunately I inadvertently broke building Elasticsearch from a specific commit hash from remote sources in https://github.com/elastic/rally/pull/1587.

This PR reinstates the `pull_revision` function, refactors the existing `is_commit_hash` to instead validate whether the argument is a valid SHA1 hash (5-40 characters, to allow shorthand), and adds `git.checkout_remote`, which checkouts a remote branch (note the checkout `{remote}/{branch}`)

I have tested this locally with `rally.ini` (note that we always assume Elasticsearch has a remote repo available):
```
[source]
remote.repo.url = https://github.com/b-deam/elasticsearch.git
```

And invocations:
```
esrally build --revision="test-branch" --target-os=linux --target-arch="x86_64" --source-build-method=docker
esrally build --revision="3a8dc92da20" --target-os=linux --target-arch="x86_64" --source-build-method=docker
```