### PR TITLE
Increase 'mapping.total_fields.limit' to '2000'

### DIFF
--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -2,6 +2,7 @@
   "index_patterns": ["rally-metrics-*"],
   "settings": {
     "index": {
+      "mapping.total_fields.limit": 2000
     }
   },
   "mappings": {


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/94543 introduced new `transport.actions.*.requests` and `transport.actions.*.responses` keys in the node stats API response from 8.8.0 onwards. 

If you run Rally with the `node-stats` telemetry device enabled, these fields are collected and added to the `rally-metrics*` mappings, alone accounting for ~400 or so fields. [By default, indices can only have 1000 fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-settings-limit.html), so this commit increases the limit to 2000, otherwise it's likely users will encounter errors like this:
```
Running validate-package-template-installation                                 [  0% done]                                                             [128/5844]
                                                                                                                                                                 
[ERROR] Cannot race. Traceback (most recent call last):                                                                                                          
  File "/home/esbench/rally/esrally/metrics.py", line 117, in guarded                                                                                            
    return target(*args, **kwargs)                                                                                                                               
           ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                               
  File "/home/esbench/.local/lib/python3.11/site-packages/elasticsearch/helpers/actions.py", line 524, in bulk                                                   
    for ok, item in streaming_bulk(                                                                                                                              
  File "/home/esbench/.local/lib/python3.11/site-packages/elasticsearch/helpers/actions.py", line 438, in streaming_bulk                                         
    for data, (ok, info) in zip(                                                                                                                                 
  File "/home/esbench/.local/lib/python3.11/site-packages/elasticsearch/helpers/actions.py", line 355, in _process_bulk_chunk                                    
    yield from gen                                                                                                                                               
  File "/home/esbench/.local/lib/python3.11/site-packages/elasticsearch/helpers/actions.py", line 274, in _process_bulk_chunk_success                            
    raise BulkIndexError(f"{len(errors)} document(s) failed to index.", errors)                                                                                  
elasticsearch.helpers.BulkIndexError: 9 document(s) failed to index.                                                                                             
                                                                                                                                                                 
During handling of the above exception, another exception occurred:                                                                                              
                                                                                                                                                                 
Traceback (most recent call last):                                                                                                                               
  File "/home/esbench/rally/esrally/actor.py", line 92, in guard                                                                                                 
    return f(self, msg, sender)                                                                                                                                  
           ^^^^^^^^^^^^^^^^^^^^                                                                                                                                  
  File "/home/esbench/rally/esrally/driver/driver.py", line 289, in receiveMsg_JoinPointReached                                                                  
    self.coordinator.joinpoint_reached(msg.worker_id, msg.worker_timestamp, msg.task)                                                                            
  File "/home/esbench/rally/esrally/driver/driver.py", line 792, in joinpoint_reached                                                                            
    self.post_process_samples()                                                                                                                                  
  File "/home/esbench/rally/esrally/driver/driver.py", line 955, in post_process_samples                                                                         
    self.sample_post_processor(raw_samples)                                                                                                                      
  File "/home/esbench/rally/esrally/driver/driver.py", line 1068, in __call__
    self.metrics_store.flush(refresh=False)
  File "/home/esbench/rally/esrally/metrics.py", line 928, in flush
    self._client.bulk_index(index=self._index, items=self._docs)
  File "/home/esbench/rally/esrally/metrics.py", line 93, in bulk_index
    self.guarded(elasticsearch.helpers.bulk, self._client, items, index=index, chunk_size=5000)
  File "/home/esbench/rally/esrally/metrics.py", line 181, in guarded
    raise exceptions.RallyError(msg)
esrally.exceptions.RallyError: Unretryable error encountered when sending metrics to remote metrics store: [document_parsing_exception]

Getting further help:
*********************
* Check the log files in /home/esbench/.rally/logs for errors.
* Read the documentation at https://esrally.readthedocs.io/en/latest/.
* Ask a question on the forum at https://discuss.elastic.co/tags/c/elastic-stack/elasticsearch/rally.
* Raise an issue at https://github.com/elastic/rally/issues and include the log files in /home/esbench/.rally/logs.

----------------------------------
[INFO] FAILURE (took 1434 seconds)
----------------------------------

# rally.log
2023-06-01 01:01:00,539 ActorAddr-(T|:34825)/PID:5445 esrally.metrics ERROR Unretryable error encountered when sending metrics to remote metrics store: [document_parsing_exception] - Full error(s) [[{'index': {'_index': 'rally-metrics-2023-06', '_id': 'tVB4dIgBGYsqP9Qh5iCk', 'status': 400, 'error': {'type': 'document_parsing_exception', 'reason': '[1:681] failed to parse: Limit of total fields [1000] has been exceeded while adding new fields [32]',  [...]
```

