### PR TITLE
Evenly distribute client connections across hosts

### DIFF
--- a/esrally/client/factory.py
+++ b/esrally/client/factory.py
@@ -184,7 +184,7 @@ class EsClientFactory:
             distribution_version=self.distribution_version, hosts=self.hosts, ssl_context=self.ssl_context, **self.client_options
         )
 
-    def create_async(self, api_key=None):
+    def create_async(self, api_key=None, client_id=None):
         # pylint: disable=import-outside-toplevel
         import io
 
@@ -239,6 +239,7 @@ class EsClientFactory:
             node_connection.trace_configs = [trace_config]
             node_connection.enable_cleanup_closed = self.enable_cleanup_closed
             node_connection.static_responses = self.static_responses
+            node_connection.client_id = client_id
 
         return async_client
 

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1736,7 +1736,7 @@ class AsyncIoAdapter:
             for cluster_name, cluster_hosts in all_hosts.items():
                 es[cluster_name] = client.EsClientFactory(
                     cluster_hosts, all_client_options[cluster_name], distribution_version=distribution_version
-                ).create_async(api_key=api_key)
+                ).create_async(api_key=api_key, client_id=client_id)
             return es
 
         if self.assertions_enabled:

--- a/tests/client/asynchronous_test.py
+++ b/tests/client/asynchronous_test.py
@@ -16,8 +16,13 @@
 # under the License.
 
 import json
+import math
+import random
+from unittest import mock
 
-from esrally.client.asynchronous import ResponseMatcher
+import pytest
+
+from esrally.client.asynchronous import RallyTCPConnector, ResponseMatcher
 
 
 class TestResponseMatcher:
@@ -49,3 +54,76 @@ class TestResponseMatcher:
     def assert_response_type(self, matcher, path, expected_response_type):
         response = json.loads(matcher.response(path))
         assert response["response-type"] == expected_response_type
+
+
+class TestResolveHost:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "num_of_dns_resp, num_clients",
+        [(1, 256), (2, 128), (3, 1), (3, 64), (4, 16), (3, 2000)],
+    )
+    @mock.patch("esrally.client.asynchronous.aiohttp.ThreadedResolver.resolve")
+    async def test_resolve_host_even_client_allocation(
+        self,
+        mocked_resolver,
+        num_of_dns_resp,
+        num_clients,
+    ):
+        """
+        TCPConnector._resolve_host() returns all the IPs a given name resolves to, but the underlying connection but the
+        logic in TCPConnector._create_direct_connection() only ever selects the first succesful host from this list.
+
+        So, we use the factory assigned client_id to deterministically return an IP and then place it at the beginning
+        of the list to evenly distributes connections across _all_ clients.
+
+        https://github.com/elastic/rally/issues/1598
+        """
+
+        def generate_dns_response(num_of_dns_resp):
+            dns_resp = []
+            for _ in range(num_of_dns_resp):
+                dns_resp.append(
+                    {
+                        "hostname": "rally-dns-test.es.us-east-1.aws.found.io",
+                        "host": ".".join([str(random.randint(0, 255)) for _ in range(4)]),
+                        "port": 443,
+                        "family": "test-family",
+                        "proto": 6,
+                        "flags": "test-flag",
+                    },
+                )
+            return dns_resp
+
+        dns_responses = generate_dns_response(num_of_dns_resp)
+        mocked_resolver.return_value = dns_responses
+
+        hostinfo = []
+        for i in range(num_clients):
+            hostinfo.append(
+                # pylint: disable=protected-access
+                await RallyTCPConnector(limit_per_host=256, use_dns_cache=True, enable_cleanup_closed=True, client_id=i)._resolve_host(
+                    "rally-dns-test.es.us-east-1.aws.found.io", 443
+                )
+            )
+
+        first_host_per_client = []
+        for host in hostinfo:
+            # for each host extract the first 'host' resolved as that's what will be used to establish a connection
+            first_host_per_client.append(host[0]["host"])
+
+        # count the distribution of the allocation
+        ip_alloc = {}
+        for ip in first_host_per_client:
+            if ip in ip_alloc:
+                ip_alloc[ip] += 1
+            else:
+                ip_alloc[ip] = 1
+
+        # maximum and minimum number of clients a single ip should have
+        upper_bound = math.ceil(num_clients / num_of_dns_resp)
+        lower_bound = math.floor(num_clients / num_of_dns_resp)
+
+        for num_of_clients in ip_alloc.values():
+            assert num_of_clients == upper_bound or lower_bound
+
+        assert sum(ip_alloc.values()) == num_clients

--- a/tests/client/asynchronous_test.py
+++ b/tests/client/asynchronous_test.py
@@ -56,74 +56,62 @@ class TestResponseMatcher:
         assert response["response-type"] == expected_response_type
 
 
-class TestResolveHost:
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "num_of_dns_resp, num_clients",
-        [(1, 256), (2, 128), (3, 1), (3, 64), (4, 16), (3, 2000)],
-    )
-    @mock.patch("esrally.client.asynchronous.aiohttp.ThreadedResolver.resolve")
-    async def test_resolve_host_even_client_allocation(
-        self,
-        mocked_resolver,
-        num_of_dns_resp,
-        num_clients,
-    ):
-        """
-        TCPConnector._resolve_host() returns all the IPs a given name resolves to, but the underlying connection but the
-        logic in TCPConnector._create_direct_connection() only ever selects the first succesful host from this list.
-
-        So, we use the factory assigned client_id to deterministically return an IP and then place it at the beginning
-        of the list to evenly distributes connections across _all_ clients.
-
-        https://github.com/elastic/rally/issues/1598
-        """
-
-        def generate_dns_response(num_of_dns_resp):
-            dns_resp = []
-            for _ in range(num_of_dns_resp):
-                dns_resp.append(
-                    {
-                        "hostname": "rally-dns-test.es.us-east-1.aws.found.io",
-                        "host": ".".join([str(random.randint(0, 255)) for _ in range(4)]),
-                        "port": 443,
-                        "family": "test-family",
-                        "proto": 6,
-                        "flags": "test-flag",
-                    },
-                )
-            return dns_resp
-
-        dns_responses = generate_dns_response(num_of_dns_resp)
-        mocked_resolver.return_value = dns_responses
-
-        hostinfo = []
-        for i in range(num_clients):
-            hostinfo.append(
-                # pylint: disable=protected-access
-                await RallyTCPConnector(limit_per_host=256, use_dns_cache=True, enable_cleanup_closed=True, client_id=i)._resolve_host(
-                    "rally-dns-test.es.us-east-1.aws.found.io", 443
-                )
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "num_of_dns_resp, num_clients",
+    [(1, 256), (2, 128), (3, 1), (3, 64), (4, 16), (3, 2000)],
+)
+@mock.patch("esrally.client.asynchronous.aiohttp.ThreadedResolver.resolve")
+async def test_resolve_host_even_client_allocation(
+    mocked_resolver,
+    num_of_dns_resp,
+    num_clients,
+):
+    def generate_dns_response(num_of_dns_resp):
+        dns_resp = []
+        for _ in range(num_of_dns_resp):
+            dns_resp.append(
+                {
+                    "hostname": "rally-dns-test.es.us-east-1.aws.found.io",
+                    "host": ".".join([str(random.randint(0, 255)) for _ in range(4)]),
+                    "port": 443,
+                    "family": "test-family",
+                    "proto": 6,
+                    "flags": "test-flag",
+                },
             )
+        return dns_resp
 
-        first_host_per_client = []
-        for host in hostinfo:
-            # for each host extract the first 'host' resolved as that's what will be used to establish a connection
-            first_host_per_client.append(host[0]["host"])
+    dns_responses = generate_dns_response(num_of_dns_resp)
+    mocked_resolver.return_value = dns_responses
 
-        # count the distribution of the allocation
-        ip_alloc = {}
-        for ip in first_host_per_client:
-            if ip in ip_alloc:
-                ip_alloc[ip] += 1
-            else:
-                ip_alloc[ip] = 1
+    hostinfo = []
+    for i in range(num_clients):
+        hostinfo.append(
+            # pylint: disable=protected-access
+            await RallyTCPConnector(limit_per_host=256, use_dns_cache=True, enable_cleanup_closed=True, client_id=i)._resolve_host(
+                "rally-dns-test.es.us-east-1.aws.found.io", 443
+            )
+        )
 
-        # maximum and minimum number of clients a single ip should have
-        upper_bound = math.ceil(num_clients / num_of_dns_resp)
-        lower_bound = math.floor(num_clients / num_of_dns_resp)
+    first_host_per_client = []
+    for host in hostinfo:
+        # for each host extract the first 'host' resolved as that's what will be used to establish a connection
+        first_host_per_client.append(host[0]["host"])
 
-        for num_of_clients in ip_alloc.values():
-            assert num_of_clients == upper_bound or lower_bound
+    # count the distribution of the allocation
+    ip_alloc = {}
+    for ip in first_host_per_client:
+        if ip in ip_alloc:
+            ip_alloc[ip] += 1
+        else:
+            ip_alloc[ip] = 1
 
-        assert sum(ip_alloc.values()) == num_clients
+    # maximum and minimum number of clients a single ip should have
+    upper_bound = math.ceil(num_clients / num_of_dns_resp)
+    lower_bound = math.floor(num_clients / num_of_dns_resp)
+
+    for num_of_clients in ip_alloc.values():
+        assert num_of_clients == upper_bound or lower_bound
+
+    assert sum(ip_alloc.values()) == num_clients


### PR DESCRIPTION
With this commit we evenly distribute connections across
all IPs a given hostname resolves. 

Fixes https://github.com/elastic/rally/issues/1598 

Visualised:
|Bulk requests per AZ| HTTP Connections per Node|
| ---      | ---      |
|![image](https://user-images.githubusercontent.com/54515790/233548204-ad8b6794-7b33-41e6-8668-f575cacc0f31.png)| ![image](https://user-images.githubusercontent.com/54515790/233547976-bae3d341-ede1-471f-8898-fac2dd80267f.png) |