### PR TITLE
Improve exception handling for metrics store errors

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -119,7 +119,7 @@ class EsClient:
                     err_type = err.get("index", {}).get("error", {}).get("type", None)
                     if err.get("index", {}).get("status", None) not in (502, 503, 504, 429):
                         msg = f"Unretryable error encountered when sending metrics to remote metrics store: [{err_type}]"
-                        self.logger.exception(msg)
+                        self.logger.exception("%s - Full error(s) [%s]", msg, str(e.errors))
                         raise exceptions.RallyError(msg)
 
                 if execution_count <= max_execution_count:
@@ -133,7 +133,7 @@ class EsClient:
                     time.sleep(time_to_sleep)
                 else:
                     msg = f"Failed to send metrics to remote metrics store: [{e.errors}]"
-                    self.logger.exception(msg)
+                    self.logger.exception("%s - Full error(s) [%s]", msg, str(e.errors))
                     raise exceptions.RallyError(msg)
             except elasticsearch.exceptions.ConnectionTimeout as e:
                 if execution_count <= max_execution_count:

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -249,7 +249,7 @@ class TestEsClient:
                             sleep_slots[v],
                         )
                     )
-                logging_statements.append(f"Failed to send metrics to remote metrics store: [{self.errors}]")
+                logging_statements.append(f"Failed to send metrics to remote metrics store: [{self.errors}] - Full error(s) [{self.errors}]")
                 return logging_statements
 
             def raise_error(self):

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -276,7 +276,7 @@ class TestEsClient:
             },
         ]
 
-        retriable_errors = [
+        retryable_errors = [
             ApiError(429),
             ApiError(502),
             ApiError(503),
@@ -300,7 +300,7 @@ class TestEsClient:
         exepcted_logger_calls = []
         expected_sleep_calls = []
 
-        for e in retriable_errors:
+        for e in retryable_errors:
             exepcted_logger_calls += e.logging_statements(max_retry)
             expected_sleep_calls += [mock.call(int(sleep_slots[i])) for i in range(0, max_retry)]
 

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -249,7 +249,9 @@ class TestEsClient:
                             sleep_slots[v],
                         )
                     )
-                logging_statements.append(f"Failed to send metrics to remote metrics store: [{self.errors}] - Full error(s) [{self.errors}]")
+                logging_statements.append(
+                    f"Failed to send metrics to remote metrics store: [{self.errors}] - Full error(s) [{self.errors}]"
+                )
                 return logging_statements
 
             def raise_error(self):

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from unittest import mock
 
 import elasticsearch.exceptions
+import elasticsearch.helpers
 import pytest
 
 from esrally import config, exceptions, metrics, paths, track
@@ -231,7 +232,57 @@ class TestEsClient:
                 err = elasticsearch.exceptions.ApiError("unit-test", meta=TestEsClient.ApiResponseMeta(status=self.status_code), body={})
                 raise err
 
-        retriable_errors = [ApiError(429), ApiError(502), ApiError(503), ApiError(504), ConnectionError(), ConnectionTimeout()]
+        class BulkIndexError:
+            def __init__(self, errors):
+                self.errors = errors
+                self.error_message = f"{len(self.errors)} document(s) failed to index"
+
+            def logging_statements(self, retries):
+                logging_statements = []
+                for i, v in enumerate(range(retries)):
+                    logging_statements.append(
+                        "Error in sending metrics to remote metrics store [%s] in attempt [%d/%d]. Sleeping for [%f] seconds."
+                        % (
+                            self.error_message,
+                            i + 1,
+                            max_retry,
+                            sleep_slots[v],
+                        )
+                    )
+                logging_statements.append(f"Failed to send metrics to remote metrics store: [{self.errors}]")
+                return logging_statements
+
+            def raise_error(self):
+                raise elasticsearch.helpers.BulkIndexError(self.error_message, self.errors)
+
+        bulk_index_errors = [
+            {
+                "index": {
+                    "_index": "rally-metrics-2023-04",
+                    "_id": "dffAc4cBOnIJ2Omtflwg",
+                    "status": 429,
+                    "error": {
+                        "type": "circuit_breaking_exception",
+                        "reason": "[parent] Data too large, data for [<http_request>] would be [123848638/118.1mb], "
+                        "which is larger than the limit of [123273216/117.5mb], real usage: [120182112/114.6mb], "
+                        "new bytes reserved: [3666526/3.4mb]",
+                        "bytes_wanted": 123848638,
+                        "bytes_limit": 123273216,
+                        "durability": "TRANSIENT",
+                    },
+                }
+            },
+        ]
+
+        retriable_errors = [
+            ApiError(429),
+            ApiError(502),
+            ApiError(503),
+            ApiError(504),
+            ConnectionError(),
+            ConnectionTimeout(),
+            BulkIndexError(bulk_index_errors),
+        ]
 
         max_retry = 10
 
@@ -301,6 +352,60 @@ class TestEsClient:
             "Transport error(s) [unit-test] occurred while running the operation [raise_unknown_error] against your Elasticsearch metrics "
             "store on host [127.0.0.1] at port [9243]."
         )
+
+    def test_raises_rally_error_on_unretryable_bulk_indexing_errors(self):
+        bulk_index_errors = [
+            {
+                "index": {
+                    "_index": "rally-metrics-2023-04",
+                    "_id": "dffAc4cBOnIJ2Omtflwg",
+                    "status": 429,
+                    "error": {
+                        "type": "circuit_breaking_exception",
+                        "reason": "[parent] Data too large, data for [<http_request>] would be [123848638/118.1mb], "
+                        "which is larger than the limit of [123273216/117.5mb], real usage: [120182112/114.6mb], "
+                        "new bytes reserved: [3666526/3.4mb]",
+                        "bytes_wanted": 123848638,
+                        "bytes_limit": 123273216,
+                        "durability": "TRANSIENT",
+                    },
+                }
+            },
+            {
+                "index": {
+                    "_id": "1",
+                    "_index": "rally-metrics-2023-04",
+                    "error": {"type": "version_conflict_engine_exception"},
+                    "status": 409,
+                }
+            },
+            {
+                "index": {
+                    "_index": "rally-metrics-2023-04",
+                    "_id": "dffAc4cBOnIJ2Omtflwg",
+                    "status": 400,
+                    "error": {
+                        "type": "mapper_parsing_exception",
+                        "reason": "failed to parse field [meta.error-description] of type [keyword] in document with id "
+                        "'dffAc4cBOnIJ2Omtflwg'. Preview of field's value: 'HTTP status: 400, message: failed to parse "
+                        "field [@timestamp] of type [date] in document with id '-PXAc4cBOnIJ2OmtX33J'. Preview of "
+                        "field's value: '1998-04-30T15:02:56-05:00'",
+                    },
+                }
+            },
+        ]
+
+        def raise_bulk_index_error():
+            err = elasticsearch.helpers.BulkIndexError(f"{len(bulk_index_errors)} document(s) failed to index", bulk_index_errors)
+            raise err
+
+        client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
+
+        with pytest.raises(
+            exceptions.RallyError,
+            match=(r"Unretryable error encountered when sending metrics to remote metrics store: \[version_conflict_engine_exception\]"),
+        ):
+            client.guarded(raise_bulk_index_error)
 
 
 class TestEsMetrics:


### PR DESCRIPTION
Prior to this commit, Rally could hang indefinitely whenever its respective metrics store failed to `flush()` successfully.

This is because the respective remote metric store's `close()` method only attempted to set itself as closed _after_ a successful call to the `flush()` method.  If we failed to `flush()` successfully, then we never set the metric store's `opened` attribute to `false`, eventually leading to a deadlock where Rally couldn't ever shut down successfully:
https://github.com/elastic/rally/blob/431af5f52a19f12cf2bc483863066e3f081f7c4e/esrally/driver/driver.py#L918-L921

This commit ensures we properly close the respective metrics store by setting the `opened` attribute to `false` _prior_ to attempting a final `flush()`, as well as ensures we capture and log any `BulkIndexError`s raised by the bulk index helper method.

Fixes https://github.com/elastic/rally/issues/1697


You can reproduce this locally with a remote metrics store and by running this specific `http_logs` revision to generate a mappings exception:

Fails due to metrics store mappings exception:
```shell
$ esrally race --telemetry="gc" --target-host="localhost:9200" --track-revision="cffc8641055233485b9d1c9a773b1303c7c5313f" --track-repository="default" --track="http_logs" --challenge="append-index-only-with-ingest-pipeline" --on-error="abort" --client-options="timeout:240,use_ssl:true,verify_certs:false,basic_auth_user:'elastic',basic_auth_password:'changeme'" --track-params='{"bulk_indexing_clients": 1,"source_enabled": false, "ingest_pipeline": "grok" }' --pipeline="benchmark-only"  --kill-running-processes
``` 

<details>

<summary> Output </summary>

```shell
$ esrally race --telemetry="gc" --target-host="localhost:9200" --track-revision="cffc8641055233485b9d1c9a773b1303c7c5313f" --track-repository="default" --track="http_logs" --challenge="append-index-only-with-ingest-pipeline" --on-error="abort" --client-options="timeout:240,use_ssl:true,verify_certs:false,basic_auth_user:'elastic',basic_auth_password:'changeme'" --track-params='{"bulk_indexing_clients": 1,"source_enabled": false, "ingest_pipeline": "grok" }' --pipeline="benchmark-only"  --kill-running-processes

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/

[INFO] Race id is [1415f777-8547-4193-bb0e-c8d02f05483f]
[INFO] Racing on track [http_logs], challenge [append-index-only-with-ingest-pipeline] and car ['external'] with version [8.6.2].

Running delete-index                                                           [100% done]
Running create-index                                                           [100% done]
Running check-cluster-health                                                   [100% done]
Running create-http-log-grok-pipeline                                          [100% done]
Running index-append-with-ingest-grok-pipeline                                 [  0% done]
[ERROR] Cannot race. Traceback (most recent call last):
  File "/home/b/perf/github.com/b-deam/rally/esrally/metrics.py", line 116, in guarded
    return target(*args, **kwargs)
  File "/home/b/perf/github.com/b-deam/rally/.venv/lib/python3.8/site-packages/elasticsearch/helpers/actions.py", line 524, in bulk
    for ok, item in streaming_bulk(
  File "/home/b/perf/github.com/b-deam/rally/.venv/lib/python3.8/site-packages/elasticsearch/helpers/actions.py", line 438, in streaming_bulk
    for data, (ok, info) in zip(
  File "/home/b/perf/github.com/b-deam/rally/.venv/lib/python3.8/site-packages/elasticsearch/helpers/actions.py", line 355, in _process_bulk_chunk
    yield from gen
  File "/home/b/perf/github.com/b-deam/rally/.venv/lib/python3.8/site-packages/elasticsearch/helpers/actions.py", line 274, in _process_bulk_chunk_success
    raise BulkIndexError(f"{len(errors)} document(s) failed to index.", errors)
elasticsearch.helpers.BulkIndexError: 45 document(s) failed to index.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/b/perf/github.com/b-deam/rally/esrally/actor.py", line 92, in guard
    return f(self, msg, sender)
  File "/home/b/perf/github.com/b-deam/rally/esrally/driver/driver.py", line 303, in receiveMsg_WakeupMessage
    self.coordinator.post_process_samples()
  File "/home/b/perf/github.com/b-deam/rally/esrally/driver/driver.py", line 955, in post_process_samples
    self.sample_post_processor(raw_samples)
  File "/home/b/perf/github.com/b-deam/rally/esrally/driver/driver.py", line 1068, in __call__
    self.metrics_store.flush(refresh=False)
  File "/home/b/perf/github.com/b-deam/rally/esrally/metrics.py", line 933, in flush
    self._client.bulk_index(index=self._index, items=self._docs)
  File "/home/b/perf/github.com/b-deam/rally/esrally/metrics.py", line 92, in bulk_index
    self.guarded(elasticsearch.helpers.bulk, self._client, items, index=index, chunk_size=5000)
  File "/home/b/perf/github.com/b-deam/rally/esrally/metrics.py", line 123, in guarded
    raise exceptions.RallyError(
esrally.exceptions.RallyError: Unretryable error encountered when sending metrics to remote metrics store: [mapper_parsing_exception]


Getting further help:
*********************
* Check the log files in /home/b/.rally/logs for errors.
* Read the documentation at https://esrally.readthedocs.io/en/latest/.
* Ask a question on the forum at https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally.
* Raise an issue at https://github.com/elastic/rally/issues and include the log files in /home/b/.rally/logs.

--------------------------------
[INFO] FAILURE (took 63 seconds)
--------------------------------
```

</details>