### PR TITLE
Refactor version number checks

### DIFF
--- a/esrally/client/__init__.py
+++ b/esrally/client/__init__.py
@@ -18,6 +18,7 @@
 from .context import RequestContextHolder, RequestContextManager
 from .factory import (
     EsClientFactory,
+    cluster_distribution_version,
     create_api_key,
     delete_api_keys,
     wait_for_rest_layer,

--- a/esrally/client/asynchronous.py
+++ b/esrally/client/asynchronous.py
@@ -339,7 +339,7 @@ class RallyAsyncElasticsearch(AsyncElasticsearch, RequestContextHolder):
         # see https://github.com/elastic/elasticsearch/issues/51816
         # Not applicable to serverless
         if not self.is_serverless:
-            if self.distribution_version is not None and (
+            if versions.is_version_identifier(self.distribution_version) and (
                 versions.Version.from_string(self.distribution_version) >= versions.Version.from_string("8.0.0")
             ):
                 _mimetype_header_to_compat("Accept", request_headers)

--- a/esrally/client/factory.py
+++ b/esrally/client/factory.py
@@ -412,7 +412,8 @@ def delete_api_keys(es, ids, max_attempts=5):
 
     # Before ES 7.10, deleting API keys by ID had to be done individually.
     # After ES 7.10, a list of API key IDs can be deleted in one request.
-    current_version = versions.Version.from_string(es.info()["version"]["number"])
+    version = es.info()["version"]
+    current_version = versions.Version.from_string(version.get("number", "7.10.0"))
     minimum_version = versions.Version.from_string("7.10.0")
 
     deleted = []
@@ -423,7 +424,7 @@ def delete_api_keys(es, ids, max_attempts=5):
         import elasticsearch
 
         try:
-            if current_version >= minimum_version:
+            if current_version >= minimum_version or es.is_serverless:
                 resp = es.security.invalidate_api_key(ids=remaining)
                 deleted += resp["invalidated_api_keys"]
                 remaining = [i for i in ids if i not in deleted]

--- a/esrally/client/synchronous.py
+++ b/esrally/client/synchronous.py
@@ -181,7 +181,7 @@ class RallySyncElasticsearch(Elasticsearch):
         # from application/X -> application/vnd.elasticsearch+X
         # see https://github.com/elastic/elasticsearch/issues/51816
         if not self.is_serverless:
-            if self.distribution_version is not None and (
+            if versions.is_version_identifier(self.distribution_version) and (
                 versions.Version.from_string(self.distribution_version) >= versions.Version.from_string("8.0.0")
             ):
                 _mimetype_header_to_compat("Accept", headers)

--- a/esrally/client/synchronous.py
+++ b/esrally/client/synchronous.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import re
 import warnings
 from typing import Any, Iterable, Mapping, Optional
 
@@ -76,24 +75,25 @@ class _ProductChecker:
     @classmethod
     def check_product(cls, headers, response):
         # type: (dict[str, str], dict[str, str]) -> int
-        """Verifies that the server we're talking to is Elasticsearch.
+        """
+        Verifies that the server we're talking to is Elasticsearch.
         Does this by checking HTTP headers and the deserialized
         response to the 'info' API. Returns one of the states above.
         """
+
+        version = response.get("version", {})
         try:
-            version = response.get("version", {})
-            version_number = tuple(
-                int(x) if x is not None else 999 for x in re.search(r"^([0-9]+)\.([0-9]+)(?:\.([0-9]+))?", version["number"]).groups()
-            )
-        except (KeyError, TypeError, ValueError, AttributeError):
-            # No valid 'version.number' field, effectively 0.0.0
-            version = {}
-            version_number = (0, 0, 0)
+            version_number = versions.Version.from_string(version.get("number", None))
+        except TypeError:
+            # No valid 'version.number' field, either Serverless Elasticsearch, or not Elasticsearch at all
+            version_number = versions.Version.from_string("0.0.0")
+
+        build_flavor = version.get("build_flavor", None)
 
         # Check all of the fields and headers for missing/valid values.
         try:
             bad_tagline = response.get("tagline", None) != "You Know, for Search"
-            bad_build_flavor = version.get("build_flavor", None) != "default"
+            bad_build_flavor = build_flavor not in ("default", "serverless")
             bad_product_header = headers.get("x-elastic-product", None) != "Elasticsearch"
         except (AttributeError, TypeError):
             bad_tagline = True
@@ -101,19 +101,19 @@ class _ProductChecker:
             bad_product_header = True
 
         # 7.0-7.13 and there's a bad 'tagline' or unsupported 'build_flavor'
-        if (7, 0, 0) <= version_number < (7, 14, 0):
+        if versions.Version.from_string("7.0.0") <= version_number < versions.Version.from_string("7.14.0"):
             if bad_tagline:
                 return cls.UNSUPPORTED_PRODUCT
             elif bad_build_flavor:
                 return cls.UNSUPPORTED_DISTRIBUTION
 
         elif (
-            # No version or version less than 6.x
-            version_number < (6, 0, 0)
-            # 6.x and there's a bad 'tagline'
-            or ((6, 0, 0) <= version_number < (7, 0, 0) and bad_tagline)
+            # No version or version less than 6.8.0, and we're not talking to a serverless elasticsearch
+            (version_number < versions.Version.from_string("6.8.0") and not versions.is_serverless(build_flavor))
+            # 6.8.0 and there's a bad 'tagline'
+            or (versions.Version.from_string("6.8.0") <= version_number < versions.Version.from_string("7.0.0") and bad_tagline)
             # 7.14+ and there's a bad 'X-Elastic-Product' HTTP header
-            or ((7, 14, 0) <= version_number and bad_product_header)
+            or (versions.Version.from_string("7.14.0") <= version_number and bad_product_header)
         ):
             return cls.UNSUPPORTED_PRODUCT
 
@@ -125,11 +125,19 @@ class RallySyncElasticsearch(Elasticsearch):
         distribution_version = kwargs.pop("distribution_version", None)
         super().__init__(*args, **kwargs)
         self._verified_elasticsearch = None
+        self._serverless = False
 
+        # this isn't always available because any call to self.options() doesn't pass any custom args
+        # to the constructor
+        # https://github.com/elastic/rally/issues/1673
         if distribution_version:
-            self.distribution_version = versions.Version.from_string(distribution_version)
+            self.distribution_version = distribution_version
         else:
             self.distribution_version = None
+
+    @property
+    def is_serverless(self):
+        return self._serverless
 
     def perform_request(
         self,
@@ -172,9 +180,12 @@ class RallySyncElasticsearch(Elasticsearch):
         # Converts all parts of a Accept/Content-Type headers
         # from application/X -> application/vnd.elasticsearch+X
         # see https://github.com/elastic/elasticsearch/issues/51816
-        if self.distribution_version is not None and self.distribution_version >= versions.Version.from_string("8.0.0"):
-            _mimetype_header_to_compat("Accept", request_headers)
-            _mimetype_header_to_compat("Content-Type", request_headers)
+        if not self.is_serverless:
+            if self.distribution_version is not None and (
+                versions.Version.from_string(self.distribution_version) >= versions.Version.from_string("8.0.0")
+            ):
+                _mimetype_header_to_compat("Accept", headers)
+                _mimetype_header_to_compat("Content-Type", headers)
 
         if params:
             target = f"{path}?{_quote_query(params)}"
@@ -243,3 +254,17 @@ class RallySyncElasticsearch(Elasticsearch):
             response = ApiResponse(body=resp_body, meta=meta)  # type: ignore[assignment]
 
         return response
+
+
+class RallySyncElasticsearchServerless(RallySyncElasticsearch):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # we set this as an instance attribute because we can't afford to make any calls to external APIs to verify
+        # whether we're talking to a serverless cluster or not once we're executing the benchmark.
+        #
+        # the reason for this is because the client can reinstantiate itself (e.g. with a call to .options()) during
+        # the execution of the benchmark, which means external API calls add unnecessary latency, and it reinstantiates
+        # itself without the ability to pass any custom arguments (i.e. distribution_version) to the constructor
+        #
+        # see https://github.com/elastic/rally/issues/1673
+        self._serverless = True

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2094,12 +2094,13 @@ class WaitForCurrentSnapshotsCreate(Runner):
         repository = mandatory(params, "repository", repr(self))
         wait_period = params.get("completion-recheck-wait-period", 1)
         es_info = await es.info()
-        es_version = Version.from_string(es_info["version"]["number"])
+        es_version = es_info["version"].get("number", "8.3.0")
+
         request_args = {"repository": repository, "snapshot": "_current", "verbose": False}
 
         # significantly reduce response size when lots of snapshots have been taken
         # only available since ES 8.3.0 (https://github.com/elastic/elasticsearch/pull/86269)
-        if (es_version.major, es_version.minor) >= (8, 3):
+        if (Version.from_string(es_version) >= Version.from_string("8.3.0")) or es.is_serverless:
             request_args["index_names"] = False
 
         while True:

--- a/esrally/mechanic/__init__.py
+++ b/esrally/mechanic/__init__.py
@@ -24,7 +24,6 @@ from .mechanic import (
     StartEngine,
     StopEngine,
     build,
-    cluster_distribution_version,
     download,
     install,
     start,

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 
 import thespian.actors
 
-from esrally import PROGRAM_NAME, actor, client, config, exceptions, metrics, paths
+from esrally import PROGRAM_NAME, actor, config, exceptions, metrics, paths
 from esrally.mechanic import launcher, provisioner, supplier, team
 from esrally.utils import console, net
 
@@ -269,23 +269,6 @@ class StopNodes:
 
 class NodesStopped:
     pass
-
-
-def cluster_distribution_version(cfg, client_factory=client.EsClientFactory):
-    """
-    Attempt to get the cluster's distribution version even before it is actually started (which makes only sense for externally
-    provisioned clusters).
-
-    :param cfg: The current config object.
-    :param client_factory: Factory class that creates the Elasticsearch client.
-    :return: The distribution version.
-    """
-    hosts = cfg.opts("client", "hosts").default
-    client_options = cfg.opts("client", "options").default
-    es = client_factory(hosts, client_options).create()
-    # unconditionally wait for the REST layer - if it's not up by then, we'll intentionally raise the original error
-    client.wait_for_rest_layer(es)
-    return es.info()["version"]["number"]
 
 
 def to_ip_port(hosts):

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1772,9 +1772,11 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
         except BaseException:
             self.logger.exception("Could not retrieve cluster version info")
             return
-        revision = client_info["version"]["build_hash"]
-        distribution_version = client_info["version"]["number"]
         distribution_flavor = client_info["version"].get("build_flavor", "oss")
+        # build hash will only be available on serverless if the client has operator privs
+        revision = client_info["version"].get("build_hash", distribution_flavor)
+        # build version does not exist for serverless
+        distribution_version = client_info["version"].get("number", distribution_flavor)
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "source_revision", revision)
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "distribution_version", distribution_version)
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "distribution_flavor", distribution_flavor)

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -757,8 +757,9 @@ class NodeStats(TelemetryDevice):
 
     def on_benchmark_start(self):
         default_client = self.clients["default"]
-        distribution_version = default_client.info()["version"]["number"]
-        if Version.from_string(distribution_version) < Version(major=7, minor=2, patch=0):
+        es_info = default_client.info()
+        es_version = es_info["version"].get("number", "7.2.0")
+        if Version.from_string(es_version) < Version(major=7, minor=2, patch=0):
             console.warn(NodeStats.warning, logger=self.logger)
 
         for cluster_name in self.specified_cluster_names:

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1351,9 +1351,9 @@ class DataStreamStats(TelemetryDevice):
     def on_benchmark_start(self):
         for cluster_name in self.specified_cluster_names:
             recorder = DataStreamStatsRecorder(cluster_name, self.clients[cluster_name], self.metrics_store, self.sample_interval)
-            client_info = self.clients[cluster_name].info()
-            distribution_version = client_info["version"]["number"]
-            distribution_flavor = client_info["version"].get("build_flavor", "oss")
+            es_info = self.clients[cluster_name].info()
+            distribution_version = es_info["version"].get("number", "7.9.0")
+            distribution_flavor = es_info["version"].get("build_flavor", "oss")
             if Version.from_string(distribution_version) < Version(major=7, minor=9, patch=0):
                 raise exceptions.SystemSetupError(
                     "The data-stream-stats telemetry device can only be used with clusters from version 7.9 onwards"

--- a/esrally/tracker/tracker.py
+++ b/esrally/tracker/tracker.py
@@ -22,9 +22,9 @@ from elastic_transport import ApiError, TransportError
 from jinja2 import Environment, FileSystemLoader
 
 from esrally import PROGRAM_NAME
-from esrally.client import EsClientFactory
+from esrally.client import factory
 from esrally.tracker import corpus, index
-from esrally.utils import console, io, opts
+from esrally.utils import console, io
 
 
 def process_template(templates_path, template_filename, template_vars, output_path):
@@ -74,16 +74,19 @@ def create_track(cfg):
     track_name = cfg.opts("track", "track.name")
     indices = cfg.opts("generator", "indices")
     root_path = cfg.opts("generator", "output.path")
-    target_hosts = cfg.opts("client", "hosts")
-    client_options = cfg.opts("client", "options")
+    target_hosts = cfg.opts("client", "hosts").default
+    client_options = cfg.opts("client", "options").default
     data_streams = cfg.opts("generator", "data_streams")
 
-    client = EsClientFactory(
-        hosts=target_hosts.all_hosts[opts.TargetHosts.DEFAULT], client_options=client_options.all_client_options[opts.TargetHosts.DEFAULT]
+    distribution_flavor, distribution_version, _ = factory.cluster_distribution_version(target_hosts, client_options)
+    client = factory.EsClientFactory(
+        hosts=target_hosts,
+        client_options=client_options,
+        distribution_version=distribution_version,
+        distribution_flavor=distribution_flavor,
     ).create()
 
-    info = client.info()
-    console.info(f"Connected to Elasticsearch cluster [{info['name']}] version [{info['version']['number']}].\n", logger=logger)
+    console.info(f"Connected to Elasticsearch cluster version [{distribution_version}]\n", logger=logger)
 
     output_path = os.path.abspath(os.path.join(io.normalize_path(root_path), track_name))
     io.ensure_dir(output_path)

--- a/esrally/tracker/tracker.py
+++ b/esrally/tracker/tracker.py
@@ -86,7 +86,7 @@ def create_track(cfg):
         distribution_flavor=distribution_flavor,
     ).create()
 
-    console.info(f"Connected to Elasticsearch cluster version [{distribution_version}]\n", logger=logger)
+    console.info(f"Connected to Elasticsearch cluster version [{distribution_version}] flavor [{distribution_flavor}] \n", logger=logger)
 
     output_path = os.path.abspath(os.path.join(io.normalize_path(root_path), track_name))
     io.ensure_dir(output_path)

--- a/esrally/utils/versions.py
+++ b/esrally/utils/versions.py
@@ -33,6 +33,10 @@ def is_version_identifier(text, strict=True):
     return text is not None and _versions_pattern(strict).match(text) is not None
 
 
+def is_serverless(text):
+    return text == "serverless"
+
+
 def major_version(version):
     """
     Determines the major version of a given version string.
@@ -180,6 +184,8 @@ def best_match(available_alternatives, distribution_version):
         major, _, _, _ = components(distribution_version)
         if major > _latest_major(available_alternatives):
             return "master"
+    elif is_serverless(distribution_version):
+        return "master"
     elif not distribution_version:
         return "master"
     return None

--- a/tests/client/factory_test.py
+++ b/tests/client/factory_test.py
@@ -342,6 +342,7 @@ class TestEsClientFactory:
 
         es.assert_called_once_with(
             distribution_version=None,
+            distribution_flavor=None,
             hosts=["https://localhost:9200"],
             transport_class=RallyAsyncTransport,
             ssl_context=f.ssl_context,

--- a/tests/client/factory_test.py
+++ b/tests/client/factory_test.py
@@ -566,6 +566,7 @@ class TestApiKeys:
     @mock.patch("elasticsearch.Elasticsearch")
     def test_successfully_deletes_api_keys(self, es, version):
         ids = ["foo", "bar", "baz"]
+        es.is_serverless = False
         es.info.return_value = {"version": {"number": version}}
         if version == "7.9.0":
             es.security.invalidate_api_key.return_value = [
@@ -590,6 +591,7 @@ class TestApiKeys:
     @mock.patch("elasticsearch.Elasticsearch")
     def test_retries_api_keys_deletion_on_transport_errors(self, es, sleep, version):
         max_attempts = 5
+        es.is_serverless = False
         es.info.return_value = {"version": {"number": version}}
         ids = ["foo", "bar", "baz"]
         if version == "7.9.0":
@@ -625,6 +627,7 @@ class TestApiKeys:
     @pytest.mark.parametrize("version", ["7.9.0", "7.10.0"])
     @mock.patch("elasticsearch.Elasticsearch")
     def test_raises_exception_when_api_key_deletion_fails(self, es, version):
+        es.is_serverless = False
         es.info.return_value = {"version": {"number": version}}
         ids = ["foo", "bar", "baz", "qux"]
         failed_to_delete = ["baz", "qux"]

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -4107,6 +4107,7 @@ class TestWaitForCurrentSnapshotsCreate:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_wait_for_current_snapshots_create_before_8_3_0(self, es):
+        es.is_serverless = False
         es.info = mock.AsyncMock(
             return_value={
                 "name": "es01",

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -123,11 +123,13 @@ class TestEsClient:
         _datastore_user = "".join([random.choice(string.ascii_letters) for _ in range(8)])
         _datastore_password = "".join([random.choice(string.ascii_letters + string.digits + "_-@#$/") for _ in range(12)])
         _datastore_verify_certs = random.choice([True, False])
+        _datastore_probe_version = False
 
         cfg.add(config.Scope.applicationOverride, "reporting", "datastore.host", _datastore_host)
         cfg.add(config.Scope.applicationOverride, "reporting", "datastore.port", _datastore_port)
         cfg.add(config.Scope.applicationOverride, "reporting", "datastore.secure", _datastore_secure)
         cfg.add(config.Scope.applicationOverride, "reporting", "datastore.user", _datastore_user)
+        cfg.add(config.Scope.applicationOverride, "reporting", "datastore.probe.cluster_version", _datastore_probe_version)
 
         if password_configuration == "config":
             cfg.add(config.Scope.applicationOverride, "reporting", "datastore.password", _datastore_password)
@@ -158,7 +160,10 @@ class TestEsClient:
         }
 
         client_esclientfactory.assert_called_with(
-            hosts=[{"host": _datastore_host, "port": _datastore_port}], client_options=expected_client_options
+            hosts=[{"host": _datastore_host, "port": _datastore_port}],
+            client_options=expected_client_options,
+            distribution_version=None,
+            distribution_flavor=None,
         )
 
     @mock.patch("random.random")

--- a/tests/utils/versions_test.py
+++ b/tests/utils/versions_test.py
@@ -26,6 +26,7 @@ from esrally.utils import versions
 
 class TestsVersions:
     def test_is_version_identifier(self):
+        assert versions.is_version_identifier("serverless") is False
         assert versions.is_version_identifier(None) is False
         assert versions.is_version_identifier("") is False
         assert versions.is_version_identifier("     \t ") is False
@@ -43,6 +44,18 @@ class TestsVersions:
         assert versions.is_version_identifier("5", strict=False)
         assert versions.is_version_identifier("23", strict=False)
         assert versions.is_version_identifier("20.3.7-SNAPSHOT", strict=False)
+
+    def test_is_serverless(self):
+        assert versions.is_serverless("serverless")
+        assert versions.is_serverless("default") is False
+        assert versions.is_serverless(None) is False
+        assert versions.is_serverless("") is False
+        assert versions.is_serverless("     \t ") is False
+        assert versions.is_serverless("8-ab-c") is False
+        assert versions.is_serverless("8.9.0") is False
+        assert versions.is_serverless("8.1") is False
+        assert versions.is_serverless("8") is False
+        assert versions.is_serverless("20.3.7-SNAPSHOT") is False
 
     def test_finds_components_for_valid_version(self):
         assert versions.components("5.0.3") == (5, 0, 3, None)


### PR DESCRIPTION
Serverless Elasticsearch doesn't return a `version.number` field from the [Info API](https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html) (`/`) , which is actually something we rely on somewhat commonly throughout the codebase.

To fix this, we need a clearly defined way of determining whether or not Rally is talking to a Serverless Elasticsearch, this applies for both clients used to target the system under test, as well as any ancillary clients like those used by a remote metrics store.

In order to do so, we'll take two approaches:
- Create a `is_serverless | bool` property on both existing and new 'serverless' specific clients
- Refactor all version checks to default to selecting the 'minimum' version required for a specific conditional, and only use the `is_serverless` property if we need to do something specific for serverless


I think this is a balanced approach, given that serverless has no concept of 'versioning'.

Note:

~~The underlying client's [use of `.options()` complicates things](https://github.com/elastic/rally/issues/1673), because every call reinstantiates a new copy of itself, but without the ability for us to pass in any custom arguments (e.g. `distribution_version`). To work around this we must work out upfront whether or not we'd like the factory to create a serverless or non-serverless client, each of which have a static `is_serverless` attribute.~~ Fixed in https://github.com/elastic/rally/pull/1738/commits/abf43207e1ebde6899876dcc3ebadf5998e7eab1


<details>

<summary> Example tests </summary>

```
# http_logs with node-stats and data-stream-stats telemetry devices
esrally race --track http_logs --pipeline=benchmark-only --target-hosts https://serverless-es --client-options='{ "default": {"headers": {"X-Found-Cluster": "09895e10-efb8-42da-be30-888eb623d6cf.es"}, "basic_auth_user":"esbench", "basic_auth_password":"changeme", "verify_certs": false}}' --kill-running-processes --test-mode --track-params 'number_of_replicas: 1' --telemetry "node-stats, data-stream-stats"

# create-track
esrally create-track --track test --indices logs-221998 --target-hosts https://serverless-es --client-options '{ "default": {"headers": {"X-Found-Cluster": "09895e10-efb8-42da-be30-888eb623d6cf.es"}, "basic_auth_user":"elastic", "basic_auth_password":"changeme", "verify_certs": false}}'
```

</summary>