### PR TITLE
Ignore HTTP 404 consistently in runners

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -1396,7 +1396,7 @@ class DeleteIndex(Runner):
         try:
             for index_name in indices:
                 if not only_if_exists:
-                    await es.indices.delete(index=index_name, params=request_params)
+                    await es.indices.delete(index=index_name, ignore=[404], params=request_params)
                     ops += 1
                 elif only_if_exists and await es.indices.exists(index=index_name):
                     self.logger.info("Index [%s] already exists. Deleting it.", index_name)
@@ -1585,7 +1585,7 @@ class DeleteIndexTemplate(Runner):
 
         for template_name, delete_matching_indices, index_pattern in template_names:
             if not only_if_exists:
-                await es.indices.delete_template(name=template_name, params=request_params)
+                await es.indices.delete_template(name=template_name, ignore=[404], params=request_params)
                 ops_count += 1
             elif only_if_exists and await es.indices.exists_template(name=template_name):
                 self.logger.info("Index template [%s] already exists. Deleting it.", template_name)
@@ -1949,7 +1949,7 @@ class DeleteSnapshotRepository(Runner):
     """
 
     async def __call__(self, es, params):
-        await es.snapshot.delete_repository(repository=mandatory(params, "repository", repr(self)))
+        await es.snapshot.delete_repository(repository=mandatory(params, "repository", repr(self)), ignore=[404])
 
     def __repr__(self, *args, **kwargs):
         return "delete-snapshot-repository"
@@ -2650,7 +2650,7 @@ class DeleteIlmPolicy(Runner):
         timeout = request_params.get("timeout", None)
 
         await es.ilm.delete_lifecycle(
-            name=policy_name, error_trace=error_trace, filter_path=filter_path, master_timeout=master_timeout, timeout=timeout
+            name=policy_name, error_trace=error_trace, filter_path=filter_path, master_timeout=master_timeout, timeout=timeout, ignore=[404]
         )
         return {
             "weight": 1,

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -2782,8 +2782,8 @@ class TestDeleteIndexRunner:
         )
         es.indices.delete.assert_has_awaits(
             [
-                mock.call(index="indexA", params=params["request-params"]),
-                mock.call(index="indexB", params=params["request-params"]),
+                mock.call(index="indexA", params=params["request-params"], ignore=[404]),
+                mock.call(index="indexB", params=params["request-params"], ignore=[404]),
             ]
         )
         assert es.indices.exists.call_count == 0
@@ -2916,7 +2916,10 @@ class TestDeleteIndexTemplateRunner:
         }
 
         es.indices.delete_template.assert_has_awaits(
-            [mock.call(name="templateA", params=params["request-params"]), mock.call(name="templateB", params=params["request-params"])]
+            [
+                mock.call(name="templateA", ignore=[404], params=params["request-params"]),
+                mock.call(name="templateB", ignore=[404], params=params["request-params"]),
+            ]
         )
         es.indices.delete.assert_awaited_once_with(index="logs-*")
 
@@ -3744,7 +3747,7 @@ class TestDeleteSnapshotRepository:
         r = runner.DeleteSnapshotRepository()
         await r(es, params)
 
-        es.snapshot.delete_repository.assert_called_once_with(repository="backups")
+        es.snapshot.delete_repository.assert_called_once_with(repository="backups", ignore=[404])
 
 
 class TestCreateSnapshotRepository:
@@ -5189,6 +5192,7 @@ class TestDeleteIlmPolicyRunner:
             timeout=self.params["request-params"].get("timeout"),
             error_trace=None,
             filter_path=None,
+            ignore=[404],
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -5211,6 +5215,7 @@ class TestDeleteIlmPolicyRunner:
             timeout=None,
             error_trace=None,
             filter_path=None,
+            ignore=[404],
         )
 
 


### PR DESCRIPTION
Some runners that deleted resources have ignored HTTP 404 already but we did not apply this consistently. With this commit, all runners that delete resources ignore HTTP 404 to avoid spurious request errors.

