### PR TITLE
Add daily schedule to GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 14 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
The PR adds daily run of GitHub Actions CI workflow at 14:00 UTC.
Related: https://github.com/elastic/rally/pull/1734
