### PR TITLE
Add shard data to search operation's detailed-results meta-data

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1034,10 +1034,10 @@ class Query(Runner):
                 timed_out = props.get("timed_out", False)
                 took = props.get("took", 0)
 
-                shards_total = props.get("_shards.total")
-                shards_successful = props.get("_shards.successful")
-                shards_skipped = props.get("_shards.skipped")
-                shards_failed = props.get("_shards.failed")
+                shards_total = props.get("_shards.total", 0)
+                shards_successful = props.get("_shards.successful", 0)
+                shards_skipped = props.get("_shards.skipped", 0)
+                shards_failed = props.get("_shards.failed", 0)
 
                 return {
                     "weight": 1,

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1015,11 +1015,29 @@ class Query(Runner):
             r = await self._raw_search(es, doc_type, index, body, request_params, headers=headers)
 
             if detailed_results:
-                props = parse(r, ["hits.total", "hits.total.value", "hits.total.relation", "timed_out", "took"])
+                props = parse(
+                    r,
+                    [
+                        "hits.total",
+                        "hits.total.value",
+                        "hits.total.relation",
+                        "timed_out",
+                        "took",
+                        "_shards.total",
+                        "_shards.successful",
+                        "_shards.skipped",
+                        "_shards.failed",
+                    ],
+                )
                 hits_total = props.get("hits.total.value", props.get("hits.total", 0))
                 hits_relation = props.get("hits.total.relation", "eq")
                 timed_out = props.get("timed_out", False)
                 took = props.get("took", 0)
+
+                shards_total = props.get("_shards.total")
+                shards_successful = props.get("_shards.successful")
+                shards_skipped = props.get("_shards.skipped")
+                shards_failed = props.get("_shards.failed")
 
                 return {
                     "weight": 1,
@@ -1029,6 +1047,12 @@ class Query(Runner):
                     "hits_relation": hits_relation,
                     "timed_out": timed_out,
                     "took": took,
+                    "shards": {
+                        "total": shards_total,
+                        "successful": shards_successful,
+                        "skipped": shards_skipped,
+                        "failed": shards_failed,
+                    },
                 }
             else:
                 return {

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1549,6 +1549,7 @@ class TestQueryRunner:
         search_response = {
             "timed_out": False,
             "took": 5,
+            "_shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
             "hits": {
                 "total": {
                     "value": 1,
@@ -1587,6 +1588,7 @@ class TestQueryRunner:
             "hits_relation": "gte",
             "timed_out": False,
             "took": 5,
+            "shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
         }
 
         es.perform_request.assert_awaited_once_with(
@@ -1600,6 +1602,7 @@ class TestQueryRunner:
         search_response = {
             "timed_out": False,
             "took": 5,
+            "_shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
             "hits": {
                 "total": {"value": 1, "relation": "gte"},
                 "hits": [
@@ -1634,6 +1637,7 @@ class TestQueryRunner:
             "hits_relation": "gte",
             "timed_out": False,
             "took": 5,
+            "shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
         }
 
         es.perform_request.assert_awaited_once_with(
@@ -1651,6 +1655,7 @@ class TestQueryRunner:
         response = {
             "timed_out": False,
             "took": 62,
+            "_shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
             "hits": {
                 "total": {
                     "value": 2,
@@ -1687,6 +1692,7 @@ class TestQueryRunner:
             "hits_relation": "eq",
             "timed_out": False,
             "took": 62,
+            "shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
         }
 
         es.perform_request.assert_awaited_once_with(
@@ -1760,6 +1766,7 @@ class TestQueryRunner:
         search_response = {
             "timed_out": False,
             "took": 5,
+            "_shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
             "hits": {
                 "total": 2,
                 "hits": [
@@ -1795,6 +1802,7 @@ class TestQueryRunner:
             "hits_relation": "eq",
             "timed_out": False,
             "took": 5,
+            "shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
         }
 
         es.perform_request.assert_awaited_once_with(
@@ -1814,6 +1822,7 @@ class TestQueryRunner:
         search_response = {
             "timed_out": False,
             "took": 5,
+            "_shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
             "hits": {
                 "total": {
                     "value": 2,
@@ -1852,6 +1861,7 @@ class TestQueryRunner:
             "hits_relation": "eq",
             "timed_out": False,
             "took": 5,
+            "shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
         }
 
         es.perform_request.assert_awaited_once_with(
@@ -1871,6 +1881,7 @@ class TestQueryRunner:
         search_response = {
             "timed_out": False,
             "took": 5,
+            "_shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
             "hits": {
                 "total": {"value": 2, "relation": "eq"},
                 "hits": [
@@ -1908,6 +1919,7 @@ class TestQueryRunner:
             "hits_relation": "eq",
             "timed_out": False,
             "took": 5,
+            "shards": {"total": 808, "successful": 808, "skipped": 0, "failed": 0},
         }
 
         es.perform_request.assert_awaited_once_with(


### PR DESCRIPTION
With this commit we include the shard meta-data from Elasticsearch's 
search API response when specifying `detailed-results` for Rally's search
operation.