### PR TITLE
Add blob-store-stats telemetry device and tests

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -328,3 +328,69 @@ It also works with ``esrally compare``::
 .. note::
 
     This telemetry device has no runtime overhead. It does all of it's work after the race is complete.
+
+blob-store-stats
+----------------
+
+The blob-store-stats telemetry device regularly calls the blob store stats API and records one metrics document for cluster level stats (``_all``), and one metrics document per node.
+
+Supported telemetry parameters:
+
+* ``blob-store-stats-sample-interval`` (default 1): A positive number greater than zero denoting the sampling interval in seconds.
+
+Example of recorded documents given two nodes in the target cluster::
+
+
+    {
+      "name": "blob-store-stats",
+      "node": "_all",
+      "meta": {
+        "cluster": "es",
+        "_nodes": {
+          "total": 2,
+          "successful": 2,
+          "failed": 0
+        }
+      },
+      "ListObjects": 30,
+      "PutMultipartObject": 0,
+      "PutObject": 0,
+      "GetObject": 2334
+    },
+    {
+      "name": "blob-store-stats",
+      "node": "OkuSgfZWSq2fprKXD6CNOw",
+      "meta": {
+        "cluster": "es",
+        "_nodes": {
+          "total": 2,
+          "successful": 2,
+          "failed": 0
+        }
+      },
+      "ListObjects": 30,
+      "PutMultipartObject": 0,
+      "PutObject": 0,
+      "GetObject": 1167
+    },
+    {
+      "name": "blob-store-stats",
+      "node": "ufg1tLOiTIiHkmgGiztW9Q",
+      "meta": {
+        "cluster": "es",
+        "_nodes": {
+          "total": 2,
+          "successful": 2,
+          "failed": 0
+        },
+        "ListObjects": 0,
+        "PutMultipartObject": 0,
+        "PutObject": 0,
+        "GetObject": 1167
+      }
+    }
+
+
+.. note::
+
+    This telemetry device is only applicable to `Stateless Elasticsearch <https://www.elastic.co/blog/stateless-your-new-state-of-find-with-elasticsearch>`_ and requires elevated privleges only available to Elastic developers.

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -640,6 +640,7 @@ class Driver:
                 telemetry.DataStreamStats(telemetry_params, es, self.metrics_store),
                 telemetry.IngestPipelineStats(es, self.metrics_store),
                 telemetry.DiskUsageStats(telemetry_params, es_default, self.metrics_store, index_names, data_stream_names),
+                telemetry.BlobStoreStats(telemetry_params, es, self.metrics_store),
             ]
         else:
             devices = []

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -2386,7 +2386,7 @@ class BlobStoreStats(TelemetryDevice):
         self.sample_interval = telemetry_params.get("blob-store-stats-sample-interval", 1)
         if self.sample_interval <= 0:
             raise exceptions.SystemSetupError(
-                f"The telemetry parameter 'blob-store-stats-sample-interval' must be greater than zero " f"but was {self.sample_interval}."
+                f"The telemetry parameter 'blob-store-stats-sample-interval' must be greater than zero but was {self.sample_interval}."
             )
         self.specified_cluster_names = self.clients.keys()
         self.metrics_store = metrics_store


### PR DESCRIPTION
This commit adds a new `blob-store-stats` telemetry device that based on the sample rate collects per-cluster, and per-node blob store statistics as they are reported by the respective API.

You can test this yourself with:
```
$ esrally race [...] --telemetry='blob-store-stats'
```

And then checking in the configured remote metrics store:
![image](https://github.com/elastic/rally/assets/54515790/cbc095d5-e137-4e70-9f7e-af7162c88e61)


Notes:
- This is intentionally unlisted from `esrally list telemetry` given the elevated privileges required to collect these metrics
  - Running without the correct privleges will show:
   ```
  elasticsearch.NotFoundError: NotFoundError(404, 'Request for uri [/_internal/blob_store/stats] with method [GET] exists but is not available when running in serverless mode', 'Request for uri [/_internal/blob_store/stats] with method [GET] exists but is not available when running in serverless mode')
  ```
- The API doesn't return node names, only IDs. Refactoring the existing metadata collection or adding a separate call to the Info API to allow us to do lookups seems like overkill here