### PR TITLE
Define Buildkite IT pipeline file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -51,6 +51,7 @@ spec:
       name: Rally
       description:  Macrobenchmarking framework for Elasticsearch
     spec:
+      pipeline_file: .buildkite/it/pipeline.yml
       repository: elastic/rally
       teams:
         elasticsearch-team: {}


### PR DESCRIPTION
I'm not using the default pipeline location (.buildkite/pipeline.yml) but https://github.com/elastic/rally/blob/buildkite/.buildkite/it/pipeline.yml in the buildkite branch that I'm using to test things.