### PR TITLE
Don't use --short when retrieving revisions from git

### DIFF
--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -120,7 +120,7 @@ def checkout_revision(src_dir, *, revision):
 
 @probed
 def head_revision(src_dir):
-    return process.run_subprocess_with_output("git -C {0} rev-parse --short HEAD".format(io.escape_path(src_dir)))[0].strip()
+    return process.run_subprocess_with_output("git -C {0} rev-parse HEAD".format(io.escape_path(src_dir)))[0].strip()
 
 
 @probed


### PR DESCRIPTION
Rally uses the git revision in several places, one of which when building Elasticsearch from source. Historically it used `--short`[^1] which results in shorter filenames, but they are unpredictable and more importantly cause an unnecessary git clone when using the `build` and `install` subcommands separately as described in #1635.

In this commit we switch to the full SHA length for all cases.

Closes #1635

[^1]: https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse
      .txt---shortlength
