### PR TITLE
Allow configuring logging to use local time

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -179,7 +179,7 @@ Logging in Rally is configured in ``~/.rally/logging.json``. For more informatio
 * The Python reference documentation on the `logging configuration schema <https://docs.python.org/3/library/logging.config.html#logging-config-dictschema>`_ explains the file format.
 * The `logging handler documentation <https://docs.python.org/3/library/logging.handlers.html>`_ describes how to customize where log output is written to.
 
-By default, Rally will log all output to ``~/.rally/logs/rally.log``.
+By default, Rally will log all output to ``~/.rally/logs/rally.log``. The default timestamp is UTC, but users can opt for the local time by setting ``"timezone": "localtime"`` in the logging configuration file.
 
 The log file will not be rotated automatically as this is problematic due to Rally's multi-process architecture. Setup an external tool like `logrotate <https://linux.die.net/man/8/logrotate>`_ to achieve that. See the following example as a starting point for your own ``logrotate`` configuration and ensure to replace the path ``/home/user/.rally/logs/rally.log`` with the proper one::
 
@@ -211,6 +211,7 @@ With the following configuration Rally will log all output to standard error::
         "normal": {
           "format": "%(asctime)s,%(msecs)d %(actorAddress)s/PID:%(process)d %(name)s %(levelname)s %(message)s",
           "datefmt": "%Y-%m-%d %H:%M:%S",
+          "timezone": "localtime",
           "()": "esrally.log.configure_utc_formatter"
         }
       },

--- a/esrally/log.py
+++ b/esrally/log.py
@@ -28,11 +28,15 @@ from esrally.utils import io
 # pylint: disable=unused-argument
 def configure_utc_formatter(*args, **kwargs):
     """
-    Logging formatter that renders timestamps in UTC to ensure consistent
-    timestamps across all deployments regardless of machine settings.
+    Logging formatter that renders timestamps UTC, or in the local system time zone when the user requests it.
     """
     formatter = logging.Formatter(fmt=kwargs["format"], datefmt=kwargs["datefmt"])
-    formatter.converter = time.gmtime
+    user_tz = kwargs.get("timezone", None)
+    if user_tz == "localtime":
+        formatter.converter = time.localtime
+    else:
+        formatter.converter = time.gmtime
+
     return formatter
 
 

--- a/tests/log_test.py
+++ b/tests/log_test.py
@@ -18,6 +18,7 @@
 import copy
 import json
 import os
+import time
 from unittest import mock
 from unittest.mock import mock_open, patch
 
@@ -53,3 +54,13 @@ class TestLog:
             log.add_missing_loggers_to_config()
             handle = mock_file()
             handle.write.assert_called_once_with(expected_configuration)
+
+    log_format = "%(asctime)s %(message)s"
+
+    def test_configure_formatter_utc(self):
+        formatter = log.configure_utc_formatter(format=self.log_format, datefmt="%Y-%m-%d %H:%M:%S")
+        assert formatter.converter is time.gmtime
+
+    def test_configure_formatter_localtime(self):
+        formatter = log.configure_utc_formatter(format=self.log_format, datefmt="%Y-%m-%d %H:%M:%S", timezone="localtime")
+        assert formatter.converter is time.localtime


### PR DESCRIPTION
I've thought about https://github.com/elastic/rally/pull/1699 from @vaibhavsolanki1193 quite a lot, and I think I'd rather *not* rename the formatter for now. Having used this pull request while developing Rally, I can confirm the automatic migration works, but it only works forward, not backwards, which makes bisecting Rally more difficult.

As a result, this pull request is #1699 without the formatter rename. The main author is still @vaibhavsolanki1193. If we do want to change the name eventually, those commits in my fork do it:

1. [Prepare migrating more than missing loggers](https://github.com/pquentin/rally/commit/e824cca945d34e23a174e5a3c9bd8566574cb4aa)
2. [Rename esrally.log formatter](https://github.com/pquentin/rally/commit/35181291e8811fb4c025372668859e7a9ed5189e)

Closes #1699 