### PR TITLE
Use correct params for create component template

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1454,8 +1454,8 @@ class CreateComponentTemplate(Runner):
     async def __call__(self, es, params):
         templates = mandatory(params, "templates", self)
         request_params = mandatory(params, "request-params", self)
-        for template, body in templates:
-            await es.cluster.put_component_template(name=template, body=body, params=request_params)
+        for name, body in templates:
+            await es.cluster.put_component_template(name=name, template=body["template"], params=request_params)
         return {
             "weight": len(templates),
             "unit": "ops",

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2992,12 +2992,12 @@ class TestCreateComponentTemplateRunner:
             [
                 mock.call(
                     name="templateA",
-                    body={"template": {"mappings": {"properties": {"@timestamp": {"type": "date"}}}}},
+                    template={"mappings": {"properties": {"@timestamp": {"type": "date"}}}},
                     params=params["request-params"],
                 ),
                 mock.call(
                     name="templateB",
-                    body={"template": {"settings": {"index.number_of_shards": 1, "index.number_of_replicas": 1}}},
+                    template={"settings": {"index.number_of_shards": 1, "index.number_of_replicas": 1}},
                     params=params["request-params"],
                 ),
             ]


### PR DESCRIPTION
The Elasticsearch Python client does not accept a request body but rather requires parts of the body to be passed for the create component template API call. With this commit we adapt Rally to these changes.