### PR TITLE
Skip building plugins moved to modules

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,16 @@
 Migration Guide
 ===============
 
+Migrating to Rally 2.7.1
+------------------------
+
+Snapshot repository plugins are no longer built from source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``repository-s3``, ``repository-gcs``, and ``repository-azure`` snapshot plugins were converted into Elasticsearch modules from version 8.0 onwards, meaning that they are always included in the Elasticsearch distribution. Installing or removing these plugins is now a no-op, but attempting to build them from source will fail.
+
+Rally will no longer attempt to build these plugins because they have been removed from the corresponding `rally-team's <https://github.com/elastic/rally-teams/pull/76>`_ ``core-plugins.txt``.
+
 Migrating to Rally 2.5.1
 ------------------------
 

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -219,6 +219,13 @@ class BareProvisioner:
         plugin_variables = {}
         mandatory_plugins = []
         for installer in self.plugin_installers:
+            if installer.plugin.moved_to_module:
+                self.logger.info(
+                    "Skipping adding plugin [%s] to cluster setting 'plugin.mandatory' as it has been moved to a module",
+                    installer.plugin_name,
+                )
+                continue
+
             mandatory_plugins.append(installer.plugin_name)
             plugin_variables.update(installer.variables)
 

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -198,8 +198,7 @@ def _supply_requirements(sources, distribution, plugins, revisions, distribution
         if plugin.moved_to_module:
             # TODO: https://github.com/elastic/rally/issues/1622
             continue
-
-        if plugin.core_plugin:
+        elif plugin.core_plugin:
             # core plugins are entirely dependent upon Elasticsearch.
             supply_requirements[plugin.name] = supply_requirements["elasticsearch"]
         else:

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -120,6 +120,13 @@ def create(cfg, sources, distribution, car, plugins=None):
         suppliers.append(ElasticsearchDistributionSupplier(repo, es_version, distributions_root))
 
     for plugin in plugins:
+        if plugin.moved_to_module:
+            # TODO: https://github.com/elastic/rally/issues/1622
+            # If it is listed as a core plugin (i.e. a user has overriden the team's path or revision), then we will build
+            # We still need to use the post-install hooks to configure the keystore, so don't remove from list of plugins
+            logger.info("Plugin [%s] is now an Elasticsearch module and no longer needs to be built from source.", plugin.name)
+            continue
+
         supplier_type, plugin_version, _ = supply_requirements[plugin.name]
 
         if supplier_type == "source":

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -195,6 +195,10 @@ def _supply_requirements(sources, distribution, plugins, revisions, distribution
         supply_requirements["elasticsearch"] = ("distribution", _required_version(distribution_version), False)
 
     for plugin in plugins:
+        if plugin.moved_to_module:
+            # TODO: https://github.com/elastic/rally/issues/1622
+            continue
+
         if plugin.core_plugin:
             # core plugins are entirely dependent upon Elasticsearch.
             supply_requirements[plugin.name] = supply_requirements["elasticsearch"]

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -435,6 +435,14 @@ class PluginDescriptor:
             r.append("%s = [%s]" % (prop, repr(value)))
         return ", ".join(r)
 
+    @property
+    def moved_to_module(self):
+        # For a BWC escape hatch we first check if the plugin is listed in rally-teams' "core-plugin.txt",
+        # thus allowing users to override the teams path or revision to include the repository-s3/azure/gcs plugins in
+        # "core-plugin.txt"
+        # TODO: https://github.com/elastic/rally/issues/1622
+        return self.name in ["repository-s3", "repository-gcs", "repository-azure"] and not self.core_plugin
+
     def __hash__(self):
         return hash(self.name) ^ hash(self.config) ^ hash(self.core_plugin)
 

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -111,6 +111,7 @@ class TestBareProvisioner:
         def __init__(self):
             self.name = "x-pack"
             self.core_plugin = False
+            self.moved_to_module = False
             self.config = {"base": "internal_base,security"}
             self.root_path = None
             self.config_paths = []
@@ -213,6 +214,66 @@ class TestBareProvisioner:
             "plugin_name": "x-pack-security",
             "xpack_security_enabled": True,
         }
+
+    @mock.patch("glob.glob", lambda p: ["/opt/elasticsearch-6.8.0"])
+    @mock.patch("esrally.utils.io.decompress")
+    @mock.patch("esrally.utils.io.ensure_dir")
+    @mock.patch("esrally.mechanic.provisioner.PluginInstaller.install")
+    @mock.patch("shutil.rmtree")
+    def test_prepare_distribution_skips_plugins_moved_to_modules(self, mock_rm, mock_ensure_dir, mock_install, mock_decompress):
+        """
+        Test that plugin.mandatory is not set for plugins moved to modules
+
+        See: https://github.com/elastic/rally/issues/1622
+        """
+        apply_config_calls = []
+
+        def null_apply_config(source_root_path, target_root_path, config_vars):
+            apply_config_calls.append((source_root_path, target_root_path, config_vars))
+
+        installer = provisioner.ElasticsearchInstaller(
+            car=team.Car(
+                names="unit-test-car",
+                root_path=None,
+                config_paths=[HOME_DIR + "/.rally/benchmarks/teams/default/my-car"],
+                variables={
+                    "heap": "4g",
+                    "runtime.jdk": "8",
+                    "runtime.jdk.bundled": "true",
+                },
+            ),
+            java_home="/usr/local/javas/java8",
+            node_name="rally-node-0",
+            cluster_name="rally-benchmark",
+            node_root_dir=HOME_DIR + "/.rally/benchmarks/races/unittest",
+            all_node_ips=["10.17.22.22", "10.17.22.23"],
+            all_node_names=["rally-node-0", "rally-node-1"],
+            ip="10.17.22.23",
+            http_port=9200,
+        )
+
+        plugins_moved_to_modules = ["repository-s3", "repository-gcs", "repository-azure"]
+        plugin_installers = []
+        for p in plugins_moved_to_modules:
+            plugin_installers.append(
+                provisioner.PluginInstaller(
+                    team.PluginDescriptor(p, core_plugin=False),
+                    java_home="/usr/local/javas/java8",
+                    hook_handler_class=self.NoopHookHandler,
+                )
+            )
+
+        p = provisioner.BareProvisioner(
+            es_installer=installer,
+            plugin_installers=plugin_installers,
+            distribution_version="6.8.0",
+            apply_config=null_apply_config,
+        )
+        p.prepare({"elasticsearch": "/opt/elasticsearch-6.8.0.tar.gz"})
+
+        _, _, config_vars = apply_config_calls[0]
+
+        assert not config_vars["cluster_settings"].get("plugin.mandatory")
 
 
 class NoopHookHandler:


### PR DESCRIPTION
Since 8.0, we've converted the `repository-azure`, `repository-gcs` and `repository-s3` plugins into Elasticsearch modules, so that they are always included. Whilst adding or removing these plugins still succeeds, it is now a no-op.

However, if you try and build these plugins with something like:
```
esrally install --http-port=29200 --node=rally-node --master-nodes=rally-node --car=4gheap,trial-license --seed-hosts="127.0.0.1:29300" --revision "@2022-02-04" --elasticsearch-plugins repository-s3,repository-gcs,repository-azure --plugin-params="s3_client_name:mys3client,s3_access_key:XXXXX,s3_secret_key:YYYYY,s3_session_token:ZZZZZ" --source-build-method=docker

esrally build --revision "@2022-02-04" --elasticsearch-plugins repository-s3,repository-gcs,repository-azure --plugin-params="s3_client_name:mys3client,s3_access_key:XXXXX,s3_secret_key:YYYYY,s3_session_token:ZZZZZ"
```

It will fail, with this error in Rally's `~/.rally/logs/build.log`:
```
FAILURE: Build failed with an exception.

* What went wrong:
Project 'repository-s3' not found in project ':plugins'.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 6s
```

For now we still need to retain the existing post-install hooks (see https://github.com/elastic/rally-teams/pull/76), so this is a first step in gracefully skipping any build steps.

Must be merged with: 
- https://github.com/elastic/rally-teams/pull/76

Relates: 
- https://github.com/elastic/rally/issues/1622