### PR TITLE
Ensure serverless.mode/operator are always set

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -708,8 +708,8 @@ class Driver:
         else:
             self.wait_for_rest_api(es_clients)
             self.target.cluster_details = self.retrieve_cluster_info(es_clients)
-            serverless_mode = self.config.opts("driver", "serverless.mode", default_value=False, mandatory=False)
-            serverless_operator = self.config.opts("driver", "serverless.operator", default_value=False, mandatory=False)
+            serverless_mode = self.config.opts("driver", "serverless.mode")
+            serverless_operator = self.config.opts("driver", "serverless.operator")
             if serverless_mode and serverless_operator:
                 build_hash = self.retrieve_build_hash_from_nodes_info(es_clients)
                 self.logger.info("Retrieved actual build hash [%s] from serverless cluster.", build_hash)

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -180,6 +180,9 @@ class BenchmarkCoordinator:
         self.current_challenge = None
 
     def setup(self, sources=False):
+        serverless_mode = False
+        serverless_operator = False
+
         # to load the track we need to know the correct cluster distribution version. Usually, this value should be set
         # but there are rare cases (external pipeline and user did not specify the distribution version) where we need
         # to derive it ourselves. For source builds we always assume "main"
@@ -198,17 +201,20 @@ class BenchmarkCoordinator:
             )
             self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", distribution_version)
             self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.flavor", distribution_flavor)
-            if not versions.is_serverless(distribution_flavor):
+            if versions.is_serverless(distribution_flavor):
+                serverless_mode = True
+                # operator privileges assumed for now
+                serverless_operator = True
+            else:
                 min_es_version = versions.Version.from_string(version.minimum_es_version())
                 specified_version = versions.Version.from_string(distribution_version)
                 if specified_version < min_es_version:
                     raise exceptions.SystemSetupError(
                         f"Cluster version must be at least [{min_es_version}] but was [{distribution_version}]"
                     )
-            else:
-                self.cfg.add(config.Scope.benchmark, "driver", "serverless.mode", True)
-                # operator privileges assumed for now
-                self.cfg.add(config.Scope.benchmark, "driver", "serverless.operator", True)
+
+        self.cfg.add(config.Scope.benchmark, "driver", "serverless.mode", serverless_mode)
+        self.cfg.add(config.Scope.benchmark, "driver", "serverless.operator", serverless_operator)
 
         self.current_track = track.load_track(self.cfg, install_dependencies=True)
         self.track_revision = self.cfg.opts("track", "repository.revision", mandatory=False)


### PR DESCRIPTION
And invert one condition to avoid using `not`.

The idea is to avoid having to encode the default value (with the annoying `mandatory=False`) in every place where we will read those configuration values.