### PR TITLE
Update blob store stats telemetry device

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -352,10 +352,18 @@ Example of recorded documents given two nodes in the target cluster::
           "failed": 0
         }
       },
-      "ListObjects": 30,
-      "PutMultipartObject": 0,
-      "PutObject": 0,
-      "GetObject": 2334
+      "object_store_request_counts_ListObjects": 20,
+      "object_store_request_counts_PutMultipartObject": 20,
+      "object_store_request_counts_DeleteObjects": 20,
+      "object_store_request_counts_AbortMultipartObject": 20,
+      "object_store_request_counts_PutObject": 20,
+      "object_store_request_counts_GetObject": 20,
+      "operational_backup_request_counts_ListObjects": 22,
+      "operational_backup_request_counts_PutMultipartObject": 22,
+      "operational_backup_request_counts_DeleteObjects": 22,
+      "operational_backup_request_counts_AbortMultipartObject": 22,
+      "operational_backup_request_counts_PutObject": 22,
+      "operational_backup_request_counts_GetObject": 22
     },
     {
       "name": "blob-store-stats",
@@ -368,10 +376,18 @@ Example of recorded documents given two nodes in the target cluster::
           "failed": 0
         }
       },
-      "ListObjects": 30,
-      "PutMultipartObject": 0,
-      "PutObject": 0,
-      "GetObject": 1167
+      "object_store_request_counts_ListObjects": 10,
+      "object_store_request_counts_PutMultipartObject": 10,
+      "object_store_request_counts_DeleteObjects": 10,
+      "object_store_request_counts_AbortMultipartObject": 10,
+      "object_store_request_counts_PutObject": 10,
+      "object_store_request_counts_GetObject": 10,
+      "operational_backup_request_counts_ListObjects": 22,
+      "operational_backup_request_counts_PutMultipartObject": 22,
+      "operational_backup_request_counts_DeleteObjects": 22,
+      "operational_backup_request_counts_AbortMultipartObject": 22,
+      "operational_backup_request_counts_PutObject": 22,
+      "operational_backup_request_counts_GetObject": 22
     },
     {
       "name": "blob-store-stats",
@@ -383,10 +399,12 @@ Example of recorded documents given two nodes in the target cluster::
           "successful": 2,
           "failed": 0
         },
-        "ListObjects": 0,
-        "PutMultipartObject": 0,
-        "PutObject": 0,
-        "GetObject": 1167
+      "object_store_request_counts_ListObjects": 10,
+      "object_store_request_counts_PutMultipartObject": 10,
+      "object_store_request_counts_DeleteObjects": 10,
+      "object_store_request_counts_AbortMultipartObject": 10,
+      "object_store_request_counts_PutObject": 10,
+      "object_store_request_counts_GetObject": 10
       }
     }
 

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -866,74 +866,49 @@ class NodeStatsRecorder:
                 dict(collected_node_stats), level=MetaInfoScope.node, node_name=node_name, meta_data=metrics_store_meta_data
             )
 
-    def flatten_stats_fields(self, prefix=None, stats=None):
-        """
-        Flatten provided dict using an optional prefix and top level key filters.
-
-        :param prefix: The prefix for all flattened values. Defaults to None.
-        :param stats: Dict with values to be flattened, using _ as a separator. Defaults to {}.
-        :return: Return flattened dictionary, separated by _ and prefixed with prefix.
-        """
-
-        def iterate():
-            for section_name, section_value in stats.items():
-                if isinstance(section_value, dict):
-                    new_prefix = f"{prefix}_{section_name}"
-                    # https://www.python.org/dev/peps/pep-0380/
-                    yield from self.flatten_stats_fields(prefix=new_prefix, stats=section_value).items()
-                # Avoid duplication for metric fields that have unit embedded in value as they are also recorded elsewhere
-                # example: `breakers_parent_limit_size_in_bytes` vs `breakers_parent_limit_size`
-                elif isinstance(section_value, (int, float)) and not isinstance(section_value, bool):
-                    yield "{}{}".format(prefix + "_" if prefix else "", section_name), section_value
-
-        if stats:
-            return dict(iterate())
-        else:
-            return {}
-
     def indices_stats(self, node_name, node_stats, include):
         idx_stats = node_stats["indices"]
         ordered_results = collections.OrderedDict()
         for section in include:
             if section in idx_stats:
-                ordered_results.update(self.flatten_stats_fields(prefix="indices_" + section, stats=idx_stats[section]))
+                ordered_results.update(flatten_stats_fields(prefix="indices_" + section, stats=idx_stats[section]))
 
         return ordered_results
 
     def thread_pool_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="thread_pool", stats=node_stats["thread_pool"])
+        return flatten_stats_fields(prefix="thread_pool", stats=node_stats["thread_pool"])
 
     def circuit_breaker_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="breakers", stats=node_stats["breakers"])
+        return flatten_stats_fields(prefix="breakers", stats=node_stats["breakers"])
 
     def jvm_buffer_pool_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="jvm_buffer_pools", stats=node_stats["jvm"]["buffer_pools"])
+        return flatten_stats_fields(prefix="jvm_buffer_pools", stats=node_stats["jvm"]["buffer_pools"])
 
     def jvm_mem_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="jvm_mem", stats=node_stats["jvm"]["mem"])
+        return flatten_stats_fields(prefix="jvm_mem", stats=node_stats["jvm"]["mem"])
 
     def os_mem_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="os_mem", stats=node_stats["os"]["mem"])
+        return flatten_stats_fields(prefix="os_mem", stats=node_stats["os"]["mem"])
 
     def os_cgroup_stats(self, node_name, node_stats):
         cgroup_stats = {}
         try:
-            cgroup_stats = self.flatten_stats_fields(prefix="os_cgroup", stats=node_stats["os"]["cgroup"])
+            cgroup_stats = flatten_stats_fields(prefix="os_cgroup", stats=node_stats["os"]["cgroup"])
         except KeyError:
             self.logger.debug("Node cgroup stats requested with none present.")
         return cgroup_stats
 
     def jvm_gc_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="jvm_gc", stats=node_stats["jvm"]["gc"])
+        return flatten_stats_fields(prefix="jvm_gc", stats=node_stats["jvm"]["gc"])
 
     def network_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="transport", stats=node_stats.get("transport"))
+        return flatten_stats_fields(prefix="transport", stats=node_stats.get("transport"))
 
     def process_stats(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="process_cpu", stats=node_stats["process"]["cpu"])
+        return flatten_stats_fields(prefix="process_cpu", stats=node_stats["process"]["cpu"])
 
     def indexing_pressure(self, node_name, node_stats):
-        return self.flatten_stats_fields(prefix="indexing_pressure", stats=node_stats["indexing_pressure"])
+        return flatten_stats_fields(prefix="indexing_pressure", stats=node_stats["indexing_pressure"])
 
     def sample(self):
         # pylint: disable=import-outside-toplevel
@@ -1754,6 +1729,32 @@ def extract_value(node, path, fallback="unknown"):
     except KeyError:
         value = fallback
     return value
+
+
+def flatten_stats_fields(prefix=None, stats=None):
+    """
+    Flatten provided dict using an optional prefix and top level key filters.
+
+    :param prefix: The prefix for all flattened values. Defaults to None.
+    :param stats: Dict with values to be flattened, using _ as a separator. Defaults to {}.
+    :return: Return flattened dictionary, separated by _ and prefixed with prefix.
+    """
+
+    def iterate():
+        for section_name, section_value in stats.items():
+            if isinstance(section_value, dict):
+                new_prefix = f"{prefix}_{section_name}"
+                # https://www.python.org/dev/peps/pep-0380/
+                yield from flatten_stats_fields(prefix=new_prefix, stats=section_value).items()
+            # Avoid duplication for metric fields that have unit embedded in value as they are also recorded elsewhere
+            # example: `breakers_parent_limit_size_in_bytes` vs `breakers_parent_limit_size`
+            elif isinstance(section_value, (int, float)) and not isinstance(section_value, bool):
+                yield "{}{}".format(prefix + "_" if prefix else "", section_name), section_value
+
+    if stats:
+        return dict(iterate())
+    else:
+        return {}
 
 
 class ClusterEnvironmentInfo(InternalTelemetryDevice):

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -4988,11 +4988,67 @@ class TestBlobStoreStatsRecorder:
     blob_store_stats_response = {
         "_nodes": {"total": 2, "successful": 2, "failed": 0},
         "cluster_name": "es",
-        "_all": {"object_store_stats": {"ListObjects": 5, "PutMultipartObject": 3, "PutObject": 161, "GetObject": 54}},
+        "_all": {
+            "object_store_stats": {
+                "request_counts": {
+                    "ListObjects": 20,
+                    "PutMultipartObject": 20,
+                    "DeleteObjects": 20,
+                    "AbortMultipartObject": 20,
+                    "PutObject": 20,
+                    "GetObject": 20,
+                }
+            },
+            "operational_backup_service_stats": {
+                "request_counts": {
+                    "ListObjects": 22,
+                    "PutMultipartObject": 22,
+                    "DeleteObjects": 22,
+                    "AbortMultipartObject": 22,
+                    "PutObject": 22,
+                    "GetObject": 22,
+                }
+            },
+        },
         "nodes": {
-            "xwc71ug5QtOYWrEkNiVgYw": {"object_store_stats": {"ListObjects": 1, "PutMultipartObject": 0, "PutObject": 0, "GetObject": 5}},
-            "qRu2kq0_RnyVn-xmLIN5ZA": {
-                "object_store_stats": {"ListObjects": 4, "PutMultipartObject": 3, "PutObject": 161, "GetObject": 49}
+            "PaIdh023RvS0J99uWF_A7Q": {
+                "object_store_stats": {
+                    "request_counts": {
+                        "ListObjects": 10,
+                        "PutMultipartObject": 10,
+                        "DeleteObjects": 10,
+                        "AbortMultipartObject": 10,
+                        "PutObject": 10,
+                        "GetObject": 10,
+                    }
+                },
+                "operational_backup_service_stats": {
+                    "request_counts": {
+                        "ListObjects": 22,
+                        "PutMultipartObject": 22,
+                        "DeleteObjects": 22,
+                        "AbortMultipartObject": 22,
+                        "PutObject": 22,
+                        "GetObject": 22,
+                    }
+                },
+            },
+            "4RKUvXhKTMOoslA9V_4EmA": {
+                "object_store_stats": {
+                    "request_counts": {
+                        "ListObjects": 10,
+                        "PutMultipartObject": 10,
+                        "DeleteObjects": 10,
+                        "AbortMultipartObject": 10,
+                        "PutObject": 10,
+                        "GetObject": 10,
+                    }
+                },
+                "operational_backup_service_stats": {"request_counts": {}},
+            },
+            "ufg1tLOiTIiHkmgGiztW9Q": {
+                "object_store_stats": {"request_counts": {}},
+                "operational_backup_service_stats": {"request_counts": {}},
             },
         },
     }
@@ -5011,10 +5067,18 @@ class TestBlobStoreStatsRecorder:
                     {
                         "name": "blob-store-stats",
                         "node": "_all",
-                        "ListObjects": 5,
-                        "PutMultipartObject": 3,
-                        "PutObject": 161,
-                        "GetObject": 54,
+                        "object_store_request_counts_ListObjects": 20,
+                        "object_store_request_counts_PutMultipartObject": 20,
+                        "object_store_request_counts_DeleteObjects": 20,
+                        "object_store_request_counts_AbortMultipartObject": 20,
+                        "object_store_request_counts_PutObject": 20,
+                        "object_store_request_counts_GetObject": 20,
+                        "operational_backup_request_counts_ListObjects": 22,
+                        "operational_backup_request_counts_PutMultipartObject": 22,
+                        "operational_backup_request_counts_DeleteObjects": 22,
+                        "operational_backup_request_counts_AbortMultipartObject": 22,
+                        "operational_backup_request_counts_PutObject": 22,
+                        "operational_backup_request_counts_GetObject": 22,
                     },
                     level=MetaInfoScope.cluster,
                     meta_data={"cluster": "es", "_nodes": {"total": 2, "successful": 2, "failed": 0}},
@@ -5022,27 +5086,37 @@ class TestBlobStoreStatsRecorder:
                 mock.call(
                     {
                         "name": "blob-store-stats",
-                        "node": "xwc71ug5QtOYWrEkNiVgYw",
-                        "ListObjects": 1,
-                        "PutMultipartObject": 0,
-                        "PutObject": 0,
-                        "GetObject": 5,
+                        "node": "PaIdh023RvS0J99uWF_A7Q",
+                        "object_store_request_counts_ListObjects": 10,
+                        "object_store_request_counts_PutMultipartObject": 10,
+                        "object_store_request_counts_DeleteObjects": 10,
+                        "object_store_request_counts_AbortMultipartObject": 10,
+                        "object_store_request_counts_PutObject": 10,
+                        "object_store_request_counts_GetObject": 10,
+                        "operational_backup_request_counts_ListObjects": 22,
+                        "operational_backup_request_counts_PutMultipartObject": 22,
+                        "operational_backup_request_counts_DeleteObjects": 22,
+                        "operational_backup_request_counts_AbortMultipartObject": 22,
+                        "operational_backup_request_counts_PutObject": 22,
+                        "operational_backup_request_counts_GetObject": 22,
                     },
                     level=MetaInfoScope.node,
-                    node_name="xwc71ug5QtOYWrEkNiVgYw",
+                    node_name="PaIdh023RvS0J99uWF_A7Q",
                     meta_data={"cluster": "es", "_nodes": {"total": 2, "successful": 2, "failed": 0}},
                 ),
                 mock.call(
                     {
                         "name": "blob-store-stats",
-                        "node": "qRu2kq0_RnyVn-xmLIN5ZA",
-                        "ListObjects": 4,
-                        "PutMultipartObject": 3,
-                        "PutObject": 161,
-                        "GetObject": 49,
+                        "node": "4RKUvXhKTMOoslA9V_4EmA",
+                        "object_store_request_counts_ListObjects": 10,
+                        "object_store_request_counts_PutMultipartObject": 10,
+                        "object_store_request_counts_DeleteObjects": 10,
+                        "object_store_request_counts_AbortMultipartObject": 10,
+                        "object_store_request_counts_PutObject": 10,
+                        "object_store_request_counts_GetObject": 10,
                     },
                     level=MetaInfoScope.node,
-                    node_name="qRu2kq0_RnyVn-xmLIN5ZA",
+                    node_name="4RKUvXhKTMOoslA9V_4EmA",
                     meta_data={"cluster": "es", "_nodes": {"total": 2, "successful": 2, "failed": 0}},
                 ),
             ],

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -2152,12 +2152,7 @@ class TestNodeStatsRecorder:
             telemetry.NodeStatsRecorder(telemetry_params, cluster_name="default", client=client, metrics_store=metrics_store)
 
     def test_flatten_indices_fields(self):
-        client = Client(nodes=SubClient(stats=self.node_stats_response))
-        cfg = create_config()
-        metrics_store = metrics.EsMetricsStore(cfg)
-        telemetry_params = {}
-        recorder = telemetry.NodeStatsRecorder(telemetry_params, cluster_name="remote", client=client, metrics_store=metrics_store)
-        flattened_fields = recorder.flatten_stats_fields(
+        flattened_fields = telemetry.flatten_stats_fields(
             prefix="indices",
             stats=self.node_stats_response["nodes"]["Zbl_e8EyRXmiR47gbHgPfg"]["indices"],
         )


### PR DESCRIPTION
The response format of the blob store stats API has changed, this PR updates the telemetry device to handle this, as well as flatten the metric fields. 

Technically a breaking change, but it's been done within releases, and this is an internal device anyway.

Relates https://github.com/elastic/rally/pull/1755