### PR TITLE
Allow specifying branch together with timestamp in revision

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -603,7 +603,7 @@ You can specify the revision in different formats:
 * ``--revision=current``: Use the current revision (i.e. don't alter the local source tree).
 * ``--revision=abc123``: Where ``abc123`` is some git revision hash.
 * ``--revision=v8.4.0``: Where ``v8.4.0`` is some git tag.
-* ``--revision=<optional branch name>@2013-07-27T10:37:00Z``: Determines the revision that is closest to the provided date. By default, assumes ``main`` is the branch, but it can be override with ``branchname@timestamp``. Rally logs to which git revision hash the date has been resolved and if you use Elasticsearch as metrics store (instead of the default in-memory one), :doc:`each metric record will contain the git revision hash also in the meta-data section </metrics>`.
+* ``--revision=<optional branch name>@2013-07-27T10:37:00Z``: Determines the revision that is closest to the provided date. By default, assumes ``main`` is the branch, but it can be overriden with ``branchname@timestamp``. Rally logs to which git revision hash the date has been resolved and if you use Elasticsearch as metrics store (instead of the default in-memory one), :doc:`each metric record will contain the git revision hash also in the meta-data section </metrics>`.
 * ``--revision=my-branch-name``: Where ``my-branch-name`` is the name of an existing branch name. If you are using a :ref:`remote source repository <configuration_source>`, Rally will fetch and checkout the remote branch.
 
 Supported date format: If you specify a date, it has to be ISO-8601 conformant and must start with an ``@`` sign to make it easier for Rally to determine that you actually mean a date.

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -603,7 +603,7 @@ You can specify the revision in different formats:
 * ``--revision=current``: Use the current revision (i.e. don't alter the local source tree).
 * ``--revision=abc123``: Where ``abc123`` is some git revision hash.
 * ``--revision=v8.4.0``: Where ``v8.4.0`` is some git tag.
-* ``--revision=@2013-07-27T10:37:00Z``: Determines the revision that is closest to the provided date. Rally logs to which git revision hash the date has been resolved and if you use Elasticsearch as metrics store (instead of the default in-memory one), :doc:`each metric record will contain the git revision hash also in the meta-data section </metrics>`.
+* ``--revision=<optional branch name>@2013-07-27T10:37:00Z``: Determines the revision that is closest to the provided date. By default, assumes ``main`` is the branch, but it can be override with ``branchname@timestamp``. Rally logs to which git revision hash the date has been resolved and if you use Elasticsearch as metrics store (instead of the default in-memory one), :doc:`each metric record will contain the git revision hash also in the meta-data section </metrics>`.
 * ``--revision=my-branch-name``: Where ``my-branch-name`` is the name of an existing branch name. If you are using a :ref:`remote source repository <configuration_source>`, Rally will fetch and checkout the remote branch.
 
 Supported date format: If you specify a date, it has to be ISO-8601 conformant and must start with an ``@`` sign to make it easier for Rally to determine that you actually mean a date.

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -292,7 +292,8 @@ def create_arg_parser():
         help="Define the source code revision for building the benchmark candidate. 'current' uses the source tree as is,"
         " 'latest' fetches the latest version on the main branch. It is also possible to specify a commit id or a timestamp."
         ' The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, '
-        'e.g. "@2013-07-27T10:37:00Z" (default: current).',
+        'e.g. "@2013-07-27T10:37:00Z" (default: current). A combination of branch and timestamp is also possible,'
+        'e.g. "@feature-branch@2023-04-06T14:52:31Z".',
         default="current",
     )  # optimized for local usage, don't fetch sources
     build_parser.add_argument(

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -38,22 +38,49 @@ class TestRevisionExtractor:
             "elasticsearch": "current",
             "all": "current",
         }
-        assert supplier._extract_revisions("@2015-01-01-01:00:00") == {
-            "elasticsearch": "@2015-01-01-01:00:00",
-            "all": "@2015-01-01-01:00:00",
+        assert supplier._extract_revisions("@2022-12-12T11:12:13Z") == {
+            "elasticsearch": "@2022-12-12T11:12:13Z",
+            "all": "@2022-12-12T11:12:13Z",
+        }
+        assert supplier._extract_revisions("feature/branch@2024-04-20T08:00:00Z") == {
+            "elasticsearch": "feature/branch@2024-04-20T08:00:00Z",
+            "all": "feature/branch@2024-04-20T08:00:00Z",
         }
 
     def test_multiple_revisions(self):
-        assert supplier._extract_revisions("elasticsearch:67c2f42,x-pack:@2015-01-01-01:00:00,some-plugin:current") == {
+        assert supplier._extract_revisions("elasticsearch:67c2f42,one-plugin:@2023-04-04T12:34:56,another-plugin:current") == {
             "elasticsearch": "67c2f42",
-            "x-pack": "@2015-01-01-01:00:00",
-            "some-plugin": "current",
+            "one-plugin": "@2023-04-04T12:34:56",
+            "another-plugin": "current",
         }
 
     def test_invalid_revisions(self):
         with pytest.raises(exceptions.SystemSetupError) as exc:
             supplier._extract_revisions("elasticsearch 67c2f42,x-pack:current")
         assert exc.value.args[0] == "Revision [elasticsearch 67c2f42] does not match expected format [name:revision]."
+
+
+class TestComponentFromRevision:
+    def test_revision_sha(self):
+        assert supplier._component_from_revision("e8d4211de73ad498df865e7df935feb890808eb9") == (
+            "",
+            "e8d4211de73ad498df865e7df935feb890808eb9",
+        )
+
+    def test_revision_ts_only(self):
+        assert supplier._component_from_revision("@2023-04-03T03:04:05Z") == ("", "@2023-04-03T03:04:05Z")
+
+    def test_revision_component_and_sha(self):
+        assert supplier._component_from_revision("elasticsearch:latest") == ("elasticsearch", "latest")
+
+    def test_revision_component_and_ts(self):
+        assert supplier._component_from_revision("elasticsearch:@2023-04-03T03:04:05Z") == ("elasticsearch", "@2023-04-03T03:04:05Z")
+
+    def test_revision_component_branch_and_ts(self):
+        assert supplier._component_from_revision("elasticsearch:feature/branch@2023-04-03T03:04:05Z") == (
+            "elasticsearch",
+            "feature/branch@2023-04-03T03:04:05Z",
+        )
 
 
 class TestSourceRepository:
@@ -117,10 +144,10 @@ class TestSourceRepository:
         mock_head_revision.return_value = "HEAD"
 
         s = supplier.SourceRepository(name="Elasticsearch", remote_url="some-github-url", src_dir="/src", branch="main")
-        s.fetch("@2015-01-01-01:00:00")
+        s.fetch("@2023-04-20T11:09:12Z")
 
         mock_is_working_copy.assert_called_with("/src")
-        mock_pull_ts.assert_called_with("/src", "2015-01-01-01:00:00", remote="origin", branch="main")
+        mock_pull_ts.assert_called_with("/src", "2023-04-20T11:09:12Z", remote="origin", branch="main")
         mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.fetch", autospec=True)


### PR DESCRIPTION
With this commit, we add support for an optional branch when a timestamp is specified in `--revision`. This is intended primarily for Elasticsearch nightly benchmarks.
