### PR TITLE
Sort AUTHORS file using en_US.UTF-8

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,17 +7,18 @@ Brad Deam
 Brian Lesperance
 Christian Dahlqvist
 Christopher Manning
-DJRickyB
 Dale McDiarmid
 Daniel Mitterdorfer
 David Turner
 Debanjan Choudhury
 Dennis Lawler
 Dimitrios Liappis
+DJRickyB
 Domenico Andreoli
 Evgenia Badiyanova
 Evgenia Badyanova
 Gavin Fowler
+gdmello
 Grzegorz Banasiak
 Guido Lena Cota
 Hendrik Muhs
@@ -49,6 +50,7 @@ Mike Baamonde
 MoBoo
 Nhat Nguyen
 Nicholas Knize
+nicholaskuechler
 Nik Everett
 Paul Coghlan
 Peter Dyson
@@ -58,13 +60,11 @@ Quentin Pradet
 Rick Boyd
 Rohit Nair
 Salvatore Campagna
+sstults
 Thomas Decaux
 Tobias Suckow
+tomcallahan
+uparamonau-es
 Vitor Anjos
 Vladimir Masarik
 Yannick Welsch
-gdmello
-nicholaskuechler
-sstults
-tomcallahan
-uparamonau-es

--- a/release.sh
+++ b/release.sh
@@ -33,7 +33,7 @@ echo "Preparing ${__NOTICE_OUTPUT_FILE}"
 source create-notice.sh
 
 echo "Updating author information"
-git log --format='%aN' | sort -u > AUTHORS
+git log --format='%aN' | LC_ALL=en_US.UTF-8 sort -u > AUTHORS
 # This will produce a non-zero exit code iff there are changes.
 # Obviously we should disable exiting on error temporarily.
 set +e


### PR DESCRIPTION
This achieves two things: making the output stable and avoiding ASCIIbetical order where lower case authors are put last.