### PR TITLE
Prepare release Docker pipeline

### DIFF
--- a/.buildkite/release-docker/pipeline.yml
+++ b/.buildkite/release-docker/pipeline.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: "Release Docker Artifacts for Rally :docker:"
+    command: echo "TODO"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -57,3 +57,34 @@ spec:
         elasticsearch-team: {}
         everyone:
           access_level: READ_ONLY
+
+# Declare Rally Release Docker pipeline.
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: rally-release-docker-pipeline
+  description: Release Docker Artifacts for Rally
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/rally-release-docker
+
+spec:
+  type: buildkite-pipeline
+  owner: group:es-perf
+  system: buildkite
+
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: Rally - Release Docker
+      description: Release Docker Artifacts for Rally
+    spec:
+      pipeline_file: .buildkite/relase-docker/pipeline.yml
+      provider_settings:
+        trigger_mode: none
+      repository: elastic/rally
+      teams:
+        es-perf: {}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -25,6 +25,7 @@ spec:
   lifecycle: production
   dependsOn:
     - resource:rally-it-pipeline
+    - resource:rally-releaser-docker-pipeline
 
 
 # Declare Rally's Buildkite pipeline.


### PR DESCRIPTION
Declaring the pipeline before actually working on it is useful as it allows iterating on a branch.