### PR TITLE
Bump up version to 2.9.0

### DIFF
--- a/esrally/_version.py
+++ b/esrally/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.8.1.dev0"
+__version__ = "2.9.0.dev0"


### PR DESCRIPTION
I'm bumping up version to `2.9.0` to signal our intention of releasing https://github.com/elastic/rally/pull/1750 in a minor release, instead of a patch release.
