### PR TITLE
Bump test es docker container to 7.17

### DIFF
--- a/docker/docker-compose-tests.yml
+++ b/docker/docker-compose-tests.yml
@@ -12,7 +12,7 @@ services:
       es01:
         condition: service_healthy
   es01:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.1.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
     container_name: es01
     environment:
       - discovery.type=single-node


### PR DESCRIPTION
As noted in https://github.com/elastic/rally/pull/1628, bumps to a version that supports MacOS ARM.