### PR TITLE
Explain why we're using pytoml in test

### DIFF
--- a/it/resources/track_with_dependency/track.json
+++ b/it/resources/track_with_dependency/track.json
@@ -7,6 +7,6 @@
         }
     ],
     "dependencies": [
-      "pytoml"
+      "tomli"
     ]
 }

--- a/it/resources/track_with_dependency/track.json
+++ b/it/resources/track_with_dependency/track.json
@@ -7,6 +7,6 @@
         }
     ],
     "dependencies": [
-      "tomli"
+      "pytoml"
     ]
 }

--- a/it/resources/track_with_dependency/track.py
+++ b/it/resources/track_with_dependency/track.py
@@ -1,13 +1,13 @@
 async def noop(es, params):
     # pylint: disable=import-outside-toplevel,import-error
-    import pytoml as toml
+    import tomli as tomllib
 
     ret_val = {}
     # no-ops is our correctness marker
     toml_values = ["weight = 1", 'unit = "no-ops"']
     await es.cluster.health()
     for toml_value in toml_values:
-        ret_val.update(toml.loads(toml_value))
+        ret_val.update(tomllib.loads(toml_value))
     return ret_val
 
 

--- a/it/resources/track_with_dependency/track.py
+++ b/it/resources/track_with_dependency/track.py
@@ -1,5 +1,8 @@
 async def noop(es, params):
     # pylint: disable=import-outside-toplevel,import-error
+    # We want to use a library that will never be a Rally dependency, otherwise the test
+    # could succeed regardless of whether the dependencies function actually succeeds.
+    # For this reason we're using pytoml, which was deprecated long ago
     import pytoml as toml
 
     ret_val = {}

--- a/it/resources/track_with_dependency/track.py
+++ b/it/resources/track_with_dependency/track.py
@@ -1,13 +1,13 @@
 async def noop(es, params):
     # pylint: disable=import-outside-toplevel,import-error
-    import tomli as tomllib
+    import pytoml as toml
 
     ret_val = {}
     # no-ops is our correctness marker
     toml_values = ["weight = 1", 'unit = "no-ops"']
     await es.cluster.health()
     for toml_value in toml_values:
-        ret_val.update(tomllib.loads(toml_value))
+        ret_val.update(toml.loads(toml_value))
     return ret_val
 
 


### PR DESCRIPTION
tomli is maintained and supports TOML v1.0.0. It does not really matter in this case but this code could be easily copy/pasted for other purposes.