### PR TITLE
Add 'Bootstrap' message handler to 'Worker' actor

### DIFF
--- a/esrally/utils/repo.py
+++ b/esrally/utils/repo.py
@@ -126,4 +126,11 @@ class RallyRepository:
         git.checkout(self.repo_dir, branch=revision)
 
     def correct_revision(self, revision):
-        return git.head_revision(self.repo_dir) == revision
+        if git.is_branch(self.repo_dir, revision):
+            current_branch = git.current_branch(self.repo_dir)
+            self.logger.info("Checking current branch [%s] is equal to specified branch [%s].", current_branch, revision)
+            return current_branch == revision
+
+        current_revision = git.head_revision(self.repo_dir)
+        self.logger.info("Checking current revision [%s] is equal to specified revision [%s].", current_revision, revision)
+        return current_revision == revision

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -166,6 +166,7 @@ class TestDriver:
 
     @mock.patch("esrally.utils.net.resolve")
     def test_start_benchmark_and_prepare_track(self, resolve):
+        worker_id = [0, 1, 2, 3]
         # override load driver host
         self.cfg.add(config.Scope.applicationOverride, "driver", "load_driver_hosts", ["10.5.5.1", "10.5.5.2"])
         resolve.side_effect = ["10.5.5.1", "10.5.5.2"]
@@ -179,10 +180,10 @@ class TestDriver:
 
         target.create_client.assert_has_calls(
             calls=[
-                mock.call("10.5.5.1", d.config),
-                mock.call("10.5.5.1", d.config),
-                mock.call("10.5.5.2", d.config),
-                mock.call("10.5.5.2", d.config),
+                mock.call("10.5.5.1", d.config, worker_id[0]),
+                mock.call("10.5.5.1", d.config, worker_id[1]),
+                mock.call("10.5.5.2", d.config, worker_id[2]),
+                mock.call("10.5.5.2", d.config, worker_id[3]),
             ]
         )
 
@@ -216,6 +217,7 @@ class TestDriver:
         }
 
     def test_assign_drivers_round_robin(self):
+        worker_id = [0, 1, 2, 3]
         target = self.create_test_driver_target()
         d = driver.Driver(target, self.cfg, es_client_factory_class=self.StaticClientFactory)
 
@@ -227,10 +229,10 @@ class TestDriver:
 
         target.create_client.assert_has_calls(
             calls=[
-                mock.call("localhost", d.config),
-                mock.call("localhost", d.config),
-                mock.call("localhost", d.config),
-                mock.call("localhost", d.config),
+                mock.call("localhost", d.config, worker_id[0]),
+                mock.call("localhost", d.config, worker_id[1]),
+                mock.call("localhost", d.config, worker_id[2]),
+                mock.call("localhost", d.config, worker_id[3]),
             ]
         )
 


### PR DESCRIPTION
This commit adds a 'new' `Bootstrap` message handler to the `Worker` actor, which is responsible for ensuring that the new actor has the correct configuration and track modules loaded into its system path. This restores the ability to run tracks across multiple load driver machines.

The reason tracks worked across `Worker` actors on coordinator machine (where the race was invoked) is because the default behaviour for new actors created with `multiprocTCPBase` is that they fork (in the Unix sense) from their parent process. When a process is forked, it inherits the memory and other properties from the parent, including the system path. 

When a new `Worker` was created on a remote load driver machine the existing parent was missing paths, meaning there were missing modules for the load path.

Notes:
- This was actually supposed to have been 'fixed' in https://github.com/elastic/rally/pull/1315, but there was a [misnamed handler called `receiveMsg_RallyConfig` that was unused](https://github.com/elastic/rally/pull/1315/files#diff-7c569d2e27cf4d285afa9e91cf4e6919e9f50c8fda95de56e1a3bcf4b3554aedR1122-R1125), meaning it was unlikely this ever worked  
- This dead code was coincidentally removed only days ago in https://github.com/elastic/rally/pull/1749

Fixes https://github.com/elastic/rally/issues/1752
Relates https://github.com/elastic/rally/issues/1206