### PR TITLE
Revert "Upgrade Jinja2 to version 3.1.2"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ dependencies = [
     "jsonschema==3.1.1",
     # License: BSD
     # transitive dependency Markupsafe: BSD
-    "Jinja2==3.1.2",
-    "markupsafe==2.1.2",
+    "Jinja2==2.11.3",
+    "markupsafe==2.0.1",
     # License: MIT
     "thespian==3.10.1",
     # recommended library for thespian to identify actors more easily with `ps`


### PR DESCRIPTION
Reverts elastic/rally#1711. @gbanasiak has noticed a performance regression with this upgrade that we would like to address. It currently affects the tail latencies of [one specific benchmark](https://elasticsearch-benchmarks.elastic.co/#tracks/percolator/nightly/default/90d) and appears to be due to the garbage collector pausing Rally. Since we're still investigating, I don't want to release Rally 2.8.0 with this change.

<img width="992" alt="239218986-17cae921-ca2a-4b7b-b503-71487db7b018" src="https://github.com/elastic/rally/assets/42327/3193205b-bf9f-47c2-b36f-c04873411138">
