### PR TITLE
Fix broken log archival/upload where there CI failures

### DIFF
--- a/.ci/templates/it.yml
+++ b/.ci/templates/it.yml
@@ -12,7 +12,6 @@
       - shell: |
           #!/usr/local/bin/runbld
           archive_logs() {
-            # archive logs for ^^ google-cloud-storage uploader
             bash .ci/build.sh archive
           }
             

--- a/.ci/templates/it.yml
+++ b/.ci/templates/it.yml
@@ -11,6 +11,14 @@
     builders:
       - shell: |
           #!/usr/local/bin/runbld
-          set -o errexit
+          archive_logs() {
+            # archive logs for ^^ google-cloud-storage uploader
+            bash .ci/build.sh archive
+          }
+            
+          # need to additionally trap errtrace otherwise functions don't inherit the trap
+          # https://stackoverflow.com/a/35800451
+          set -o errexit -o errtrace 
+          trap archive_logs ERR
+            
           bash .ci/build.sh it{py_version}
-          bash .ci/build.sh archive

--- a/.ci/templates/pull-request-it.yml
+++ b/.ci/templates/pull-request-it.yml
@@ -23,6 +23,14 @@
     builders:
       - shell: |
           #!/usr/local/bin/runbld
-          set -o errexit
+          archive_logs() {
+            # archive logs for ^^ google-cloud-storage uploader
+            bash .ci/build.sh archive
+          }
+          
+          # need to additionally trap errtrace otherwise functions don't inherit the trap
+          # https://stackoverflow.com/a/35800451
+          set -o errexit -o errtrace 
+          trap archive_logs ERR
+
           bash .ci/build.sh it{py_version}
-          bash .ci/build.sh archive

--- a/.ci/templates/pull-request-it.yml
+++ b/.ci/templates/pull-request-it.yml
@@ -24,7 +24,6 @@
       - shell: |
           #!/usr/local/bin/runbld
           archive_logs() {
-            # archive logs for ^^ google-cloud-storage uploader
             bash .ci/build.sh archive
           }
           

--- a/it/basic_test.py
+++ b/it/basic_test.py
@@ -25,7 +25,7 @@ from esrally.utils import process
 def test_run_without_arguments(cfg):
     cmd = it.esrally_command_line_for(cfg, "")
     output = process.run_subprocess_with_output(cmd)
-    expected = "FAIL DELIBERATELY! usage: esrally [-h] [--version]"
+    expected = "usage: esrally [-h] [--version]"
     assert expected in "\n".join(output)
 
 

--- a/it/basic_test.py
+++ b/it/basic_test.py
@@ -25,7 +25,7 @@ from esrally.utils import process
 def test_run_without_arguments(cfg):
     cmd = it.esrally_command_line_for(cfg, "")
     output = process.run_subprocess_with_output(cmd)
-    expected = "usage: esrally [-h] [--version]"
+    expected = "FAIL DELIBERATELY! usage: esrally [-h] [--version]"
     assert expected in "\n".join(output)
 
 


### PR DESCRIPTION
Currently, CI failures for it tests fail immediately and prohibit
log archival/upload which makes understanding failures an impossible
task.

The approach taken here is an approach successfully taken in a different
repository.