### PR TITLE
Simplify create_readers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -963,32 +963,32 @@ def create_readers(
             offset, num_docs, num_lines = bounds(
                 docs.number_of_documents, start_client_index, end_client_index, num_clients, docs.includes_action_and_meta_data
             )
-            if num_docs > 0:
-                target = f"{docs.target_index}/{docs.target_type}" if docs.target_index else "/"
-                if docs.target_data_stream:
-                    target = docs.target_data_stream
-                logger.debug(
-                    "Task-relative clients at index [%d-%d] will bulk index [%d] docs starting from line offset [%d] for [%s] "
-                    "from corpus [%s].",
-                    start_client_index,
-                    end_client_index,
-                    num_docs,
-                    offset,
-                    target,
-                    corpus.name,
-                )
-                reader = create_reader(
-                    docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict, recency
-                )
-                readers[-1].append(reader)
-                total_readers += 1
-            else:
+            if num_docs == 0:
                 logger.debug(
                     "Task-relative clients at index [%d-%d] skip [%s] (no documents to read).",
                     start_client_index,
                     end_client_index,
                     corpus.name,
                 )
+
+            target = f"{docs.target_index}/{docs.target_type}" if docs.target_index else "/"
+            if docs.target_data_stream:
+                target = docs.target_data_stream
+            logger.debug(
+                "Task-relative clients at index [%d-%d] will bulk index [%d] docs starting from line offset [%d] for [%s] "
+                "from corpus [%s].",
+                start_client_index,
+                end_client_index,
+                num_docs,
+                offset,
+                target,
+                corpus.name,
+            )
+            reader = create_reader(
+                docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict, recency
+            )
+            readers[-1].append(reader)
+            total_readers += 1
 
     # Instead of reading all files from the first corpus, and then all files from the
     # second corpus, etc. we want to read the first file of all corpora, then the second

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -970,6 +970,7 @@ def create_readers(
                     end_client_index,
                     corpus.name,
                 )
+                continue
 
             target = f"{docs.target_index}/{docs.target_type}" if docs.target_index else "/"
             if docs.target_data_stream:

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -957,7 +957,7 @@ def create_readers(
     # stagger which corpus each client starts with for better parallelism
     reordered_corpora = corpora[start_client_index:] + corpora[:start_client_index]
     for corpus in reordered_corpora:
-        readers.append(collections.deque())
+        reader_queue = collections.dequeue()
         for docs in corpus.documents:
             offset, num_docs, num_lines = bounds(
                 docs.number_of_documents, start_client_index, end_client_index, num_clients, docs.includes_action_and_meta_data
@@ -968,8 +968,9 @@ def create_readers(
             reader = create_reader(
                 docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict, recency
             )
-            readers[-1].append(reader)
+            reader_queue.append(reader)
             total_readers += 1
+        readers.append(reader_queue)
 
     # Instead of reading all files from the first corpus, and then all files from the
     # second corpus, etc. we want to read the first file of all corpora, then the second

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -974,7 +974,8 @@ def create_readers(
     corpora_readers: List[Deque[IndexDataReader]] = []
     total_readers = 0
     # stagger which corpus each client starts with for better parallelism (see 1. above)
-    reordered_corpora = corpora[start_client_index:] + corpora[:start_client_index]
+    start_corpora_id = start_client_index % len(corpora)
+    reordered_corpora = corpora[start_corpora_id:] + corpora[:start_corpora_id]
 
     for corpus in reordered_corpora:
         reader_queue: Deque[IndexDataReader] = collections.deque()

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -952,7 +952,6 @@ def create_readers(
     recency,
     create_reader,
 ):
-    logger = logging.getLogger(__name__)
     readers = []
     total_readers = 0
     # stagger which corpus each client starts with for better parallelism
@@ -964,27 +963,8 @@ def create_readers(
                 docs.number_of_documents, start_client_index, end_client_index, num_clients, docs.includes_action_and_meta_data
             )
             if num_docs == 0:
-                logger.debug(
-                    "Task-relative clients at index [%d-%d] skip [%s] (no documents to read).",
-                    start_client_index,
-                    end_client_index,
-                    corpus.name,
-                )
                 continue
 
-            target = f"{docs.target_index}/{docs.target_type}" if docs.target_index else "/"
-            if docs.target_data_stream:
-                target = docs.target_data_stream
-            logger.debug(
-                "Task-relative clients at index [%d-%d] will bulk index [%d] docs starting from line offset [%d] for [%s] "
-                "from corpus [%s].",
-                start_client_index,
-                end_client_index,
-                num_docs,
-                offset,
-                target,
-                corpus.name,
-            )
             reader = create_reader(
                 docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict, recency
             )

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -962,14 +962,12 @@ def create_readers(
             offset, num_docs, num_lines = bounds(
                 docs.number_of_documents, start_client_index, end_client_index, num_clients, docs.includes_action_and_meta_data
             )
-            if num_docs == 0:
-                continue
-
-            reader = create_reader(
-                docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict, recency
-            )
-            reader_queue.append(reader)
-            total_readers += 1
+            if num_docs > 0:
+                reader = create_reader(
+                    docs, offset, num_lines, num_docs, batch_size, bulk_size, id_conflicts, conflict_probability, on_conflict, recency
+                )
+                reader_queue.append(reader)
+                total_readers += 1
         readers.append(reader_queue)
 
     # Instead of reading all files from the first corpus, and then all files from the

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1391,7 +1391,13 @@ class TestBulkDataGenerator:
                         number_of_documents=5,
                         target_index="logs-2017-01",
                         target_type="docs",
-                    )
+                    ),
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=0,
+                        target_index="logs-2017-02",
+                        target_type="docs",
+                    ),
                 ],
             ),
             track.DocumentCorpus(

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1467,6 +1467,67 @@ class TestBulkDataGenerator:
             },
         ]
 
+    def test_generate_bulks_with_more_clients_than_corpora(self):
+        corpora = [
+            track.DocumentCorpus(
+                name="special",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=5,
+                        target_index="logs-2017-01",
+                        target_type="docs",
+                    ),
+                ],
+            ),
+            track.DocumentCorpus(
+                name="default",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=5,
+                        target_index="logs-2018-01",
+                        target_type="docs",
+                    ),
+                ],
+            ),
+            track.DocumentCorpus(
+                name="defaults",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=5,
+                        target_index="logs-2019-01",
+                        target_type="docs",
+                    ),
+                ],
+            ),
+        ]
+
+        for client_index, indices in [
+            (0, ["logs-2017-01", "logs-2018-01", "logs-2019-01"]),
+            (1, ["logs-2018-01", "logs-2019-01", "logs-2017-01"]),
+            (2, ["logs-2019-01", "logs-2017-01", "logs-2018-01"]),
+            (3, ["logs-2017-01", "logs-2018-01", "logs-2019-01"]),
+            (4, ["logs-2018-01", "logs-2019-01", "logs-2017-01"]),
+        ]:
+            bulks = params.bulk_data_based(
+                num_clients=5,
+                start_client_index=client_index,
+                end_client_index=client_index,
+                corpora=corpora,
+                batch_size=5,
+                bulk_size=5,
+                id_conflicts=params.IndexIdConflict.NoConflicts,
+                conflict_probability=None,
+                on_conflict=None,
+                recency=None,
+                pipeline=None,
+                original_params={},
+                create_reader=self.create_test_reader([["1", "2", "3", "4", "5"]]),
+            )
+            assert [bulk["index"] for bulk in bulks] == indices
+
     def test_internal_params_take_precedence(self):
         corpus = track.DocumentCorpus(
             name="default",

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1384,6 +1384,17 @@ class TestBulkDataGenerator:
     def test_generate_bulks_from_multiple_corpora(self):
         corpora = [
             track.DocumentCorpus(
+                name="special",
+                documents=[
+                    track.Documents(
+                        source_format=track.Documents.SOURCE_FORMAT_BULK,
+                        number_of_documents=5,
+                        target_index="logs-2017-01",
+                        target_type="docs",
+                    )
+                ],
+            ),
+            track.DocumentCorpus(
                 name="default",
                 documents=[
                     track.Documents(
@@ -1398,17 +1409,6 @@ class TestBulkDataGenerator:
                         target_index="logs-2018-02",
                         target_type="docs",
                     ),
-                ],
-            ),
-            track.DocumentCorpus(
-                name="special",
-                documents=[
-                    track.Documents(
-                        source_format=track.Documents.SOURCE_FORMAT_BULK,
-                        number_of_documents=5,
-                        target_index="logs-2017-01",
-                        target_type="docs",
-                    )
                 ],
             ),
         ]
@@ -1434,7 +1434,7 @@ class TestBulkDataGenerator:
                 "body": ["1", "2", "3", "4", "5"],
                 "bulk-size": 5,
                 "unit": "docs",
-                "index": "logs-2018-01",
+                "index": "logs-2017-01",
                 "type": "docs",
                 "my-custom-parameter": "foo",
                 "my-custom-parameter-2": True,
@@ -1444,7 +1444,7 @@ class TestBulkDataGenerator:
                 "body": ["1", "2", "3", "4", "5"],
                 "bulk-size": 5,
                 "unit": "docs",
-                "index": "logs-2017-01",
+                "index": "logs-2018-01",
                 "type": "docs",
                 "my-custom-parameter": "foo",
                 "my-custom-parameter-2": True,

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -1358,29 +1358,28 @@ class TestBulkDataGenerator:
             original_params={"my-custom-parameter": "foo", "my-custom-parameter-2": True},
             create_reader=self.create_test_reader([["1", "2", "3", "4", "5"], ["6", "7", "8"]]),
         )
-        all_bulks = list(bulks)
-        assert len(all_bulks) == 2
-        assert all_bulks[0] == {
-            "action-metadata-present": True,
-            "body": ["1", "2", "3", "4", "5"],
-            "bulk-size": 5,
-            "unit": "docs",
-            "index": "test-idx",
-            "type": "test-type",
-            "my-custom-parameter": "foo",
-            "my-custom-parameter-2": True,
-        }
-
-        assert all_bulks[1] == {
-            "action-metadata-present": True,
-            "body": ["6", "7", "8"],
-            "bulk-size": 3,
-            "unit": "docs",
-            "index": "test-idx",
-            "type": "test-type",
-            "my-custom-parameter": "foo",
-            "my-custom-parameter-2": True,
-        }
+        assert list(bulks) == [
+            {
+                "action-metadata-present": True,
+                "body": ["1", "2", "3", "4", "5"],
+                "bulk-size": 5,
+                "unit": "docs",
+                "index": "test-idx",
+                "type": "test-type",
+                "my-custom-parameter": "foo",
+                "my-custom-parameter-2": True,
+            },
+            {
+                "action-metadata-present": True,
+                "body": ["6", "7", "8"],
+                "bulk-size": 3,
+                "unit": "docs",
+                "index": "test-idx",
+                "type": "test-type",
+                "my-custom-parameter": "foo",
+                "my-custom-parameter-2": True,
+            },
+        ]
 
     def test_generate_bulks_from_multiple_corpora(self):
         corpora = [
@@ -1429,40 +1428,38 @@ class TestBulkDataGenerator:
             original_params={"my-custom-parameter": "foo", "my-custom-parameter-2": True},
             create_reader=self.create_test_reader([["1", "2", "3", "4", "5"]]),
         )
-        all_bulks = list(bulks)
-        assert len(all_bulks) == 3
-        assert all_bulks[0] == {
-            "action-metadata-present": True,
-            "body": ["1", "2", "3", "4", "5"],
-            "bulk-size": 5,
-            "unit": "docs",
-            "index": "logs-2018-01",
-            "type": "docs",
-            "my-custom-parameter": "foo",
-            "my-custom-parameter-2": True,
-        }
-
-        assert all_bulks[1] == {
-            "action-metadata-present": True,
-            "body": ["1", "2", "3", "4", "5"],
-            "bulk-size": 5,
-            "unit": "docs",
-            "index": "logs-2017-01",
-            "type": "docs",
-            "my-custom-parameter": "foo",
-            "my-custom-parameter-2": True,
-        }
-
-        assert all_bulks[2] == {
-            "action-metadata-present": True,
-            "body": ["1", "2", "3", "4", "5"],
-            "bulk-size": 5,
-            "unit": "docs",
-            "index": "logs-2018-02",
-            "type": "docs",
-            "my-custom-parameter": "foo",
-            "my-custom-parameter-2": True,
-        }
+        assert list(bulks) == [
+            {
+                "action-metadata-present": True,
+                "body": ["1", "2", "3", "4", "5"],
+                "bulk-size": 5,
+                "unit": "docs",
+                "index": "logs-2018-01",
+                "type": "docs",
+                "my-custom-parameter": "foo",
+                "my-custom-parameter-2": True,
+            },
+            {
+                "action-metadata-present": True,
+                "body": ["1", "2", "3", "4", "5"],
+                "bulk-size": 5,
+                "unit": "docs",
+                "index": "logs-2017-01",
+                "type": "docs",
+                "my-custom-parameter": "foo",
+                "my-custom-parameter-2": True,
+            },
+            {
+                "action-metadata-present": True,
+                "body": ["1", "2", "3", "4", "5"],
+                "bulk-size": 5,
+                "unit": "docs",
+                "index": "logs-2018-02",
+                "type": "docs",
+                "my-custom-parameter": "foo",
+                "my-custom-parameter-2": True,
+            },
+        ]
 
     def test_internal_params_take_precedence(self):
         corpus = track.DocumentCorpus(
@@ -1492,18 +1489,18 @@ class TestBulkDataGenerator:
             original_params={"body": "foo", "custom-param": "bar"},
             create_reader=self.create_test_reader([["1", "2", "3"]]),
         )
-        all_bulks = list(bulks)
-        assert len(all_bulks) == 1
         # body must not contain 'foo'!
-        assert all_bulks[0] == {
-            "action-metadata-present": True,
-            "body": ["1", "2", "3"],
-            "bulk-size": 3,
-            "unit": "docs",
-            "index": "test-idx",
-            "type": "test-type",
-            "custom-param": "bar",
-        }
+        assert list(bulks) == [
+            {
+                "action-metadata-present": True,
+                "body": ["1", "2", "3"],
+                "bulk-size": 3,
+                "unit": "docs",
+                "index": "test-idx",
+                "type": "test-type",
+                "custom-param": "bar",
+            }
+        ]
 
 
 class TestParamsRegistration:
@@ -1789,11 +1786,12 @@ class TestCreateDataStreamParamSource:
             track.Track(name="unit-test"),
             params={"data-stream": "test-data-stream"},
         )
-        p = source.params()
-        assert len(p["data-streams"]) == 1
-        ds = p["data-streams"][0]
-        assert ds == "test-data-stream"
-        assert p["request-params"] == {}
+
+        assert source.params() == {
+            "data-stream": "test-data-stream",
+            "data-streams": ["test-data-stream"],
+            "request-params": {},
+        }
 
     def test_create_data_stream_inline_without_body(self):
         source = params.CreateDataStreamParamSource(
@@ -1804,11 +1802,11 @@ class TestCreateDataStreamParamSource:
             },
         )
 
-        p = source.params()
-        assert len(p["data-streams"]) == 1
-        ds = p["data-streams"][0]
-        assert ds == "test-data-stream"
-        assert p["request-params"] == {"wait_for_active_shards": True}
+        assert source.params() == {
+            "data-stream": "test-data-stream",
+            "data-streams": ["test-data-stream"],
+            "request-params": {"wait_for_active_shards": True},
+        }
 
     def test_filter_data_stream(self):
         source = params.CreateDataStreamParamSource(
@@ -1823,11 +1821,11 @@ class TestCreateDataStreamParamSource:
             params={"data-stream": "data-stream-2"},
         )
 
-        p = source.params()
-        assert len(p["data-streams"]) == 1
-
-        ds = p["data-streams"][0]
-        assert ds == "data-stream-2"
+        assert source.params() == {
+            "data-stream": "data-stream-2",
+            "data-streams": ["data-stream-2"],
+            "request-params": {},
+        }
 
 
 class TestDeleteIndexParamSource:
@@ -1844,11 +1842,11 @@ class TestDeleteIndexParamSource:
             params={},
         )
 
-        p = source.params()
-
-        assert p["indices"] == ["index1", "index2", "index3"]
-        assert p["request-params"] == {}
-        assert p["only-if-exists"]
+        assert source.params() == {
+            "indices": ["index1", "index2", "index3"],
+            "request-params": {},
+            "only-if-exists": True,
+        }
 
     def test_filter_index_from_track(self):
         source = params.DeleteIndexParamSource(
@@ -1867,18 +1865,27 @@ class TestDeleteIndexParamSource:
             },
         )
 
-        p = source.params()
-
-        assert ["index2"] == p["indices"]
-        assert p["request-params"] == {"allow_no_indices": True}
-        assert not p["only-if-exists"]
+        assert source.params() == {
+            "indices": ["index2"],
+            "index": "index2",
+            "request-params": {"allow_no_indices": True},
+            "only-if-exists": False,
+        }
 
     def test_delete_index_by_name(self):
-        source = params.DeleteIndexParamSource(track.Track(name="unit-test"), params={"index": "index2"})
+        source = params.DeleteIndexParamSource(
+            track.Track(
+                name="unit-test",
+            ),
+            params={"index": "index2"},
+        )
 
-        p = source.params()
-
-        assert p["indices"] == ["index2"]
+        assert source.params() == {
+            "indices": ["index2"],
+            "index": "index2",
+            "request-params": {},
+            "only-if-exists": True,
+        }
 
     def test_delete_no_index(self):
         with pytest.raises(exceptions.InvalidSyntax) as exc:
@@ -1900,11 +1907,11 @@ class TestDeleteDataStreamParamSource:
             params={},
         )
 
-        p = source.params()
-
-        assert p["data-streams"] == ["data-stream-1", "data-stream-2", "data-stream-3"]
-        assert p["request-params"] == {}
-        assert p["only-if-exists"]
+        assert source.params() == {
+            "data-streams": ["data-stream-1", "data-stream-2", "data-stream-3"],
+            "request-params": {},
+            "only-if-exists": True,
+        }
 
     def test_filter_data_stream_from_track(self):
         source = params.DeleteDataStreamParamSource(
@@ -1923,22 +1930,32 @@ class TestDeleteDataStreamParamSource:
             },
         )
 
-        p = source.params()
-
-        assert p["data-streams"] == ["data-stream-2"]
-        assert p["request-params"] == {"allow_no_indices": True}
-        assert not p["only-if-exists"]
+        assert source.params() == {
+            "data-stream": "data-stream-2",
+            "data-streams": ["data-stream-2"],
+            "only-if-exists": False,
+            "request-params": {"allow_no_indices": True},
+        }
 
     def test_delete_data_stream_by_name(self):
-        source = params.DeleteDataStreamParamSource(track.Track(name="unit-test"), params={"data-stream": "data-stream-2"})
+        source = params.DeleteDataStreamParamSource(
+            track.Track(name="unit-test"),
+            params={"data-stream": "data-stream-2"},
+        )
 
-        p = source.params()
-
-        assert p["data-streams"] == ["data-stream-2"]
+        assert source.params() == {
+            "data-stream": "data-stream-2",
+            "data-streams": ["data-stream-2"],
+            "request-params": {},
+            "only-if-exists": True,
+        }
 
     def test_delete_no_data_stream(self):
         with pytest.raises(exceptions.InvalidSyntax) as exc:
-            params.DeleteDataStreamParamSource(track.Track(name="unit-test"), params={})
+            params.DeleteDataStreamParamSource(
+                track.Track(name="unit-test"),
+                params={},
+            )
         assert exc.value.args[0] == "delete-data-stream operation targets no data stream"
 
 
@@ -2011,14 +2028,17 @@ class TestCreateIndexTemplateParamSource:
 
 class TestDeleteIndexTemplateParamSource:
     def test_delete_index_template_by_name(self):
-        source = params.DeleteIndexTemplateParamSource(track.Track(name="unit-test"), params={"template": "default"})
+        source = params.DeleteIndexTemplateParamSource(
+            track.Track(name="unit-test"),
+            params={"template": "default"},
+        )
 
-        p = source.params()
-
-        assert len(p["templates"]) == 1
-        assert p["templates"][0] == ("default", False, None)
-        assert p["only-if-exists"]
-        assert p["request-params"] == {}
+        assert source.params() == {
+            "template": "default",
+            "templates": [("default", False, None)],
+            "only-if-exists": True,
+            "request-params": {},
+        }
 
     def test_delete_index_template_by_name_and_matching_indices(self):
         source = params.DeleteIndexTemplateParamSource(
@@ -2030,17 +2050,23 @@ class TestDeleteIndexTemplateParamSource:
             },
         )
 
-        p = source.params()
-
-        assert len(p["templates"]) == 1
-        assert p["templates"][0] == ("default", True, "logs-*")
-        assert p["only-if-exists"]
-        assert p["request-params"] == {}
+        assert source.params() == {
+            "template": "default",
+            "delete-matching-indices": True,
+            "index-pattern": "logs-*",
+            "templates": [("default", True, "logs-*")],
+            "only-if-exists": True,
+            "request-params": {},
+        }
 
     def test_delete_index_template_by_name_and_matching_indices_missing_index_pattern(self):
         with pytest.raises(exceptions.InvalidSyntax) as exc:
             params.DeleteIndexTemplateParamSource(
-                track.Track(name="unit-test"), params={"template": "default", "delete-matching-indices": True}
+                track.Track(name="unit-test"),
+                params={
+                    "template": "default",
+                    "delete-matching-indices": True,
+                },
             )
         assert (
             exc.value.args[0] == "The property 'index-pattern' is required for delete-index-template if 'delete-matching-indices' is true."
@@ -2070,16 +2096,20 @@ class TestDeleteIndexTemplateParamSource:
 
         source = params.DeleteIndexTemplateParamSource(
             track.Track(name="unit-test", templates=[tpl1, tpl2]),
-            params={"request-params": {"master_timeout": 20}, "only-if-exists": False},
+            params={
+                "request-params": {"master_timeout": 20},
+                "only-if-exists": False,
+            },
         )
 
-        p = source.params()
-
-        assert len(p["templates"]) == 2
-        assert p["templates"][0] == ("metrics", True, "metrics-*")
-        assert p["templates"][1] == ("logs", False, "logs-*")
-        assert not p["only-if-exists"]
-        assert p["request-params"] == {"master_timeout": 20}
+        assert source.params() == {
+            "request-params": {"master_timeout": 20},
+            "only-if-exists": False,
+            "templates": [
+                ("metrics", True, "metrics-*"),
+                ("logs", False, "logs-*"),
+            ],
+        }
 
 
 class TestCreateComposableTemplateParamSource:
@@ -2096,16 +2126,18 @@ class TestCreateComposableTemplateParamSource:
             },
         )
 
-        p = source.params()
-
-        assert len(p["templates"]) == 1
-        assert p["request-params"] == {}
-        template, body = p["templates"][0]
-        assert template == "test"
-        assert body == {
-            "index_patterns": ["my*"],
-            "template": {"settings": {"index.number_of_shards": 3}},
-            "composed_of": ["ct1", "ct2"],
+        assert source.params() == {
+            "request-params": {},
+            "templates": [
+                (
+                    "test",
+                    {
+                        "index_patterns": ["my*"],
+                        "template": {"settings": {"index.number_of_shards": 3}},
+                        "composed_of": ["ct1", "ct2"],
+                    },
+                )
+            ],
         }
 
     def test_create_composable_index_template_from_track(self):
@@ -2126,16 +2158,23 @@ class TestCreateComposableTemplateParamSource:
             },
         )
 
-        p = source.params()
-
-        assert len(p["templates"]) == 1
-        assert p["request-params"] == {}
-        template, body = p["templates"][0]
-        assert template == "default"
-        assert body == {
-            "index_patterns": ["my*"],
-            "template": {"settings": {"index.number_of_shards": 3, "index.number_of_replicas": 1}},
-            "composed_of": ["ct1", "ct2"],
+        assert source.params() == {
+            "request-params": {},
+            "templates": [
+                (
+                    "default",
+                    {
+                        "index_patterns": ["my*"],
+                        "template": {
+                            "settings": {
+                                "index.number_of_shards": 3,
+                                "index.number_of_replicas": 1,
+                            }
+                        },
+                        "composed_of": ["ct1", "ct2"],
+                    },
+                )
+            ],
         }
 
     def test_create_composable_index_template_from_track_wrong_filter(self):
@@ -2176,41 +2215,41 @@ class TestCreateComposableTemplateParamSource:
             },
         )
 
-        p = source.params()
-
-        assert len(p["templates"]) == 1
-        assert p["request-params"] == {}
-        template, body = p["templates"][0]
-        assert template == "default"
-        assert body == {
-            "index_patterns": ["my*"],
-            "template": {"settings": {"index.number_of_replicas": 1}},
-            "composed_of": ["ct1", "ct2"],
+        assert source.params() == {
+            "request-params": {},
+            "templates": [
+                (
+                    "default",
+                    {
+                        "index_patterns": ["my*"],
+                        "template": {
+                            "settings": {
+                                "index.number_of_replicas": 1,
+                            }
+                        },
+                        "composed_of": ["ct1", "ct2"],
+                    },
+                )
+            ],
         }
 
     def test_create_or_merge(self):
         content = params.CreateComposableTemplateParamSource._create_or_merge(
             {"parent": {}},
             ["parent", "child", "grandchild"],
-            {
-                "name": "Mike",
-            },
+            {"name": "Mike"},
         )
         assert content["parent"]["child"]["grandchild"]["name"] == "Mike"
         content = params.CreateComposableTemplateParamSource._create_or_merge(
             {"parent": {"child": {}}},
             ["parent", "child", "grandchild"],
-            {
-                "name": "Mike",
-            },
+            {"name": "Mike"},
         )
         assert content["parent"]["child"]["grandchild"]["name"] == "Mike"
         content = params.CreateComposableTemplateParamSource._create_or_merge(
             {"parent": {"child": {"grandchild": {}}}},
             ["parent", "child", "grandchild"],
-            {
-                "name": "Mike",
-            },
+            {"name": "Mike"},
         )
         assert content["parent"]["child"]["grandchild"]["name"] == "Mike"
         content = params.CreateComposableTemplateParamSource._create_or_merge(
@@ -2300,24 +2339,26 @@ class TestCreateComponentTemplateParamSource:
             },
         )
 
-        p = source.params()
-
-        assert len(p["templates"]) == 1
-        assert p["request-params"] == {}
-        template, body = p["templates"][0]
-        assert template == "default"
-        assert body == {
-            "template": {
-                "settings": {
-                    "index.number_of_shards": 1,
-                    "index.number_of_replicas": 1,
-                },
-                "mappings": {
-                    "properties": {
-                        "@timestamp": {"type": "date"},
+        assert source.params() == {
+            "request-params": {},
+            "templates": [
+                (
+                    "default",
+                    {
+                        "template": {
+                            "settings": {
+                                "index.number_of_shards": 1,
+                                "index.number_of_replicas": 1,
+                            },
+                            "mappings": {
+                                "properties": {
+                                    "@timestamp": {"type": "date"},
+                                },
+                            },
+                        }
                     },
-                },
-            }
+                )
+            ],
         }
 
     def test_create_component_index_template_from_track_wrong_filter(self):
@@ -2342,16 +2383,23 @@ class TestCreateComponentTemplateParamSource:
 
 class TestDeleteComponentTemplateParamSource:
     def test_delete_component_template_by_name(self):
-        source = params.DeleteComponentTemplateParamSource(track.Track(name="unit-test"), params={"template": "default"})
-        p = source.params()
-        assert len(p["templates"]) == 1
-        assert p["templates"][0] == "default"
-        assert p["only-if-exists"]
-        assert p["request-params"] == {}
+        source = params.DeleteComponentTemplateParamSource(
+            track.Track(name="unit-test"),
+            params={"template": "default"},
+        )
+
+        assert source.params() == {
+            "templates": ["default"],
+            "only-if-exists": True,
+            "request-params": {},
+        }
 
     def test_no_component_templates(self):
         with pytest.raises(exceptions.InvalidSyntax) as exc:
-            params.DeleteComponentTemplateParamSource(track.Track(name="unit-test"), params={"operation-type": "delete-component-template"})
+            params.DeleteComponentTemplateParamSource(
+                track.Track(name="unit-test"),
+                params={"operation-type": "delete-component-template"},
+            )
         assert exc.value.args[0] == "Please set the property 'template' for the delete-component-template operation."
 
     def test_delete_component_template_from_track(self):
@@ -2405,17 +2453,22 @@ class TestDeleteComponentTemplateParamSource:
 
 class TestDeleteComposableTemplateParamSource:
     def test_delete_composable_template_by_name(self):
-        source = params.DeleteComposableTemplateParamSource(track.Track(name="unit-test"), params={"template": "default"})
-        p = source.params()
-        assert len(p["templates"]) == 1
-        assert p["templates"][0][0] == "default"
-        assert p["only-if-exists"]
-        assert p["request-params"] == {}
+        source = params.DeleteComposableTemplateParamSource(
+            track.Track(name="unit-test"),
+            params={"template": "default"},
+        )
+        assert source.params() == {
+            "template": "default",
+            "templates": [("default", False, None)],
+            "only-if-exists": True,
+            "request-params": {},
+        }
 
     def test_no_composable_templates(self):
         with pytest.raises(exceptions.InvalidSyntax) as exc:
             params.DeleteComponentTemplateParamSource(
-                track.Track(name="unit-test"), params={"operation-type": "delete-composable-template"}
+                track.Track(name="unit-test"),
+                params={"operation-type": "delete-composable-template"},
             )
         assert exc.value.args[0] == "Please set the property 'template' for the delete-composable-template operation."
 
@@ -2486,22 +2539,21 @@ class TestSearchParamSource:
                 "cache": True,
             },
         )
-        p = source.params()
 
-        assert len(p) == 10
-        assert p["index"] == "index1"
-        assert p["type"] is None
-        assert p["request-timeout"] is None
-        assert p["opaque-id"] is None
-        assert p["headers"] == {"header1": "value1"}
-        assert p["request-params"] == {}
-        # Explicitly check in these tests for equality, `assert not x` succeeds if `x` is None
-        assert p["cache"] is True
-        assert p["response-compression-enabled"] is True
-        assert p["detailed-results"] is False
-        assert p["body"] == {
-            "query": {
-                "match_all": {},
+        assert source.params() == {
+            "index": "index1",
+            "type": None,
+            "request-timeout": None,
+            "opaque-id": None,
+            "headers": {"header1": "value1"},
+            "request-params": {},
+            "cache": True,
+            "response-compression-enabled": True,
+            "detailed-results": False,
+            "body": {
+                "query": {
+                    "match_all": {},
+                },
             },
         }
 
@@ -2522,22 +2574,21 @@ class TestSearchParamSource:
                 "cache": True,
             },
         )
-        p = source.params()
 
-        assert len(p) == 10
-        assert p["index"] == "data-stream-1"
-        assert p["type"] is None
-        assert p["request-timeout"] == 1.0
-        assert p["headers"] == {"header1": "value1", "header2": "value2"}
-        assert p["opaque-id"] == "12345abcde"
-        assert p["request-params"] == {}
-        # Explicitly check in these tests for equality, `assert not x` succeeds if `x` is None
-        assert p["cache"] is True
-        assert p["response-compression-enabled"] is True
-        assert p["detailed-results"] is False
-        assert p["body"] == {
-            "query": {
-                "match_all": {},
+        assert source.params() == {
+            "index": "data-stream-1",
+            "type": None,
+            "request-timeout": 1.0,
+            "headers": {"header1": "value1", "header2": "value2"},
+            "opaque-id": "12345abcde",
+            "request-params": {},
+            "cache": True,
+            "response-compression-enabled": True,
+            "detailed-results": False,
+            "body": {
+                "query": {
+                    "match_all": {},
+                },
             },
         }
 
@@ -2572,22 +2623,21 @@ class TestSearchParamSource:
                 },
             },
         )
-        p = source.params()
 
-        assert len(p) == 10
-        assert p["index"] == "index1"
-        assert p["type"] is None
-        assert p["request-timeout"] is None
-        assert p["headers"] is None
-        assert p["opaque-id"] is None
-        assert p["request-params"] == {"_source_include": "some_field"}
-        # Explicitly check in these tests for equality, `assert not x` succeeds if `x` is None
-        assert p["cache"] is None
-        assert p["response-compression-enabled"] is True
-        assert p["detailed-results"] is False
-        assert p["body"] == {
-            "query": {
-                "match_all": {},
+        assert source.params() == {
+            "index": "index1",
+            "type": None,
+            "request-timeout": None,
+            "opaque-id": None,
+            "headers": None,
+            "request-params": {"_source_include": "some_field"},
+            "cache": None,
+            "response-compression-enabled": True,
+            "detailed-results": False,
+            "body": {
+                "query": {
+                    "match_all": {},
+                },
             },
         }
 
@@ -2610,22 +2660,21 @@ class TestSearchParamSource:
                 },
             },
         )
-        p = source.params()
 
-        assert len(p) == 10
-        assert p["index"] == "_all"
-        assert p["type"] == "type1"
-        assert p["request-params"] == {}
-        assert p["request-timeout"] is None
-        assert p["headers"] is None
-        assert p["opaque-id"] == "12345abcde"
-        # Explicitly check in these tests for equality, `assert not x` succeeds if `x` is None
-        assert p["cache"] is False
-        assert p["response-compression-enabled"] is False
-        assert p["detailed-results"] is True
-        assert p["body"] == {
-            "query": {
-                "match_all": {},
+        assert source.params() == {
+            "index": "_all",
+            "type": "type1",
+            "request-timeout": None,
+            "opaque-id": "12345abcde",
+            "headers": None,
+            "request-params": {},
+            "cache": False,
+            "response-compression-enabled": False,
+            "detailed-results": True,
+            "body": {
+                "query": {
+                    "match_all": {},
+                },
             },
         }
 
@@ -2646,22 +2695,21 @@ class TestSearchParamSource:
                 },
             },
         )
-        p = source.params()
 
-        assert len(p) == 10
-        assert p["index"] == "data-stream-2"
-        assert p["type"] is None
-        assert p["request-timeout"] == 1.0
-        assert p["headers"] is None
-        assert p["opaque-id"] is None
-        assert p["request-params"] == {}
-        # Explicitly check in these tests for equality, `assert not x` succeeds if `x` is None
-        assert p["cache"] is False
-        assert p["response-compression-enabled"] is False
-        assert p["detailed-results"] is False
-        assert p["body"] == {
-            "query": {
-                "match_all": {},
+        assert source.params() == {
+            "index": "data-stream-2",
+            "type": None,
+            "request-timeout": 1.0,
+            "opaque-id": None,
+            "headers": None,
+            "request-params": {},
+            "cache": False,
+            "response-compression-enabled": False,
+            "detailed-results": False,
+            "body": {
+                "query": {
+                    "match_all": {},
+                },
             },
         }
 
@@ -2709,12 +2757,18 @@ class TestSearchParamSource:
 class TestForceMergeParamSource:
     def test_force_merge_index_from_track(self):
         source = params.ForceMergeParamSource(
-            track.Track(name="unit-test", indices=[track.Index(name="index1"), track.Index(name="index2"), track.Index(name="index3")]),
+            track.Track(
+                name="unit-test",
+                indices=[
+                    track.Index(name="index1"),
+                    track.Index(name="index2"),
+                    track.Index(name="index3"),
+                ],
+            ),
             params={},
         )
 
         p = source.params()
-
         assert p["index"] == "index1,index2,index3"
         assert p["mode"] == "blocking"
 
@@ -2732,20 +2786,24 @@ class TestForceMergeParamSource:
         )
 
         p = source.params()
-
         assert p["index"] == "data-stream-1,data-stream-2,data-stream-3"
         assert p["mode"] == "blocking"
 
     def test_force_merge_index_by_name(self):
-        source = params.ForceMergeParamSource(track.Track(name="unit-test"), params={"index": "index2"})
+        source = params.ForceMergeParamSource(
+            track.Track(name="unit-test"),
+            params={"index": "index2"},
+        )
 
         p = source.params()
-
         assert p["index"] == "index2"
         assert p["mode"] == "blocking"
 
     def test_force_merge_by_data_stream_name(self):
-        source = params.ForceMergeParamSource(track.Track(name="unit-test"), params={"data-stream": "data-stream-2"})
+        source = params.ForceMergeParamSource(
+            track.Track(name="unit-test"),
+            params={"data-stream": "data-stream-2"},
+        )
 
         p = source.params()
 
@@ -2753,7 +2811,10 @@ class TestForceMergeParamSource:
         assert p["mode"] == "blocking"
 
     def test_default_force_merge_index(self):
-        source = params.ForceMergeParamSource(track.Track(name="unit-test"), params={})
+        source = params.ForceMergeParamSource(
+            track.Track(name="unit-test"),
+            params={},
+        )
 
         p = source.params()
 
@@ -2763,7 +2824,13 @@ class TestForceMergeParamSource:
     def test_force_merge_all_params(self):
         source = params.ForceMergeParamSource(
             track.Track(name="unit-test"),
-            params={"index": "index2", "request-timeout": 30, "max-num-segments": 1, "polling-period": 20, "mode": "polling"},
+            params={
+                "index": "index2",
+                "request-timeout": 30,
+                "max-num-segments": 1,
+                "polling-period": 20,
+                "mode": "polling",
+            },
         )
 
         p = source.params()
@@ -2778,7 +2845,11 @@ class TestDownsampleParamSource:
     def test_downsample_all_params(self):
         source = params.DownsampleParamSource(
             track.Track(name="unit-test"),
-            params={"source-index": "test-source-index", "target-index": "test-target-index", "fixed-interval": "1m"},
+            params={
+                "source-index": "test-source-index",
+                "target-index": "test-target-index",
+                "fixed-interval": "1m",
+            },
         )
 
         p = source.params()
@@ -2789,8 +2860,14 @@ class TestDownsampleParamSource:
 
     def test_downsample_default_index_param(self):
         source = params.DownsampleParamSource(
-            track.Track(name="unit-test", indices=[track.Index(name="test-source-index", body="index.json")]),
-            params={"fixed-interval": "1m", "target-index": "test-target-index"},
+            track.Track(
+                name="unit-test",
+                indices=[track.Index(name="test-source-index", body="index.json")],
+            ),
+            params={
+                "fixed-interval": "1m",
+                "target-index": "test-target-index",
+            },
         )
 
         p = source.params()
@@ -2801,8 +2878,15 @@ class TestDownsampleParamSource:
 
     def test_downsample_source_index_override_default_index_param(self):
         source = params.DownsampleParamSource(
-            track.Track(name="unit-test", indices=[track.Index(name="test-source-index", body="index.json")]),
-            params={"source-index": "another-index", "fixed-interval": "1m", "target-index": "test-target-index"},
+            track.Track(
+                name="unit-test",
+                indices=[track.Index(name="test-source-index", body="index.json")],
+            ),
+            params={
+                "source-index": "another-index",
+                "fixed-interval": "1m",
+                "target-index": "test-target-index",
+            },
         )
 
         p = source.params()


### PR DESCRIPTION
This builds upon #1657. The second commit shows a bug in the current implementation of create_readers. It was hidden by the fact we multiply by num_clients which is often more than 1 in multi-corpora implementations.