### PR TITLE
Pass plugin-params also for modules

### DIFF
--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -219,15 +219,14 @@ class BareProvisioner:
         plugin_variables = {}
         mandatory_plugins = []
         for installer in self.plugin_installers:
+            plugin_variables.update(installer.variables)
             if installer.plugin.moved_to_module:
                 self.logger.info(
                     "Skipping adding plugin [%s] to cluster setting 'plugin.mandatory' as it has been moved to a module",
                     installer.plugin_name,
                 )
-                continue
-
-            mandatory_plugins.append(installer.plugin_name)
-            plugin_variables.update(installer.variables)
+            else:
+                mandatory_plugins.append(installer.plugin_name)
 
         cluster_settings = {}
         if mandatory_plugins:

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -257,7 +257,7 @@ class TestBareProvisioner:
         for p in plugins_moved_to_modules:
             plugin_installers.append(
                 provisioner.PluginInstaller(
-                    team.PluginDescriptor(p, core_plugin=False),
+                    team.PluginDescriptor(p, core_plugin=False, variables={"plugin-turned-to-module": "some value"}),
                     java_home="/usr/local/javas/java8",
                     hook_handler_class=self.NoopHookHandler,
                 )
@@ -274,6 +274,7 @@ class TestBareProvisioner:
         _, _, config_vars = apply_config_calls[0]
 
         assert not config_vars["cluster_settings"].get("plugin.mandatory")
+        assert "plugin-turned-to-module" in p._provisioner_variables()
 
 
 class NoopHookHandler:


### PR DESCRIPTION
In #1624 we've ensured that plugins that have turned into modules are now skipped from the mandatory plugin check. However, we've also not passed any plugin parameters to the provisioner and this made post installation hooks fail, if they expected parameters to be passed on the command line via `--plugin-params` (e.g. `repository-gcs`). With this commit we make sure that `--plugin-params` is still honored even in these cases.

Relates #1624