### PR TITLE
Fix Buildkite URL

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -38,7 +38,7 @@ metadata:
   description: Run Rally integration tests
   links:
     - title: Pipeline
-      url: https://buildkite.com/elastic/rally
+      url: https://buildkite.com/elastic/rally-it
 
 spec:
   type: buildkite-pipeline


### PR DESCRIPTION
Follow-up to https://github.com/elastic/rally/pull/1734.
Aligning URL with the pipeline name change.
