### PR TITLE
Print errors when --quiet is used

### DIFF
--- a/esrally/utils/console.py
+++ b/esrally/utils/console.py
@@ -163,7 +163,7 @@ def error(msg, end="\n", flush=False, force=False, logger=None, overline=None, u
         console_prefix="[ERROR]",
         end=end,
         flush=flush,
-        force=force,
+        force=True,
         overline=overline,
         underline=underline,
         logger=logger.error if logger else None,

--- a/it/error_test.py
+++ b/it/error_test.py
@@ -1,0 +1,26 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import it
+from esrally.utils import process
+
+
+@it.rally_in_mem
+def test_error_prints_when_quiet(cfg):
+    cmd = it.esrally_command_line_for(cfg, "build --revision=nonsense --quiet")
+    output = process.run_subprocess_with_output(cmd)
+    expected = "[ERROR] Cannot build."
+    assert expected in "\n".join(output)


### PR DESCRIPTION
Quick and easy. Closes #1614 