### PR TITLE
Use ubuntu/squid docker image

### DIFF
--- a/it/proxy_test.py
+++ b/it/proxy_test.py
@@ -36,7 +36,7 @@ def http_proxy():
         f"docker run --rm --name squid -d "
         f"-v {config_dir}/squidpasswords:/etc/squid/squidpasswords "
         f"-v {config_dir}/squid.conf:/etc/squid/squid.conf "
-        f"-p 3128:3128 datadog/squid"
+        f"-p 3128:3128 ubuntu/squid"
     )
     proxy_container_id = lines[-1].strip()
     proxy = HttpProxy(authenticated_url="http://testuser:testuser@127.0.0.1:3128", anonymous_url="http://127.0.0.1:3128")


### PR DESCRIPTION
ITs were failing for me in https://github.com/elastic/rally/pull/1602, and troubleshooting led me here:
```
$ docker run --rm --name squid -d -v it/resources/squid//squidpasswords:/etc/squid/squidpasswords -v it/resources/squid//squid.conf:/etc/squid/squid.conf -p 3128:3128 datadog/squid
Unable to find image 'datadog/squid:latest' locally
docker: Error response from daemon: pull access denied for datadog/squid, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.

$ docker search squid
NAME                         DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
sameersbn/squid                                                              222                  [OK]
squidfunk/mkdocs-material    Documentation that simply works                 113                  [OK]
minimum2scp/squid            squid3 cache service container running on de…   66                   [OK]
ubuntu/squid                 Squid is a caching proxy for the Web. Long-t…   40
b4tman/squid                 Squid container based on Alpine Linux           17                   [OK]
squidex/squidex              Squidex Headless CMS                            13
lucacri/squid-ext-conf       Squid server on alpine, gathering configurat…   12
babim/squid                  Squid 4 on alpine linux. With or without auth   3                    [OK]
photoprism/mkdocs-material   Tracks stable major versions of squidfunk/mk…   2
cloudreach/squid-utm         Squid Proxy UTM                                 1
kasmweb/squid                A proxy intended to redirect users to a Kasm…   1
boynux/squid-exporter        Squid metrics exporter for Prometheus           1                    [OK]
squids/squids-exporter                                                       0
squids/mysql                                                                 0
squids/mycilium                                                              0
squids/mysqlleader                                                           0
squids/mycilium-amd64                                                        0
squidex/nginx-proxy                                                          0
squids/qfb-mysql-8.0                                                         0
squidex/caddy-proxy                                                          0
squidtoon99/apiserver-rs                                                     0
squids/qfb-backup-job                                                        0
squidex/squidex-identity     Squidex Identity Server                         0
squidcache/buildfarm         Images for the project's Jenkins build farm     0
squids/fluent-bit                                                            0
```

[The `datadog/squid` image doesn't seem to exist anymore](https://hub.docker.com/r/datadog/squid), but because it was cached locally for me ITs continued to work. This commit updates it to [use the `ubuntu/squid` Docker Image](https://hub.docker.com/r/ubuntu/squid)  