### PR TITLE
Inject build_flavor in track templates

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -18,7 +18,6 @@ Extensions
 Rally also provides a few extensions to Jinja2:
 
 * ``now``: a global variable that represents the current date and time when the template is evaluated by Rally.
-* ``build_flavor``: a global variable that holds build flavor reported by Elasticsearch cluster targetted by Rally.
 * ``days_ago()``: a `filter <http://jinja.pocoo.org/docs/dev/templates/#filters>`_ that you can use for date calculations.
 
 You can find an example in the ``http_logs`` track::
@@ -87,6 +86,8 @@ Assuming we pass ``--track-params="es_snapshot_restore_recovery_max_bytes_per_se
 
 
 The parameter ``default_value`` controls the value to use for the setting if it is undefined. If the setting is undefined and there is no default value, nothing will be added.
+
+* ``build_flavor``: a global variable that holds build flavor reported by Elasticsearch cluster targetted by Rally.
 
 .. _adding_tracks_custom_param_sources:
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -10,12 +10,15 @@ Rally uses `Jinja2 <http://jinja.pocoo.org/docs/dev/>`_ as a template language s
 
 Elasticsearch utilizes Mustache formatting in a few places, notably in `search templates <https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-template.html>`_ and `Watcher templates <https://www.elastic.co/guide/en/elasticsearch/reference/7.4/actions-email.html>`_. If you are using Mustache in your Rally tracks you must `escape them properly <https://jinja.palletsprojects.com/en/2.10.x/templates/#escaping>`_. See :ref:`put_pipeline` for an example.
 
+.. _advanced_extensions:
+
 Extensions
 """"""""""
 
 Rally also provides a few extensions to Jinja2:
 
 * ``now``: a global variable that represents the current date and time when the template is evaluated by Rally.
+* ``build_flavor``: a global variable that holds build flavor reported by Elasticsearch cluster targetted by Rally.
 * ``days_ago()``: a `filter <http://jinja.pocoo.org/docs/dev/templates/#filters>`_ that you can use for date calculations.
 
 You can find an example in the ``http_logs`` track::

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -10,6 +10,10 @@ Migrating to Rally 2.9.0
 Rally now treats ``build_flavor`` as a :ref:`global variable<advanced_extensions>` in Jinja2 templates. The value of the variable depends on the build flavor reported by Elasticsearch cluster targetted by Rally.
 The ``build_flavor`` becomes a reserved name so user-supplied track parameters must be named differently. Rename your track parameters before upgrade if needed.
 
+Example error when running with ``--track-params="build_flavor:test"``::
+
+  Some of your track parameter(s) "build_flavor" are defined by Rally and cannot be modified.
+
 Migrating to Rally 2.7.1
 ------------------------
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,11 +1,21 @@
 Migration Guide
 ===============
 
+Migrating to Rally 2.9.0
+------------------------
+
+``build_flavor`` becomes a global variable in track templates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Rally now treats ``build_flavor`` as a :ref:`global variable<advanced_extensions>` in Jinja2 templates. The value of the variable depends on the build flavor reported by Elasticsearch cluster targetted by Rally.
+The ``build_flavor`` becomes a reserved name so user-supplied track parameters must be named differently. Rename your track parameters before upgrade if needed.
+
 Migrating to Rally 2.7.1
 ------------------------
 
 Elasticsearch client logs are now captured by the `elastic_transport <https://github.com/elastic/elastic-transport-python/>`_ logger
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Rally migrated to the 8.x version of the ``elasticsearch-py`` library which uses a new logger named ``elastic_transport``. Rally will automatically configure this logger to only emit logs of level ``WARNING`` and above, even if a past Rally version configured logging using the ``~./rally/logging.json`` file without that logger.
 
 Snapshot repository plugins are no longer built from source

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1087,9 +1087,8 @@ class TrackFileReader:
 
         internal_user_defined_track_params = self.complete_track_params.internal_user_defined_track_params()
         if len(internal_user_defined_track_params) > 0:
-            err_msg = "Some of your track parameter(s) {} are defined by Rally and cannot be modified.\n".format(
-                ",".join(opts.double_quoted_list_of(sorted(internal_user_defined_track_params)))
-            )
+            params_list = ",".join(opts.double_quoted_list_of(sorted(internal_user_defined_track_params)))
+            err_msg = f"Some of your track parameter(s) {params_list} are defined by Rally and cannot be modified.\n"
 
             self.logger.critical(err_msg)
             # also dump the message on the console


### PR DESCRIPTION
Here's an attempt at injecting `build_flavor` in track templates. It is part of Rally modifications for serverless.

The idea is to handle `build_flavor` as Jinja2 _internal variable_, similarly to `now` ([doc](https://esrally.readthedocs.io/en/stable/advanced.html#extensions)).

Internal variables take precedence over user-supplied parameters and are excluded from a list of parameters exposed by a track (see [here](https://github.com/elastic/rally/blob/7d913f7c9e4ec6bc039fee22ee1b91a662fbcd75/esrally/track/loader.py#L794-L806)). As a result, today if a user provides `now` parameter via `--track-params` it is not recognised as a valid parameter even if it is present in a track definition. I found [current error](https://github.com/elastic/rally/blob/7d913f7c9e4ec6bc039fee22ee1b91a662fbcd75/esrally/track/loader.py#L1079-L1100) slightly misleading so this PR adds a dedicated error message when user-provided parameter collides with any of the variables defined internally.

Internal variables are not used today when rendering index settings, index templates, component templates and composable templates. This PR changes that adding `build_flavor` internal variable alone to these as well. That's necessary to support scenarios such as https://github.com/elastic/rally-tracks/pull/406 where `build_flavor` could be used in component template definition.

With this approach `build_flavor` _cannot_ be determined within custom runner or custom parameter source Python code. Their interface simply does not expose the necessary data structures. To workaround this we would need to inject `build_flavor` as an extra operation parameter which I did not find compelling. I don't think it's a blocker because `build_flavor`-driven customisation can still be achieved at the track definition level.

The `build_flavor` value is taken from Elasticsearch REST API call in an early stage of benchmark preparation flow, i.e. `setup()` in `BenchmarkCoordinator` (see https://github.com/elastic/rally/pull/1748 diagram) and saved to configuration [here](https://github.com/elastic/rally/blob/7d913f7c9e4ec6bc039fee22ee1b91a662fbcd75/esrally/racecontrol.py#L182). This call does not happen in case of source builds. If configuration entry is missing, `default` value of `build_flavor` is assumed.

This is a breaking change because `build_flavor` becomes reserved, so the plan is to ~~release `2.8.1` and~~ bump up version to `2.9.0` before merging it.