### PR TITLE
Add additional admin functions: delete race, list/delete annotations

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1657,12 +1657,11 @@ class EsRaceStore(RaceStore):
         return f"{EsRaceStore.INDEX_PREFIX}{race_timestamp:%Y-%m}"
 
     def list_annotations(self):
-        limit = args.limit
-        environment = args.environment
-        track = args.track
-        from_date = args.from_date
-        to_date = args.to_date
-        output_format = args.output_format
+        limit = self._max_results()
+        environment = self.environment_name
+        track = self._track()
+        from_date = self._from_date()
+        to_date = self._to_date()
         query = {
             "query": {
                 "bool": {

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -1059,10 +1059,10 @@ def dispatch_sub_command(arg_parser, args, cfg):
             reporter.compare(cfg, args.baseline, args.contender)
         elif sub_command == "list":
             cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
-            cfg.add(config.Scope.applicationOverride, "system", "list.races.max_results", args.limit)
-            cfg.add(config.Scope.applicationOverride, "system", "list.races.track", args.track)
+            cfg.add(config.Scope.applicationOverride, "system", "list.max_results", args.limit)
+            cfg.add(config.Scope.applicationOverride, "system", "admin.track", args.track)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.benchmark_name", args.benchmark_name)
-            cfg.add(config.Scope.applicationOverride, "system", "list.races.from_date", args.from_date)
+            cfg.add(config.Scope.applicationOverride, "system", "list.from_date", args.from_date)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.to_date", args.to_date)
             configure_mechanic_params(args, cfg, command_requires_car=False)
             configure_track_params(arg_parser, args, cfg, command_requires_track=False)
@@ -1070,7 +1070,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
         elif sub_command == "delete":
             cfg.add(config.Scope.applicationOverride, "system", "delete.config.option", args.configuration)
             cfg.add(config.Scope.applicationOverride, "system", "delete.id", args.id)
-            cfg.add(config.Scope.applicationOverride, "system", "delete.dry_run", args.dry_run)
+            cfg.add(config.Scope.applicationOverride, "system", "admin.dry_run", args.dry_run)
             dispatch_delete(cfg)
         elif sub_command == "build":
             cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", opts.csv_to_list(args.elasticsearch_plugins))

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -1033,6 +1033,12 @@ def dispatch_sub_command(arg_parser, args, cfg):
             configure_mechanic_params(args, cfg, command_requires_car=False)
             configure_track_params(arg_parser, args, cfg, command_requires_track=False)
             dispatch_list(cfg)
+        elif sub_command == "delete":
+            cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
+            cfg.add(config.Scope.applicationOverride, "system", "list.races.max_results", args.limit)
+            configure_mechanic_params(args, cfg, command_requires_car=False)
+            configure_track_params(arg_parser, args, cfg, command_requires_track=False)
+            dispatch_list(cfg)
         elif sub_command == "build":
             cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", opts.csv_to_list(args.elasticsearch_plugins))
             cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", opts.to_dict(args.plugin_params))

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -147,7 +147,7 @@ def create_arg_parser():
         metavar="configuration",
         help="The configuration for which Rally should show the available options. "
         "Possible values are: telemetry, tracks, pipelines, races, cars, elasticsearch-plugins",
-        choices=["telemetry", "tracks", "pipelines", "races", "cars", "elasticsearch-plugins"],
+        choices=["telemetry", "tracks", "pipelines", "races", "cars", "elasticsearch-plugins", "annotations"],
     )
     list_parser.add_argument(
         "--limit",
@@ -836,6 +836,8 @@ def dispatch_list(cfg):
         racecontrol.list_pipelines()
     elif what == "races":
         metrics.list_races(cfg)
+    elif what == "annotations":
+        metrics.list_annotations(cfg)
     elif what == "cars":
         team.list_cars(cfg)
     elif what == "elasticsearch-plugins":

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -862,7 +862,7 @@ class TestEsRaceStore:
 
     def setup_method(self, method):
         self.cfg = config.Config()
-        self.cfg.add(config.Scope.application, "system", "list.races.max_results", 100)
+        self.cfg.add(config.Scope.application, "system", "list.max_results", 100)
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
         self.cfg.add(config.Scope.application, "system", "time.start", self.RACE_TIMESTAMP)
         self.cfg.add(config.Scope.application, "system", "race.id", self.RACE_ID)
@@ -1003,10 +1003,10 @@ class TestEsRaceStore:
 
     def test_filter_race(self):
         self.es_mock.search.return_value = {"hits": {"total": 0}}
-        self.cfg.add(config.Scope.application, "system", "list.races.track", "unittest")
+        self.cfg.add(config.Scope.application, "system", "list.track", "unittest")
         self.cfg.add(config.Scope.application, "system", "list.races.benchmark_name", "unittest-test")
-        self.cfg.add(config.Scope.application, "system", "list.races.to_date", "20160131")
-        self.cfg.add(config.Scope.application, "system", "list.races.from_date", "20160230")
+        self.cfg.add(config.Scope.application, "system", "list.to_date", "20160131")
+        self.cfg.add(config.Scope.application, "system", "list.from_date", "20160230")
         self.race_store.list()
         expected_query = {
             "query": {
@@ -1598,7 +1598,7 @@ class TestFileRaceStore:
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "node", "root.dir", os.path.join(tempfile.gettempdir(), str(uuid.uuid4())))
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
-        self.cfg.add(config.Scope.application, "system", "list.races.max_results", 100)
+        self.cfg.add(config.Scope.application, "system", "list.max_results", 100)
         self.cfg.add(config.Scope.application, "system", "time.start", self.RACE_TIMESTAMP)
         self.cfg.add(config.Scope.application, "system", "race.id", self.RACE_ID)
         self.race_store = metrics.FileRaceStore(self.cfg)
@@ -1688,19 +1688,19 @@ class TestFileRaceStore:
 
         self.race_store.store_race(race)
         assert len(self.race_store.list()) == 1
-        self.cfg.add(config.Scope.application, "system", "list.races.track", "unittest-2")
+        self.cfg.add(config.Scope.application, "system", "list.track", "unittest-2")
         assert len(self.race_store.list()) == 0
-        self.cfg.add(config.Scope.application, "system", "list.races.track", "unittest")
+        self.cfg.add(config.Scope.application, "system", "list.track", "unittest")
         assert len(self.race_store.list()) == 1
         self.cfg.add(config.Scope.application, "system", "list.races.benchmark_name", "unittest-test-2")
         assert len(self.race_store.list()) == 0
         self.cfg.add(config.Scope.application, "system", "list.races.benchmark_name", "unittest-test")
         assert len(self.race_store.list()) == 1
-        self.cfg.add(config.Scope.application, "system", "list.races.to_date", "20160129")
+        self.cfg.add(config.Scope.application, "system", "list.to_date", "20160129")
         assert len(self.race_store.list()) == 0
-        self.cfg.add(config.Scope.application, "system", "list.races.to_date", "20160131")
+        self.cfg.add(config.Scope.application, "system", "list.to_date", "20160131")
         assert len(self.race_store.list()) == 1
-        self.cfg.add(config.Scope.application, "system", "list.races.from_date", "20160131")
+        self.cfg.add(config.Scope.application, "system", "list.from_date", "20160131")
         assert len(self.race_store.list()) == 1
 
 
@@ -2374,7 +2374,7 @@ class TestIndexTemplateProvider:
         self.cfg.add(config.Scope.application, "node", "root.dir", os.path.join(tempfile.gettempdir(), str(uuid.uuid4())))
         self.cfg.add(config.Scope.application, "node", "rally.root", paths.rally_root())
         self.cfg.add(config.Scope.application, "system", "env.name", "unittest-env")
-        self.cfg.add(config.Scope.application, "system", "list.races.max_results", 100)
+        self.cfg.add(config.Scope.application, "system", "list.max_results", 100)
         self.cfg.add(config.Scope.application, "system", "time.start", TestFileRaceStore.RACE_TIMESTAMP)
         self.cfg.add(config.Scope.application, "system", "race.id", TestFileRaceStore.RACE_ID)
 


### PR DESCRIPTION
Added the following helper admin functions:
- delete a race from metric store. Use `esrally delete race --id=..`
- list annotations. Use: `esrally list annotations ..`
- delete annotations. Use: `esrally delete annotation --id=...`

Relates to https://github.com/elastic/rally/pull/1597