### PR TITLE
Remove mocks from git tests

### DIFF
--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -90,7 +90,7 @@ def checkout(src_dir, *, branch):
 
 @probed
 def checkout_branch(src_dir, remote, branch):
-    if process.run_subprocess_with_logging("git -C {0} checkout {1}/{2}".format(io.escape_path(src_dir), remote, branch)):
+    if process.run_subprocess_with_logging(with_retry("git -C {0} checkout {1}/{2}".format(io.escape_path(src_dir), remote, branch))):
         raise exceptions.SupplyError("Could not checkout [%s]. Do you have uncommitted changes?" % branch)
 
 

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -22,11 +22,6 @@ from esrally import exceptions
 from esrally.utils import io, process
 
 
-def with_retry(command):
-    # git has no native concept of retries
-    return f'/bin/bash -c "for i in {{1..5}}; do {command} && s=0 && break || s=1 && sleep 1; done; (exit $s)"'
-
-
 def probed(f):
     def probe(src, *args, **kwargs):
         # Probe for -C
@@ -72,13 +67,13 @@ def is_branch(src_dir, identifier):
 def clone(src, *, remote):
     io.ensure_dir(src)
     # Don't swallow subprocess output, user might need to enter credentials...
-    if process.run_subprocess_with_logging(with_retry("git clone %s %s" % (remote, io.escape_path(src)))):
+    if process.run_subprocess_with_logging("git clone %s %s" % (remote, io.escape_path(src))):
         raise exceptions.SupplyError("Could not clone from [%s] to [%s]" % (remote, src))
 
 
 @probed
 def fetch(src, *, remote):
-    if process.run_subprocess_with_logging(with_retry("git -C {0} fetch --prune --tags {1}".format(io.escape_path(src), remote))):
+    if process.run_subprocess_with_logging("git -C {0} fetch --prune --tags {1}".format(io.escape_path(src), remote)):
         raise exceptions.SupplyError("Could not fetch source tree from [%s]" % remote)
 
 
@@ -97,7 +92,7 @@ def checkout_branch(src_dir, remote, branch):
 @probed
 def rebase(src_dir, *, remote, branch):
     checkout(src_dir, branch=branch)
-    if process.run_subprocess_with_logging(with_retry("git -C {0} rebase {1}/{2}".format(io.escape_path(src_dir), remote, branch))):
+    if process.run_subprocess_with_logging("git -C {0} rebase {1}/{2}".format(io.escape_path(src_dir), remote, branch)):
         raise exceptions.SupplyError("Could not rebase on branch [%s]" % branch)
 
 
@@ -111,7 +106,7 @@ def pull(src_dir, *, remote, branch):
 def pull_ts(src_dir, ts, *, remote, branch):
     fetch(src_dir, remote=remote)
     clean_src = io.escape_path(src_dir)
-    rev_list_command = with_retry(f'git -C {clean_src} rev-list -n 1 --before="{ts}" --date=iso8601 {remote}/{branch}')
+    rev_list_command = f'git -C {clean_src} rev-list -n 1 --before="{ts}" --date=iso8601 {remote}/{branch}'
     revision = process.run_subprocess_with_output(rev_list_command)[0].strip()
     if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(clean_src, revision)):
         raise exceptions.SupplyError("Could not checkout source tree for timestamped revision [%s]" % ts)
@@ -119,7 +114,7 @@ def pull_ts(src_dir, ts, *, remote, branch):
 
 @probed
 def checkout_revision(src_dir, *, revision):
-    if process.run_subprocess_with_logging(with_retry("git -C {0} checkout {1}".format(io.escape_path(src_dir), revision))):
+    if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), revision)):
         raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
 
 
@@ -139,9 +134,7 @@ def branches(src_dir, remote=True):
     if remote:
         # alternatively: git for-each-ref refs/remotes/ --format='%(refname:short)'
         return _cleanup_remote_branch_names(
-            process.run_subprocess_with_output(
-                with_retry("git -C {src} for-each-ref refs/remotes/ --format='%(refname:short)'".format(src=clean_src))
-            )
+            process.run_subprocess_with_output("git -C {src} for-each-ref refs/remotes/ --format='%(refname:short)'".format(src=clean_src))
         )
     else:
         return _cleanup_local_branch_names(

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -85,7 +85,7 @@ def checkout(src_dir, *, branch):
 
 @probed
 def checkout_branch(src_dir, remote, branch):
-    if process.run_subprocess_with_logging(with_retry("git -C {0} checkout {1}/{2}".format(io.escape_path(src_dir), remote, branch))):
+    if process.run_subprocess_with_logging("git -C {0} checkout {1}/{2}".format(io.escape_path(src_dir), remote, branch)):
         raise exceptions.SupplyError("Could not checkout [%s]. Do you have uncommitted changes?" % branch)
 
 

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -190,8 +190,9 @@ class TestGit:
         assert git.head_revision(TestGit.tmp_src_dir).startswith("09980cd")
 
     def test_pull_ts(self, setup_teardown_remote):
+        # results in commit 28474f4f097106ff3507be35958db0c3c8be0fc6
         git.pull_ts(TestGit.tmp_src_dir, "20160101T110000Z", remote="esrally", branch="master")
-        assert "28474f4f097106ff3507be35958db0c3c8be0fc6" == git.head_revision(TestGit.tmp_src_dir)
+        assert git.head_revision(TestGit.tmp_src_dir).startswith("28474f4")
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_rebase(self, run_subprocess_with_logging):

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -160,7 +160,9 @@ class TestGit:
         git.checkout_revision(TestGit.tmp_src_dir, revision="bd368741951c643f9eb1958072c316e493c15b96")
 
     def test_head_revision(self, setup_teardown_head_revision):
-        assert git.head_revision(TestGit.tmp_src_dir) == "09980cd5"
+        # Apple Git 'core.abbrev' defaults to return 7 char prefixes (09980cd)
+        # Linux defaults to return 8 char prefixes (09980cd5)
+        assert git.head_revision(TestGit.tmp_src_dir).startswith("09980cd")
 
     def test_list_remote_branches(self):
         assert TestGit.remote_branch in git.branches(TestGit.tmp_src_dir, remote=True)

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# add assertions to git tests
+
 import logging
 import os
 import shutil
@@ -32,14 +34,13 @@ class TestGit:
     def setup_class(cls):
         cls.local_branch = "rally-unit-test-local-only-branch"
         cls.remote_branch = "rally-unit-test-remote-only-branch"
-
-        # location to for 'clone' tests
-        cls.tmp_clone_dir = io.escape_path("/tmp/rally-unit-test-tmp-clone-dir")
         # this is assuming that nobody stripped the git repo info in their Rally working copy
         cls.src_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        cls.tmp_src_dir = io.escape_path("/tmp/rally-unit-test-tmp-dir")
+        cls.tmp_src_dir = io.escape_path("/tmp/rally-unit-test-dir")
+        # location for 'clone' tests
+        cls.tmp_clone_dir = io.escape_path("/tmp/rally-unit-test-clone-dir")
 
-        # delete any pre-existing tmp src (maybe last test setup cancelled early)
+        # delete any pre-existing dirs (maybe last test setup cancelled early)
         shutil.rmtree(TestGit.tmp_src_dir, ignore_errors=True)
         # create a copy to perform git operations in
         shutil.copytree(TestGit.src_dir, TestGit.tmp_src_dir)
@@ -54,29 +55,22 @@ class TestGit:
         # delete copy of git dir
         shutil.rmtree(TestGit.tmp_src_dir)
 
-    @pytest.fixture
-    def setup_teardown_rebase(self):
+    @pytest.fixture(autouse=True)
+    def checkout_previous_branch(self):
         yield
+        # checkout the 'original' branch after each test
         git.checkout(TestGit.tmp_src_dir, branch=TestGit.current_branch)
 
     @pytest.fixture
-    def setup_teardown_head_revision(self):
-        # rev is 09980cd5
-        git.checkout(TestGit.tmp_src_dir, branch="2.6.0")
+    def teardown_clone(self):
         yield
-        git.checkout(TestGit.tmp_src_dir, branch=TestGit.current_branch)
+        shutil.rmtree(TestGit.tmp_clone_dir)
 
     @pytest.fixture
     def setup_teardown_local_branch(self):
         process.run_subprocess_with_logging(f"git -C {TestGit.tmp_src_dir} branch {TestGit.local_branch}")
         yield
         process.run_subprocess_with_logging(f"git -C {TestGit.tmp_src_dir} branch -D {TestGit.local_branch}")
-
-    @pytest.fixture
-    def teardown_clone_dir(self):
-        yield
-        # delete existing test tmp clone
-        shutil.rmtree(TestGit.tmp_clone_dir)
 
     @pytest.fixture
     def delete_local_tags(self):
@@ -108,62 +102,6 @@ class TestGit:
         # rally's initial commit :-)
         assert not git.is_branch(TestGit.tmp_src_dir, identifier="bd368741951c643f9eb1958072c316e493c15b96")
 
-    @mock.patch("esrally.utils.process.run_subprocess_with_output")
-    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_git_version_too_old(self, run_subprocess_with_logging, run_subprocess):
-        # any non-zero return value will do
-        run_subprocess_with_logging.return_value = 64
-        run_subprocess.return_value = "1.0.0"
-
-        with pytest.raises(exceptions.SystemSetupError) as exc:
-            git.head_revision("/src")
-        assert exc.value.args[0] == "Your git version is [1.0.0] but Rally requires at least git 1.9. Please update git."
-        run_subprocess_with_logging.assert_called_with("git -C /src --version", level=logging.DEBUG)
-
-    def test_clone_successful(self, teardown_clone_dir):
-        remote = "https://github.com/elastic/rally"
-        git.clone(TestGit.tmp_clone_dir, remote=remote)
-
-    def test_clone_with_error(self):
-        remote = "https://github.com/elastic/this-project-doesnt-actually-exist"
-        with pytest.raises(exceptions.SupplyError) as exc:
-            git.clone(TestGit.tmp_clone_dir, remote=remote)
-        assert exc.value.args[0] == f"Could not clone from [{remote}] to [{TestGit.tmp_clone_dir}]"
-
-    def test_fetch_successful(self):
-        git.fetch(TestGit.tmp_src_dir, remote="origin")
-
-    def test_fetch_with_error(self):
-        with pytest.raises(exceptions.SupplyError) as exc:
-            git.fetch(TestGit.tmp_src_dir, remote="this-remote-doesnt-actually-exist")
-        assert exc.value.args[0] == "Could not fetch source tree from [this-remote-doesnt-actually-exist]"
-
-    def test_checkout_successful(self, setup_teardown_local_branch):
-        git.checkout(TestGit.tmp_src_dir, branch=TestGit.local_branch)
-
-    def test_checkout_with_error(self):
-        branch = "this-branch-doesnt-actually-exist"
-        with pytest.raises(exceptions.SupplyError) as exc:
-            git.checkout(TestGit.tmp_src_dir, branch=branch)
-        assert exc.value.args[0] == f"Could not checkout [{branch}]. Do you have uncommitted changes?"
-
-    def test_rebase(self, setup_teardown_rebase):
-        git.rebase(TestGit.tmp_src_dir, remote="origin", branch="master")
-
-    def test_pull(self, setup_teardown_rebase):
-        git.pull(TestGit.tmp_src_dir, remote="origin", branch="master")
-
-    def test_pull_ts(self, setup_teardown_rebase):
-        git.pull_ts(TestGit.tmp_src_dir, "20160101T110000Z", remote="origin", branch="master")
-
-    def test_checkout_revision(self, setup_teardown_rebase):
-        git.checkout_revision(TestGit.tmp_src_dir, revision="bd368741951c643f9eb1958072c316e493c15b96")
-
-    def test_head_revision(self, setup_teardown_head_revision):
-        # Apple Git 'core.abbrev' defaults to return 7 char prefixes (09980cd)
-        # Linux defaults to return 8 char prefixes (09980cd5)
-        assert git.head_revision(TestGit.tmp_src_dir).startswith("09980cd")
-
     def test_list_remote_branches(self):
         assert TestGit.remote_branch in git.branches(TestGit.tmp_src_dir, remote=True)
 
@@ -178,3 +116,104 @@ class TestGit:
 
     def test_list_tags_no_tags_available(self, delete_local_tags):
         assert git.tags(TestGit.tmp_src_dir) == []
+
+    @mock.patch("esrally.utils.process.run_subprocess_with_output")
+    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
+    def test_git_version_too_old(self, run_subprocess_with_logging, run_subprocess):
+        # any non-zero return value will do
+        run_subprocess_with_logging.return_value = 64
+        run_subprocess.return_value = "1.0.0"
+
+        with pytest.raises(exceptions.SystemSetupError) as exc:
+            git.head_revision("/src")
+        assert exc.value.args[0] == "Your git version is [1.0.0] but Rally requires at least git 1.9. Please update git."
+        run_subprocess_with_logging.assert_called_with("git -C /src --version", level=logging.DEBUG)
+
+    def test_clone_successful(self, teardown_clone):
+        remote = "https://github.com/elastic/rally"
+        git.clone(TestGit.tmp_clone_dir, remote=remote)
+        assert git.is_working_copy(TestGit.tmp_clone_dir)
+
+    def test_clone_with_error(self):
+        remote = "https://github.com/elastic/this-project-doesnt-actually-exist"
+        with pytest.raises(exceptions.SupplyError) as exc:
+            git.clone(TestGit.tmp_clone_dir, remote=remote)
+        assert exc.value.args[0] == f"Could not clone from [{remote}] to [{TestGit.tmp_clone_dir}]"
+
+    def test_fetch_successful(self):
+        before_time = os.path.getmtime(os.path.join(TestGit.tmp_src_dir, ".git/FETCH_HEAD"))
+        git.fetch(TestGit.tmp_src_dir, remote="origin")
+        after_time = os.path.getmtime(os.path.join(TestGit.tmp_src_dir, ".git/FETCH_HEAD"))
+        fetch_head_modified = after_time > before_time
+        assert fetch_head_modified
+
+    def test_fetch_with_error(self):
+        with pytest.raises(exceptions.SupplyError) as exc:
+            git.fetch(TestGit.tmp_src_dir, remote="this-remote-doesnt-actually-exist")
+        assert exc.value.args[0] == "Could not fetch source tree from [this-remote-doesnt-actually-exist]"
+
+    def test_checkout_successful(self, setup_teardown_local_branch):
+        git.checkout(TestGit.tmp_src_dir, branch=TestGit.local_branch)
+        assert git.current_branch(TestGit.tmp_src_dir) == TestGit.local_branch
+
+    def test_checkout_with_error(self):
+        branch = "this-branch-doesnt-actually-exist"
+        with pytest.raises(exceptions.SupplyError) as exc:
+            git.checkout(TestGit.tmp_src_dir, branch=branch)
+        assert exc.value.args[0] == f"Could not checkout [{branch}]. Do you have uncommitted changes?"
+
+    def test_checkout_revision(self):
+        git.checkout_revision(TestGit.tmp_src_dir, revision="bd368741951c643f9eb1958072c316e493c15b96")
+        assert "bd368741951c643f9eb1958072c316e493c15b96" == git.head_revision(TestGit.tmp_src_dir)
+
+    def test_checkout_branch(self):
+        git.checkout_branch(TestGit.tmp_src_dir, remote="upstream", branch=TestGit.remote_branch)
+        assert "be3eeda86e12616fa744f6cde7fcfe41b3a1c963" == git.head_revision(TestGit.tmp_src_dir)
+
+    def test_head_revision(self):
+        # Apple Git 'core.abbrev' defaults to return 7 char prefixes (09980cd)
+        # Linux defaults to return 8 char prefixes (09980cd5)
+        git.checkout(TestGit.tmp_src_dir, branch="2.6.0")
+        assert git.head_revision(TestGit.tmp_src_dir).startswith("09980cd")
+
+    def test_pull_ts(self):
+        git.pull_ts(TestGit.tmp_src_dir, "20160101T110000Z", remote="origin", branch="master")
+        assert "28474f4f097106ff3507be35958db0c3c8be0fc6" == git.head_revision(TestGit.tmp_src_dir)
+
+    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
+    def test_rebase(self, run_subprocess_with_logging):
+        run_subprocess_with_logging.return_value = 0
+        git.rebase("/src", remote="my-origin", branch="feature-branch")
+        calls = [
+            mock.call("git -C /src checkout feature-branch"),
+            mock.call(
+                '/bin/bash -c "for i in {1..5}; do git -C /src rebase '
+                'my-origin/feature-branch && s=0 && break || s=1 && sleep 1; done; (exit $s)"'
+            ),
+        ]
+        run_subprocess_with_logging.assert_has_calls(calls)
+
+    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
+    def test_pull(self, run_subprocess_with_logging):
+        run_subprocess_with_logging.return_value = 0
+        git.pull("/src", remote="my-origin", branch="feature-branch")
+        calls = [
+            # pull
+            mock.call("git -C /src --version", level=logging.DEBUG),
+            # fetch
+            mock.call("git -C /src --version", level=logging.DEBUG),
+            mock.call(
+                '/bin/bash -c "for i in {1..5}; do git -C /src fetch --prune '
+                '--tags my-origin && s=0 && break || s=1 && sleep 1; done; (exit $s)"'
+            ),
+            # rebase
+            mock.call("git -C /src --version", level=logging.DEBUG),
+            # checkout
+            mock.call("git -C /src --version", level=logging.DEBUG),
+            mock.call("git -C /src checkout feature-branch"),
+            mock.call(
+                '/bin/bash -c "for i in {1..5}; do git -C /src rebase '
+                'my-origin/feature-branch && s=0 && break || s=1 && sleep 1; done; (exit $s)"'
+            ),
+        ]
+        run_subprocess_with_logging.assert_has_calls(calls)

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -61,7 +61,7 @@ class TestGit:
 
     @pytest.fixture
     def setup_teardown_head_revision(self):
-        # rev is 09980cd
+        # rev is 09980cd5
         git.checkout(TestGit.tmp_src_dir, branch="2.6.0")
         yield
         git.checkout(TestGit.tmp_src_dir, branch=TestGit.current_branch)
@@ -160,7 +160,7 @@ class TestGit:
         git.checkout_revision(TestGit.tmp_src_dir, revision="bd368741951c643f9eb1958072c316e493c15b96")
 
     def test_head_revision(self, setup_teardown_head_revision):
-        assert git.head_revision(TestGit.tmp_src_dir) == "09980cd"
+        assert git.head_revision(TestGit.tmp_src_dir) == "09980cd5"
 
     def test_list_remote_branches(self):
         assert TestGit.remote_branch in git.branches(TestGit.tmp_src_dir, remote=True)

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -191,7 +191,7 @@ class TestGit:
 
     def test_pull_ts(self, setup_teardown_remote):
         # results in commit 28474f4f097106ff3507be35958db0c3c8be0fc6
-        git.pull_ts(TestGit.tmp_src_dir, "20160101T110000Z", remote="esrally", branch="master")
+        git.pull_ts(TestGit.tmp_src_dir, "2016-01-01T110000Z", remote="esrally", branch="master")
         assert git.head_revision(TestGit.tmp_src_dir).startswith("28474f4")
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -30,101 +30,104 @@ from esrally.utils import git, io, process
 class TestGit:
     @classmethod
     def setup_class(cls):
+        cls.remote_repo = "esrally"
         cls.local_branch = "rally-unit-test-local-only-branch"
         cls.remote_branch = "rally-unit-test-remote-only-branch"
+
         # this is assuming that nobody stripped the git repo info in their Rally working copy
-        cls.src_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        cls.tmp_src_dir = io.escape_path("/tmp/rally-unit-test-dir")
-        # location for 'clone' tests
+        cls.original_src_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        cls.local_tmp_src_dir = io.escape_path("/tmp/rally-unit-test-local-dir")
+        cls.remote_tmp_src_dir = io.escape_path("/tmp/rally-unit-test-remote-dir")
         cls.tmp_clone_dir = io.escape_path("/tmp/rally-unit-test-clone-dir")
 
         # delete any pre-existing dirs (maybe last test setup cancelled early)
-        shutil.rmtree(TestGit.tmp_src_dir, ignore_errors=True)
-        # create a copy to perform git operations in
-        shutil.copytree(TestGit.src_dir, TestGit.tmp_src_dir)
+        shutil.rmtree(TestGit.local_tmp_src_dir, ignore_errors=True)
+        shutil.rmtree(TestGit.remote_tmp_src_dir, ignore_errors=True)
+        shutil.rmtree(TestGit.tmp_clone_dir, ignore_errors=True)
 
+        # create tmp git repos
+        shutil.copytree(TestGit.original_src_dir, TestGit.local_tmp_src_dir)
         # stash any current changes in copied dir
-        process.run_subprocess_with_logging(f"git -C {TestGit.tmp_src_dir} stash")
+        process.run_subprocess_with_logging(f"git -C {TestGit.local_tmp_src_dir} stash")
+        shutil.copytree(TestGit.local_tmp_src_dir, TestGit.remote_tmp_src_dir)
+        # so we can restore the working tree after some tests
+        cls.starting_branch = git.current_branch(TestGit.local_tmp_src_dir)
 
-        cls.current_branch = git.current_branch(TestGit.tmp_src_dir)
+        # setup test branches
+        process.run_subprocess_with_logging(f"git -C {TestGit.local_tmp_src_dir} branch {TestGit.local_branch}")
+        process.run_subprocess_with_logging(f"git -C {TestGit.remote_tmp_src_dir} branch {TestGit.remote_branch}")
+        cls.remote_branch_hash = process.run_subprocess_with_output(
+            f"git -C {TestGit.remote_tmp_src_dir} rev-parse {TestGit.remote_branch}"
+        )[0]
+        # setup remote
+        process.run_subprocess_with_logging(
+            f"git -C {TestGit.local_tmp_src_dir} remote add {TestGit.remote_repo} {os.path.join(TestGit.remote_tmp_src_dir, '.git')}"
+        )
+
+        # fetch branches from remote
+        git.fetch(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo)
 
     @classmethod
     def teardown_class(cls):
         # delete copy of git dir
-        shutil.rmtree(TestGit.tmp_src_dir)
-
-    @pytest.fixture(autouse=True)
-    def checkout_previous_branch(self):
-        yield
-        # checkout the 'original' branch after each test
-        git.checkout(TestGit.tmp_src_dir, branch=TestGit.current_branch)
+        shutil.rmtree(TestGit.local_tmp_src_dir)
+        shutil.rmtree(TestGit.remote_tmp_src_dir)
 
     @pytest.fixture
     def teardown_clone(self):
         yield
         shutil.rmtree(TestGit.tmp_clone_dir)
 
-    @pytest.fixture
-    def setup_teardown_local_branch(self):
-        process.run_subprocess_with_logging(f"git -C {TestGit.tmp_src_dir} branch {TestGit.local_branch}")
+    @pytest.fixture(autouse=True)
+    def checkout_previous_branch(self):
         yield
-        process.run_subprocess_with_logging(f"git -C {TestGit.tmp_src_dir} branch -D {TestGit.local_branch}")
-
-    @pytest.fixture
-    def setup_teardown_remote(self):
-        """
-        Because 'origin' is relative to where the test is invoked we call this fixture to add a consistently named
-        remote for both CI and local test invocations.
-        """
-        process.run_subprocess_with_logging(f"git -C {TestGit.tmp_src_dir} remote add esrally git@github.com:elastic/rally.git")
-        git.fetch(TestGit.tmp_src_dir, remote="esrally")
-        yield
-        process.run_subprocess_with_logging(f"git -C {TestGit.tmp_src_dir} remote remove esrally")
+        # checkout the 'original' branch after each test
+        git.checkout(TestGit.local_tmp_src_dir, branch=TestGit.starting_branch)
 
     @pytest.fixture
     def delete_local_tags(self):
         # delete tags, locally
-        process.run_subprocess(f"git -C {TestGit.tmp_src_dir} tag | xargs git -C {TestGit.tmp_src_dir} tag -d")
+        process.run_subprocess(f"git -C {TestGit.local_tmp_src_dir} tag | xargs git -C {TestGit.local_tmp_src_dir} tag -d")
         yield
         # reinstate local tags from remote
-        git.fetch(TestGit.tmp_src_dir, remote="origin")
+        git.fetch(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo)
 
     def test_is_git_working_copy(self):
         # this test is assuming that nobody stripped the git repo info in their Rally working copy
-        assert not git.is_working_copy(os.path.dirname(TestGit.tmp_src_dir))
-        assert git.is_working_copy(TestGit.tmp_src_dir)
+        assert not git.is_working_copy(os.path.dirname(TestGit.local_tmp_src_dir))
+        assert git.is_working_copy(TestGit.local_tmp_src_dir)
 
-    def test_is_branch(self, setup_teardown_local_branch):
+    def test_is_branch(self):
         # only remote
-        assert git.is_branch(TestGit.tmp_src_dir, identifier=TestGit.remote_branch)
+        assert git.is_branch(TestGit.local_tmp_src_dir, identifier=TestGit.remote_branch)
 
         # only local
-        assert git.is_branch(TestGit.tmp_src_dir, identifier=TestGit.local_branch)
+        assert git.is_branch(TestGit.local_tmp_src_dir, identifier=TestGit.local_branch)
 
         # both remote, and local
-        assert git.is_branch(TestGit.tmp_src_dir, identifier="master")
+        assert git.is_branch(TestGit.local_tmp_src_dir, identifier="master")
 
     def test_is_not_branch_tags(self):
-        assert not git.is_branch(TestGit.tmp_src_dir, identifier="2.6.0")
+        assert not git.is_branch(TestGit.local_tmp_src_dir, identifier="2.6.0")
 
     def test_is_not_branch_commit_hash(self):
         # rally's initial commit :-)
-        assert not git.is_branch(TestGit.tmp_src_dir, identifier="bd368741951c643f9eb1958072c316e493c15b96")
+        assert not git.is_branch(TestGit.local_tmp_src_dir, identifier="bd368741951c643f9eb1958072c316e493c15b96")
 
     def test_list_remote_branches(self):
-        assert TestGit.remote_branch in git.branches(TestGit.tmp_src_dir, remote=True)
+        assert TestGit.remote_branch in git.branches(TestGit.local_tmp_src_dir, remote=True)
 
-    def test_list_local_branches(self, setup_teardown_local_branch):
-        assert TestGit.local_branch in git.branches(TestGit.tmp_src_dir, remote=False)
+    def test_list_local_branches(self):
+        assert TestGit.local_branch in git.branches(TestGit.local_tmp_src_dir, remote=False)
 
     def test_list_tags_with_tags_present(self):
         expected_tags = ["2.6.0", "2.5.0", "2.4.0", "2.3.1", "2.3.0"]
-        tags = git.tags(TestGit.tmp_src_dir)
+        tags = git.tags(TestGit.local_tmp_src_dir)
         for tag in expected_tags:
             assert tag in tags
 
     def test_list_tags_no_tags_available(self, delete_local_tags):
-        assert git.tags(TestGit.tmp_src_dir) == []
+        assert git.tags(TestGit.local_tmp_src_dir) == []
 
     @mock.patch("esrally.utils.process.run_subprocess_with_output")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
@@ -139,60 +142,57 @@ class TestGit:
         run_subprocess_with_logging.assert_called_with("git -C /src --version", level=logging.DEBUG)
 
     def test_clone_successful(self, teardown_clone):
-        remote = "https://github.com/elastic/rally"
-        git.clone(TestGit.tmp_clone_dir, remote=remote)
+        git.clone(TestGit.tmp_clone_dir, remote=TestGit.remote_tmp_src_dir)
         assert git.is_working_copy(TestGit.tmp_clone_dir)
 
     def test_clone_with_error(self):
-        remote = "https://github.com/elastic/this-project-doesnt-actually-exist"
+        remote = "/this/remote/doesnt/exist.git"
         with pytest.raises(exceptions.SupplyError) as exc:
             git.clone(TestGit.tmp_clone_dir, remote=remote)
         assert exc.value.args[0] == f"Could not clone from [{remote}] to [{TestGit.tmp_clone_dir}]"
 
     def test_fetch_successful(self):
-        before_time = os.path.getmtime(os.path.join(TestGit.tmp_src_dir, ".git/FETCH_HEAD"))
-        git.fetch(TestGit.tmp_src_dir, remote="origin")
-        after_time = os.path.getmtime(os.path.join(TestGit.tmp_src_dir, ".git/FETCH_HEAD"))
+        before_time = os.path.getmtime(os.path.join(TestGit.local_tmp_src_dir, ".git/FETCH_HEAD"))
+        git.fetch(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo)
+        after_time = os.path.getmtime(os.path.join(TestGit.local_tmp_src_dir, ".git/FETCH_HEAD"))
         fetch_head_modified = after_time > before_time
         assert fetch_head_modified
 
     def test_fetch_with_error(self):
         with pytest.raises(exceptions.SupplyError) as exc:
-            git.fetch(TestGit.tmp_src_dir, remote="this-remote-doesnt-actually-exist")
+            git.fetch(TestGit.local_tmp_src_dir, remote="this-remote-doesnt-actually-exist")
         assert exc.value.args[0] == "Could not fetch source tree from [this-remote-doesnt-actually-exist]"
 
-    def test_checkout_successful(self, setup_teardown_local_branch):
-        git.checkout(TestGit.tmp_src_dir, branch=TestGit.local_branch)
-        assert git.current_branch(TestGit.tmp_src_dir) == TestGit.local_branch
+    def test_checkout_successful(self):
+        git.checkout(TestGit.local_tmp_src_dir, branch=TestGit.local_branch)
+        assert git.current_branch(TestGit.local_tmp_src_dir) == TestGit.local_branch
 
     def test_checkout_with_error(self):
         branch = "this-branch-doesnt-actually-exist"
         with pytest.raises(exceptions.SupplyError) as exc:
-            git.checkout(TestGit.tmp_src_dir, branch=branch)
+            git.checkout(TestGit.local_tmp_src_dir, branch=branch)
         assert exc.value.args[0] == f"Could not checkout [{branch}]. Do you have uncommitted changes?"
 
     def test_checkout_revision(self):
         # Apple Git 'core.abbrev' defaults to return 7 char prefixes (09980cd)
         # Linux defaults to return 8 char prefixes (09980cd5)
-        git.checkout_revision(TestGit.tmp_src_dir, revision="bd368741951c643f9eb1958072c316e493c15b96")
-        assert git.head_revision(TestGit.tmp_src_dir).startswith("bd36874")
+        git.checkout_revision(TestGit.local_tmp_src_dir, revision="bd368741951c643f9eb1958072c316e493c15b96")
+        assert git.head_revision(TestGit.local_tmp_src_dir).startswith("bd36874")
 
-    def test_checkout_branch(self, setup_teardown_remote):
-        # Apple Git 'core.abbrev' defaults to return 7 char prefixes (09980cd)
-        # Linux defaults to return 8 char prefixes (09980cd5)
-        git.checkout_branch(TestGit.tmp_src_dir, remote="esrally", branch=TestGit.remote_branch)
-        assert git.head_revision(TestGit.tmp_src_dir).startswith("be3eeda")
+    def test_checkout_branch(self):
+        git.checkout_branch(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo, branch=TestGit.remote_branch)
+        assert git.head_revision(TestGit.local_tmp_src_dir).startswith(TestGit.remote_branch_hash)
 
     def test_head_revision(self):
         # Apple Git 'core.abbrev' defaults to return 7 char prefixes (09980cd)
         # Linux defaults to return 8 char prefixes (09980cd5)
-        git.checkout(TestGit.tmp_src_dir, branch="2.6.0")
-        assert git.head_revision(TestGit.tmp_src_dir).startswith("09980cd")
+        git.checkout(TestGit.local_tmp_src_dir, branch="2.6.0")
+        assert git.head_revision(TestGit.local_tmp_src_dir).startswith("09980cd")
 
-    def test_pull_ts(self, setup_teardown_remote):
+    def test_pull_ts(self):
         # results in commit 28474f4f097106ff3507be35958db0c3c8be0fc6
-        git.pull_ts(TestGit.tmp_src_dir, "2016-01-01T110000Z", remote="esrally", branch="master")
-        assert git.head_revision(TestGit.tmp_src_dir).startswith("28474f4")
+        git.pull_ts(TestGit.local_tmp_src_dir, "2016-01-01T110000Z", remote=TestGit.remote_repo, branch="master")
+        assert git.head_revision(TestGit.local_tmp_src_dir).startswith("28474f4")
 
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
     def test_rebase(self, run_subprocess_with_logging):

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# add assertions to git tests
-
 import logging
 import os
 import shutil

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -24,132 +24,123 @@ from unittest import mock
 import pytest
 
 from esrally import exceptions
-from esrally.utils import git, io, process
+from esrally.utils import git, process
+
+
+@pytest.fixture(scope="class", autouse=True)
+def setup(request, tmp_path_factory):
+    request.cls.remote_repo = "esrally"
+    request.cls.local_branch = "rally-unit-test-local-only-branch"
+    request.cls.remote_branch = "rally-unit-test-remote-only-branch"
+    request.cls.rebase_branch = "rally-unit-test-rebase-branch"
+
+    # this is assuming that nobody stripped the git repo info in their Rally working copy
+    request.cls.original_src_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    request.cls.local_tmp_src_dir = str(tmp_path_factory.mktemp("rally-unit-test-local-dir"))
+    request.cls.remote_tmp_src_dir = str(tmp_path_factory.mktemp("rally-unit-test-remote-dir"))
+    request.cls.tmp_clone_dir = str(tmp_path_factory.mktemp("rally-unit-test-clone-dir"))
+
+    # # delete any pre-existing dirs (maybe last test setup cancelled early)
+    shutil.rmtree(request.cls.local_tmp_src_dir, ignore_errors=True)
+    shutil.rmtree(request.cls.remote_tmp_src_dir, ignore_errors=True)
+    shutil.rmtree(request.cls.tmp_clone_dir, ignore_errors=True)
+
+    # create tmp git repos
+    shutil.copytree(request.cls.original_src_dir, request.cls.local_tmp_src_dir)
+    # stash any current changes in copied dir
+    process.run_subprocess_with_logging(f"git -C {request.cls.local_tmp_src_dir} stash")
+    shutil.copytree(request.cls.original_src_dir, request.cls.remote_tmp_src_dir)
+    # so we can restore the working tree after some tests
+    request.cls.starting_branch = git.current_branch(request.cls.local_tmp_src_dir)
+
+    # setup test branches
+    process.run_subprocess_with_logging(f"git -C {request.cls.local_tmp_src_dir} branch {request.cls.local_branch}")
+    process.run_subprocess_with_logging(f"git -C {request.cls.remote_tmp_src_dir} branch {request.cls.remote_branch}")
+    request.cls.remote_branch_hash = process.run_subprocess_with_output(
+        f"git -C {request.cls.remote_tmp_src_dir} rev-parse {request.cls.remote_branch}"
+    )[0]
+    # setup remote
+    process.run_subprocess_with_logging(
+        f"git -C {request.cls.local_tmp_src_dir} remote add {request.cls.remote_repo} "
+        f"{os.path.join(request.cls.remote_tmp_src_dir, '.git')}"
+    )
+
+    # fetch branches from remote
+    git.fetch(request.cls.local_tmp_src_dir, remote=request.cls.remote_repo)
 
 
 # pylint: disable=too-many-public-methods
 class TestGit:
-    @classmethod
-    def setup_class(cls):
-        cls.remote_repo = "esrally"
-        cls.local_branch = "rally-unit-test-local-only-branch"
-        cls.remote_branch = "rally-unit-test-remote-only-branch"
-        cls.rebase_branch = "rally-unit-test-rebase-branch"
-
-        # this is assuming that nobody stripped the git repo info in their Rally working copy
-        cls.original_src_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        cls.local_tmp_src_dir = io.escape_path("/tmp/rally-unit-test-local-dir")
-        cls.remote_tmp_src_dir = io.escape_path("/tmp/rally-unit-test-remote-dir")
-        cls.tmp_clone_dir = io.escape_path("/tmp/rally-unit-test-clone-dir")
-
-        # delete any pre-existing dirs (maybe last test setup cancelled early)
-        shutil.rmtree(TestGit.local_tmp_src_dir, ignore_errors=True)
-        shutil.rmtree(TestGit.remote_tmp_src_dir, ignore_errors=True)
-        shutil.rmtree(TestGit.tmp_clone_dir, ignore_errors=True)
-
-        # create tmp git repos
-        shutil.copytree(TestGit.original_src_dir, TestGit.local_tmp_src_dir)
-        # stash any current changes in copied dir
-        process.run_subprocess_with_logging(f"git -C {TestGit.local_tmp_src_dir} stash")
-        shutil.copytree(TestGit.original_src_dir, TestGit.remote_tmp_src_dir)
-        # so we can restore the working tree after some tests
-        cls.starting_branch = git.current_branch(TestGit.local_tmp_src_dir)
-
-        # setup test branches
-        process.run_subprocess_with_logging(f"git -C {TestGit.local_tmp_src_dir} branch {TestGit.local_branch}")
-        process.run_subprocess_with_logging(f"git -C {TestGit.remote_tmp_src_dir} branch {TestGit.remote_branch}")
-        cls.remote_branch_hash = process.run_subprocess_with_output(
-            f"git -C {TestGit.remote_tmp_src_dir} rev-parse {TestGit.remote_branch}"
-        )[0]
-        # setup remote
-        process.run_subprocess_with_logging(
-            f"git -C {TestGit.local_tmp_src_dir} remote add {TestGit.remote_repo} {os.path.join(TestGit.remote_tmp_src_dir, '.git')}"
-        )
-
-        # fetch branches from remote
-        git.fetch(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo)
-
-    @classmethod
-    def teardown_class(cls):
-        # delete copy of git dir
-        shutil.rmtree(TestGit.local_tmp_src_dir)
-        shutil.rmtree(TestGit.remote_tmp_src_dir)
-
-    @pytest.fixture
-    def teardown_clone(self):
-        yield
-        shutil.rmtree(TestGit.tmp_clone_dir)
-
     @pytest.fixture(autouse=True)
     def checkout_previous_branch(self):
         yield
         # checkout the 'original' branch after each test
-        git.checkout(TestGit.local_tmp_src_dir, branch=TestGit.starting_branch)
+        git.checkout(self.local_tmp_src_dir, branch=self.starting_branch)
 
     @pytest.fixture
     def delete_local_tags(self):
         # delete tags, locally
-        process.run_subprocess(f"git -C {TestGit.local_tmp_src_dir} tag | xargs git -C {TestGit.local_tmp_src_dir} tag -d")
+        process.run_subprocess(f"git -C {self.local_tmp_src_dir} tag | xargs git -C {self.local_tmp_src_dir} tag -d")
         yield
         # reinstate local tags from remote
-        git.fetch(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo)
+        git.fetch(self.local_tmp_src_dir, remote=self.remote_repo)
 
     @pytest.fixture
     def setup_teardown_rebase(self):
         # create branches on local and remote
-        process.run_subprocess_with_logging(f"git -C {TestGit.local_tmp_src_dir} branch {TestGit.rebase_branch}")
-        process.run_subprocess_with_logging(f"git -C {TestGit.remote_tmp_src_dir} checkout -b {TestGit.rebase_branch}")
+        process.run_subprocess_with_logging(f"git -C {self.local_tmp_src_dir} branch {self.rebase_branch}")
+        process.run_subprocess_with_logging(f"git -C {self.remote_tmp_src_dir} checkout -b {self.rebase_branch}")
         # create remote commit from which to rebase on in local
-        process.run_subprocess_with_logging(f"git -C {TestGit.remote_tmp_src_dir} commit --allow-empty -m 'Rally rebase/pull test'")
+        process.run_subprocess_with_logging(f"git -C {self.remote_tmp_src_dir} commit --allow-empty -m 'Rally rebase/pull test'")
         # run rebase
         yield
         # undo rebase
-        process.run_subprocess_with_logging(f"git -C {TestGit.local_tmp_src_dir} reset --hard ORIG_HEAD")
+        process.run_subprocess_with_logging(f"git -C {self.local_tmp_src_dir} reset --hard ORIG_HEAD")
 
         # checkout starting branches
-        git.checkout(TestGit.local_tmp_src_dir, branch=TestGit.starting_branch)
-        git.checkout(TestGit.remote_tmp_src_dir, branch=TestGit.starting_branch)
+        git.checkout(self.local_tmp_src_dir, branch=self.starting_branch)
+        git.checkout(self.remote_tmp_src_dir, branch=self.starting_branch)
 
         # delete branches
-        process.run_subprocess_with_logging(f"git -C {TestGit.local_tmp_src_dir} branch -D {TestGit.rebase_branch}")
-        process.run_subprocess_with_logging(f"git -C {TestGit.remote_tmp_src_dir} branch -D {TestGit.rebase_branch}")
+        process.run_subprocess_with_logging(f"git -C {self.local_tmp_src_dir} branch -D {self.rebase_branch}")
+        process.run_subprocess_with_logging(f"git -C {self.remote_tmp_src_dir} branch -D {self.rebase_branch}")
 
     def test_is_git_working_copy(self):
         # this test is assuming that nobody stripped the git repo info in their Rally working copy
-        assert not git.is_working_copy(os.path.dirname(TestGit.local_tmp_src_dir))
-        assert git.is_working_copy(TestGit.local_tmp_src_dir)
+        assert not git.is_working_copy(os.path.dirname(self.local_tmp_src_dir))
+        assert git.is_working_copy(self.local_tmp_src_dir)
 
     def test_is_branch(self):
         # only remote
-        assert git.is_branch(TestGit.local_tmp_src_dir, identifier=TestGit.remote_branch)
+        assert git.is_branch(self.local_tmp_src_dir, identifier=self.remote_branch)
 
         # only local
-        assert git.is_branch(TestGit.local_tmp_src_dir, identifier=TestGit.local_branch)
+        assert git.is_branch(self.local_tmp_src_dir, identifier=self.local_branch)
 
         # both remote, and local
-        assert git.is_branch(TestGit.local_tmp_src_dir, identifier="master")
+        assert git.is_branch(self.local_tmp_src_dir, identifier="master")
 
     def test_is_not_branch_tags(self):
-        assert not git.is_branch(TestGit.local_tmp_src_dir, identifier="2.6.0")
+        assert not git.is_branch(self.local_tmp_src_dir, identifier="2.6.0")
 
     def test_is_not_branch_commit_hash(self):
         # rally's initial commit :-)
-        assert not git.is_branch(TestGit.local_tmp_src_dir, identifier="bd368741951c643f9eb1958072c316e493c15b96")
+        assert not git.is_branch(self.local_tmp_src_dir, identifier="bd368741951c643f9eb1958072c316e493c15b96")
 
     def test_list_remote_branches(self):
-        assert TestGit.remote_branch in git.branches(TestGit.local_tmp_src_dir, remote=True)
+        assert self.remote_branch in git.branches(self.local_tmp_src_dir, remote=True)
 
     def test_list_local_branches(self):
-        assert TestGit.local_branch in git.branches(TestGit.local_tmp_src_dir, remote=False)
+        assert self.local_branch in git.branches(self.local_tmp_src_dir, remote=False)
 
     def test_list_tags_with_tags_present(self):
         expected_tags = ["2.6.0", "2.5.0", "2.4.0", "2.3.1", "2.3.0"]
-        tags = git.tags(TestGit.local_tmp_src_dir)
+        tags = git.tags(self.local_tmp_src_dir)
         for tag in expected_tags:
             assert tag in tags
 
     def test_list_tags_no_tags_available(self, delete_local_tags):
-        assert git.tags(TestGit.local_tmp_src_dir) == []
+        assert git.tags(self.local_tmp_src_dir) == []
 
     @mock.patch("esrally.utils.process.run_subprocess_with_output")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
@@ -163,75 +154,75 @@ class TestGit:
         assert exc.value.args[0] == "Your git version is [1.0.0] but Rally requires at least git 1.9. Please update git."
         run_subprocess_with_logging.assert_called_with("git -C /src --version", level=logging.DEBUG)
 
-    def test_clone_successful(self, teardown_clone):
-        git.clone(TestGit.tmp_clone_dir, remote=TestGit.remote_tmp_src_dir)
-        assert git.is_working_copy(TestGit.tmp_clone_dir)
+    def test_clone_successful(self):
+        git.clone(self.tmp_clone_dir, remote=self.remote_tmp_src_dir)
+        assert git.is_working_copy(self.tmp_clone_dir)
 
     def test_clone_with_error(self):
         remote = "/this/remote/doesnt/exist.git"
         with pytest.raises(exceptions.SupplyError) as exc:
-            git.clone(TestGit.tmp_clone_dir, remote=remote)
-        assert exc.value.args[0] == f"Could not clone from [{remote}] to [{TestGit.tmp_clone_dir}]"
+            git.clone(self.tmp_clone_dir, remote=remote)
+        assert exc.value.args[0] == f"Could not clone from [{remote}] to [{self.tmp_clone_dir}]"
 
     def test_fetch_successful(self):
-        before_time = os.path.getmtime(os.path.join(TestGit.local_tmp_src_dir, ".git/FETCH_HEAD"))
-        git.fetch(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo)
-        after_time = os.path.getmtime(os.path.join(TestGit.local_tmp_src_dir, ".git/FETCH_HEAD"))
+        before_time = os.path.getmtime(os.path.join(self.local_tmp_src_dir, ".git/FETCH_HEAD"))
+        git.fetch(self.local_tmp_src_dir, remote=self.remote_repo)
+        after_time = os.path.getmtime(os.path.join(self.local_tmp_src_dir, ".git/FETCH_HEAD"))
         fetch_head_modified = after_time > before_time
         assert fetch_head_modified
 
     def test_fetch_with_error(self):
         with pytest.raises(exceptions.SupplyError) as exc:
-            git.fetch(TestGit.local_tmp_src_dir, remote="this-remote-doesnt-actually-exist")
+            git.fetch(self.local_tmp_src_dir, remote="this-remote-doesnt-actually-exist")
         assert exc.value.args[0] == "Could not fetch source tree from [this-remote-doesnt-actually-exist]"
 
     def test_checkout_successful(self):
-        git.checkout(TestGit.local_tmp_src_dir, branch=TestGit.local_branch)
-        assert git.current_branch(TestGit.local_tmp_src_dir) == TestGit.local_branch
+        git.checkout(self.local_tmp_src_dir, branch=self.local_branch)
+        assert git.current_branch(self.local_tmp_src_dir) == self.local_branch
 
     def test_checkout_with_error(self):
         branch = "this-branch-doesnt-actually-exist"
         with pytest.raises(exceptions.SupplyError) as exc:
-            git.checkout(TestGit.local_tmp_src_dir, branch=branch)
+            git.checkout(self.local_tmp_src_dir, branch=branch)
         assert exc.value.args[0] == f"Could not checkout [{branch}]. Do you have uncommitted changes?"
 
     def test_checkout_revision(self):
         # Apple Git 'core.abbrev' defaults to return 7 char prefixes (09980cd)
         # Linux defaults to return 8 char prefixes (09980cd5)
-        git.checkout_revision(TestGit.local_tmp_src_dir, revision="bd368741951c643f9eb1958072c316e493c15b96")
-        assert git.head_revision(TestGit.local_tmp_src_dir).startswith("bd36874")
+        git.checkout_revision(self.local_tmp_src_dir, revision="bd368741951c643f9eb1958072c316e493c15b96")
+        assert git.head_revision(self.local_tmp_src_dir).startswith("bd36874")
 
     def test_checkout_branch(self):
-        git.checkout_branch(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo, branch=TestGit.remote_branch)
-        assert git.head_revision(TestGit.local_tmp_src_dir).startswith(TestGit.remote_branch_hash[0:7])
+        git.checkout_branch(self.local_tmp_src_dir, remote=self.remote_repo, branch=self.remote_branch)
+        assert git.head_revision(self.local_tmp_src_dir).startswith(self.remote_branch_hash[0:7])
 
     def test_head_revision(self):
         # Apple Git 'core.abbrev' defaults to return 7 char prefixes (09980cd)
         # Linux defaults to return 8 char prefixes (09980cd5)
-        git.checkout(TestGit.local_tmp_src_dir, branch="2.6.0")
-        assert git.head_revision(TestGit.local_tmp_src_dir).startswith("09980cd")
+        git.checkout(self.local_tmp_src_dir, branch="2.6.0")
+        assert git.head_revision(self.local_tmp_src_dir).startswith("09980cd")
 
     def test_pull_ts(self):
         # results in commit 28474f4f097106ff3507be35958db0c3c8be0fc6
-        git.pull_ts(TestGit.local_tmp_src_dir, "2016-01-01T110000Z", remote=TestGit.remote_repo, branch=TestGit.remote_branch)
-        assert git.head_revision(TestGit.local_tmp_src_dir).startswith("28474f4")
+        git.pull_ts(self.local_tmp_src_dir, "2016-01-01T110000Z", remote=self.remote_repo, branch=self.remote_branch)
+        assert git.head_revision(self.local_tmp_src_dir).startswith("28474f4")
 
     def test_rebase(self, setup_teardown_rebase):
         # fetch required first to get remote branch
-        git.fetch(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo)
-        git.rebase(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo, branch=TestGit.rebase_branch)
-        ops = " ".join(process.run_subprocess_with_output(f"git -C {TestGit.local_tmp_src_dir} reflog --since=10.seconds.ago"))
+        git.fetch(self.local_tmp_src_dir, remote=self.remote_repo)
+        git.rebase(self.local_tmp_src_dir, remote=self.remote_repo, branch=self.rebase_branch)
+        ops = " ".join(process.run_subprocess_with_output(f"git -C {self.local_tmp_src_dir} reflog --since=10.seconds.ago"))
         # reflog format differs from Apple Git to Linux
-        finished_pattern = re.compile(f"rebase (\\(finish\\)|finished).*returning to refs\\/heads\\/{TestGit.rebase_branch}")
-        started_pattern = re.compile(f"rebase:? (\\(start\\)*.|checkout).*{TestGit.remote_repo}\\/{TestGit.rebase_branch}")
+        finished_pattern = re.compile(f"rebase (\\(finish\\)|finished).*returning to refs\\/heads\\/{self.rebase_branch}")
+        started_pattern = re.compile(f"rebase:? (\\(start\\)*.|checkout).*{self.remote_repo}\\/{self.rebase_branch}")
         assert re.search(started_pattern, ops)
         assert re.search(finished_pattern, ops)
 
     def test_pull_rebase(self, setup_teardown_rebase):
-        git.pull(TestGit.local_tmp_src_dir, remote=TestGit.remote_repo, branch=TestGit.rebase_branch)
-        ops = " ".join(process.run_subprocess_with_output(f"git -C {TestGit.local_tmp_src_dir} reflog --since=10.seconds.ago"))
+        git.pull(self.local_tmp_src_dir, remote=self.remote_repo, branch=self.rebase_branch)
+        ops = " ".join(process.run_subprocess_with_output(f"git -C {self.local_tmp_src_dir} reflog --since=10.seconds.ago"))
         # reflog format differs from Apple Git to Linux
-        finished_pattern = re.compile(f"rebase (\\(finish\\)|finished).*returning to refs\\/heads\\/{TestGit.rebase_branch}")
-        started_pattern = re.compile(f"rebase:? (\\(start\\)*.|checkout).*{TestGit.remote_repo}\\/{TestGit.rebase_branch}")
+        finished_pattern = re.compile(f"rebase (\\(finish\\)|finished).*returning to refs\\/heads\\/{self.rebase_branch}")
+        started_pattern = re.compile(f"rebase:? (\\(start\\)*.|checkout).*{self.remote_repo}\\/{self.rebase_branch}")
         assert re.search(started_pattern, ops)
         assert re.search(finished_pattern, ops)

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -40,16 +40,11 @@ def setup(request, tmp_path_factory):
     request.cls.remote_tmp_src_dir = str(tmp_path_factory.mktemp("rally-unit-test-remote-dir"))
     request.cls.tmp_clone_dir = str(tmp_path_factory.mktemp("rally-unit-test-clone-dir"))
 
-    # # delete any pre-existing dirs (maybe last test setup cancelled early)
-    shutil.rmtree(request.cls.local_tmp_src_dir, ignore_errors=True)
-    shutil.rmtree(request.cls.remote_tmp_src_dir, ignore_errors=True)
-    shutil.rmtree(request.cls.tmp_clone_dir, ignore_errors=True)
-
     # create tmp git repos
-    shutil.copytree(request.cls.original_src_dir, request.cls.local_tmp_src_dir)
+    shutil.copytree(request.cls.original_src_dir, request.cls.local_tmp_src_dir, dirs_exist_ok=True)
     # stash any current changes in copied dir
     process.run_subprocess_with_logging(f"git -C {request.cls.local_tmp_src_dir} stash")
-    shutil.copytree(request.cls.original_src_dir, request.cls.remote_tmp_src_dir)
+    shutil.copytree(request.cls.original_src_dir, request.cls.remote_tmp_src_dir, dirs_exist_ok=True)
     # so we can restore the working tree after some tests
     request.cls.starting_branch = git.current_branch(request.cls.local_tmp_src_dir)
 

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -51,7 +51,7 @@ class TestGit:
         shutil.copytree(TestGit.original_src_dir, TestGit.local_tmp_src_dir)
         # stash any current changes in copied dir
         process.run_subprocess_with_logging(f"git -C {TestGit.local_tmp_src_dir} stash")
-        shutil.copytree(TestGit.local_tmp_src_dir, TestGit.remote_tmp_src_dir)
+        shutil.copytree(TestGit.original_src_dir, TestGit.remote_tmp_src_dir)
         # so we can restore the working tree after some tests
         cls.starting_branch = git.current_branch(TestGit.local_tmp_src_dir)
 
@@ -213,7 +213,7 @@ class TestGit:
 
     def test_pull_ts(self):
         # results in commit 28474f4f097106ff3507be35958db0c3c8be0fc6
-        git.pull_ts(TestGit.local_tmp_src_dir, "2016-01-01T110000Z", remote=TestGit.remote_repo, branch="master")
+        git.pull_ts(TestGit.local_tmp_src_dir, "2016-01-01T110000Z", remote=TestGit.remote_repo, branch=TestGit.remote_branch)
         assert git.head_revision(TestGit.local_tmp_src_dir).startswith("28474f4")
 
     def test_rebase(self, setup_teardown_rebase):

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -182,8 +182,7 @@ class TestGit:
         assert exc.value.args[0] == f"Could not checkout [{branch}]. Do you have uncommitted changes?"
 
     def test_checkout_revision(self):
-        # Apple Git 'core.abbrev' defaults to return 7 char prefixes (09980cd)
-        # Linux defaults to return 8 char prefixes (09980cd5)
+        # minimum 'core.abbrev' is to return 7 char prefixes
         git.checkout_revision(self.local_tmp_src_dir, revision="bd368741951c643f9eb1958072c316e493c15b96")
         assert git.head_revision(self.local_tmp_src_dir).startswith("bd36874")
 
@@ -192,13 +191,13 @@ class TestGit:
         assert git.head_revision(self.local_tmp_src_dir).startswith(self.remote_branch_hash[0:7])
 
     def test_head_revision(self):
-        # Apple Git 'core.abbrev' defaults to return 7 char prefixes (09980cd)
-        # Linux defaults to return 8 char prefixes (09980cd5)
+        # minimum 'core.abbrev' is to return 7 char prefixes
         git.checkout(self.local_tmp_src_dir, branch="2.6.0")
         assert git.head_revision(self.local_tmp_src_dir).startswith("09980cd")
 
     def test_pull_ts(self):
         # results in commit 28474f4f097106ff3507be35958db0c3c8be0fc6
+        # minimum 'core.abbrev' is to return 7 char prefixes
         git.pull_ts(self.local_tmp_src_dir, "2016-01-01T110000Z", remote=self.remote_repo, branch=self.remote_branch)
         assert git.head_revision(self.local_tmp_src_dir).startswith("28474f4")
 

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -104,6 +104,11 @@ class TestGit:
         yield
         # undo rebase
         process.run_subprocess_with_logging(f"git -C {TestGit.local_tmp_src_dir} reset --hard ORIG_HEAD")
+
+        # checkout starting branches
+        git.checkout(TestGit.local_tmp_src_dir, branch=TestGit.starting_branch)
+        git.checkout(TestGit.remote_tmp_src_dir, branch=TestGit.starting_branch)
+
         # delete branches
         process.run_subprocess_with_logging(f"git -C {TestGit.local_tmp_src_dir} branch -D {TestGit.rebase_branch}")
         process.run_subprocess_with_logging(f"git -C {TestGit.remote_tmp_src_dir} branch -D {TestGit.rebase_branch}")

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -160,11 +160,7 @@ class TestGit:
         assert exc.value.args[0] == f"Could not clone from [{remote}] to [{self.tmp_clone_dir}]"
 
     def test_fetch_successful(self):
-        before_time = os.path.getmtime(os.path.join(self.local_tmp_src_dir, ".git/FETCH_HEAD"))
         git.fetch(self.local_tmp_src_dir, remote=self.remote_repo)
-        after_time = os.path.getmtime(os.path.join(self.local_tmp_src_dir, ".git/FETCH_HEAD"))
-        fetch_head_modified = after_time > before_time
-        assert fetch_head_modified
 
     def test_fetch_with_error(self):
         with pytest.raises(exceptions.SupplyError) as exc:


### PR DESCRIPTION
We learned in https://github.com/elastic/rally/pull/1587 that perhaps we were overusing 'mocks', as we didn't catch a subtle bug I introduced. This change adds approx ~20s to the total test runtime when invoking real git commands (~45s, up from ~25s). 

With this commit we remove all usage
of mocks in the `git` module tests, instead
taking the approach of copying the local Rally
checkout to a temp location and performing
a series of git operations.

Closes https://github.com/elastic/rally/issues/1596