### PR TITLE
Bump jsonschema to 4.17.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     # License: MIT
     "tabulate==0.8.9",
     # License: MIT
-    "jsonschema==3.1.1",
+    "jsonschema==4.17.1",
     # License: BSD
     # transitive dependency Markupsafe: BSD
     "Jinja2==2.11.3",


### PR DESCRIPTION
Since 4.2.0, jsonschema uses importlib.resources to load schemas, fixing an incompatibility with PyOxidizer.

See https://github.com/python-jsonschema/jsonschema/pull/873

I tested this manually by removing an operation-type key, and got this as expected:

```
ERROR] Cannot race. Traceback (most recent call last):                                                                                                        
  File "/home/q/src/rally/esrally/track/loader.py", line 1059, in read                                                                                         
    jsonschema.validate(track_spec, self.track_schema)                                                                                                         
  File "/home/q/.virtualenvs/rally/lib64/python3.11/site-packages/jsonschema/validators.py", line 1120, in validate                                            
    raise error                                                                                                                                                
jsonschema.exceptions.ValidationError: 'operation-type' is a required property
 ```