### PR TITLE
Bulk action refresh param

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -501,6 +501,8 @@ class BulkIndex(Runner):
             bulk_params["timeout"] = params["timeout"]
         if "pipeline" in params:
             bulk_params["pipeline"] = params["pipeline"]
+        if "refresh" in params:
+            bulk_params["refresh"] = params["refresh"]
 
         with_action_metadata = mandatory(params, "action-metadata-present", self)
         bulk_size = mandatory(params, "bulk-size", self)

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -634,6 +634,7 @@ class BulkIndexParamSource(ParamSource):
             raise exceptions.InvalidSyntax("'batch-size' must be numeric")
 
         self.ingest_percentage = self.float_param(params, name="ingest-percentage", default_value=100, min_value=0, max_value=100)
+        self.refresh = params.get("refresh")
         self.param_source = PartitionBulkIndexParamSource(
             self.corpora,
             self.batch_size,
@@ -644,6 +645,7 @@ class BulkIndexParamSource(ParamSource):
             self.on_conflict,
             self.recency,
             self.pipeline,
+            self.refresh,
             self._params,
         )
 
@@ -705,6 +707,7 @@ class PartitionBulkIndexParamSource:
         on_conflict,
         recency,
         pipeline=None,
+        refresh=None,
         original_params=None,
     ):
         """
@@ -732,6 +735,7 @@ class PartitionBulkIndexParamSource:
         self.on_conflict = on_conflict
         self.recency = recency
         self.pipeline = pipeline
+        self.refresh = refresh
         self.original_params = original_params
         # this is only intended for unit-testing
         self.create_reader = original_params.pop("__create_reader", create_default_reader)

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -1243,6 +1243,82 @@ class TestBulkIndexRunner:
 
         es.bulk.assert_awaited_with(body=bulk_params["body"], params={})
 
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_bulk_index_success_with_refresh_true(self, es):
+        bulk_response = {
+            "errors": False,
+            "took": 8,
+            "items": [{"create": {"_index": "test", "result": "created", "status": 201, "forced_refresh": True}}],
+        }
+        es.bulk = mock.AsyncMock(return_value=bulk_response)
+
+        bulk = runner.BulkIndex()
+
+        bulk_params = {
+            "body": _build_bulk_body("index_line"),
+            "index": "test",
+            "action-metadata-present": False,
+            "type": "_doc",
+            "bulk-size": 1,
+            "unit": "docs",
+            "detailed-results": True,
+            "refresh": "true",
+        }
+
+        result = await bulk(es, dict(bulk_params))
+
+        assert result == {
+            "took": 8,
+            "index": "test",
+            "weight": 1,
+            "unit": "docs",
+            "success": True,
+            "success-count": 1,
+            "error-count": 0,
+            "bulk-request-size-bytes": 10,
+            "ops": {"create": collections.Counter({"item-count": 1, "created": 1})},
+            "shards_histogram": [],
+            "total-document-size-bytes": 10,
+        }
+
+        es.bulk.assert_awaited_with(doc_type="_doc", index="test", body=bulk_params["body"], params={"refresh": "true"})
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_bulk_index_success_with_refresh_wait_for(self, es):
+        bulk_response = {
+            "errors": False,
+            "took": 8,
+        }
+        es.bulk = mock.AsyncMock(return_value=io.BytesIO(json.dumps(bulk_response).encode()))
+
+        bulk = runner.BulkIndex()
+
+        bulk_params = {
+            "body": _build_bulk_body("index_line"),
+            "index": "test",
+            "action-metadata-present": False,
+            "type": "_doc",
+            "bulk-size": 1,
+            "unit": "docs",
+            "refresh": "wait_for",
+        }
+
+        result = await bulk(es, bulk_params)
+
+        assert result == {
+            "took": 8,
+            "index": "test",
+            "weight": 1,
+            "unit": "docs",
+            "success": True,
+            "success-count": 1,
+            "error-count": 0,
+        }
+
+        es.bulk.assert_awaited_with(doc_type="_doc", index="test", body=bulk_params["body"], params={"refresh": "wait_for"})
+
 
 class TestForceMergeRunner:
     @mock.patch("elasticsearch.Elasticsearch")


### PR DESCRIPTION
This commit adds support for the bulk `?refresh` query parameter to address [feedback](https://github.com/elastic/rally-tracks/pull/425#issuecomment-1612358005) for a new workload for serverless. Possible values for `refresh` are `"true"`, `"false"`, and `"wait_for"`, consistent with https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-refresh.

@pquentin @b-deam you have been tagged as reviewers. If you are fine with the approach, then I will add docs and take this PR out of draft form.