### PR TITLE
Retrieve serverless build hash from nodes info API

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -706,8 +706,8 @@ class Driver:
         else:
             self.wait_for_rest_api(es_clients)
             self.target.cluster_details = self.retrieve_cluster_info(es_clients)
-            serverless_mode = self.config.opts("driver", "serverless.mode", default_value=False)
-            serverless_operator = self.config.opts("driver", "serverless.operator", default_value=False)
+            serverless_mode = self.config.opts("driver", "serverless.mode", default_value=False, mandatory=False)
+            serverless_operator = self.config.opts("driver", "serverless.operator", default_value=False, mandatory=False)
             if serverless_mode and serverless_operator:
                 build_hash = self.retrieve_build_hash_from_nodes_info(es_clients)
                 self.logger.info("Retrieved actual build hash [%s] from serverless cluster.", build_hash)

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -47,7 +47,7 @@ from esrally import (
 from esrally.client import delete_api_keys
 from esrally.driver import runner, scheduler
 from esrally.track import TrackProcessorRegistry, load_track, load_track_plugins
-from esrally.utils import console, convert, net, versions
+from esrally.utils import console, convert, net
 
 
 ##################################
@@ -710,7 +710,7 @@ class Driver:
             serverless_operator = self.config.opts("driver", "serverless.operator", default_value=False)
             if serverless_mode and serverless_operator:
                 build_hash = self.retrieve_build_hash_from_nodes_info(es_clients)
-                self.logger.info(f"Retrieved actual build hash [{build_hash}] from serverless cluster.")
+                self.logger.info("Retrieved actual build hash [%s] from serverless cluster.", build_hash)
                 self.target.cluster_details["version"]["build_hash"] = build_hash
 
         # Avoid issuing any requests to the target cluster when static responses are enabled. The results

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -615,7 +615,7 @@ class Driver:
             ).create()
         return es
 
-    def prepare_telemetry(self, es, enable, index_names, data_stream_names):
+    def prepare_telemetry(self, es, enable, index_names, data_stream_names, build_hash):
         enabled_devices = self.config.opts("telemetry", "devices")
         telemetry_params = self.config.opts("telemetry", "params")
         log_root = paths.race_root(self.config)
@@ -626,7 +626,7 @@ class Driver:
             devices = [
                 telemetry.NodeStats(telemetry_params, es, self.metrics_store),
                 telemetry.ExternalEnvironmentInfo(es_default, self.metrics_store),
-                telemetry.ClusterEnvironmentInfo(es_default, self.metrics_store),
+                telemetry.ClusterEnvironmentInfo(es_default, self.metrics_store, build_hash),
                 telemetry.JvmStatsSummary(es_default, self.metrics_store),
                 telemetry.IndexStats(es_default, self.metrics_store),
                 telemetry.MlBucketProcessingTime(es_default, self.metrics_store),
@@ -700,6 +700,7 @@ class Driver:
 
         skip_rest_api_check = self.config.opts("mechanic", "skip.rest.api.check")
         uses_static_responses = self.config.opts("client", "options").uses_static_responses
+        build_hash = None
         if skip_rest_api_check:
             self.logger.info("Skipping REST API check as requested explicitly.")
         elif uses_static_responses:
@@ -721,6 +722,7 @@ class Driver:
             enable=not uses_static_responses,
             index_names=self.track.index_names(),
             data_stream_names=self.track.data_stream_names(),
+            build_hash=build_hash,
         )
 
         for host in self.config.opts("driver", "load_driver_hosts"):

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -664,9 +664,10 @@ class Driver:
     def retrieve_build_hash_from_nodes_info(self, es):
         try:
             nodes_info = es["default"].nodes.info(filter_path="**.build_hash")
-            nodes = list(nodes_info["nodes"].keys())
+            nodes = nodes_info["nodes"]
             # assumption: build hash is the same across all the nodes
-            return nodes_info["nodes"][nodes[0]]["build_hash"]
+            first_node_id = next(iter(nodes))
+            return nodes[first_node_id]["build_hash"]
         except BaseException:
             self.logger.exception("Could not retrieve build hash from nodes info")
             return None

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -205,6 +205,10 @@ class BenchmarkCoordinator:
                     raise exceptions.SystemSetupError(
                         f"Cluster version must be at least [{min_es_version}] but was [{distribution_version}]"
                     )
+            else:
+                self.cfg.add(config.Scope.benchmark, "driver", "serverless.mode", True)
+                # operator privileges assumed for now
+                self.cfg.add(config.Scope.benchmark, "driver", "serverless.operator", True)
 
         self.current_track = track.load_track(self.cfg, install_dependencies=True)
         self.track_revision = self.cfg.opts("track", "repository.revision", mandatory=False)

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1761,10 +1761,11 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
     Gathers static environment information on a cluster level (e.g. version numbers).
     """
 
-    def __init__(self, client, metrics_store):
+    def __init__(self, client, metrics_store, revision_override):
         super().__init__()
         self.metrics_store = metrics_store
         self.client = client
+        self.revision_override = revision_override
 
     def on_benchmark_start(self):
         # noinspection PyBroadException
@@ -1774,8 +1775,10 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
             self.logger.exception("Could not retrieve cluster version info")
             return
         distribution_flavor = client_info["version"].get("build_flavor", "oss")
-        # build hash will only be available on serverless if the client has operator privs
+        # serverless returns dummy build hash which gets overridden when running with operator privileges
         revision = client_info["version"].get("build_hash", distribution_flavor)
+        if self.revision_override:
+            revision = self.revision_override
         # build version does not exist for serverless
         distribution_version = client_info["version"].get("number", distribution_flavor)
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "source_revision", revision)

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1776,6 +1776,7 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
             return
         distribution_flavor = client_info["version"].get("build_flavor", "oss")
         # serverless returns dummy build hash which gets overridden when running with operator privileges
+        # TODO: refactor if config object gets included in telemetry base class (ES-6459)
         revision = client_info["version"].get("build_hash", distribution_flavor)
         if self.revision_override:
             revision = self.revision_override

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -3256,7 +3256,7 @@ class TestClusterEnvironmentInfo:
         cfg = create_config()
         client = Client(nodes=SubClient(info=nodes_info), info=cluster_info)
         metrics_store = metrics.EsMetricsStore(cfg)
-        env_device = telemetry.ClusterEnvironmentInfo(client, metrics_store)
+        env_device = telemetry.ClusterEnvironmentInfo(client, metrics_store, None)
         t = telemetry.Telemetry(cfg, devices=[env_device])
         t.on_benchmark_start()
         calls = [
@@ -3282,7 +3282,7 @@ class TestClusterEnvironmentInfo:
         cfg = create_config()
         client = Client(nodes=SubClient(stats=raiseTransportError, info=raiseTransportError), info=raiseTransportError)
         metrics_store = metrics.EsMetricsStore(cfg)
-        env_device = telemetry.ClusterEnvironmentInfo(client, metrics_store)
+        env_device = telemetry.ClusterEnvironmentInfo(client, metrics_store, None)
         t = telemetry.Telemetry(cfg, devices=[env_device])
         t.on_benchmark_start()
 


### PR DESCRIPTION
This PR adds retrieval of build hash for serverless clusters from nodes info API (`_nodes?filter_path=**.build_hash`).

The PR introduces 2 configuration settings under `driver` section:
* `serverless.mode` - equals `true` if Rally targets serverless cluster
* `serverless.operator` - equals `true` if Elasticsearch user has operator privileges