### PR TITLE
Add daily schedule to Buildkite IT pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -28,7 +28,7 @@ spec:
     - resource:rally-releaser-docker-pipeline
 
 
-# Declare Rally's Buildkite pipeline.
+# Declare Rally's Buildkite IT pipeline.
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 ---
 apiVersion: backstage.io/v1alpha1
@@ -49,11 +49,16 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      name: Rally
+      name: Rally - IT
       description:  Macrobenchmarking framework for Elasticsearch
     spec:
       pipeline_file: .buildkite/it/pipeline.yml
       repository: elastic/rally
+      schedules:
+        Daily:
+          branch: master
+          cronline: "0 14 * * *"
+          message: periodic it
       teams:
         es-perf: {}
         everyone:


### PR DESCRIPTION
This PR adds daily IT (integration tests) builds at 14:00 UTC to Buildkite.
The new `catalog-info.yml` file content was validated with Backstage validator.
