### PR TITLE
Upgraded Elasticsearch python client version to 8.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     #   urllib3: MIT
     #   aiohttp: Apache 2.0
 
-    "elasticsearch[async]==8.6.1",
+    "elasticsearch[async]==8.9.0",
     "elastic-transport==8.4.0",
     "urllib3==1.26.9",
     "docker==6.0.0",


### PR DESCRIPTION
This change is required to incorporate an API change in the 8.9 version of the elasticsearch python client, which is needed for a new rally track I am creating