### PR TITLE
Add timeout and ES logs in rally-tracks-compat job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
         run: python -m pip install --upgrade nox
       - name: "Run tests"
         run: nox -s rally_tracks_compat
+        timeout-minutes: 120
         env:
           # elastic/endpoint fetches assets from GitHub, authenticate to avoid
           # being rate limited
@@ -99,7 +100,9 @@ jobs:
         if: always()
         with:
           name: rally-tracks-compat-logs
-          path: /home/runner/.rally/logs/
+          path: |
+            /home/runner/.rally/logs/
+            /home/runner/.rally/benchmarks/races/**/*.log
           if-no-files-found: error
 
   install-with-pyenv:


### PR DESCRIPTION
This adjusts `rally-tracks-compat` job in GitHub Actions `CI` workflow for symmetry with `rally-tracks`.
