### PR TITLE
Add additional filter options to rally list races

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1270,12 +1270,14 @@ def list_races(cfg):
                 race.race_id,
                 time.to_iso8601(race.race_timestamp),
                 race.track,
-                format_dict(race.track_params),
                 race.challenge_name,
                 race.car_name,
-                format_dict(race.user_tags),
+                race.distribution_version,
+                race.revision,
+                race.rally_version,
                 race.track_revision,
                 race.team_revision,
+                format_dict(race.user_tags),
             ]
         )
 
@@ -1288,12 +1290,14 @@ def list_races(cfg):
                     "Race ID",
                     "Race Timestamp",
                     "Track",
-                    "Track Parameters",
                     "Challenge",
                     "Car",
-                    "User Tags",
+                    "ES Version",
+                    "Revision",
+                    "Rally Version",
                     "Track Revision",
                     "Team Revision",
+                    "User Tags",
                 ],
             )
         )

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -160,8 +160,8 @@ def create_arg_parser():
         default=None,
     )
     list_parser.add_argument(
-        "--name",
-        help="Show only records from with corresponding 'name' user tag",
+        "--benchmark-name",
+        help="Show only records from with corresponding 'name' or 'benchmark-name' user tag",
         default=None,
     )
     list_parser.add_argument(
@@ -1026,7 +1026,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.max_results", args.limit)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.track", args.track)
-            cfg.add(config.Scope.applicationOverride, "system", "list.races.name", args.name)
+            cfg.add(config.Scope.applicationOverride, "system", "list.races.benchmark_name", args.benchmark_name)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.from_date", args.from_date)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.to_date", args.to_date)
             configure_mechanic_params(args, cfg, command_requires_car=False)

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -60,6 +60,16 @@ class ExitStatus(Enum):
 
 
 def create_arg_parser():
+    def valid_date(v):
+        pattern = "%Y%m%d"
+        try:
+            datetime.datetime.strptime(v, pattern)
+            # don't convert, just check that the format is correct, we'll use the string value later on anyway
+            return v
+        except ValueError:
+            msg = "[{}] does not conform to the pattern [yyyyMMdd]".format(v)
+            raise argparse.ArgumentTypeError(msg)
+
     def positive_number(v):
         value = int(v)
         if value <= 0:
@@ -143,6 +153,23 @@ def create_arg_parser():
         "--limit",
         help="Limit the number of search results for recent races (default: 10).",
         default=10,
+    )
+    list_parser.add_argument(
+        "--track",
+        help="Show only records from this track",
+        default=None,
+    )
+    list_parser.add_argument(
+        "--from-date",
+        help="Show only records on or after this date (format: yyyyMMdd)",
+        type=valid_date,
+        default=None,
+    )
+    list_parser.add_argument(
+        "--to-date",
+        help="Show only records before or on this date (format: yyyyMMdd)",
+        type=valid_date,
+        default=None,
     )
     add_track_source(list_parser)
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -160,6 +160,11 @@ def create_arg_parser():
         default=None,
     )
     list_parser.add_argument(
+        "--name",
+        help="Show only records from with corresponding 'name' user tag",
+        default=None,
+    )
+    list_parser.add_argument(
         "--from-date",
         help="Show only records on or after this date (format: yyyyMMdd)",
         type=valid_date,
@@ -1020,6 +1025,10 @@ def dispatch_sub_command(arg_parser, args, cfg):
         elif sub_command == "list":
             cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.max_results", args.limit)
+            cfg.add(config.Scope.applicationOverride, "system", "list.races.track", args.track)
+            cfg.add(config.Scope.applicationOverride, "system", "list.races.name", args.name)
+            cfg.add(config.Scope.applicationOverride, "system", "list.races.from_date", args.from_date)
+            cfg.add(config.Scope.applicationOverride, "system", "list.races.to_date", args.to_date)
             configure_mechanic_params(args, cfg, command_requires_car=False)
             configure_track_params(arg_parser, args, cfg, command_requires_track=False)
             dispatch_list(cfg)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -886,6 +886,7 @@ class TestEsRaceStore:
 
     def setup_method(self, method):
         self.cfg = config.Config()
+        self.cfg.add(config.Scope.application, "system", "list.races.max_results", 100)
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
         self.cfg.add(config.Scope.application, "system", "time.start", self.RACE_TIMESTAMP)
         self.cfg.add(config.Scope.application, "system", "race.id", self.RACE_ID)
@@ -1023,6 +1024,36 @@ class TestEsRaceStore:
             },
         }
         self.es_mock.index.assert_called_with(index="rally-races-2016-01", id=self.RACE_ID, item=expected_doc)
+
+    def test_filter_race(self):
+        self.es_mock.search.return_value = {"hits": {"total": 0}}
+        self.cfg.add(config.Scope.application, "system", "list.races.track", "unittest")
+        self.cfg.add(config.Scope.application, "system", "list.races.benchmark_name", "unittest-test")
+        self.cfg.add(config.Scope.application, "system", "list.races.to_date", "20160131")
+        self.cfg.add(config.Scope.application, "system", "list.races.from_date", "20160230")
+        self.race_store.list()
+        expected_query = {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"term": {"environment": "unittest-env"}},
+                        {"range": {"race-timestamp": {"gte": "20160230", "lte": "20160131", "format": "basic_date"}}},
+                        {"term": {"track": "unittest"}},
+                        {
+                            "bool": {
+                                "should": [
+                                    {"term": {"user-tags.benchmark-name": "unittest-test"}},
+                                    {"term": {"user-tags.name": "unittest-test"}},
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+            "size": 100,
+            "sort": [{"race-timestamp": {"order": "desc"}}],
+        }
+        self.es_mock.search.assert_called_with(index="rally-races-*", body=expected_query)
 
 
 class TestEsResultsStore:
@@ -1654,6 +1685,46 @@ class TestFileRaceStore:
         retrieved_race = self.race_store.find_by_race_id(race_id=self.RACE_ID)
         assert race.race_id == retrieved_race.race_id
         assert race.race_timestamp == retrieved_race.race_timestamp
+        assert len(self.race_store.list()) == 1
+
+    def test_filter_race(self):
+        t = track.Track(
+            name="unittest",
+            indices=[track.Index(name="tests", types=["_doc"])],
+            challenges=[track.Challenge(name="index", default=True)],
+        )
+
+        race = metrics.Race(
+            rally_version="0.4.4",
+            rally_revision="123abc",
+            environment_name="unittest",
+            race_id=self.RACE_ID,
+            race_timestamp=self.RACE_TIMESTAMP,
+            pipeline="from-sources",
+            user_tags={"name": "unittest-test"},
+            track=t,
+            track_params={"clients": 12},
+            challenge=t.default_challenge,
+            car="4gheap",
+            car_params=None,
+            plugin_params=None,
+        )
+
+        self.race_store.store_race(race)
+        assert len(self.race_store.list()) == 1
+        self.cfg.add(config.Scope.application, "system", "list.races.track", "unittest-2")
+        assert len(self.race_store.list()) == 0
+        self.cfg.add(config.Scope.application, "system", "list.races.track", "unittest")
+        assert len(self.race_store.list()) == 1
+        self.cfg.add(config.Scope.application, "system", "list.races.benchmark_name", "unittest-test-2")
+        assert len(self.race_store.list()) == 0
+        self.cfg.add(config.Scope.application, "system", "list.races.benchmark_name", "unittest-test")
+        assert len(self.race_store.list()) == 1
+        self.cfg.add(config.Scope.application, "system", "list.races.to_date", "20160129")
+        assert len(self.race_store.list()) == 0
+        self.cfg.add(config.Scope.application, "system", "list.races.to_date", "20160131")
+        assert len(self.race_store.list()) == 1
+        self.cfg.add(config.Scope.application, "system", "list.races.from_date", "20160131")
         assert len(self.race_store.list()) == 1
 
 


### PR DESCRIPTION
- Added extra files to display for listing races ( `ES Version`, `Revision` and `Rally Version`).
- Removed `Track Parameters` from being displayed, as for some races (e.g. logs) it's very long and makes it hard to understand the output. 
- Added new filters for list races: `--track`, `--name` and `--to-date`, `--from-date`