### PR TITLE
Output last 20 lines of docker logs to stdout on failure

### DIFF
--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -865,8 +865,16 @@ class DockerBuilder:
 
     def check_container_return_code(self, completion, container_name):
         if completion["StatusCode"] != 0:
-            raise SystemSetupError(
-                f"Docker container [{container_name}] failed with status code [{completion['StatusCode']}]: Error [{completion['Error']}]"
+            msg = "Executing '{}' failed. The last 20 lines in the build log file are:\n".format(container_name)
+            msg += "=========================================================================================================\n"
+            with open(self.log_file, "r", encoding="utf-8") as f:
+                msg += "\t"
+                msg += "\t".join(f.readlines()[-20:])
+            msg += "=========================================================================================================\n"
+            msg += "The full build log is available at [{}]".format(self.log_file)
+            raise BuildError(
+                f"Docker container [{container_name}] failed with status code [{completion['StatusCode']}]: "
+                f"Error [{completion['Error']}]: Build log output [{msg}]"
             )
         self.logger.info("Container [%s] completed successfully.", container_name)
 

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -865,13 +865,13 @@ class DockerBuilder:
 
     def check_container_return_code(self, completion, container_name):
         if completion["StatusCode"] != 0:
-            msg = "Executing '{}' failed. The last 20 lines in the build log file are:\n".format(container_name)
+            msg = f"Executing '{container_name}' failed. The last 20 lines in the build log file are:\n"
             msg += "=========================================================================================================\n"
             with open(self.log_file, "r", encoding="utf-8") as f:
                 msg += "\t"
                 msg += "\t".join(f.readlines()[-20:])
             msg += "=========================================================================================================\n"
-            msg += "The full build log is available at [{}]".format(self.log_file)
+            msg += f"The full build log is available at [{self.log_file}]"
             raise BuildError(
                 f"Docker container [{container_name}] failed with status code [{completion['StatusCode']}]: "
                 f"Error [{completion['Error']}]: Build log output [{msg}]"

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -865,7 +865,7 @@ class DockerBuilder:
 
     def check_container_return_code(self, completion, container_name):
         if completion["StatusCode"] != 0:
-            msg = f"Executing '{container_name}' failed. The last 20 lines in the build log file are:\n"
+            msg = f"Executing '{container_name}' failed. The last 20 lines in the build.log file are:\n"
             msg += "=========================================================================================================\n"
             with open(self.log_file, "r", encoding="utf-8") as f:
                 msg += "\t"

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -358,8 +358,7 @@ class TestDockerBuilder:
         assert "Container [test-container-name] completed successfully." in caplog.text
 
         completion = {"StatusCode": 1, "Error": "Vague error message"}
-        with mock.patch("builtins.open", mock.mock_open()) as file:
-            file.return_value.readlines.return_value = "my error"
+        with mock.patch("builtins.open", mock.mock_open()):
             with pytest.raises(exceptions.BuildError) as e:
                 builder.check_container_return_code(completion, "test-container-name")
             assert (

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -353,15 +353,19 @@ class TestDockerBuilder:
     def test_check_container_return_code(self, caplog):
         mock_docker_client = mock.MagicMock()
         builder = supplier.DockerBuilder(src_dir="/src", build_jdk=8, log_dir="logs", client=mock_docker_client)
-
         completion = {"StatusCode": 0, "Error": None}
         builder.check_container_return_code(completion, "test-container-name")
         assert "Container [test-container-name] completed successfully." in caplog.text
 
         completion = {"StatusCode": 1, "Error": "Vague error message"}
-        with pytest.raises(exceptions.SystemSetupError) as e:
-            builder.check_container_return_code(completion, "test-container-name")
-        assert "Docker container [test-container-name] failed with status code [1]: Error [Vague error message]" in str(e.value)
+        with mock.patch("builtins.open", mock.mock_open()) as file:
+            file.return_value.readlines.return_value = "my error"
+            with pytest.raises(exceptions.BuildError) as e:
+                builder.check_container_return_code(completion, "test-container-name")
+            assert (
+                "Docker container [test-container-name] failed with status code [1]: Error [Vague error message]: "
+                "Build log output [Executing 'test-container-name' failed. The last 20 lines in the build log file are" in str(e.value)
+            )
 
 
 class TestTemplateRenderer:

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -363,7 +363,7 @@ class TestDockerBuilder:
                 builder.check_container_return_code(completion, "test-container-name")
             assert (
                 "Docker container [test-container-name] failed with status code [1]: Error [Vague error message]: "
-                "Build log output [Executing 'test-container-name' failed. The last 20 lines in the build log file are" in str(e.value)
+                "Build log output [Executing 'test-container-name' failed. The last 20 lines in the build.log file are" in str(e.value)
             )
 
 


### PR DESCRIPTION
With this commit we print the last 20 lines when a container created by
`DockerBuilder` fails.

This brings the behaviour in line with the existing native `Builder`.


<details>

<summary> Example </summary>

Before:
```shell
$ esrally build --revision "@2022-02-02" --elasticsearch-plugins repository-s3,repository-gcs,repository-azure --source-build-method docker
    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/

[INFO] Using Docker to create installable binary from source files
[ERROR] Cannot build. Docker container [esrally-source-builder] failed with status code [143]: Error [None]

Getting further help:
*********************
* Check the log files in /Users/bradleydeam/.rally/logs for errors.
* Read the documentation at https://esrally.readthedocs.io/en/latest/.
* Ask a question on the forum at https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally.
* Raise an issue at https://github.com/elastic/rally/issues and include the log files in /Users/bradleydeam/.rally/logs.

--------------------------------
[INFO] FAILURE (took 28 seconds)
--------------------------------
```

After:
```shell
$ esrally build --revision "@2022-02-02" --elasticsearch-plugins repository-s3,repository-gcs,repository-azure --source-build-method docker

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/

[INFO] Using Docker to create installable binary from source files
[ERROR] Cannot build. Docker container [esrally-source-builder] failed with status code [143]: Error [None]: Build log output [Executing 'esrally-source-builder' failed. The last 20 lines in the build log file are:
=========================================================================================================
        Get:7 http://ports.ubuntu.com/ubuntu-ports jammy/multiverse arm64 Packages [224 kB]
        Get:8 http://ports.ubuntu.com/ubuntu-ports jammy/universe arm64 Packages [17.2 MB]
        Get:9 http://ports.ubuntu.com/ubuntu-ports jammy-updates/universe arm64 Packages [817 kB]
        Get:10 http://ports.ubuntu.com/ubuntu-ports jammy-updates/multiverse arm64 Packages [2,308 B]
        Get:11 http://ports.ubuntu.com/ubuntu-ports jammy-updates/main arm64 Packages [848 kB]
        Get:12 http://ports.ubuntu.com/ubuntu-ports jammy-updates/restricted arm64 Packages [222 kB]
        Get:13 http://ports.ubuntu.com/ubuntu-ports jammy-backports/main arm64 Packages [3,184 B]
        Get:14 http://ports.ubuntu.com/ubuntu-ports jammy-backports/universe arm64 Packages [7,266 B]
        Get:15 http://ports.ubuntu.com/ubuntu-ports jammy-security/universe arm64 Packages [632 kB]
        Get:16 http://ports.ubuntu.com/ubuntu-ports jammy-security/main arm64 Packages [553 kB]
        Get:17 http://ports.ubuntu.com/ubuntu-ports jammy-security/restricted arm64 Packages [209 kB]
        Fetched 23.1 MB in 7s (3,154 kB/s)
        Reading package lists...
        Building dependency tree...
        Reading state information...
        23 packages can be upgraded. Run 'apt list --upgradable' to see them.
        groupadd: group 'staff' already exists
        /bin/bash: line 1: git: command not found
        Downloading https://services.gradle.org/distributions/gradle-7.3.3-all.zip
        ...............10%...............20%...............30%...............40%...............50%...............60%................70%...............80%....Downloading https://services.gradle.org/distributions/gradle-7.3.3-all.zip
=========================================================================================================
The full build log is available at [/Users/bradleydeam/.rally/logs/build.log].]

Getting further help:
*********************
* Check the log files in /Users/bradleydeam/.rally/logs for errors.
* Read the documentation at https://esrally.readthedocs.io/en/latest/.
* Ask a question on the forum at https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally.
* Raise an issue at https://github.com/elastic/rally/issues and include the log files in /Users/bradleydeam/.rally/logs.

--------------------------------
[INFO] FAILURE (took 25 seconds)
--------------------------------
```

</details>