### PR TITLE
Use simply expanded vars assignment in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,26 +15,26 @@
 # specific language governing permissions and limitations
 # under the License.
 
-SHELL = /bin/bash
+SHELL := /bin/bash
 # We assume an active virtualenv for development
-PYENV_REGEX = .pyenv/shims
-PY_BIN = python3
+PYENV_REGEX := .pyenv/shims
+PY_BIN := python3
 # https://github.com/pypa/pip/issues/5599
-PIP_WRAPPER = $(PY_BIN) -m pip
-export PY38 = $(shell jq -r '.python_versions.PY38' .ci/variables.json)
-export PY39 = $(shell jq -r '.python_versions.PY39' .ci/variables.json)
-export PY310 = $(shell jq -r '.python_versions.PY310' .ci/variables.json)
-export HATCH_VERSION = $(shell jq -r '.prerequisite_versions.HATCH' .ci/variables.json)
-export HATCHLING_VERSION = $(shell jq -r '.prerequisite_versions.HATCHLING' .ci/variables.json)
-export PIP_VERSION = $(shell jq -r '.prerequisite_versions.PIP' .ci/variables.json)
-export WHEEL_VERSION = $(shell jq -r '.prerequisite_versions.WHEEL' .ci/variables.json)
+PIP_WRAPPER := $(PY_BIN) -m pip
+export PY38 := $(shell jq -r '.python_versions.PY38' .ci/variables.json)
+export PY39 := $(shell jq -r '.python_versions.PY39' .ci/variables.json)
+export PY310 := $(shell jq -r '.python_versions.PY310' .ci/variables.json)
+export HATCH_VERSION := $(shell jq -r '.prerequisite_versions.HATCH' .ci/variables.json)
+export HATCHLING_VERSION := $(shell jq -r '.prerequisite_versions.HATCHLING' .ci/variables.json)
+export PIP_VERSION := $(shell jq -r '.prerequisite_versions.PIP' .ci/variables.json)
+export WHEEL_VERSION := $(shell jq -r '.prerequisite_versions.WHEEL' .ci/variables.json)
 VIRTUAL_ENV ?= .venv
-VENV_ACTIVATE_FILE = $(VIRTUAL_ENV)/bin/activate
-VENV_ACTIVATE = . $(VENV_ACTIVATE_FILE)
-VEPYTHON = $(VIRTUAL_ENV)/bin/$(PY_BIN)
-PYENV_ERROR = "\033[0;31mIMPORTANT\033[0m: Please install pyenv.\n"
-PYENV_PREREQ_HELP = "\033[0;31mIMPORTANT\033[0m: please type \033[0;31mpyenv init\033[0m, follow the instructions there and restart your terminal before proceeding any further.\n"
-VE_MISSING_HELP = "\033[0;31mIMPORTANT\033[0m: Couldn't find $(PWD)/$(VIRTUAL_ENV); have you executed make venv-create?\033[0m\n"
+VENV_ACTIVATE_FILE := $(VIRTUAL_ENV)/bin/activate
+VENV_ACTIVATE := . $(VENV_ACTIVATE_FILE)
+VEPYTHON := $(VIRTUAL_ENV)/bin/$(PY_BIN)
+PYENV_ERROR := "\033[0;31mIMPORTANT\033[0m: Please install pyenv.\n"
+PYENV_PREREQ_HELP := "\033[0;31mIMPORTANT\033[0m: please type \033[0;31mpyenv init\033[0m, follow the instructions there and restart your terminal before proceeding any further.\n"
+VE_MISSING_HELP := "\033[0;31mIMPORTANT\033[0m: Couldn't find $(PWD)/$(VIRTUAL_ENV); have you executed make venv-create?\033[0m\n"
 
 prereq:
 	pyenv install --skip-existing $(PY38)


### PR DESCRIPTION
With `make` version 4.4, execution of make targets hangs indefinitely. Running it with `--debug=verbose` shows:

```
Makefile:24: not recursively expanding PY38 to export to shell function
Makefile:24: not recursively expanding PY38 to export to shell function
Makefile:25: not recursively expanding PY39 to export to shell function
Makefile:24: not recursively expanding PY38 to export to shell function
Makefile:25: not recursively expanding PY39 to export to shell function
Makefile:25: not recursively expanding PY39 to export to shell function
...
```

This continues eternally. With this commit we switch to [simply expanded variable
assignment](https://www.gnu.org/software/make/manual/html_node/Simple-Assignment.html) avoiding this unnecessary recursion.