### PR TITLE
Remove useless pylint suppressions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -105,7 +105,7 @@ disable=raw-checker-failed,
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=c-extension-no-member
+enable=c-extension-no-member,useless-suppression
 
 
 [REPORTS]

--- a/esrally/client/asynchronous.py
+++ b/esrally/client/asynchronous.py
@@ -152,7 +152,6 @@ class ResponseMatcher:
 
     @staticmethod
     def always():
-        # pylint: disable=unused-variable
         def f(p):
             return True
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1220,7 +1220,6 @@ class ClusterHealth(Runner):
 
             def __lt__(self, other):
                 if self.__class__ is other.__class__:
-                    # pylint: disable=comparison-with-callable
                     return self.value < other.value
                 return NotImplemented
 

--- a/esrally/driver/scheduler.py
+++ b/esrally/driver/scheduler.py
@@ -231,7 +231,6 @@ class DeterministicScheduler(SimpleScheduler):
 
     name = "deterministic"
 
-    # pylint: disable=unused-variable
     def __init__(self, task, target_throughput):
         super().__init__()
         self.wait_time = 1 / target_throughput
@@ -255,7 +254,6 @@ class PoissonScheduler(SimpleScheduler):
 
     name = "poisson"
 
-    # pylint: disable=unused-variable
     def __init__(self, task, target_throughput):
         super().__init__()
         self.rate = target_throughput

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1440,8 +1440,6 @@ class IngestPipelineStats(InternalTelemetryDevice):
         self.logger.info("Gathering Ingest Pipeline stats at benchmark end")
         end_stats = self.get_ingest_pipeline_stats()
 
-        # The nesting level is ok here given the structure of the Ingest Pipeline stats
-        # pylint: disable=too-many-nested-blocks
         for cluster_name, node in end_stats.items():
             if cluster_name not in self.start_stats:
                 self.logger.warning(

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -729,15 +729,12 @@ class OperationType(Enum):
 
     @property
     def admin_op(self):
-        # pylint: disable=comparison-with-callable
         return self.value > 1000
 
     def to_hyphenated_string(self):
         """
         Turns enum constants into hyphenated names, e.g. ``WaitForTransform`` becomes ``wait-for-transform``.
         """
-        # Pylint complains that self.name is not iterable
-        # pylint: disable=not-an-iterable
         return "".join(["-" + c.lower() if c.isupper() else c for c in self.name]).lstrip("-")
 
     # pylint: disable=too-many-return-statements

--- a/tests/driver/scheduler_test.py
+++ b/tests/driver/scheduler_test.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=protected-access
 
 import random
 
@@ -84,19 +83,13 @@ class TestUnitAwareScheduler:
 
         s = scheduler.UnitAwareScheduler(task=task, scheduler_class=scheduler.DeterministicScheduler)
         # first request is unthrottled
-        # suppress pylint false positive
-        # pylint: disable=not-callable
         assert s.next(0) == 0
         # we'll start with bulks of 1.000 docs, which corresponds to 5 requests per second for all clients
         s.after_request(now=None, weight=1000, unit="docs", request_meta_data=None)
-        # suppress pylint false positive
-        # pylint: disable=not-callable
         assert s.next(0) == 1 / 5 * task.clients
 
         # bulk size changes to 10.000 docs, which means one request every two seconds for all clients
         s.after_request(now=None, weight=10000, unit="docs", request_meta_data=None)
-        # suppress pylint false positive
-        # pylint: disable=not-callable
         assert s.next(0) == 2 * task.clients
 
     def test_scheduler_accepts_differing_units_pages_and_ops(self):
@@ -112,14 +105,10 @@ class TestUnitAwareScheduler:
 
         s = scheduler.UnitAwareScheduler(task=task, scheduler_class=scheduler.DeterministicScheduler)
         # first request is unthrottled
-        # suppress pylint false positive
-        # pylint: disable=not-callable
         assert s.next(0) == 0
         # no exception despite differing units ...
         s.after_request(now=None, weight=20, unit="pages", request_meta_data=None)
         # ... and it is still throttled in ops/s
-        # suppress pylint false positive
-        # pylint: disable=not-callable
         assert s.next(0) == 0.1 * task.clients
 
     def test_scheduler_does_not_change_throughput_for_empty_requests(self):
@@ -136,21 +125,15 @@ class TestUnitAwareScheduler:
         s = scheduler.UnitAwareScheduler(task=task, scheduler_class=scheduler.DeterministicScheduler)
         # first request is unthrottled...
         s.before_request(now=0)
-        # suppress pylint false positive
-        # pylint: disable=not-callable
         assert s.next(0) == 0
         # ... but it also produced an error (zero ops)
         s.after_request(now=1, weight=0, unit="ops", request_meta_data=None)
         # next request is still unthrottled
         s.before_request(now=1)
-        # suppress pylint false positive
-        # pylint: disable=not-callable
         assert s.next(0) == 0
         s.after_request(now=2, weight=1, unit="ops", request_meta_data=None)
         # now we throttle
         s.before_request(now=2)
-        # suppress pylint false positive
-        # pylint: disable=not-callable
         assert s.next(0) == 0.1 * task.clients
 
 

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -221,7 +221,7 @@ class TestProcessLauncher:
         assert env["ES_JAVA_OPTS"] == (
             "-XX:+ExitOnOutOfMemoryError -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints "
             "-XX:+UnlockCommercialFeatures -XX:+FlightRecorder "
-            "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath=/tmp/telemetry/profile.jfr "  # pylint: disable=line-too-long
+            "-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath=/tmp/telemetry/profile.jfr "
             "-XX:StartFlightRecording=defaultrecording=true"
         )
 


### PR DESCRIPTION
pylint improves over times, which means some suppressions are not necessary. It helps limiting the pylint clutter we have.