### PR TITLE
Revert "Add a variable in the provisioner for the seed node count"

### DIFF
--- a/esrally/mechanic/provisioner.py
+++ b/esrally/mechanic/provisioner.py
@@ -319,7 +319,6 @@ class ElasticsearchInstaller:
             "transport_port": str(self.http_port + 100),
             "all_node_ips": '["%s"]' % '","'.join(self.all_node_ips),
             "all_node_names": '["%s"]' % '","'.join(self.all_node_names),
-            "all_node_ips_count": len(self.all_node_ips),
             # at the moment we are strict and enforce that all nodes are master eligible nodes
             "minimum_master_nodes": len(self.all_node_ips),
             "install_root_path": self.es_home_path,

--- a/tests/mechanic/provisioner_test.py
+++ b/tests/mechanic/provisioner_test.py
@@ -88,7 +88,6 @@ class TestBareProvisioner:
             "transport_port": "9300",
             "all_node_ips": '["10.17.22.22","10.17.22.23"]',
             "all_node_names": '["rally-node-0","rally-node-1"]',
-            "all_node_ips_count": 2,
             "minimum_master_nodes": 2,
             "install_root_path": "/opt/elasticsearch-5.0.0",
         }
@@ -210,7 +209,6 @@ class TestBareProvisioner:
             "transport_port": "9300",
             "all_node_ips": '["10.17.22.22","10.17.22.23"]',
             "all_node_names": '["rally-node-0","rally-node-1"]',
-            "all_node_ips_count": 2,
             "minimum_master_nodes": 2,
             "install_root_path": "/opt/elasticsearch-6.8.0",
             "plugin_name": "x-pack-security",
@@ -326,7 +324,6 @@ class TestElasticsearchInstaller:
             "transport_port": "9300",
             "all_node_ips": '["10.17.22.22","10.17.22.23"]',
             "all_node_names": '["rally-node-0","rally-node-1"]',
-            "all_node_ips_count": 2,
             "minimum_master_nodes": 2,
             "install_root_path": "/install/elasticsearch-5.0.0-SNAPSHOT",
         }
@@ -372,7 +369,6 @@ class TestElasticsearchInstaller:
             "transport_port": "9300",
             "all_node_ips": '["10.17.22.22","10.17.22.23"]',
             "all_node_names": '["rally-node-0","rally-node-1"]',
-            "all_node_ips_count": 2,
             "minimum_master_nodes": 2,
             "install_root_path": "/install/elasticsearch-5.0.0-SNAPSHOT",
         }


### PR DESCRIPTION
Reverts elastic/rally#1647

Knowing the number of nodes does not have any useful purpose: https://github.com/elastic/rally/issues/1644#issuecomment-1386985098