### PR TITLE
Support wait_for_completion for force-merge operations

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -664,10 +664,13 @@ class ForceMerge(Runner):
         import elasticsearch
 
         max_num_segments = params.get("max-num-segments")
+        wait_for_completion = params.get("wait-for-completion")
         mode = params.get("mode")
         merge_params = self._default_kw_params(params)
         if max_num_segments:
             merge_params["max_num_segments"] = max_num_segments
+        if isinstance(wait_for_completion, bool):
+            merge_params["wait_for_completion"] = wait_for_completion
         if mode == "polling":
             complete = False
             try:

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -829,6 +829,7 @@ class ForceMergeParamSource(ParamSource):
         self._max_num_segments = params.get("max-num-segments")
         self._poll_period = params.get("poll-period", 10)
         self._mode = params.get("mode", "blocking")
+        self._wait_for_completion = params.get("wait-for-completion")
 
     def params(self):
         parsed_params = {
@@ -836,6 +837,7 @@ class ForceMergeParamSource(ParamSource):
             "max-num-segments": self._max_num_segments,
             "mode": self._mode,
             "poll-period": self._poll_period,
+            "wait-for-completion": self._wait_for_completion,
         }
         parsed_params.update(self._client_params())
         return parsed_params

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1398,6 +1398,76 @@ class TestForceMergeRunner:
         )
         es.indices.forcemerge.assert_awaited_once_with(index="_all", max_num_segments=1, request_timeout=50000)
 
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_force_merge_with_wait_for_completion_false(self, es):
+        es.indices.forcemerge = mock.AsyncMock()
+        force_merge = runner.ForceMerge()
+        await force_merge(es, params={"index": "_all", "max-num-segments": 1, "wait-for-completion": False})
+        es.indices.forcemerge.assert_awaited_once_with(index="_all", max_num_segments=1, wait_for_completion=False)
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_force_merge_with_wait_for_completion_true_with_polling(self, es):
+        es.indices.forcemerge = mock.AsyncMock(side_effect=elasticsearch.ConnectionTimeout(message="connection timeout"))
+        es.tasks.list = mock.AsyncMock(
+            side_effect=[
+                {
+                    "nodes": {
+                        "Ap3OfntPT7qL4CBeKvamxg": {
+                            "name": "instance-0000000001",
+                            "transport_address": "10.46.79.231:19693",
+                            "host": "10.46.79.231",
+                            "ip": "10.46.79.231:19693",
+                            "roles": ["data", "ingest", "master", "remote_cluster_client", "transform"],
+                            "attributes": {
+                                "logical_availability_zone": "zone-1",
+                                "server_name": "instance-0000000001.64cb4c66f4f24d85b41f120ef2df5526",
+                                "availability_zone": "us-east4-a",
+                                "xpack.installed": "true",
+                                "instance_configuration": "gcp.data.highio.1",
+                                "transform.node": "true",
+                                "region": "unknown-region",
+                            },
+                            "tasks": {
+                                "Ap3OfntPT7qL4CBeKvamxg:417009036": {
+                                    "node": "Ap3OfntPT7qL4CBeKvamxg",
+                                    "id": 417009036,
+                                    "type": "transport",
+                                    "action": "indices:admin/forcemerge",
+                                    "start_time_in_millis": 1598018980850,
+                                    "running_time_in_nanos": 3659821411,
+                                    "cancellable": False,
+                                    "headers": {},
+                                }
+                            },
+                        }
+                    }
+                },
+                {
+                    "nodes": {},
+                },
+            ]
+        )
+        force_merge = runner.ForceMerge()
+        await force_merge(
+            es,
+            params={
+                "index": "_all",
+                "max-num-segments": 1,
+                "request-timeout": 50000,
+                "wait-for-completion": True,
+                "mode": "polling",
+                "poll-period": 0,
+            },
+        )
+        es.indices.forcemerge.assert_awaited_once_with(
+            index="_all",
+            max_num_segments=1,
+            request_timeout=50000,
+            wait_for_completion=True,
+        )
+
 
 class TestIndicesStatsRunner:
     @mock.patch("elasticsearch.Elasticsearch")

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2895,6 +2895,7 @@ class TestForceMergeParamSource:
                 "max-num-segments": 1,
                 "polling-period": 20,
                 "mode": "polling",
+                "wait-for-completion": False,
             },
         )
 
@@ -2903,6 +2904,7 @@ class TestForceMergeParamSource:
         assert p["request-timeout"] == 30
         assert p["max-num-segments"] == 1
         assert p["mode"] == "polling"
+        assert p["wait-for-completion"] is False
 
 
 class TestDownsampleParamSource:


### PR DESCRIPTION
Closes https://github.com/elastic/rally/issues/1726.

This PR adds support for the `wait_for_completion` `force-merge` boolean parameter to allow Rally to execute forcemerge asynchronously without relying only on polling mode.

- [x] Add support via `wait-for-completion` operation parameter
- [ ] Add parameter documentation
- [ ] Fix polling mode to correctly timeout after one second
- [ ] https://github.com/elastic/rally/issues/1726