### PR TITLE
Add role metadata to node-stats telemetry device

### DIFF
--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -259,7 +259,6 @@ def bootstrap_actor_system(try_join=False, prefer_local_only=False, local_ip=Non
         if coordinator_ip:
             # Make the coordinator node the convention leader
             capabilities["Convention Address.IPv4"] = "%s:1900" % coordinator_ip
-        print(system_base, capabilities)
         logger.info("Starting actor system with system base [%s] and capabilities [%s].", system_base, capabilities)
         return thespian.actors.ActorSystem(system_base, logDefs=log.load_configuration(), capabilities=capabilities)
     except thespian.actors.ActorSystemException:

--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -259,6 +259,7 @@ def bootstrap_actor_system(try_join=False, prefer_local_only=False, local_ip=Non
         if coordinator_ip:
             # Make the coordinator node the convention leader
             capabilities["Convention Address.IPv4"] = "%s:1900" % coordinator_ip
+        print(system_base, capabilities)
         logger.info("Starting actor system with system base [%s] and capabilities [%s].", system_base, capabilities)
         return thespian.actors.ActorSystem(system_base, logDefs=log.load_configuration(), capabilities=capabilities)
     except thespian.actors.ActorSystemException:

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -829,7 +829,8 @@ class NodeStatsRecorder:
         current_sample = self.sample()
         for node_stats in current_sample:
             node_name = node_stats["name"]
-            metrics_store_meta_data = {"cluster": self.cluster_name, "node_name": node_name}
+            roles = node_stats["roles"]
+            metrics_store_meta_data = {"cluster": self.cluster_name, "node_name": node_name, "roles": roles}
             collected_node_stats = collections.OrderedDict()
             collected_node_stats["name"] = "node-stats"
 

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -2145,13 +2145,14 @@ class TestNodeStatsRecorder:
         client = Client(nodes=SubClient(stats=self.node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        node_name = [self.node_stats_response["nodes"][node]["name"] for node in self.node_stats_response["nodes"]][0]
-        roles = [self.node_stats_response["nodes"][node]["roles"] for node in self.node_stats_response["nodes"]][0]
-        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
 
         telemetry_params = {}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         recorder.record()
+
+        node_name = [self.node_stats_response["nodes"][node]["name"] for node in self.node_stats_response["nodes"]][0]
+        roles = [self.node_stats_response["nodes"][node]["roles"] for node in self.node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
 
         expected_doc = collections.OrderedDict()
         expected_doc["name"] = "node-stats"
@@ -2396,12 +2397,13 @@ class TestNodeStatsRecorder:
         client = Client(nodes=SubClient(stats=node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
-        roles = [node_stats_response["nodes"][node]["roles"] for node in node_stats_response["nodes"]][0]
-        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
         telemetry_params = {"node-stats-include-indices": True}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         recorder.record()
+
+        node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
+        roles = [node_stats_response["nodes"][node]["roles"] for node in node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
 
         metrics_store_put_doc.assert_called_once_with(
             {
@@ -2733,12 +2735,13 @@ class TestNodeStatsRecorder:
         client = Client(nodes=SubClient(stats=node_stats_response))
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
-        roles = [node_stats_response["nodes"][node]["roles"] for node in node_stats_response["nodes"]][0]
-        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
         telemetry_params = {"node-stats-include-indices-metrics": "refresh,docs"}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         recorder.record()
+
+        node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
+        roles = [node_stats_response["nodes"][node]["roles"] for node in node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
 
         metrics_store_put_doc.assert_called_once_with(
             {

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -2146,7 +2146,8 @@ class TestNodeStatsRecorder:
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         node_name = [self.node_stats_response["nodes"][node]["name"] for node in self.node_stats_response["nodes"]][0]
-        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
+        roles = [self.node_stats_response["nodes"][node]["roles"] for node in self.node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
 
         telemetry_params = {}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
@@ -2396,7 +2397,8 @@ class TestNodeStatsRecorder:
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
-        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
+        roles = [node_stats_response["nodes"][node]["roles"] for node in node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
         telemetry_params = {"node-stats-include-indices": True}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         recorder.record()
@@ -2732,7 +2734,8 @@ class TestNodeStatsRecorder:
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
         node_name = [node_stats_response["nodes"][node]["name"] for node in node_stats_response["nodes"]][0]
-        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name}
+        roles = [node_stats_response["nodes"][node]["roles"] for node in node_stats_response["nodes"]][0]
+        metrics_store_meta_data = {"cluster": "remote", "node_name": node_name, "roles": roles}
         telemetry_params = {"node-stats-include-indices-metrics": "refresh,docs"}
         recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
         recorder.record()


### PR DESCRIPTION
It's useful to know what roles a node was configured for when analysing metrics in a remote metrics store. 

For example:
<img width="3200" alt="image" src="https://user-images.githubusercontent.com/54515790/212801958-ab363fac-1d58-44fe-a3b9-508dd513d66d.png">


I've tested this with a local 8.5 metrics store:
```shell
esrally race --track=geopoint  --pipeline=benchmark-only --target-hosts=https://localhost:9222 --challenge=append-fast-with-conflicts --telemetry=node-stats  --client-options="timeout:180,verify_certs:false,basic_auth_user:'elastic',basic_auth_password:'changeme'" --kill-running-processes --test-mode
```
