### PR TITLE
Fix to-date option for list subcommand

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -1026,7 +1026,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, "system", "admin.track", args.track)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.benchmark_name", args.benchmark_name)
             cfg.add(config.Scope.applicationOverride, "system", "list.from_date", args.from_date)
-            cfg.add(config.Scope.applicationOverride, "system", "list.races.to_date", args.to_date)
+            cfg.add(config.Scope.applicationOverride, "system", "list.to_date", args.to_date)
             configure_mechanic_params(args, cfg, command_requires_car=False)
             configure_track_params(arg_parser, args, cfg, command_requires_track=False)
             dispatch_list(cfg)


### PR DESCRIPTION
PR#1597 introduced new additional filters for list races including `--to-date`, but it doesn't work as expected (gets ignored) as the name of the key is different to what it should really be (and what we are testing for).
This commit fixes the bug making `--to-date` applicable.

It might make sense to refactor those hardcoded keys in a future PR, so that they are referenced from the same location in `rally.py` and `metrics.py`.
