### PR TITLE
Stop asserting time spent in AsyncProfiler

### DIFF
--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import asyncio
 import collections
 import io
 import threading

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1898,15 +1898,13 @@ class TestAsyncExecutor:
 class TestAsyncProfiler:
     @pytest.mark.asyncio
     async def test_profiler_is_a_transparent_wrapper(self):
+        f_called = False
+
         async def f(x):
-            await asyncio.sleep(x)
+            nonlocal f_called
+            f_called = True
             return x * 2
 
         profiler = driver.AsyncProfiler(f)
-        start = time.perf_counter()
-        # this should take roughly 1 second and should return something
-        return_value = await profiler(1)
-        end = time.perf_counter()
-        assert return_value == 2
-        duration = end - start
-        assert 0.9 <= duration <= 1.2, "Should sleep for roughly 1 second but took [%.2f] seconds." % duration
+        assert await profiler(1) == 2
+        assert f_called


### PR DESCRIPTION
It was brittle in CI and wasted one second. Asserting that the return value is correct and that the function was actually called will provide enough guarantees.