### PR TITLE
Propagate request start/end lazily

### DIFF
--- a/esrally/client/context.py
+++ b/esrally/client/context.py
@@ -37,21 +37,19 @@ class RequestContextManager:
 
     @property
     def request_start(self):
-        return self.ctx["request_start"]
+        return self.ctx.get("request_start")
 
     @property
     def request_end(self):
-        return self.ctx["request_end"]
+        return self.ctx.get("request_end")
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        # propagate earliest request start and most recent request end to parent
-        request_start = self.request_start
-        request_end = self.request_end
         self.ctx_holder.restore_context(self.token)
         # don't attempt to restore these values on the top-level context as they don't exist
         if self.token.old_value != contextvars.Token.MISSING:
-            self.ctx_holder.update_request_start(request_start)
-            self.ctx_holder.update_request_end(request_end)
+            # propagate earliest request start and most recent request end to parent
+            self.ctx_holder.update_request_start(self.request_start)
+            self.ctx_holder.update_request_end(self.request_end)
         self.token = None
         return False
 

--- a/tests/client/factory_test.py
+++ b/tests/client/factory_test.py
@@ -428,6 +428,19 @@ class TestEsClientAgainstHTTPSServer:
 
 class TestRequestContextManager:
     @pytest.mark.asyncio
+    async def test_does_not_propagates_empty_toplevel_context(self):
+        test_client = client.RequestContextHolder()
+        async with test_client.new_request_context() as top_level_ctx:
+            # Simulate that we started a request context but did not issue a request.
+            # This can happen when a runner throws an exception before it issued an
+            # API request. The most typical case is that a mandatory parameter is
+            # missing.
+            pass
+
+        assert top_level_ctx.request_start is None
+        assert top_level_ctx.request_end is None
+
+    @pytest.mark.asyncio
     async def test_propagates_nested_context(self):
         test_client = client.RequestContextHolder()
         async with test_client.new_request_context() as top_level_ctx:


### PR DESCRIPTION
With this commit we only propagate request start and end time to the parent context if there actually is one. Previously we unconditionally propagated the request context which could lead to misleading errors when there was an open request context but no request was issued. This can happen when a mandatory parameter is missing and the runner was throwing exception. That exception would get masked by a `KeyError` because no request start was present yet and thus obfuscate the root cause.
