### PR TITLE
Enable pyupgrade pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,15 @@ repos:
     hooks:
       - id: isort
 
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+      - id: pyupgrade
+        args: [
+          "--py38-plus",
+          "--keep-percent-format"
+        ]
+
   - repo: local
     hooks:
       - id: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,13 @@
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+      - id: pyupgrade
+        args: [
+          "--py38-plus",
+          "--keep-percent-format"
+        ]
+
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
@@ -8,15 +17,6 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args: [
-          "--py38-plus",
-          "--keep-percent-format"
-        ]
 
   - repo: local
     hooks:

--- a/changelog.py
+++ b/changelog.py
@@ -88,7 +88,7 @@ def main():
     milestone_name = sys.argv[1]
 
     # requires a personal Github access token with permission `public_repo` (see https://github.com/settings/tokens)
-    gh = github3.login(token=open("%s/.github/rally_release_changelog.token" % os.getenv("HOME"), "r").readline().strip())
+    gh = github3.login(token=open("%s/.github/rally_release_changelog.token" % os.getenv("HOME")).readline().strip())
 
     rally_repo = gh.repository(ORG, REPO)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Licensed to Elasticsearch B.V. under one or more contributor
 # license agreements. See the NOTICE file distributed with
@@ -48,7 +47,7 @@ CI_VARS = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".ci", 
 
 def read_min_python_version():
     try:
-        with open(CI_VARS, "rt") as fp:
+        with open(CI_VARS) as fp:
             return json.load(fp)["python_versions"]["MIN_PY_VER"]
     except KeyError as e:
         raise ConfigError(f"Failed building docs as required key [{e}] couldn't be found in the file [{CI_VARS}].")

--- a/esrally/client/factory.py
+++ b/esrally/client/factory.py
@@ -114,13 +114,13 @@ class EsClientFactory:
             missing_auth = [k for k, v in provided_auth.items() if not v]
             if missing_auth:
                 console.println(
-                        "Basic auth credentials are required in order to create API keys.\n"
-                        f"Missing basic auth client options are: {missing_auth}\n"
-                        f"Read the documentation at {console.format.link(doc_link('command_line_reference.html#client-options'))}"
+                    "Basic auth credentials are required in order to create API keys.\n"
+                    f"Missing basic auth client options are: {missing_auth}\n"
+                    f"Read the documentation at {console.format.link(doc_link('command_line_reference.html#client-options'))}"
                 )
                 raise exceptions.SystemSetupError(
-                        "You must provide the 'basic_auth_user' and 'basic_auth_password' client options in addition "
-                        "to 'create_api_key_per_client' in order to create client API keys."
+                    "You must provide the 'basic_auth_user' and 'basic_auth_password' client options in addition "
+                    "to 'create_api_key_per_client' in order to create client API keys."
                 )
             self.logger.debug("Automatic creation of client API keys: on")
         else:

--- a/esrally/client/factory.py
+++ b/esrally/client/factory.py
@@ -114,17 +114,13 @@ class EsClientFactory:
             missing_auth = [k for k, v in provided_auth.items() if not v]
             if missing_auth:
                 console.println(
-                    (
                         "Basic auth credentials are required in order to create API keys.\n"
                         f"Missing basic auth client options are: {missing_auth}\n"
                         f"Read the documentation at {console.format.link(doc_link('command_line_reference.html#client-options'))}"
-                    )
                 )
                 raise exceptions.SystemSetupError(
-                    (
                         "You must provide the 'basic_auth_user' and 'basic_auth_password' client options in addition "
                         "to 'create_api_key_per_client' in order to create client API keys."
-                    )
                 )
             self.logger.debug("Automatic creation of client API keys: on")
         else:
@@ -246,7 +242,7 @@ def wait_for_rest_layer(es, max_attempts=40):
         try:
             # see also WaitForHttpResource in Elasticsearch tests. Contrary to the ES tests we consider the API also
             # available when the cluster status is RED (as long as all required nodes are present)
-            es.cluster.health(wait_for_nodes=">={}".format(expected_node_count))
+            es.cluster.health(wait_for_nodes=f">={expected_node_count}")
             logger.debug("REST API is available for >= [%s] nodes after [%s] attempts.", expected_node_count, attempt)
             return True
         except elasticsearch.ConnectionError as e:

--- a/esrally/config.py
+++ b/esrally/config.py
@@ -61,20 +61,20 @@ class ConfigFile:
             source_path = template_path
         else:
             source_path = io.normalize_path(os.path.join(os.path.dirname(__file__), "resources", "rally.ini"))
-        with open(self.location, "wt", encoding="utf-8") as target:
-            with open(source_path, "rt", encoding="utf-8") as src:
+        with open(self.location, "w", encoding="utf-8") as target:
+            with open(source_path, encoding="utf-8") as src:
                 contents = src.read()
                 target.write(Template(contents).substitute(CONFIG_DIR=self.config_dir))
 
     def store(self, config):
         io.ensure_dir(self.config_dir)
-        with open(self.location, "wt", encoding="utf-8") as configfile:
+        with open(self.location, "w", encoding="utf-8") as configfile:
             config.write(configfile)
 
     def backup(self):
         config_file = self.location
         logging.getLogger(__name__).info("Creating a backup of the current config file at [%s].", config_file)
-        shutil.copyfile(config_file, "{}.bak".format(config_file))
+        shutil.copyfile(config_file, f"{config_file}.bak")
 
     @property
     def config_dir(self):
@@ -83,10 +83,10 @@ class ConfigFile:
     @property
     def location(self):
         if self.config_name:
-            config_name_suffix = "-{}".format(self.config_name)
+            config_name_suffix = f"-{self.config_name}"
         else:
             config_name_suffix = ""
-        return os.path.join(self.config_dir, "rally{}.ini".format(config_name_suffix))
+        return os.path.join(self.config_dir, f"rally{config_name_suffix}.ini")
 
 
 def auto_load_local_config(base_config, additional_sections=None, config_file_class=ConfigFile, **kwargs):

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -802,8 +802,8 @@ class Driver:
                         delete_api_keys(self.default_sync_es_client, self.generated_api_key_ids)
                     except exceptions.RallyError:
                         console.warn(
-                                "Unable to delete auto-generated API keys. You may need to manually delete them. "
-                                "Please check the logs for details."
+                            "Unable to delete auto-generated API keys. You may need to manually delete them. "
+                            "Please check the logs for details."
                         )
                 self.logger.debug("Sending benchmark results...")
                 self.target.on_benchmark_complete(m)

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -258,7 +258,7 @@ class DriverActor(actor.RallyActor):
                 self.logger.debug("Worker [%d] has exited.", worker_index)
             else:
                 self.logger.error("Worker [%d] has exited prematurely. Aborting benchmark.", worker_index)
-                self.send(self.start_sender, actor.BenchmarkFailure("Worker [{}] has exited prematurely.".format(worker_index)))
+                self.send(self.start_sender, actor.BenchmarkFailure(f"Worker [{worker_index}] has exited prematurely."))
         else:
             self.logger.debug("A track preparator has exited.")
 
@@ -802,10 +802,8 @@ class Driver:
                         delete_api_keys(self.default_sync_es_client, self.generated_api_key_ids)
                     except exceptions.RallyError:
                         console.warn(
-                            (
                                 "Unable to delete auto-generated API keys. You may need to manually delete them. "
                                 "Please check the logs for details."
-                            )
                         )
                 self.logger.debug("Sending benchmark results...")
                 self.target.on_benchmark_complete(m)
@@ -1257,7 +1255,7 @@ class Worker(actor.RallyActor):
                     )
                     # the exception might be user-defined and not be on the load path of the master driver. Hence, it cannot be
                     # deserialized on the receiver so we convert it here to a plain string.
-                    self.send(self.master, actor.BenchmarkFailure("Error in load generator [{}]".format(self.worker_id), str(e)))
+                    self.send(self.master, actor.BenchmarkFailure(f"Error in load generator [{self.worker_id}]", str(e)))
                 else:
                     self.logger.debug("Worker[%s] is ready for the next task.", str(self.worker_id))
                     self.executor_future = None

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -129,7 +129,7 @@ def register_runner(operation_type, runner, **kwargs):
 
     if not async_runner:
         raise exceptions.RallyAssertionError(
-            "Runner [{}] must be implemented as async runner and registered with async_runner=True.".format(str(runner))
+            f"Runner [{str(runner)}] must be implemented as async runner and registered with async_runner=True."
         )
 
     if hasattr(unwrap(runner), "multi_cluster"):
@@ -1644,7 +1644,7 @@ class ShrinkIndex(Runner):
             es, params={"index": idx, "retries": sys.maxsize, "request-params": {"wait_for_no_relocating_shards": "true"}}
         )
         if not result["success"]:
-            raise exceptions.RallyAssertionError("Failed to wait for [{}].".format(description))
+            raise exceptions.RallyAssertionError(f"Failed to wait for [{description}].")
 
     async def __call__(self, es, params):
         source_index = mandatory(params, "source-index", self)
@@ -2726,7 +2726,7 @@ class Sql(Runner):
 
             if not cursor:
                 raise exceptions.DataError(
-                    "Result set has been exhausted before all pages have been fetched, {} page(s) remaining.".format(pages)
+                    f"Result set has been exhausted before all pages have been fetched, {pages} page(s) remaining."
                 )
 
             r = await es.perform_request(method="POST", path="/_sql", body={"cursor": cursor})

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2725,9 +2725,7 @@ class Sql(Runner):
             cursor = parse(r, ["cursor"]).get("cursor")
 
             if not cursor:
-                raise exceptions.DataError(
-                    f"Result set has been exhausted before all pages have been fetched, {pages} page(s) remaining."
-                )
+                raise exceptions.DataError(f"Result set has been exhausted before all pages have been fetched, {pages} page(s) remaining.")
 
             r = await es.perform_request(method="POST", path="/_sql", body={"cursor": cursor})
             pages -= 1

--- a/esrally/log.py
+++ b/esrally/log.py
@@ -56,7 +56,7 @@ def install_default_log_config():
         io.ensure_dir(io.dirname(log_config))
         source_path = io.normalize_path(os.path.join(os.path.dirname(__file__), "resources", "logging.json"))
         with open(log_config, "w", encoding="UTF-8") as target:
-            with open(source_path, "r", encoding="UTF-8") as src:
+            with open(source_path, encoding="UTF-8") as src:
                 # Ensure we have a trailing path separator as after LOG_PATH there will only be the file name
                 log_path = os.path.join(paths.logs(), "")
                 # the logging path might contain backslashes that we need to escape

--- a/esrally/mechanic/java_resolver.py
+++ b/esrally/mechanic/java_resolver.py
@@ -33,7 +33,7 @@ def java_home(car_runtime_jdks, specified_runtime_jdk=None, provides_bundled_jdk
     try:
         allowed_runtime_jdks = [int(v) for v in car_runtime_jdks.split(",")]
     except ValueError:
-        raise exceptions.SystemSetupError('Car config key "runtime.jdk" is invalid: "{}" (must be int)'.format(car_runtime_jdks))
+        raise exceptions.SystemSetupError(f'Car config key "runtime.jdk" is invalid: "{car_runtime_jdks}" (must be int)')
 
     runtime_jdk_versions = determine_runtime_jdks()
     if runtime_jdk_versions[0] == "bundled":

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -57,7 +57,7 @@ class DockerLauncher:
 
         ret = process.run_subprocess_with_logging(compose_cmd)
         if ret != 0:
-            msg = "Docker daemon startup failed with exit code [{}]".format(ret)
+            msg = f"Docker daemon startup failed with exit code [{ret}]"
             logging.error(msg)
             raise exceptions.LaunchError(msg)
 
@@ -72,7 +72,7 @@ class DockerLauncher:
         return process.run_subprocess_with_output(compose_ps_cmd)[0]
 
     def _wait_for_healthy_running_container(self, container_id, timeout):
-        cmd = 'docker ps -a --filter "id={}" --filter "status=running" --filter "health=healthy" -q'.format(container_id)
+        cmd = f'docker ps -a --filter "id={container_id}" --filter "status=running" --filter "health=healthy" -q'
         stop_watch = self.clock.stop_watch()
         stop_watch.start()
         while stop_watch.split_time() < timeout:
@@ -80,7 +80,7 @@ class DockerLauncher:
             if len(containers) > 0:
                 return
             time.sleep(0.5)
-        msg = "No healthy running container after {} seconds!".format(timeout)
+        msg = f"No healthy running container after {timeout} seconds!"
         logging.error(msg)
         raise exceptions.LaunchError(msg)
 
@@ -110,7 +110,7 @@ def wait_for_pidfile(pidfilename, timeout=60, clock=time.Clock):
         except (FileNotFoundError, EOFError):
             time.sleep(0.5)
 
-    msg = "pid file not available after {} seconds!".format(timeout)
+    msg = f"pid file not available after {timeout} seconds!"
     logging.error(msg)
     raise exceptions.LaunchError(msg)
 
@@ -217,7 +217,7 @@ class ProcessLauncher:
         cmd.extend(["-d", "-p", pid_path])
         ret = ProcessLauncher._run_subprocess(command_line=" ".join(cmd), env=env)
         if ret != 0:
-            msg = "Daemon startup failed with exit code [{}]".format(ret)
+            msg = f"Daemon startup failed with exit code [{ret}]"
             logging.error(msg)
             raise exceptions.LaunchError(msg)
 

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -86,7 +86,7 @@ def install(cfg):
         # there is no binary for Docker that can be downloaded / built upfront
         node_config = p.prepare(binary=None)
     else:
-        raise exceptions.SystemSetupError("Unknown build type [{}]".format(build_type))
+        raise exceptions.SystemSetupError(f"Unknown build type [{build_type}]")
 
     provisioner.save_node_configuration(root_path, node_config)
     console.println(json.dumps({"installation-id": cfg.opts("system", "install.id")}, indent=2), force=True)
@@ -111,7 +111,7 @@ def start(cfg):
     elif node_config.build_type == "docker":
         node_launcher = launcher.DockerLauncher(cfg)
     else:
-        raise exceptions.SystemSetupError("Unknown build type [{}]".format(node_config.build_type))
+        raise exceptions.SystemSetupError(f"Unknown build type [{node_config.build_type}]")
     nodes = node_launcher.start([node_config])
     _store_node_file(root_path, (nodes, race_id))
 
@@ -124,7 +124,7 @@ def stop(cfg):
     elif node_config.build_type == "docker":
         node_launcher = launcher.DockerLauncher(cfg)
     else:
-        raise exceptions.SystemSetupError("Unknown build type [{}]".format(node_config.build_type))
+        raise exceptions.SystemSetupError(f"Unknown build type [{node_config.build_type}]")
 
     nodes, race_id = _load_node_file(root_path)
 
@@ -423,7 +423,7 @@ class MechanicActor(actor.RallyActor):
         if msg.payload == MechanicActor.WAKEUP_RESET_RELATIVE_TIME:
             self.reset_relative_time()
         else:
-            raise exceptions.RallyAssertionError("Unknown wakeup reason [{}]".format(msg.payload))
+            raise exceptions.RallyAssertionError(f"Unknown wakeup reason [{msg.payload}]")
 
     def receiveMsg_BenchmarkFailure(self, msg, sender):
         self.send(self.race_control, msg)

--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -95,12 +95,12 @@ class NodeConfiguration:
 
 
 def save_node_configuration(path, n):
-    with open(os.path.join(path, "node-config.json"), "wt") as f:
+    with open(os.path.join(path, "node-config.json"), "w") as f:
         json.dump(n.as_dict(), f, indent=2)
 
 
 def load_node_configuration(path):
-    with open(os.path.join(path, "node-config.json"), "rt") as f:
+    with open(os.path.join(path, "node-config.json")) as f:
         return NodeConfiguration.from_dict(json.load(f))
 
 
@@ -139,7 +139,7 @@ def cleanup(preserve, install_dir, data_paths):
 
     logger = logging.getLogger(__name__)
     if preserve:
-        console.info("Preserving benchmark candidate installation at [{}].".format(install_dir), logger=logger)
+        console.info(f"Preserving benchmark candidate installation at [{install_dir}].", logger=logger)
     else:
         logger.info("Wiping benchmark candidate installation at [%s].", install_dir)
         for path in data_paths:
@@ -482,7 +482,7 @@ class DockerProvisioner:
         docker_cfg = self._render_template_from_file(self.docker_vars(mounts))
         self.logger.info("Starting Docker container with configuration:\n%s", docker_cfg)
 
-        with open(os.path.join(self.binary_path, "docker-compose.yml"), mode="wt", encoding="utf-8") as f:
+        with open(os.path.join(self.binary_path, "docker-compose.yml"), mode="w", encoding="utf-8") as f:
             f.write(docker_cfg)
 
         return NodeConfiguration(

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -29,9 +29,9 @@ TEAM_FORMAT_VERSION = 1
 
 
 def _path_for(team_root_path, team_member_type):
-    root_path = os.path.join(team_root_path, team_member_type, "v{}".format(TEAM_FORMAT_VERSION))
+    root_path = os.path.join(team_root_path, team_member_type, f"v{TEAM_FORMAT_VERSION}")
     if not os.path.exists(root_path):
-        raise exceptions.SystemSetupError("Path {} for {} does not exist.".format(root_path, team_member_type))
+        raise exceptions.SystemSetupError(f"Path {root_path} for {team_member_type} does not exist.")
     return root_path
 
 
@@ -71,12 +71,12 @@ def load_car(repo, name, car_params=None):
                     root_path = p
                 # multiple cars are based on the same hook
                 elif root_path != p:
-                    raise exceptions.SystemSetupError("Invalid car: {}. Multiple bootstrap hooks are forbidden.".format(name))
+                    raise exceptions.SystemSetupError(f"Invalid car: {name}. Multiple bootstrap hooks are forbidden.")
         all_config_base_vars.update(descriptor.config_base_variables)
         all_car_vars.update(descriptor.variables)
 
     if len(all_config_paths) == 0:
-        raise exceptions.SystemSetupError("At least one config base is required for car {}".format(name))
+        raise exceptions.SystemSetupError(f"At least one config base is required for car {name}")
     variables = {}
     # car variables *always* take precedence over config base variables
     variables.update(all_config_base_vars)
@@ -156,12 +156,12 @@ class CarLoader:
         return map(__car_name, filter(__is_car, os.listdir(self.cars_dir)))
 
     def _car_file(self, name):
-        return os.path.join(self.cars_dir, "{}.ini".format(name))
+        return os.path.join(self.cars_dir, f"{name}.ini")
 
     def load_car(self, name, car_params=None):
         car_config_file = self._car_file(name)
         if not io.exists(car_config_file):
-            raise exceptions.SystemSetupError("Unknown car [{}]. List the available cars with {} list cars.".format(name, PROGRAM_NAME))
+            raise exceptions.SystemSetupError(f"Unknown car [{name}]. List the available cars with {PROGRAM_NAME} list cars.")
         config = self._config_loader(car_config_file)
         root_paths = []
         config_paths = []
@@ -257,7 +257,7 @@ class Car:
         try:
             return self.variables[name]
         except KeyError:
-            raise exceptions.SystemSetupError('Car "{}" requires config key "{}"'.format(self.name, name))
+            raise exceptions.SystemSetupError(f'Car "{self.name}" requires config key "{name}"')
 
     @property
     def name(self):
@@ -290,7 +290,7 @@ class PluginLoader:
         core_plugins = []
         core_plugins_path = os.path.join(self.plugins_root_path, "core-plugins.txt")
         if os.path.exists(core_plugins_path):
-            with open(core_plugins_path, mode="rt", encoding="utf-8") as f:
+            with open(core_plugins_path, encoding="utf-8") as f:
                 for line in f:
                     if not line.startswith("#"):
                         # be forward compatible and allow additional values (comma-separated). At the moment, we only use the plugin name.
@@ -496,14 +496,14 @@ class BootstrapHookHandler:
             # just pass our own exceptions transparently.
             raise
         except BaseException:
-            msg = "Could not load bootstrap hooks in [{}]".format(self.loader.root_path)
+            msg = f"Could not load bootstrap hooks in [{self.loader.root_path}]"
             self.logger.exception(msg)
             raise exceptions.SystemSetupError(msg)
 
     def register(self, phase, hook):
         self.logger.info("Registering bootstrap hook [%s] for phase [%s] in component [%s]", hook.__name__, phase, self.component.name)
         if not BootstrapPhase.valid(phase):
-            raise exceptions.SystemSetupError("Unknown bootstrap phase [{}]. Valid phases are: {}.".format(phase, BootstrapPhase.names()))
+            raise exceptions.SystemSetupError(f"Unknown bootstrap phase [{phase}]. Valid phases are: {BootstrapPhase.names()}.")
         if phase not in self.hooks:
             self.hooks[phase] = []
         self.hooks[phase].append(hook)

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1896,9 +1896,7 @@ class EsRaceStore(RaceStore):
         if hits == 1:
             return Race.from_dict(result["hits"]["hits"][0]["_source"])
         elif hits > 1:
-            raise exceptions.RallyAssertionError(
-                f"Expected exactly one race to match race id [{race_id}] but there were [{hits}] matches."
-            )
+            raise exceptions.RallyAssertionError(f"Expected exactly one race to match race id [{race_id}] but there were [{hits}] matches.")
         else:
             raise exceptions.NotFound(f"No race with race id [{race_id}]")
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -636,7 +636,7 @@ class MetricsStore:
         elif level is None:
             meta = None
         else:
-            raise exceptions.SystemSetupError("Unknown meta info level [{}]".format(level))
+            raise exceptions.SystemSetupError(f"Unknown meta info level [{level}]")
 
         if meta and meta_data:
             meta.update(meta_data)
@@ -871,7 +871,7 @@ class EsMetricsStore(MetricsStore):
         return "rally-metrics-%04d-%02d" % (ts.year, ts.month)
 
     def _migrated_index_name(self, original_name):
-        return "{}.new".format(original_name)
+        return f"{original_name}.new"
 
     def _get_template(self):
         return self._index_template_provider.metrics_template()
@@ -1617,7 +1617,7 @@ class FileRaceStore(RaceStore):
         doc = race.as_dict()
         race_path = paths.race_root(self.cfg, race_id=race.race_id)
         io.ensure_dir(race_path)
-        with open(self._race_file(), mode="wt", encoding="utf-8") as f:
+        with open(self._race_file(), mode="w", encoding="utf-8") as f:
             f.write(json.dumps(doc, indent=True, ensure_ascii=False))
 
     def _race_file(self, race_id=None):
@@ -1646,7 +1646,7 @@ class FileRaceStore(RaceStore):
             races = self._to_races([race_file])
             if races:
                 return races[0]
-        raise exceptions.NotFound("No race with race id [{}]".format(race_id))
+        raise exceptions.NotFound(f"No race with race id [{race_id}]")
 
     def _to_races(self, results):
         races = []
@@ -1658,7 +1658,7 @@ class FileRaceStore(RaceStore):
         for result in results:
             # noinspection PyBroadException
             try:
-                with open(result, mode="rt", encoding="utf-8") as f:
+                with open(result, encoding="utf-8") as f:
                     races.append(Race.from_dict(json.loads(f.read())))
             except BaseException:
                 logging.getLogger(__name__).exception("Could not load race file [%s] (incompatible format?) Skipping...", result)
@@ -1897,10 +1897,10 @@ class EsRaceStore(RaceStore):
             return Race.from_dict(result["hits"]["hits"][0]["_source"])
         elif hits > 1:
             raise exceptions.RallyAssertionError(
-                "Expected exactly one race to match race id [{}] but there were [{}] matches.".format(race_id, hits)
+                f"Expected exactly one race to match race id [{race_id}] but there were [{hits}] matches."
             )
         else:
-            raise exceptions.NotFound("No race with race id [{}]".format(race_id))
+            raise exceptions.NotFound(f"No race with race id [{race_id}]")
 
 
 class EsResultsStore:

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -284,7 +284,7 @@ def set_default_hosts(cfg, host="127.0.0.1", port=9200):
         logger.info("Using configured hosts %s", configured_hosts.default)
     else:
         logger.info("Setting default host to [%s:%d]", host, port)
-        default_host_object = opts.TargetHosts("{}:{}".format(host, port))
+        default_host_object = opts.TargetHosts(f"{host}:{port}")
         cfg.add(config.Scope.benchmark, "client", "hosts", default_host_object)
 
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -66,7 +66,7 @@ def create_arg_parser():
             # don't convert, just check that the format is correct, we'll use the string value later on anyway
             return v
         except ValueError:
-            msg = "[{}] does not conform to the pattern [yyyyMMdd]".format(v)
+            msg = f"[{v}] does not conform to the pattern [yyyyMMdd]"
             raise argparse.ArgumentTypeError(msg)
 
     def positive_number(v):
@@ -127,7 +127,7 @@ def create_arg_parser():
     parser = argparse.ArgumentParser(
         prog=PROGRAM_NAME,
         description=BANNER + "\n\n You Know, for Benchmarking Elasticsearch.",
-        epilog="Find out more about Rally at {}".format(console.format.link(doc_link())),
+        epilog=f"Find out more about Rally at {console.format.link(doc_link())}",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/esrally/rallyd.py
+++ b/esrally/rallyd.py
@@ -85,7 +85,7 @@ def main():
     parser = argparse.ArgumentParser(
         prog=PROGRAM_NAME,
         description=BANNER + "\n\n Rally daemon to support remote benchmarks",
-        epilog="Find out more about Rally at {}".format(console.format.link(doc_link())),
+        epilog=f"Find out more about Rally at {console.format.link(doc_link())}",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--version", action="version", version="%(prog)s " + version.version())

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -251,9 +251,7 @@ class SummaryReporter:
     def _report_total_time_per_shard(self, name, total_time_per_shard):
         unit = "min"
         return self._join(
-            self._line(
-                f"Min cumulative {name} across primary shards", "", total_time_per_shard.get("min"), unit, convert.ms_to_minutes
-            ),
+            self._line(f"Min cumulative {name} across primary shards", "", total_time_per_shard.get("min"), unit, convert.ms_to_minutes),
             self._line(
                 f"Median cumulative {name} across primary shards",
                 "",
@@ -261,9 +259,7 @@ class SummaryReporter:
                 unit,
                 convert.ms_to_minutes,
             ),
-            self._line(
-                f"Max cumulative {name} across primary shards", "", total_time_per_shard.get("max"), unit, convert.ms_to_minutes
-            ),
+            self._line(f"Max cumulative {name} across primary shards", "", total_time_per_shard.get("max"), unit, convert.ms_to_minutes),
         )
 
     def _report_total_count(self, name, total_count):
@@ -847,9 +843,7 @@ class ComparisonReporter:
 
     def _report_total_count(self, name, baseline_total, contender_total):
         return self._join(
-            self._line(
-                f"Cumulative {name} of primary shards", baseline_total, contender_total, "", "", treat_increase_as_improvement=False
-            )
+            self._line(f"Cumulative {name} of primary shards", baseline_total, contender_total, "", "", treat_increase_as_improvement=False)
         )
 
     def _report_gc_metrics(self, baseline_stats, contender_stats):

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -245,30 +245,30 @@ class SummaryReporter:
     def _report_total_time(self, name, total_time):
         unit = "min"
         return self._join(
-            self._line("Cumulative {} of primary shards".format(name), "", total_time, unit, convert.ms_to_minutes),
+            self._line(f"Cumulative {name} of primary shards", "", total_time, unit, convert.ms_to_minutes),
         )
 
     def _report_total_time_per_shard(self, name, total_time_per_shard):
         unit = "min"
         return self._join(
             self._line(
-                "Min cumulative {} across primary shards".format(name), "", total_time_per_shard.get("min"), unit, convert.ms_to_minutes
+                f"Min cumulative {name} across primary shards", "", total_time_per_shard.get("min"), unit, convert.ms_to_minutes
             ),
             self._line(
-                "Median cumulative {} across primary shards".format(name),
+                f"Median cumulative {name} across primary shards",
                 "",
                 total_time_per_shard.get("median"),
                 unit,
                 convert.ms_to_minutes,
             ),
             self._line(
-                "Max cumulative {} across primary shards".format(name), "", total_time_per_shard.get("max"), unit, convert.ms_to_minutes
+                f"Max cumulative {name} across primary shards", "", total_time_per_shard.get("max"), unit, convert.ms_to_minutes
             ),
         )
 
     def _report_total_count(self, name, total_count):
         return self._join(
-            self._line("Cumulative {} of primary shards".format(name), "", total_count, ""),
+            self._line(f"Cumulative {name} of primary shards", "", total_count, ""),
         )
 
     def _report_ml_processing_times(self, stats):
@@ -803,7 +803,7 @@ class ComparisonReporter:
         unit = "min"
         return self._join(
             self._line(
-                "Cumulative {} of primary shards".format(name),
+                f"Cumulative {name} of primary shards",
                 baseline_total,
                 contender_total,
                 "",
@@ -817,7 +817,7 @@ class ComparisonReporter:
         unit = "min"
         return self._join(
             self._line(
-                "Min cumulative {} across primary shard".format(name),
+                f"Min cumulative {name} across primary shard",
                 baseline_per_shard.get("min"),
                 contender_per_shard.get("min"),
                 "",
@@ -826,7 +826,7 @@ class ComparisonReporter:
                 formatter=convert.ms_to_minutes,
             ),
             self._line(
-                "Median cumulative {} across primary shard".format(name),
+                f"Median cumulative {name} across primary shard",
                 baseline_per_shard.get("median"),
                 contender_per_shard.get("median"),
                 "",
@@ -835,7 +835,7 @@ class ComparisonReporter:
                 formatter=convert.ms_to_minutes,
             ),
             self._line(
-                "Max cumulative {} across primary shard".format(name),
+                f"Max cumulative {name} across primary shard",
                 baseline_per_shard.get("max"),
                 contender_per_shard.get("max"),
                 "",
@@ -848,7 +848,7 @@ class ComparisonReporter:
     def _report_total_count(self, name, baseline_total, contender_total):
         return self._join(
             self._line(
-                "Cumulative {} of primary shards".format(name), baseline_total, contender_total, "", "", treat_increase_as_improvement=False
+                f"Cumulative {name} of primary shards", baseline_total, contender_total, "", "", treat_increase_as_improvement=False
             )
         )
 

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -238,10 +238,10 @@ class FlightRecorder(TelemetryDevice):
 
         if self.java_major_version < 9:
             java_opts.append("-XX:+FlightRecorder")
-            java_opts.append("-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath={}".format(log_file))
+            java_opts.append(f"-XX:FlightRecorderOptions=disk=true,maxage=0s,maxsize=0,dumponexit=true,dumponexitpath={log_file}")
             jfr_cmd = "-XX:StartFlightRecording=defaultrecording=true"
         else:
-            jfr_cmd += "-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename={}".format(log_file)
+            jfr_cmd += f"-XX:StartFlightRecording=maxsize=0,maxage=0s,disk=true,dumponexit=true,filename={log_file}"
 
         if delay:
             self.logger.info("jfr: Using delay [%s].", delay)
@@ -278,7 +278,7 @@ class JitCompiler(TelemetryDevice):
             "-XX:+UnlockDiagnosticVMOptions",
             "-XX:+TraceClassLoading",
             "-XX:+LogCompilation",
-            "-XX:LogFile={}".format(log_file),
+            f"-XX:LogFile={log_file}",
             "-XX:+PrintAssembly",
         ]
 
@@ -304,7 +304,7 @@ class Gc(TelemetryDevice):
     def java_opts(self, log_file):
         if self.java_major_version < 9:
             return [
-                "-Xloggc:{}".format(log_file),
+                f"-Xloggc:{log_file}",
                 "-XX:+PrintGCDetails",
                 "-XX:+PrintGCDateStamps",
                 "-XX:+PrintGCTimeStamps",
@@ -331,9 +331,9 @@ class Heapdump(TelemetryDevice):
     def detach_from_node(self, node, running):
         if running:
             io.ensure_dir(self.log_root)
-            heap_dump_file = os.path.join(self.log_root, "heap_at_exit_{}.hprof".format(node.pid))
-            console.info("{}: Writing heap dump to [{}]".format(self.human_name, heap_dump_file), logger=self.logger)
-            cmd = "jmap -dump:format=b,file={} {}".format(heap_dump_file, node.pid)
+            heap_dump_file = os.path.join(self.log_root, f"heap_at_exit_{node.pid}.hprof")
+            console.info(f"{self.human_name}: Writing heap dump to [{heap_dump_file}]", logger=self.logger)
+            cmd = f"jmap -dump:format=b,file={heap_dump_file} {node.pid}"
             if process.run_subprocess_with_logging(cmd):
                 self.logger.warning("Could not write heap dump to [%s]", heap_dump_file)
 
@@ -355,7 +355,7 @@ class SegmentStats(TelemetryDevice):
             segment_stats = self.client.cat.segments(index="_all", v=True)
             stats_file = os.path.join(self.log_root, "segment_stats.log")
             console.info(f"{self.human_name}: Writing segment stats to [{stats_file}]", logger=self.logger)
-            with open(stats_file, "wt") as f:
+            with open(stats_file, "w") as f:
                 f.write(segment_stats)
         except BaseException:
             self.logger.exception("Could not retrieve segment stats.")
@@ -390,7 +390,7 @@ class CcrStats(TelemetryDevice):
         self.sample_interval = telemetry_params.get("ccr-stats-sample-interval", 1)
         if self.sample_interval <= 0:
             raise exceptions.SystemSetupError(
-                "The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was {}.".format(self.sample_interval)
+                f"The telemetry parameter 'ccr-stats-sample-interval' must be greater than zero but was {self.sample_interval}."
             )
         self.specified_cluster_names = self.clients.keys()
         self.indices_per_cluster = self.telemetry_params.get("ccr-stats-indices", False)
@@ -616,7 +616,7 @@ class RecoveryStatsRecorder:
         try:
             stats = self.client.indices.recovery(index=self.indices, active_only=True, detailed=False)
         except elasticsearch.TransportError:
-            msg = "A transport error occurred while collecting recovery stats on cluster [{}]".format(self.cluster_name)
+            msg = f"A transport error occurred while collecting recovery stats on cluster [{self.cluster_name}]"
             self.logger.exception(msg)
             raise exceptions.RallyError(msg)
 
@@ -780,7 +780,7 @@ class NodeStatsRecorder:
         self.sample_interval = telemetry_params.get("node-stats-sample-interval", 1)
         if self.sample_interval <= 0:
             raise exceptions.SystemSetupError(
-                "The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was {}.".format(self.sample_interval)
+                f"The telemetry parameter 'node-stats-sample-interval' must be greater than zero but was {self.sample_interval}."
             )
 
         self.include_indices = telemetry_params.get("node-stats-include-indices", False)
@@ -870,7 +870,7 @@ class NodeStatsRecorder:
         def iterate():
             for section_name, section_value in stats.items():
                 if isinstance(section_value, dict):
-                    new_prefix = "{}_{}".format(prefix, section_name)
+                    new_prefix = f"{prefix}_{section_name}"
                     # https://www.python.org/dev/peps/pep-0380/
                     yield from self.flatten_stats_fields(prefix=new_prefix, stats=section_value).items()
                 # Avoid duplication for metric fields that have unit embedded in value as they are also recorded elsewhere

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1244,9 +1244,7 @@ class TrackSpecificationReader:
             idx_body_tmpl_src = TemplateSource(mapping_dir, body_file, self.source)
             with self.source(os.path.join(mapping_dir, body_file), "rt") as f:
                 idx_body_tmpl_src.load_template_from_string(f.read())
-                body = self._load_template(
-                    idx_body_tmpl_src.assembled_source, f"definition for index {index_name} in {body_file}"
-                )
+                body = self._load_template(idx_body_tmpl_src.assembled_source, f"definition for index {index_name} in {body_file}")
         else:
             body = None
 

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -168,7 +168,7 @@ class SleepParamSource(ParamSource):
         if not isinstance(duration, numbers.Number):
             raise exceptions.InvalidSyntax("parameter 'duration' for sleep operation must be a number")
         if duration < 0:
-            raise exceptions.InvalidSyntax("parameter 'duration' must be non-negative but was {}".format(duration))
+            raise exceptions.InvalidSyntax(f"parameter 'duration' must be non-negative but was {duration}")
 
     def params(self):
         return dict(self._params)
@@ -583,7 +583,7 @@ class BulkIndexParamSource(ParamSource):
             )
             self.on_conflict = params.get("on-conflict", "index")
             if self.on_conflict not in ["index", "update"]:
-                raise exceptions.InvalidSyntax("Unknown 'on-conflict' setting [{}]".format(self.on_conflict))
+                raise exceptions.InvalidSyntax(f"Unknown 'on-conflict' setting [{self.on_conflict}]")
             self.recency = self.float_param(params, name="recency", default_value=0, min_value=0, max_value=1, min_operator=operator.lt)
 
         else:
@@ -650,11 +650,11 @@ class BulkIndexParamSource(ParamSource):
             if min_operator(value, min_value) or value > max_value:
                 interval_min = "(" if min_operator is operator.le else "["
                 raise exceptions.InvalidSyntax(
-                    "'{}' must be in the range {}{:.1f}, {:.1f}] but was {:.1f}".format(name, interval_min, min_value, max_value, value)
+                    f"'{name}' must be in the range {interval_min}{min_value:.1f}, {max_value:.1f}] but was {value:.1f}"
                 )
             return value
         except ValueError:
-            raise exceptions.InvalidSyntax("'{}' must be numeric".format(name))
+            raise exceptions.InvalidSyntax(f"'{name}' must be numeric")
 
     def used_corpora(self, t, params):
         corpora = []
@@ -905,8 +905,7 @@ def chain(*iterables):
     for it in filter(lambda x: x is not None, iterables):
         # execute within a context
         with it:
-            for element in it:
-                yield element
+            yield from it
 
 
 def create_default_reader(
@@ -1171,7 +1170,7 @@ class GenerateActionMetaData:
             elif action == "update":
                 return "update", self.meta_data_update_with_id % doc_id
             else:
-                raise exceptions.RallyAssertionError("Unknown action [{}]".format(action))
+                raise exceptions.RallyAssertionError(f"Unknown action [{action}]")
         else:
             if self.use_create:
                 return "create", self.meta_data_create_no_id
@@ -1268,7 +1267,7 @@ class IndexDataReader:
             if docs_in_batch == 0:
                 raise StopIteration()
             return self.index_name, self.type_name, batch
-        except IOError:
+        except OSError:
             logging.getLogger(__name__).exception("Could not read [%s]", self.data_file)
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -912,7 +912,7 @@ class Singleton(type):
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
 
 

--- a/esrally/utils/console.py
+++ b/esrally/utils/console.py
@@ -222,9 +222,9 @@ class CmdLineProgressReporter:
 
         formatted_progress = progress.rjust(w - len(final_message))
         if self._plain_output:
-            self._printer("\n{0}{1}".format(final_message, formatted_progress), end="")
+            self._printer(f"\n{final_message}{formatted_progress}", end="")
         else:
-            self._printer("\033[{0}D{1}{2}".format(w, final_message, formatted_progress), end="")
+            self._printer(f"\033[{w}D{final_message}{formatted_progress}", end="")
         sys.stdout.flush()
 
     def _truncate(self, text, max_length, omission="..."):

--- a/esrally/utils/convert.py
+++ b/esrally/utils/convert.py
@@ -76,7 +76,7 @@ def _bytes_to_human(b):
 
 
 def number_to_human_string(number):
-    return "{:,}".format(number)
+    return f"{number:,}"
 
 
 def mb_to_bytes(mb):

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -26,7 +26,7 @@ def probed(f):
     def probe(src, *args, **kwargs):
         # Probe for -C
         if not process.exit_status_as_bool(
-            lambda: process.run_subprocess_with_logging("git -C {} --version".format(io.escape_path(src)), level=logging.DEBUG), quiet=True
+            lambda: process.run_subprocess_with_logging(f"git -C {io.escape_path(src)} --version", level=logging.DEBUG), quiet=True
         ):
             version = process.run_subprocess_with_output("git --version")
             if version:
@@ -73,26 +73,26 @@ def clone(src, *, remote):
 
 @probed
 def fetch(src, *, remote):
-    if process.run_subprocess_with_logging("git -C {0} fetch --prune --tags {1}".format(io.escape_path(src), remote)):
+    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src)} fetch --prune --tags {remote}"):
         raise exceptions.SupplyError("Could not fetch source tree from [%s]" % remote)
 
 
 @probed
 def checkout(src_dir, *, branch):
-    if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), branch)):
+    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} checkout {branch}"):
         raise exceptions.SupplyError("Could not checkout [%s]. Do you have uncommitted changes?" % branch)
 
 
 @probed
 def checkout_branch(src_dir, remote, branch):
-    if process.run_subprocess_with_logging("git -C {0} checkout {1}/{2}".format(io.escape_path(src_dir), remote, branch)):
+    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} checkout {remote}/{branch}"):
         raise exceptions.SupplyError("Could not checkout [%s]. Do you have uncommitted changes?" % branch)
 
 
 @probed
 def rebase(src_dir, *, remote, branch):
     checkout(src_dir, branch=branch)
-    if process.run_subprocess_with_logging("git -C {0} rebase {1}/{2}".format(io.escape_path(src_dir), remote, branch)):
+    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} rebase {remote}/{branch}"):
         raise exceptions.SupplyError("Could not rebase on branch [%s]" % branch)
 
 
@@ -108,24 +108,24 @@ def pull_ts(src_dir, ts, *, remote, branch):
     clean_src = io.escape_path(src_dir)
     rev_list_command = f'git -C {clean_src} rev-list -n 1 --before="{ts}" --date=iso8601 {remote}/{branch}'
     revision = process.run_subprocess_with_output(rev_list_command)[0].strip()
-    if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(clean_src, revision)):
+    if process.run_subprocess_with_logging(f"git -C {clean_src} checkout {revision}"):
         raise exceptions.SupplyError("Could not checkout source tree for timestamped revision [%s]" % ts)
 
 
 @probed
 def checkout_revision(src_dir, *, revision):
-    if process.run_subprocess_with_logging("git -C {0} checkout {1}".format(io.escape_path(src_dir), revision)):
+    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} checkout {revision}"):
         raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
 
 
 @probed
 def head_revision(src_dir):
-    return process.run_subprocess_with_output("git -C {0} rev-parse HEAD".format(io.escape_path(src_dir)))[0].strip()
+    return process.run_subprocess_with_output(f"git -C {io.escape_path(src_dir)} rev-parse HEAD")[0].strip()
 
 
 @probed
 def current_branch(src_dir):
-    return process.run_subprocess_with_output("git -C {0} rev-parse --abbrev-ref HEAD".format(io.escape_path(src_dir)))[0].strip()
+    return process.run_subprocess_with_output(f"git -C {io.escape_path(src_dir)} rev-parse --abbrev-ref HEAD")[0].strip()
 
 
 @probed
@@ -134,17 +134,17 @@ def branches(src_dir, remote=True):
     if remote:
         # alternatively: git for-each-ref refs/remotes/ --format='%(refname:short)'
         return _cleanup_remote_branch_names(
-            process.run_subprocess_with_output("git -C {src} for-each-ref refs/remotes/ --format='%(refname:short)'".format(src=clean_src))
+            process.run_subprocess_with_output(f"git -C {clean_src} for-each-ref refs/remotes/ --format='%(refname:short)'")
         )
     else:
         return _cleanup_local_branch_names(
-            process.run_subprocess_with_output("git -C {src} for-each-ref refs/heads/ --format='%(refname:short)'".format(src=clean_src))
+            process.run_subprocess_with_output(f"git -C {clean_src} for-each-ref refs/heads/ --format='%(refname:short)'")
         )
 
 
 @probed
 def tags(src_dir):
-    return _cleanup_tag_names(process.run_subprocess_with_output("git -C {0} tag".format(io.escape_path(src_dir))))
+    return _cleanup_tag_names(process.run_subprocess_with_output(f"git -C {io.escape_path(src_dir)} tag"))
 
 
 def _cleanup_remote_branch_names(branch_names):

--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -471,7 +471,7 @@ class FileOffsetTable:
         prior_remaining_lines = target_line_number
 
         for line in self.offset_file:
-            line_number, offset_in_bytes = [int(i) for i in line.strip().split(";")]
+            line_number, offset_in_bytes = (int(i) for i in line.strip().split(";"))
             if line_number <= target_line_number:
                 prior_offset = offset_in_bytes
                 prior_remaining_lines = target_line_number - line_number
@@ -527,7 +527,7 @@ def prepare_file_offset_table(data_file_path):
         console.info("Preparing file offset table for [%s] ... " % data_file_path, end="", flush=True)
         line_number = 0
         with file_offset_table:
-            with open(data_file_path, mode="rt", encoding="utf-8") as data_file:
+            with open(data_file_path, encoding="utf-8") as data_file:
                 while True:
                     line = data_file.readline()
                     if len(line) == 0:

--- a/esrally/utils/jvm.py
+++ b/esrally/utils/jvm.py
@@ -34,11 +34,11 @@ def supports_option(java_home, option):
     :param option: The JVM option or combination of JVM options (separated by spaces) to check.
     :return: True iff the provided ``option`` is supported on this JVM.
     """
-    return process.exit_status_as_bool(lambda: process.run_subprocess_with_logging("{} {} -version".format(_java(java_home), option)))
+    return process.exit_status_as_bool(lambda: process.run_subprocess_with_logging(f"{_java(java_home)} {option} -version"))
 
 
 def system_property(java_home, system_property_name):
-    lines = process.run_subprocess_with_output("{} -XshowSettings:properties -version".format(_java(java_home)))
+    lines = process.run_subprocess_with_output(f"{_java(java_home)} -XshowSettings:properties -version")
     # matches e.g. "    java.runtime.version = 1.8.0_121-b13" and captures "1.8.0_121-b13"
     sys_prop_pattern = re.compile(r".*%s.*=\s?(.*)" % system_property_name)
     for line in lines:
@@ -119,7 +119,7 @@ def resolve_path(majors, sysprop_reader=system_property):
             if java_home:
                 return major, java_home
         raise exceptions.SystemSetupError(
-            "Install a JDK with one of the versions {} and point to it with one of {}.".format(majors, _checked_env_vars(majors))
+            f"Install a JDK with one of the versions {majors} and point to it with one of {_checked_env_vars(majors)}."
         )
 
 
@@ -141,14 +141,14 @@ def _resolve_single_path(major, mandatory=True, sysprop_reader=system_property):
             if actual_major == major:
                 return java_v_home
             elif mandatory:
-                raise exceptions.SystemSetupError("{} points to JDK {} but it should point to JDK {}.".format(env_var, actual_major, major))
+                raise exceptions.SystemSetupError(f"{env_var} points to JDK {actual_major} but it should point to JDK {major}.")
             else:
                 return None
         else:
             return None
 
     # this has to be consistent with _checked_env_vars()
-    specific_env_var = "JAVA{}_HOME".format(major)
+    specific_env_var = f"JAVA{major}_HOME"
     generic_env_var = "JAVA_HOME"
     java_home = do_resolve(specific_env_var, major)
     if java_home:
@@ -159,7 +159,7 @@ def _resolve_single_path(major, mandatory=True, sysprop_reader=system_property):
             return java_home
         elif mandatory:
             raise exceptions.SystemSetupError(
-                "Neither {} nor {} point to a JDK {} installation.".format(specific_env_var, generic_env_var, major)
+                f"Neither {specific_env_var} nor {generic_env_var} point to a JDK {major} installation."
             )
         else:
             return None
@@ -172,6 +172,6 @@ def _checked_env_vars(majors):
     :param majors: A list of major versions.
     :return: A list of checked environment variables.
     """
-    checked = ["JAVA{}_HOME".format(major) for major in majors]
+    checked = [f"JAVA{major}_HOME" for major in majors]
     checked.append("JAVA_HOME")
     return checked

--- a/esrally/utils/jvm.py
+++ b/esrally/utils/jvm.py
@@ -158,9 +158,7 @@ def _resolve_single_path(major, mandatory=True, sysprop_reader=system_property):
         if java_home:
             return java_home
         elif mandatory:
-            raise exceptions.SystemSetupError(
-                f"Neither {specific_env_var} nor {generic_env_var} point to a JDK {major} installation."
-            )
+            raise exceptions.SystemSetupError(f"Neither {specific_env_var} nor {generic_env_var} point to a JDK {major} installation.")
         else:
             return None
 

--- a/esrally/utils/modules.py
+++ b/esrally/utils/modules.py
@@ -106,6 +106,6 @@ class ComponentLoader:
             root_module = self._load_component(component_name, module_dirs)
             return root_module
         except BaseException:
-            msg = "Could not load component [{}]".format(component_name)
+            msg = f"Could not load component [{component_name}]"
             self.logger.exception(msg)
             raise exceptions.SystemSetupError(msg)

--- a/esrally/utils/opts.py
+++ b/esrally/utils/opts.py
@@ -29,7 +29,7 @@ def csv_to_list(csv):
     if csv is None:
         return None
     if io.has_extension(csv, ".json"):
-        with open(io.normalize_path(csv), mode="rt", encoding="utf-8") as f:
+        with open(io.normalize_path(csv), encoding="utf-8") as f:
             content = f.read()
             if not RE_JSON_ARRAY_START.match(content):
                 raise ValueError(f"csv args only support arrays in json but you supplied [{csv}]")
@@ -104,7 +104,7 @@ def kv_to_map(kvs):
 
 def to_dict(arg, default_parser=kv_to_map):
     if io.has_extension(arg, ".json"):
-        with open(io.normalize_path(arg), mode="rt", encoding="utf-8") as f:
+        with open(io.normalize_path(arg), encoding="utf-8") as f:
             return json.load(f)
     try:
         return json.loads(arg)
@@ -113,11 +113,11 @@ def to_dict(arg, default_parser=kv_to_map):
 
 
 def bulleted_list_of(src_list):
-    return ["- {}".format(param) for param in src_list]
+    return [f"- {param}" for param in src_list]
 
 
 def double_quoted_list_of(src_list):
-    return ['"{}"'.format(param) for param in src_list]
+    return [f'"{param}"' for param in src_list]
 
 
 def make_list_of_close_matches(word_list, all_possibilities):

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -55,9 +55,7 @@ class RallyRepository:
                     raise exceptions.SystemSetupError(
                         "[{src}] must be a git repository.\n\nPlease run:\ngit -C {src} init".format(src=self.repo_dir)
                     )
-                raise exceptions.SystemSetupError(
-                    f"Expected a git repository at [{self.repo_dir}] but the directory does not exist."
-                )
+                raise exceptions.SystemSetupError(f"Expected a git repository at [{self.repo_dir}] but the directory does not exist.")
 
     def update(self, distribution_version):
         try:

--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -56,7 +56,7 @@ class RallyRepository:
                         "[{src}] must be a git repository.\n\nPlease run:\ngit -C {src} init".format(src=self.repo_dir)
                     )
                 raise exceptions.SystemSetupError(
-                    "Expected a git repository at [{src}] but the directory does not exist.".format(src=self.repo_dir)
+                    f"Expected a git repository at [{self.repo_dir}] but the directory does not exist."
                 )
 
     def update(self, distribution_version):
@@ -118,7 +118,7 @@ class RallyRepository:
         tags = git.tags(self.repo_dir)
         for version in versions.variants_of(distribution_version):
             # tags have a "v" prefix by convention.
-            tag_candidate = "v{}".format(version)
+            tag_candidate = f"v{version}"
             if tag_candidate in tags:
                 return tag_candidate
         return None

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -178,10 +178,10 @@ class TestCluster:
             )
             self.installation_id = json.loads("".join(output))["installation-id"]
         except BaseException as e:
-            raise AssertionError("Failed to install Elasticsearch {}.".format(distribution_version), e)
+            raise AssertionError(f"Failed to install Elasticsearch {distribution_version}.", e)
 
     def start(self, race_id):
-        cmd = 'start --runtime-jdk="bundled" --installation-id={} --race-id={}'.format(self.installation_id, race_id)
+        cmd = f'start --runtime-jdk="bundled" --installation-id={self.installation_id} --race-id={race_id}'
         if esrally(self.cfg, cmd) != 0:
             raise AssertionError("Failed to start Elasticsearch test cluster.")
         es = client.EsClientFactory(hosts=[{"host": "127.0.0.1", "port": self.http_port}], client_options={}).create()
@@ -190,7 +190,7 @@ class TestCluster:
 
     def stop(self):
         if self.installation_id:
-            if esrally(self.cfg, "stop --installation-id={}".format(self.installation_id)) != 0:
+            if esrally(self.cfg, f"stop --installation-id={self.installation_id}") != 0:
                 raise AssertionError("Failed to stop Elasticsearch test cluster.")
 
     def __str__(self):

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -123,7 +123,7 @@ def test_cluster():
 
 @it.random_rally_config
 def test_multi_target_hosts(cfg, test_cluster):
-    hosts = ["127.0.0.1:{}".format(test_cluster.http_port)]
+    hosts = [f"127.0.0.1:{test_cluster.http_port}"]
     target_hosts = {
         "remote": hosts,
         "default": hosts,

--- a/it/installation_test.py
+++ b/it/installation_test.py
@@ -27,11 +27,11 @@ import it
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 _CI_VARS = ".ci/variables.json"
 
-with open(os.path.join(ROOT_DIR, _CI_VARS), "rt") as fp:
+with open(os.path.join(ROOT_DIR, _CI_VARS)) as fp:
     try:
         MIN_PY_VER = json.load(fp)["python_versions"]["MIN_PY_VER"]
     except KeyError:
-        raise EnvironmentError(f"Installation tests require [python_versions.MIN_PY_VER] key in [{_CI_VARS}]")
+        raise OSError(f"Installation tests require [python_versions.MIN_PY_VER] key in [{_CI_VARS}]")
 
 
 def test_installs_inside_venv():

--- a/it/proxy_test.py
+++ b/it/proxy_test.py
@@ -55,7 +55,7 @@ def fresh_log_file():
         shutil.move(log_file, bak)
         yield log_file
         # append log lines to the original file and move it back to its original
-        with open(log_file, "r") as src:
+        with open(log_file) as src:
             with open(bak, "a") as dst:
                 dst.write(src.read())
         shutil.move(bak, log_file)
@@ -64,7 +64,7 @@ def fresh_log_file():
 
 
 def assert_log_line_present(log_file, text):
-    with open(log_file, "r") as f:
+    with open(log_file) as f:
         assert any(text in line for line in f), f"Could not find [{text}] in [{log_file}]."
 
 

--- a/it/tracker_test.py
+++ b/it/tracker_test.py
@@ -75,7 +75,7 @@ def test_create_track(cfg, tmp_path, test_cluster):
         full_path = track_path / f
         assert full_path.exists(), f"Expected file to exist at path [{full_path}]"
 
-    with open(track_path / f"{base_generated_corpora}-1k.json", "rt") as f:
+    with open(track_path / f"{base_generated_corpora}-1k.json") as f:
         num_lines = sum(1 for line in f)
     assert (
         num_lines == 1000

--- a/tests/client/factory_test.py
+++ b/tests/client/factory_test.py
@@ -186,7 +186,7 @@ class TestEsClientFactory:
         client_ssl_options = {"client_cert": "../utils/resources/certs/client.crt", "client_key": "../utils/resources/certs/client.key"}
 
         random_client_ssl_option = random.choice(list(client_ssl_options.keys()))
-        missing_client_ssl_option = list(set(client_ssl_options) - set([random_client_ssl_option]))[0]
+        missing_client_ssl_option = list(set(client_ssl_options) - {random_client_ssl_option})[0]
         client_options.update({random_client_ssl_option: client_ssl_options[random_client_ssl_option]})
 
         with pytest.raises(exceptions.SystemSetupError) as ctx:

--- a/tests/mechanic/launcher_test.py
+++ b/tests/mechanic/launcher_test.py
@@ -120,7 +120,7 @@ class MockProcess:
         self.pid = pid
 
     def name(self):
-        return "p{pid}".format(pid=self.pid)
+        return f"p{self.pid}"
 
     def wait(self, timeout=None):
         raise psutil.TimeoutExpired(timeout)
@@ -173,7 +173,7 @@ class TestProcessLauncher:
                     car_runtime_jdks="12,11",
                     car_provides_bundled_jdk=True,
                     ip="127.0.0.1",
-                    node_name="testnode-{}".format(node),
+                    node_name=f"testnode-{node}",
                     node_root_path="/tmp",
                     binary_path="/tmp",
                     data_paths="/tmp",

--- a/tests/mechanic/mechanic_test.py
+++ b/tests/mechanic/mechanic_test.py
@@ -100,7 +100,7 @@ class TestMechanic:
 
         def start(self, node_configs):
             self.started = True
-            return [TestMechanic.Node("rally-node-{}".format(n)) for n in range(len(node_configs))]
+            return [TestMechanic.Node(f"rally-node-{n}") for n in range(len(node_configs))]
 
         def stop(self, nodes, metrics_store):
             self.started = False

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -127,7 +127,7 @@ class TestBareProvisioner:
         def __repr__(self):
             r = []
             for prop, value in vars(self).items():
-                r.append("%s = [%s]" % (prop, repr(value)))
+                r.append(f"{prop} = [{repr(value)}]")
             return ", ".join(r)
 
     @mock.patch("glob.glob", lambda p: ["/opt/elasticsearch-6.8.0"])

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -987,7 +987,7 @@ class TestCreateSupplier:
         assert len(composite_supplier.suppliers) == 1
         assert isinstance(composite_supplier.suppliers[0], supplier.ElasticsearchDistributionSupplier)
 
-    @mock.patch("esrally.utils.jvm.resolve_path", lambda v: (v, "/opt/java/java{}".format(v)))
+    @mock.patch("esrally.utils.jvm.resolve_path", lambda v: (v, f"/opt/java/java{v}"))
     def test_create_suppliers_for_es_distribution_plugin_source_build(self):
         cfg = config.Config()
         cfg.add(config.Scope.application, "mechanic", "distribution.version", "6.0.0")
@@ -1021,7 +1021,7 @@ class TestCreateSupplier:
         assert composite_supplier.suppliers[2].source_supplier.plugin == external_plugin
         assert composite_supplier.suppliers[2].source_supplier.builder is not None
 
-    @mock.patch("esrally.utils.jvm.resolve_path", lambda v: (v, "/opt/java/java{}".format(v)))
+    @mock.patch("esrally.utils.jvm.resolve_path", lambda v: (v, f"/opt/java/java{v}"))
     def test_create_suppliers_skips_plugins_converted_to_modules(self, caplog):
         cfg = config.Config()
         cfg.add(config.Scope.application, "mechanic", "source.revision", "current")
@@ -1047,7 +1047,7 @@ class TestCreateSupplier:
             assert f"Plugin [{p.name}] is now an Elasticsearch module and no longer needs to be built from source." in caplog.messages
             assert p not in composite_supplier.suppliers
 
-    @mock.patch("esrally.utils.jvm.resolve_path", lambda v: (v, "/opt/java/java{}".format(v)))
+    @mock.patch("esrally.utils.jvm.resolve_path", lambda v: (v, f"/opt/java/java{v}"))
     def test_create_suppliers_for_es_and_plugin_source_build(self):
         cfg = config.Config()
         cfg.add(config.Scope.application, "mechanic", "source.revision", "elasticsearch:abc,community-plugin:current")

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -367,7 +367,7 @@ class TestSegmentStats:
         # pylint: disable=unnecessary-dunder-call
         file_mock.assert_has_calls(
             [
-                call("/var/log/segment_stats.log", "wt"),
+                call("/var/log/segment_stats.log", "w"),
                 call().__enter__(),
                 call().write(stats_response),
                 call().__exit__(None, None, None),

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -117,7 +117,7 @@ class TestSimpleTrackRepository:
 class TestGitRepository:
     class MockGitRepo:
         def __init__(self, remote_url, root_dir, repo_name, resource_name, offline, fetch=True):
-            self.repo_dir = "%s/%s" % (root_dir, repo_name)
+            self.repo_dir = f"{root_dir}/{repo_name}"
 
     @mock.patch("os.path.exists")
     @mock.patch("os.walk")
@@ -889,7 +889,7 @@ class TestTemplateSource:
         )
 
         def dummy_read_glob(c):
-            return '{{"replaced {}": "true"}}'.format(c)
+            return f'{{"replaced {c}": "true"}}'
 
         patched_read_glob.side_effect = dummy_read_glob
 

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -161,7 +161,7 @@ class TestActionMetaData:
             return "index", '{"index": {"_index": "test_index", "_type": "test_type", "_id": "%s"}}\n' % id
 
         def conflict(action, id):
-            return action, '{"%s": {"_index": "test_index", "_type": "test_type", "_id": "%s"}}\n' % (action, id)
+            return action, f'{{"{action}": {{"_index": "test_index", "_type": "test_type", "_id": "{id}"}}}}\n'
 
         pseudo_random_conflicts = iter(
             [
@@ -212,15 +212,15 @@ class TestActionMetaData:
     def test_generate_action_meta_data_with_id_conflicts_and_recency_bias(self):
         def idx(type_name, id):
             if type_name:
-                return "index", '{"index": {"_index": "test_index", "_type": "%s", "_id": "%s"}}\n' % (type_name, id)
+                return "index", f'{{"index": {{"_index": "test_index", "_type": "{type_name}", "_id": "{id}"}}}}\n'
             else:
                 return "index", '{"index": {"_index": "test_index", "_id": "%s"}}\n' % id
 
         def conflict(action, type_name, id):
             if type_name:
-                return action, '{"%s": {"_index": "test_index", "_type": "%s", "_id": "%s"}}\n' % (action, type_name, id)
+                return action, f'{{"{action}": {{"_index": "test_index", "_type": "{type_name}", "_id": "{id}"}}}}\n'
             else:
-                return action, '{"%s": {"_index": "test_index", "_id": "%s"}}\n' % (action, id)
+                return action, f'{{"{action}": {{"_index": "test_index", "_id": "{id}"}}}}\n'
 
         pseudo_random_conflicts = iter(
             [

--- a/tests/utils/io_test.py
+++ b/tests/utils/io_test.py
@@ -122,5 +122,5 @@ class TestDecompression:
         assert result is False
 
     def read(self, f):
-        with open(f, "r") as content_file:
+        with open(f) as content_file:
             return content_file.read()


### PR DESCRIPTION
[pyupgrade](https://github.com/asottile/pyupgrade) is a tool that upgrades code bases to newer versions of the Python syntax, which evolves with every minor version. The main thing it does in practice for Rally is to migrate % formats to f-strings, which are faster. However, pyupgrade by default upgrades some % formats to `str.format` calls when the expressions used are too complex and could harm readability. We don't want to do that as we have some highly optimized code and `str.format` is slower than % format:

```
∮ python -m timeit '"{} {} {}".format("foo", "bar", "baz")'
1000000 loops, best of 5: 231 nsec per loop
∮ python -m timeit '"%s %s %s" % ("foo", "bar", "baz")'
2000000 loops, best of 5: 148 nsec per loop
```

Thankfully by specifying `--keep-percent-format` we can keep % formats when they would have been migrated to `str.format`.

And the real reason I'm opening this pull request is that I needed one to test the Read the Docs integration. But it will be nice to stop having to think about f-strings in reviews.