### PR TITLE
Use newer ssl parameter in aiohttp client API

### DIFF
--- a/esrally/client/asynchronous.py
+++ b/esrally/client/asynchronous.py
@@ -248,7 +248,7 @@ class AIOHttpConnection(elasticsearch.AIOHttpConnection):
             connector = StaticConnector(limit=self._limit, enable_cleanup_closed=self._enable_cleanup_closed)
         else:
             connector = aiohttp.TCPConnector(
-                limit=self._limit, use_dns_cache=True, ssl_context=self._ssl_context, enable_cleanup_closed=self._enable_cleanup_closed
+                limit=self._limit, use_dns_cache=True, ssl=self._ssl_context, enable_cleanup_closed=self._enable_cleanup_closed
             )
 
         self.session = aiohttp.ClientSession(


### PR DESCRIPTION
Using ssl= is the preferred way since 3.0 (aio-libs/aiohttp#2626) and ssl_context= goes away in the next version, 4.0 (aio-libs/aiohttp#3548).

This was noticed by @michaelbaamonde in https://github.com/elastic/rally/pull/1510/files/9627d291895ac90f7ae99143f2567f8d8cd1209c#r891133343.
