### PR TITLE
Fix precommit by updating isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
If you want to see the failure you need to force a new installation of isort by running `pre-commit clean` before `make lint`. After having checked out this pull request, cleaning is no longer needed because pre-commit will notice the updated version of isort.