### PR TITLE
Skip response parsing for raw requests

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1960,6 +1960,8 @@ class RawRequest(Runner):
         if not bool(headers):
             # counter-intuitive, but preserves prior behavior
             headers = None
+        # disable eager response parsing - responses might be huge thus skewing results
+        es.return_raw_response()
 
         await es.perform_request(
             method=params.get("method", "GET"), path=path, headers=headers, body=params.get("body"), params=request_params


### PR DESCRIPTION
With this commit we skip response parsing for raw requests. As users might leverage the `raw-request` operation type for any kind of request, it is possible that it produces arbitrarily large responses, which might introduce client-side bottlenecks. As we don't inspect the response body, we might as well just use the raw response internally and avoid an accidental bottleneck due to response parsing.