### PR TITLE
Support meta-data for composite tasks

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1029,7 +1029,7 @@ class SamplePostprocessor:
                         sample_type=timing.sample_type,
                         absolute_time=timing.absolute_time,
                         relative_time=timing.relative_time,
-                        meta_data=meta_data,
+                        meta_data=timing.request_meta_data,
                     )
 
         end = time.perf_counter()
@@ -1483,16 +1483,18 @@ class Sample:
     def dependent_timings(self):
         if self._dependent_timing:
             for t in self._dependent_timing:
+                timing = t.pop("dependent_timing")
+                meta_data = self._merge(self.request_meta_data, t)
                 yield Sample(
                     self.client_id,
-                    t["absolute_time"],
-                    t["request_start"],
+                    timing["absolute_time"],
+                    timing["request_start"],
                     self.task_start,
                     self.task,
                     self.sample_type,
-                    self.request_meta_data,
+                    meta_data,
                     0,
-                    t["service_time"],
+                    timing["service_time"],
                     0,
                     0,
                     self.total_ops,
@@ -1500,8 +1502,8 @@ class Sample:
                     self.time_period,
                     self.percent_completed,
                     None,
-                    t["operation"],
-                    t["operation-type"],
+                    timing["operation"],
+                    timing["operation-type"],
                 )
 
     def __repr__(self, *args, **kwargs):
@@ -1510,6 +1512,13 @@ class Sample:
             f"[{self.sample_type}]: [{self.latency}s] request latency, [{self.service_time}s] service time, "
             f"[{self.total_ops} {self.total_ops_unit}]"
         )
+
+    def _merge(self, *args):
+        result = {}
+        for arg in args:
+            if arg is not None:
+                result.update(arg)
+        return result
 
 
 def select_challenge(config, t):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2592,9 +2592,16 @@ class Composite(Runner):
                     async with connection_limit:
                         async with runner:
                             response = await runner({"default": es}, item)
-                            timing = response.get("dependent_timing") if response else None
-                            if timing:
-                                timings.append(timing)
+                            if response:
+                                # TODO: support calculating dependent's throughput
+                                # drop weight and unit metadata but keep the rest
+                                response.pop("weight")
+                                response.pop("unit")
+                                timing = response.get("dependent_timing")
+                                if timing:
+                                    timings.append(response)
+                            else:
+                                timings.append(None)
 
                 else:
                     raise exceptions.RallyAssertionError("Requests structure must contain [stream] or [operation-type].")

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -287,7 +287,9 @@ def op(name, operation_type):
 
 
 class TestSamplePostprocessor:
-    def throughput(self, absolute_time, relative_time, value):
+    def throughput(self, absolute_time, relative_time, value, meta_data=None):
+        if not meta_data:
+            meta_data = {}
         return mock.call(
             name="throughput",
             value=value,
@@ -298,19 +300,21 @@ class TestSamplePostprocessor:
             sample_type=metrics.SampleType.Normal,
             absolute_time=absolute_time,
             relative_time=relative_time,
-            meta_data={},
+            meta_data=meta_data,
         )
 
-    def service_time(self, absolute_time, relative_time, value):
-        return self.request_metric(absolute_time, relative_time, "service_time", value)
+    def service_time(self, absolute_time, relative_time, value, meta_data=None):
+        return self.request_metric(absolute_time, relative_time, "service_time", value, meta_data)
 
-    def processing_time(self, absolute_time, relative_time, value):
-        return self.request_metric(absolute_time, relative_time, "processing_time", value)
+    def processing_time(self, absolute_time, relative_time, value, meta_data=None):
+        return self.request_metric(absolute_time, relative_time, "processing_time", value, meta_data)
 
-    def latency(self, absolute_time, relative_time, value):
-        return self.request_metric(absolute_time, relative_time, "latency", value)
+    def latency(self, absolute_time, relative_time, value, meta_data=None):
+        return self.request_metric(absolute_time, relative_time, "latency", value, meta_data)
 
-    def request_metric(self, absolute_time, relative_time, name, value):
+    def request_metric(self, absolute_time, relative_time, name, value, meta_data=None):
+        if not meta_data:
+            meta_data = {}
         return mock.call(
             name=name,
             value=value,
@@ -321,7 +325,7 @@ class TestSamplePostprocessor:
             sample_type=metrics.SampleType.Normal,
             absolute_time=absolute_time,
             relative_time=relative_time,
-            meta_data={},
+            meta_data=meta_data,
         )
 
     @mock.patch("esrally.metrics.MetricsStore")
@@ -394,21 +398,40 @@ class TestSamplePostprocessor:
                 1,
                 1 / 2,
                 dependent_timing=[
-                    {"absolute_time": 38601, "request_start": 25, "service_time": 0.05, "operation": "index-op", "operation-type": "bulk"},
-                    {"absolute_time": 38602, "request_start": 26, "service_time": 0.08, "operation": "index-op", "operation-type": "bulk"},
+                    {
+                        "meta_key": "meta_value",
+                        "dependent_timing": {
+                            "absolute_time": 38601,
+                            "request_start": 25,
+                            "service_time": 0.05,
+                            "operation": "index-op",
+                            "operation-type": "bulk",
+                        },
+                    },
+                    {
+                        "meta_key": "meta_value",
+                        "dependent_timing": {
+                            "absolute_time": 38602,
+                            "request_start": 26,
+                            "service_time": 0.08,
+                            "operation": "index-op",
+                            "operation-type": "bulk",
+                        },
+                    },
                 ],
             ),
         ]
 
         post_process(samples)
-
+        meta_data = {"meta_key": "meta_value"}
         calls = [
             self.latency(38598, 24, 10.0),
             self.service_time(38598, 24, 7.0),
             self.processing_time(38598, 24, 9.0),
             # dependent timings
-            self.service_time(38601, 25, 50.0),
-            self.service_time(38602, 26, 80.0),
+            self.service_time(38601, 25, 50.0, meta_data),
+            self.service_time(38602, 26, 80.0, meta_data),
+            # we don't currently calculate dependent throughput
             self.throughput(38598, 24, 5000),
         ]
         metrics_store.put_value_cluster_level.assert_has_calls(calls)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -6512,23 +6512,22 @@ class TestComposite:
         assert response["unit"] == "ops"
         timings = response["dependent_timing"]
         assert len(timings) == 3
+        assert timings[0]["dependent_timing"]["operation"] == "initial-call"
+        assert timings[0]["dependent_timing"]["service_time"] == pytest.approx(0.1, abs=0.1)
 
-        assert timings[0]["operation"] == "initial-call"
-        assert timings[0]["service_time"] == pytest.approx(0.1, abs=0.1)
+        assert timings[1]["dependent_timing"]["operation"] == "stream-a"
+        assert timings[1]["dependent_timing"]["service_time"] == pytest.approx(0.2, abs=0.1)
 
-        assert timings[1]["operation"] == "stream-a"
-        assert timings[1]["service_time"] == pytest.approx(0.2, abs=0.1)
-
-        assert timings[2]["operation"] == "stream-b"
-        assert timings[2]["service_time"] == pytest.approx(0.1, abs=0.1)
+        assert timings[2]["dependent_timing"]["operation"] == "stream-b"
+        assert timings[2]["dependent_timing"]["service_time"] == pytest.approx(0.1, abs=0.1)
 
         # common properties
         for timing in timings:
-            assert timing["operation-type"] == "sleep"
-            assert "absolute_time" in timing
-            assert "request_start" in timing
-            assert "request_end" in timing
-            assert timing["request_end"] > timing["request_start"]
+            assert timing["dependent_timing"]["operation-type"] == "sleep"
+            assert "absolute_time" in timing["dependent_timing"]
+            assert "request_start" in timing["dependent_timing"]
+            assert "request_end" in timing["dependent_timing"]
+            assert timing["dependent_timing"]["request_end"] > timing["dependent_timing"]["request_start"]
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio


### PR DESCRIPTION
Whilst we collect and report timing metrics for tasks within a `composite` structure, we drop the meta-data on the floor. It'd be handy to collect this meta-data.

With this commit we add support for the collection of arbitrary meta-data
returned from `composite` tasks (streams). 


Example:
![image](https://user-images.githubusercontent.com/54515790/201826089-f44ee7dc-dfa6-4413-ad88-1d72c9ded547.png)
