### PR TITLE
Declare Buildkite pipelines

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,58 @@
+# Declare a Backstage Component that represents the Rally application.
+---
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: rally
+  description:  Macrobenchmarking framework for Elasticsearch
+  annotations:
+    backstage.io/source-location: url:https://github.com/elastic/rally/
+    github.com/project-slug: elastic/rally
+    github.com/team-slug: elastic/es-perf
+    buildkite.com/project-slug: elastic/rally
+  tags:
+    - elasticsearch
+    - benchmark
+    - python
+    - performance
+  links:
+    - title: Rally docs
+      url: https://esrally.readthedocs.io/en/stable/
+spec:
+  type: application
+  owner: group:es-perf
+  lifecycle: production
+  dependsOn:
+    - resource:marbi-buildkite-pipeline
+
+
+# Declare Rally's Buildkite pipeline.
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: rally-it-pipeline
+  description: Run Rally integration tests
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/rally-it-pipeline
+
+spec:
+  type: buildkite-pipeline
+  owner: group:es-perf
+  system: buildkite
+
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: Rally
+      description:  Macrobenchmarking framework for Elasticsearch
+    spec:
+      repository: elastic/rally
+      teams:
+        elasticsearch-team: {}
+        everyone:
+          access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,7 +24,7 @@ spec:
   owner: group:es-perf
   lifecycle: production
   dependsOn:
-    - resource:marbi-buildkite-pipeline
+    - resource:rally-it-pipeline
 
 
 # Declare Rally's Buildkite pipeline.


### PR DESCRIPTION
The .buildkite directory is still empty as I still need to iterate on the pipelines themselves. I would like to do that on a branch if possible as the pipeline is a bit tricky with Python tests running various Docker commands so I can't use a Dockerfile as I don't think Docker-in-Docker is supported.