### PR TITLE
Support specifying user tags as json

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -905,9 +905,9 @@ Rally usually installs and launches an Elasticsearch cluster internally and wipe
 ``user-tags``
 ~~~~~~~~~~~~~
 
-This is only relevant when you want to run :doc:`tournaments </tournament>`. You can use this flag to attach an arbitrary text to the meta-data of each metric record and also the corresponding race. This will help you to recognize a race when you run ``esrally list races`` as you don't need to remember the concrete timestamp on which a race has been run but can instead use your own descriptive names.
+You can use this flag to attach a arbitrary text to the meta-data of each metric record and also the corresponding race. This will help you to recognize a race when you run ``esrally list races`` as you don't need to remember the concrete timestamp on which a race has been run but can instead use your own descriptive names.
 
-The required format is ``key`` ":" ``value``. You can choose ``key`` and  ``value`` freely. You can also specify multiple tags. They need to be separated by a comma.
+The required format is in ``key`` ":" ``value`` pairs which can be defined as string (separated by comma), inline json or referenced from a json file.
 
 **Example**
 
@@ -919,16 +919,31 @@ The required format is ``key`` ":" ``value``. You can choose ``key`` and  ``valu
 
  ::
 
-   esrally race --track=pmc --user-tags="disk:SSD,data_node_count:4"
+   esrally race --track=pmc --user-tags='{"disk":"SSD","data_node_count":4}'
+
+
+
+**Example**
+
+ ::
+
+   cat user_tags.json
+   {
+     "issue": "rally-issue-1000",
+     "iteration": 9
+   }
+
+   esrally race --track=pmc --user-tags=./user_tags.json
 
 
 
 When you run ``esrally list races``, this will show up again::
 
-    Race Timestamp    Track    Track Parameters   Challenge            Car       User Tags
-    ----------------  -------  ------------------ -------------------  --------  ------------------------------------
-    20160518T122341Z  pmc                         append-no-conflicts  defaults  intention:github-issue-1234-baseline
-    20160518T112341Z  pmc                         append-no-conflicts  defaults  disk:SSD,data_node_count:4
+    Race ID                               Race Timestamp    Track     Challenge            Car       ES Version      Revision                                  Rally Version                       Track Revision    Team Revision    User Tags
+    ------------------------------------  ----------------  --------  -------------------  --------  --------------  ----------------------------------------  ----------------------------------  ----------------  ---------------  -----------------------------
+    5479b7ca-85bf-4e22-bce9-d32ab6093190  20221103T140347Z  pmc       append-no-conflicts  defaults  8.6.0-SNAPSHOT  14b2d2d37e25071f820af7e9af8edca7c5ad0ac3  2.7.1.dev0 (git revision: 16e534b)  fee27e9           c9ca37f          gc=cms, intention=github-issue-1234-baseline
+    2689abb1-2274-4919-8b21-1cbe66243040  20221103T140206Z  pmc       append-no-conflicts  defaults  8.6.0-SNAPSHOT  14b2d2d37e25071f820af7e9af8edca7c5ad0ac3  2.7.1.dev0 (git revision: 16e534b)  fee27e9           c9ca37f          disk=SSD, data_node_count=4
+    41c5be35-55e8-45a8-8bf4-1ed91cb778e8  20221103T135132Z  pmc       append-no-conflicts  defaults  8.6.0-SNAPSHOT  14b2d2d37e25071f820af7e9af8edca7c5ad0ac3  2.6.1.dev0 (git revision: c47c204)  fee27e9           c9ca37f          issue=rally-issue-1000, iteration=9
 
 This will help you recognize a specific race when running ``esrally compare``.
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -905,7 +905,7 @@ Rally usually installs and launches an Elasticsearch cluster internally and wipe
 ``user-tags``
 ~~~~~~~~~~~~~
 
-You can use this flag to attach a arbitrary text to the meta-data of each metric record and also the corresponding race. This will help you to recognize a race when you run ``esrally list races`` as you don't need to remember the concrete timestamp on which a race has been run but can instead use your own descriptive names.
+You can use this flag to attach arbitrary text to the meta-data of each metric record and also the corresponding race. This will help you to recognize a race when you run ``esrally list races`` as you don't need to remember the concrete timestamp on which a race has been run but can instead use your own descriptive names.
 
 The required format is in ``key`` ":" ``value`` pairs which can be defined as string (separated by comma), inline json or referenced from a json file.
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -1084,7 +1084,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             # use the race id implicitly also as the install id.
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.race_id)
             cfg.add(config.Scope.applicationOverride, "race", "pipeline", args.pipeline)
-            cfg.add(config.Scope.applicationOverride, "race", "user.tags", args.user_tag)
+            cfg.add(config.Scope.applicationOverride, "race", "user.tags", opts.to_dict(args.user_tag))
             cfg.add(config.Scope.applicationOverride, "driver", "profiling", args.enable_driver_profiling)
             cfg.add(config.Scope.applicationOverride, "driver", "assertions", args.enable_assertions)
             cfg.add(config.Scope.applicationOverride, "driver", "on.error", args.on_error)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -32,6 +32,7 @@ import pytest
 from esrally import config, exceptions, metrics, paths, track
 from esrally.metrics import GlobalStatsCalculator
 from esrally.track import Challenge, Operation, Task, Track
+from esrally.utils import opts
 
 
 class MockClientFactory:
@@ -107,31 +108,6 @@ class TransportErrors:
         side_effect_list.append("success")
 
         return side_effect_list
-
-
-class TestExtractUserTags:
-    def test_no_tags_returns_empty_dict(self):
-        cfg = config.Config()
-        assert len(metrics.extract_user_tags_from_config(cfg)) == 0
-
-    def test_missing_comma_raises_error(self):
-        cfg = config.Config()
-        cfg.add(config.Scope.application, "race", "user.tags", "invalid")
-        with pytest.raises(exceptions.SystemSetupError) as ctx:
-            metrics.extract_user_tags_from_config(cfg)
-        assert ctx.value.args[0] == "User tag keys and values have to separated by a ':'. Invalid value [invalid]"
-
-    def test_missing_value_raises_error(self):
-        cfg = config.Config()
-        cfg.add(config.Scope.application, "race", "user.tags", "invalid1,invalid2")
-        with pytest.raises(exceptions.SystemSetupError) as ctx:
-            metrics.extract_user_tags_from_config(cfg)
-        assert ctx.value.args[0] == "User tag keys and values have to separated by a ':'. Invalid value [invalid1,invalid2]"
-
-    def test_extracts_proper_user_tags(self):
-        cfg = config.Config()
-        cfg.add(config.Scope.application, "race", "user.tags", "os:Linux,cpu:ARM")
-        assert metrics.extract_user_tags_from_config(cfg) == {"os": "Linux", "cpu": "ARM"}
 
 
 class TestEsClient:
@@ -364,7 +340,7 @@ class TestEsMetrics:
     def test_put_value_with_meta_info(self):
         throughput = 5000
         # add a user-defined tag
-        self.cfg.add(config.Scope.application, "race", "user.tags", "intention:testing,disk_type:hdd")
+        self.cfg.add(config.Scope.application, "race", "user.tags", opts.to_dict("intention:testing,disk_type:hdd"))
         self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         # Ensure we also merge in cluster level meta info
@@ -436,7 +412,7 @@ class TestEsMetrics:
 
     def test_put_doc_with_metadata(self):
         # add a user-defined tag
-        self.cfg.add(config.Scope.application, "race", "user.tags", "intention:testing,disk_type:hdd")
+        self.cfg.add(config.Scope.application, "race", "user.tags", opts.to_dict("intention:testing,disk_type:hdd"))
         self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         # Ensure we also merge in cluster level meta info
@@ -1738,7 +1714,7 @@ class TestStatsCalculator:
         cfg.add(config.Scope.application, "mechanic", "car.names", ["unittest_car"])
         cfg.add(config.Scope.application, "mechanic", "car.params", {})
         cfg.add(config.Scope.application, "mechanic", "plugin.params", {})
-        cfg.add(config.Scope.application, "race", "user.tags", "")
+        cfg.add(config.Scope.application, "race", "user.tags", {})
         cfg.add(config.Scope.application, "race", "pipeline", "from-sources")
         cfg.add(config.Scope.application, "track", "params", {})
 
@@ -1906,7 +1882,7 @@ class TestStatsCalculator:
         cfg.add(config.Scope.application, "mechanic", "car.names", ["unittest_car"])
         cfg.add(config.Scope.application, "mechanic", "car.params", {})
         cfg.add(config.Scope.application, "mechanic", "plugin.params", {})
-        cfg.add(config.Scope.application, "race", "user.tags", "")
+        cfg.add(config.Scope.application, "race", "user.tags", {})
         cfg.add(config.Scope.application, "race", "pipeline", "from-sources")
         cfg.add(config.Scope.application, "track", "params", {})
 


### PR DESCRIPTION
While the rest of the cli options (like `car-params`, `telemetry-params`) support json, in addition to command separate K:V string, this is currently not possible in Rally.

This commit adds additionaly support for user-specified tags as inlined json or referenced from a json file.
