### PR TITLE
Build Rally binary using PyOxidizer

### DIFF
--- a/.github/workflows/pyoxidizer.yml
+++ b/.github/workflows/pyoxidizer.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   build:
     name: Build Linux binary
-    # For our binary to work on esbench (which defaults to Ubuntu 18.04), we
-    # need to link our executable with the glibc that ships with Ubuntu 18.04.
-    # The easiest way to do this is to actually build the binary from inside
-    # Ubuntu 18.04. Since GitHub Actions is removing Ubuntu 18.04, we build our
-    # executable in an Ubuntu 18.04 Docker container instead.
+    # For our binary to work on Ubuntu 18.04 and above, we need to link our
+    # executable with the glibc that ships with Ubuntu 18.04. The easiest way
+    # to do this is to actually build the binary from inside Ubuntu 18.04.
+    # Since GitHub Actions is removing Ubuntu 18.04, we build our executable in
+    # an Ubuntu 18.04 Docker container instead.
     runs-on: ubuntu-latest
     container:
       image: ubuntu:18.04

--- a/.github/workflows/pyoxidizer.yml
+++ b/.github/workflows/pyoxidizer.yml
@@ -1,0 +1,73 @@
+---
+name: Build Linux binary using PyOxidizer
+
+on:
+  push:
+    tags: ["*"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Linux binary
+    # For our binary to work on esbench (which defaults to Ubuntu 18.04), we
+    # need to link our executable with the glibc that ships with Ubuntu 18.04.
+    # The easiest way to do this is to actually build the binary from inside
+    # Ubuntu 18.04. Since GitHub Actions is removing Ubuntu 18.04, we build our
+    # executable in an Ubuntu 18.04 Docker container instead.
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:18.04
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: install dependencies
+        shell: bash
+        run: |
+          apt update
+          apt install -y git python3.8 python3-virtualenv virtualenv clang
+
+          # TODO switch to elastic/rally before merging
+          git clone https://github.com/pquentin/rally.git
+          cd rally
+
+          virtualenv -p python3.8 .venv
+          source .venv/bin/activate
+          pip install -U pip wheel
+          # https://github.com/indygreg/PyOxidizer/issues/663
+          pip install pyoxidizer==0.22.0
+
+      - name: build binary
+        shell: bash
+        run: |
+          cd rally
+          source .venv/bin/activate
+          pyoxidizer build --release
+
+      - name: check binary
+        shell: bash
+        run: |
+          ./rally/build/x86_64-unknown-linux-gnu/release/install/rally --version
+
+          cd rally
+          source .venv/bin/activate
+          pyoxidizer analyze build/x86_64-unknown-linux-gnu/release/install/rally
+
+      - name: tar files
+        shell: bash
+        run: |
+          cd rally
+          source .venv/bin/activate
+          VERSION=$(python -c 'import esrally; print(esrally.__version__)')
+
+          cd build/x86_64-unknown-linux-gnu/release
+
+          ARCHIVE=esrally-standalone-linux-$VERSION
+          mv install $ARCHIVE
+          tar cvzf $ARCHIVE.tar.gz $ARCHIVE
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rally
+          path: rally/build/x86_64-unknown-linux-gnu/release/esrally-standalone-linux*.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/pyoxidizer.yml
+++ b/.github/workflows/pyoxidizer.yml
@@ -27,8 +27,7 @@ jobs:
           apt update
           apt install -y git python3.8 python3-virtualenv virtualenv clang
 
-          # TODO switch to elastic/rally before merging
-          git clone https://github.com/pquentin/rally.git
+          git clone https://github.com/elastic/rally.git
           cd rally
 
           virtualenv -p python3.8 .venv

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -18,6 +18,12 @@ Rally does not support Windows and is only actively tested on macOS and Linux. I
 Python
 ~~~~~~
 
+    .. note::
+
+        You don't need Python if you
+        This documentation is for the version of Rally currently under development. We do not provide standalone binaries for development versions.
+        Were you looking for the `documentation of the latest stable version <//esrally.readthedocs.io/en/stable/>`_?
+
 * Python 3.8 or better available as ``python3`` on the path. Verify with: ``python3 --version``.
 * Python3 header files (included in the Python3 development package).
 * ``pip3`` available on the path. Verify with ``pip3 --version``.
@@ -117,12 +123,15 @@ S3 support is optional and can be installed using the ``s3`` extra. If you need 
 Installing Rally
 ----------------
 
+User Install
+~~~~~~~~~~~~
+
 1. Ensure ``~/.local/bin`` is in your ``$PATH``.
 2. Ensure pip is the latest version: ``python3 -m pip install --user --upgrade pip``
 3. Install Rally: ``python3 -m pip install --user esrally``.
 
 Virtual environment Install
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can also use virtualenv to install Rally into an isolated Python environment without sudo.
 
@@ -136,16 +145,35 @@ You can also use virtualenv to install Rally into an isolated Python environment
 Whenever you want to use Rally, run the activation script (step 2 above) first.  When you are done, simply execute ``deactivate`` in the shell to exit the virtual environment.
 
 Docker
-------
+~~~~~~
 
 Docker images of Rally can be found in `Docker Hub <https://hub.docker.com/r/elastic/rally>`_.
 
 Please refer to :doc:`Running Rally with Docker <docker/>` for detailed instructions.
 
+.. _install_standalone-binary:
+
+Standalone binary
+~~~~~~~~~~~~~~~~~
+
+.. ifconfig:: release.endswith('.dev0')
+
+    .. warning::
+
+        This documentation is for the version of Rally currently under development. We do not provide standalone binaries for development versions.
+        Were you looking for the `documentation of the latest stable version <//esrally.readthedocs.io/en/stable/>`_?
+
+If you don't want to install Python or pip and/or you are in a corporate environment using Linux servers that do not have any access to the Internet, you can use Rally's standalone binaries. Follow these steps to install Rally:
+
+1. Install all prerequisites as documented above, **except Python**.
+2. Download the standalone binary package for the `latest release <https://github.com/elastic/rally/releases/latest>`_ and copy it to the target machine(s).
+3. Decompress the installation package with ``tar -xvf esrally-standalone-linux-*.tar.gz``.
+4. Run Rally with ``./esrally-standalone-linux-*/rally``.
+
 .. _install_offline-install:
 
 Offline Install
----------------
+~~~~~~~~~~~~~~~
 
 .. ifconfig:: release.endswith('.dev0')
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -20,9 +20,7 @@ Python
 
     .. note::
 
-        You don't need Python if you
-        This documentation is for the version of Rally currently under development. We do not provide standalone binaries for development versions.
-        Were you looking for the `documentation of the latest stable version <//esrally.readthedocs.io/en/stable/>`_?
+        You don't need Python to use the :ref:`standalone binary <install_standalone-binary>`.
 
 * Python 3.8 or better available as ``python3`` on the path. Verify with: ``python3 --version``.
 * Python3 header files (included in the Python3 development package).

--- a/docs/offline.rst
+++ b/docs/offline.rst
@@ -6,7 +6,12 @@ In some corporate environments servers do not have Internet access. You can stil
 Installation and Configuration
 ------------------------------
 
-We provide a special offline installation package. Follow the :ref:`offline installation guide <install_offline-install>` and :doc:`configure Rally as usual </configuration>` afterwards.
+We currently provide two ways to install Rally offline on Linux.
+
+ * If you want to control the Python version, follow the :ref:`offline installation guide <install_offline-install>`.
+ * Otherwise, and if your system has glibc 2.27 or later (that is Debian 10+, Fedora 28+, RHEL 8+ and Ubuntu 18.04+), install Rally as :ref:`standalone binary <install_standalone-binary>`. This is the recommended option.
+
+After installation, :doc:`configure Rally as usual </configuration>` afterwards.
 
 Command Line Usage
 ------------------

--- a/docs/offline.rst
+++ b/docs/offline.rst
@@ -9,7 +9,7 @@ Installation and Configuration
 We currently provide two ways to install Rally offline on Linux.
 
  * If you want to control the Python version, follow the :ref:`offline installation guide <install_offline-install>`.
- * Otherwise, and if your system has glibc 2.27 or later (that is Debian 10+, Fedora 28+, RHEL 8+ and Ubuntu 18.04+), install Rally as :ref:`standalone binary <install_standalone-binary>`. This is the recommended option.
+ * Otherwise, and if your system has glibc 2.27 or later (that is Debian 10+, Fedora 28+, RHEL 8+ and Ubuntu 18.04+), install Rally as a :ref:`standalone binary <install_standalone-binary>`. This is the recommended option.
 
 After installation, :doc:`configure Rally as usual </configuration>` afterwards.
 

--- a/esrally/__init__.py
+++ b/esrally/__init__.py
@@ -19,7 +19,11 @@ import os
 import sys
 import urllib
 
+from ._package import setup_frozen_package
 from ._version import __version__
+
+if getattr(sys, "frozen", False):
+    setup_frozen_package()
 
 # Allow an alternative program name be set in case Rally is invoked a wrapper script
 PROGRAM_NAME = os.getenv("RALLY_ALTERNATIVE_BINARY_NAME", os.path.basename(sys.argv[0]))

--- a/esrally/_package.py
+++ b/esrally/_package.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+
+# https://github.com/indygreg/PyOxidizer/issues/457
+def _patch_pkgutil() -> None:
+    """Teach pkgutil.get_data() how to read files from in-memory resources.
+    This is required for jsonschema."""
+
+    def get_data_custom(package: str, resource: str) -> bytes | None:
+        try:
+            module = importlib.import_module(package)
+            reader = module.__loader__.get_resource_reader(package)  # type: ignore[attr-defined]
+            with reader.open_resource(resource) as f:
+                return f.read()
+        except Exception:
+            return None
+
+    pkgutil.get_data = get_data_custom
+
+
+def setup_frozen_package():
+    _patch_pkgutil()

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -1,0 +1,81 @@
+# This file defines how PyOxidizer application building and packaging is
+# performed. See PyOxidizer's documentation at
+# https://gregoryszorc.com/docs/pyoxidizer/stable/pyoxidizer.html for details
+# of this configuration file format.
+
+# Configuration files consist of functions which define build "targets."
+# This function creates a Python executable and installs it in a destination
+# directory.
+def make_exe():
+    # Obtain the default PythonDistribution for our build target. We link
+    # this distribution into our produced executable and extract the Python
+    # standard library from it.
+    dist = default_python_distribution()
+
+    policy = dist.make_python_packaging_policy()
+    policy.extension_module_filter = "no-copyleft"
+
+    # Resources are loaded from "in-memory" or "filesystem-relative" paths.
+    # The locations to attempt to add resources to are defined by the
+    # `resources_location` and `resources_location_fallback` attributes.
+    # The former is the first/primary location to try and the latter is
+    # an optional fallback.
+
+    # Use in-memory location for adding resources by default.
+    policy.resources_location = "in-memory"
+
+    # Use filesystem-relative location for adding resources by default.
+    policy.resources_location_fallback = "filesystem-relative:prefix"
+
+    # This variable defines the configuration of the embedded Python
+    # interpreter. By default, the interpreter will run a Python REPL
+    # using settings that are appropriate for an "isolated" run-time
+    # environment.
+    #
+    # The configuration of the embedded Python interpreter can be modified
+    # by setting attributes on the instance. Some of these are
+    # documented below.
+    python_config = dist.make_python_interpreter_config()
+
+    # Let Python choose which memory allocator to use. (This will likely
+    # use the malloc()/free() linked into the program.
+    python_config.allocator_backend = "default"
+
+    # Evaluate a string as Python code when the interpreter starts.
+    python_config.run_command = "from esrally.rally import main; main()"
+
+    # Produce a PythonExecutable from a Python distribution, embedded
+    # resources, and other options. The returned object represents the
+    # standalone executable that will be built.
+    exe = dist.to_python_executable(
+        name="rally",
+        packaging_policy=policy,
+        config=python_config,
+    )
+    for resource in exe.pip_install(["."]):
+        # https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_packaging_additional_files.html
+        resource.add_location = "filesystem-relative:lib"
+        exe.add_python_resource(resource)
+
+    return exe
+
+def make_embedded_resources(exe):
+    return exe.to_embedded_resources()
+
+def make_install(exe):
+    # Create an object that represents our installed application file layout.
+    files = FileManifest()
+
+    # Add the generated executable to our install layout in the root directory.
+    files.add_python_resource(".", exe)
+
+    return files
+
+# Tell PyOxidizer about the build targets defined above.
+register_target("exe", make_exe)
+register_target("resources", make_embedded_resources, depends=["exe"], default_build_script=True)
+register_target("install", make_install, depends=["exe"], default=True)
+
+# Resolve whatever targets the invoker of this configuration file is requesting
+# be resolved.
+resolve_targets()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dependencies = [
     # License: MIT
     "tabulate==0.8.9",
     # License: MIT
-    "jsonschema==3.1.1",
+    # https://github.com/indygreg/PyOxidizer/issues/457
+    "jsonschema==4.1.2",
     # License: BSD
     # transitive dependency Markupsafe: BSD
     "Jinja2==2.11.3",


### PR DESCRIPTION
Closes #1420 

I'm using https://github.com/indygreg/PyOxidizer to produce a 37MB zip containing:

 * COPYING.txt, the equivalent of our NOTICE file, containing the license of all the components that went into the build
 * rally, a Linux ELF x86 64-bit executable embedding Python 3.10.8 and requiring only glibc 2.27 or later, running on Debian 10+, Fedora 28+, RHEL 8+ and Ubuntu 18.04+
 * lib, a site-packages like directory containing all our third-party Python dependencies as well as the Rally Python code itself under lib/esrally

The idea is to turn this into the default way of running Rally for users would could not care less about Python. I'll have to update the docs to reflect this.

You can see the GitHub Action running at https://github.com/pquentin/rally/actions/runs/3592786698. The artifacts are kept for 90 days, we will have to add them to the GitHub release manually for now.

More notes:

### Operating systems

 * There's no binary for macOS. While that would be possible, 1/ it would require a macOS CI that could fail in its own way 2/ this binary is mainly intended for benchmark on Linux servers and we don't want to encourage people to benchmark on their laptops 3/ GitHub Actions does not support Apple Silicon at the moment 4/ code signing would be an issue
 * Linux ARM is not currently supported, this is currently a limitation of GitHub Actions https://github.com/actions/runner-images/issues/5631
 * Older Linux distributions such as Ubuntu 16.04 or RHEL 7 are not supported.

### Python

 * PyOxidizer does not currently support Python 3.11
 * PyOxidizer 0.23.0 has a bug that forced me to use 0.22.0 which only supports Python 3.10.4, so we're vulnerable to things like https://python-security.readthedocs.io/vuln/large-int-str-dos.html
 * I would have preferred to not have a `lib` directory but we and our dependencies use `__file__` extensively which does not work if the code is in memory
 * I've not tried to use better memory allocator such as jemalloc or adding SSE instructions in the code. We're not currently using SSE anywhere anyway.
 * I've had to add one hack to the code to fix an issue with packaging jsonschema. To be honest this is way less intrusive than I thought it would be.

