### PR TITLE
Show Rally builds in Buildkite default view

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -37,7 +37,7 @@ metadata:
   description: Run Rally integration tests
   links:
     - title: Pipeline
-      url: https://buildkite.com/elastic/rally-it-pipeline
+      url: https://buildkite.com/elastic/rally
 
 spec:
   type: buildkite-pipeline

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -54,6 +54,6 @@ spec:
       pipeline_file: .buildkite/it/pipeline.yml
       repository: elastic/rally
       teams:
-        elasticsearch-team: {}
+        es-perf: {}
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
Making this owned by the wider Elasticsearch team is nice in theory but in practice when I'm logged in to Buildkite I'd like to see all our builds, including Rally IT tests.