### PR TITLE
Exclude telemetry devices based on serverless status

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -620,7 +620,7 @@ class Driver:
             ).create()
         return es
 
-    def prepare_telemetry(self, es, enable, index_names, data_stream_names, build_hash):
+    def prepare_telemetry(self, es, enable, index_names, data_stream_names, build_hash, serverless_mode, serverless_operator):
         enabled_devices = self.config.opts("telemetry", "devices")
         telemetry_params = self.config.opts("telemetry", "params")
         log_root = paths.race_root(self.config)
@@ -649,7 +649,12 @@ class Driver:
             ]
         else:
             devices = []
-        self.telemetry = telemetry.Telemetry(enabled_devices, devices=devices)
+        self.telemetry = telemetry.Telemetry(
+            enabled_devices,
+            devices=devices,
+            serverless_mode=serverless_mode,
+            serverless_operator=serverless_operator,
+        )
 
     def wait_for_rest_api(self, es):
         es_default = es["default"]
@@ -706,6 +711,8 @@ class Driver:
 
         skip_rest_api_check = self.config.opts("mechanic", "skip.rest.api.check")
         uses_static_responses = self.config.opts("client", "options").uses_static_responses
+        serverless_mode = False
+        serverless_operator = False
         build_hash = None
         if skip_rest_api_check:
             self.logger.info("Skipping REST API check as requested explicitly.")
@@ -729,6 +736,8 @@ class Driver:
             index_names=self.track.index_names(),
             data_stream_names=self.track.data_stream_names(),
             build_hash=build_hash,
+            serverless_mode=serverless_mode,
+            serverless_operator=serverless_operator,
         )
 
         for host in self.config.opts("driver", "load_driver_hosts"):

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2575,7 +2575,7 @@ class Composite(Runner):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Since Composite is marked as ServerlessStatus.Public, only add public
+        # Since Composite is marked as serverless.Status.Public, only add public
         # operation types here.
         self.supported_op_types = [
             "open-point-in-time",

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -93,6 +93,7 @@ class Telemetry:
         for device in self.devices:
             if self._enabled(device):
                 if self.serverless_mode and not self._available_on_serverless(device):
+                    # Only inform about exclusion if the user explicitly asked for this device
                     if getattr(device, "command", None) in self.enabled_devices:
                         console.info(f"Excluding telemetry device [{device.command}] as it is unavailable on serverless.")
                     continue

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -92,9 +92,12 @@ class Telemetry:
     def on_benchmark_start(self):
         for device in self.devices:
             if self._enabled(device):
+                if self.serverless_mode and not self._available_on_serverless(device):
+                    if device.command in self.enabled_devices:
+                        console.info(f"Excluding telemetry device [{device.command}] as it is unavailable on serverless.")
+                    continue
+
                 device.on_benchmark_start()
-            if self._excluded_on_serverless(device):
-                console.info(f"Excluding telemetry device [{device.command}] as it is unavailable on serverless.")
 
     def on_benchmark_stop(self):
         for device in self.devices:
@@ -108,14 +111,6 @@ class Telemetry:
 
     def _enabled(self, device):
         return device.internal or device.command in self.enabled_devices
-
-    def _excluded_on_serverless(self, device):
-        return (
-            self.serverless_mode
-            and not device.internal
-            and device.command in self.enabled_devices
-            and not self._available_on_serverless(device)
-        )
 
     def _available_on_serverless(self, device):
         if self.serverless_operator:

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -93,7 +93,7 @@ class Telemetry:
         for device in self.devices:
             if self._enabled(device):
                 if self.serverless_mode and not self._available_on_serverless(device):
-                    if device.command in self.enabled_devices:
+                    if getattr(device, "command", None) in self.enabled_devices:
                         console.info(f"Excluding telemetry device [{device.command}] as it is unavailable on serverless.")
                     continue
 

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -35,7 +35,17 @@ from jinja2 import meta
 from esrally import PROGRAM_NAME, config, exceptions, paths, time, version
 from esrally.track import params, track
 from esrally.track.track import Parallel
-from esrally.utils import collections, console, convert, io, modules, net, opts, repo
+from esrally.utils import (
+    collections,
+    console,
+    convert,
+    io,
+    modules,
+    net,
+    opts,
+    repo,
+    serverless,
+)
 
 
 class TrackSyntaxError(exceptions.InvalidSyntax):
@@ -908,11 +918,11 @@ class ServerlessFilterTrackProcessor(TrackProcessor):
 
         try:
             op = track.OperationType.from_hyphenated_string(operation.type)
-            # Comparisons rely on the ordering of auto() in track.ServerlessStatus which is an IntEnum
+            # Comparisons rely on the ordering in serverless.Status which is an IntEnum
             if self.serverless_operator:
-                return op.serverless_status < track.ServerlessStatus.Internal
+                return op.serverless_status < serverless.Status.Internal
             else:
-                return op.serverless_status < track.ServerlessStatus.Public
+                return op.serverless_status < serverless.Status.Public
         except KeyError:
             self.logger.info("Treating user-provided operation type [%s] for operation [%s] as public.", operation.type, operation.name)
             return False

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -18,9 +18,10 @@
 import collections
 import numbers
 import re
-from enum import Enum, IntEnum, auto, unique
+from enum import Enum, auto, unique
 
 from esrally import exceptions
+from esrally.utils import serverless
 
 
 class Index:
@@ -674,79 +675,72 @@ class AdminStatus(Enum):
 
 
 @unique
-class ServerlessStatus(IntEnum):
-    Blocked = auto()
-    Internal = auto()
-    Public = auto()
-
-
-@unique
 class OperationType(Enum):
     # TODO replace manual counts with auto() when we drop support for Python 3.10
     # https://docs.python.org/3/library/enum.html#enum.auto
-    IndexStats = (1, AdminStatus.No, ServerlessStatus.Internal)
-    NodeStats = (2, AdminStatus.No, ServerlessStatus.Internal)
-    Search = (3, AdminStatus.No, ServerlessStatus.Public)
-    Bulk = (4, AdminStatus.No, ServerlessStatus.Public)
+    IndexStats = (1, AdminStatus.No, serverless.Status.Internal)
+    NodeStats = (2, AdminStatus.No, serverless.Status.Internal)
+    Search = (3, AdminStatus.No, serverless.Status.Public)
+    Bulk = (4, AdminStatus.No, serverless.Status.Public)
     # Public as we can't verify the actual status
-    RawRequest = (5, AdminStatus.No, ServerlessStatus.Public)
-    WaitForRecovery = (6, AdminStatus.No, ServerlessStatus.Internal)
-    WaitForSnapshotCreate = (7, AdminStatus.No, ServerlessStatus.Internal)
+    RawRequest = (5, AdminStatus.No, serverless.Status.Public)
+    WaitForRecovery = (6, AdminStatus.No, serverless.Status.Internal)
+    WaitForSnapshotCreate = (7, AdminStatus.No, serverless.Status.Internal)
     # Public as all supported operation types are Public too (including RawRequest as
     # mentioned above)
-    Composite = (8, AdminStatus.No, ServerlessStatus.Public)
-    SubmitAsyncSearch = (9, AdminStatus.No, ServerlessStatus.Public)
-    GetAsyncSearch = (10, AdminStatus.No, ServerlessStatus.Public)
-    DeleteAsyncSearch = (11, AdminStatus.No, ServerlessStatus.Public)
-    PaginatedSearch = (12, AdminStatus.No, ServerlessStatus.Public)
-    ScrollSearch = (13, AdminStatus.No, ServerlessStatus.Public)
-    OpenPointInTime = (14, AdminStatus.No, ServerlessStatus.Public)
-    ClosePointInTime = (15, AdminStatus.No, ServerlessStatus.Public)
-    Sql = (16, AdminStatus.No, ServerlessStatus.Public)
-    FieldCaps = (17, AdminStatus.No, ServerlessStatus.Public)
-    CompositeAgg = (18, AdminStatus.No, ServerlessStatus.Public)
-    WaitForCurrentSnapshotsCreate = (19, AdminStatus.No, ServerlessStatus.Internal)
-    Downsample = (20, AdminStatus.No, ServerlessStatus.Internal)
+    Composite = (8, AdminStatus.No, serverless.Status.Public)
+    SubmitAsyncSearch = (9, AdminStatus.No, serverless.Status.Public)
+    GetAsyncSearch = (10, AdminStatus.No, serverless.Status.Public)
+    DeleteAsyncSearch = (11, AdminStatus.No, serverless.Status.Public)
+    PaginatedSearch = (12, AdminStatus.No, serverless.Status.Public)
+    ScrollSearch = (13, AdminStatus.No, serverless.Status.Public)
+    OpenPointInTime = (14, AdminStatus.No, serverless.Status.Public)
+    ClosePointInTime = (15, AdminStatus.No, serverless.Status.Public)
+    Sql = (16, AdminStatus.No, serverless.Status.Public)
+    FieldCaps = (17, AdminStatus.No, serverless.Status.Public)
+    CompositeAgg = (18, AdminStatus.No, serverless.Status.Public)
+    WaitForCurrentSnapshotsCreate = (19, AdminStatus.No, serverless.Status.Internal)
+    Downsample = (20, AdminStatus.No, serverless.Status.Internal)
 
     # administrative actions
-    ForceMerge = (21, AdminStatus.Yes, ServerlessStatus.Internal)
-    ClusterHealth = (22, AdminStatus.Yes, ServerlessStatus.Internal)
-    PutPipeline = (23, AdminStatus.Yes, ServerlessStatus.Public)
-    Refresh = (24, AdminStatus.Yes, ServerlessStatus.Public)
-    CreateIndex = (25, AdminStatus.Yes, ServerlessStatus.Public)
-    DeleteIndex = (26, AdminStatus.Yes, ServerlessStatus.Public)
-    CreateIndexTemplate = (27, AdminStatus.Yes, ServerlessStatus.Blocked)
-    DeleteIndexTemplate = (28, AdminStatus.Yes, ServerlessStatus.Blocked)
-    ShrinkIndex = (29, AdminStatus.Yes, ServerlessStatus.Blocked)
-    CreateMlDatafeed = (30, AdminStatus.Yes, ServerlessStatus.Public)
-    DeleteMlDatafeed = (31, AdminStatus.Yes, ServerlessStatus.Public)
-    StartMlDatafeed = (32, AdminStatus.Yes, ServerlessStatus.Public)
-    StopMlDatafeed = (33, AdminStatus.Yes, ServerlessStatus.Public)
-    CreateMlJob = (34, AdminStatus.Yes, ServerlessStatus.Public)
-    DeleteMlJob = (35, AdminStatus.Yes, ServerlessStatus.Public)
-    OpenMlJob = (36, AdminStatus.Yes, ServerlessStatus.Public)
-    CloseMlJob = (37, AdminStatus.Yes, ServerlessStatus.Public)
-    Sleep = (38, AdminStatus.Yes, ServerlessStatus.Public)
-    DeleteSnapshotRepository = (39, AdminStatus.Yes, ServerlessStatus.Internal)
-    CreateSnapshotRepository = (40, AdminStatus.Yes, ServerlessStatus.Internal)
-    CreateSnapshot = (41, AdminStatus.Yes, ServerlessStatus.Internal)
-    RestoreSnapshot = (42, AdminStatus.Yes, ServerlessStatus.Internal)
-    PutSettings = (43, AdminStatus.Yes, ServerlessStatus.Internal)
-    CreateTransform = (44, AdminStatus.Yes, ServerlessStatus.Public)
-    StartTransform = (45, AdminStatus.Yes, ServerlessStatus.Public)
-    WaitForTransform = (46, AdminStatus.Yes, ServerlessStatus.Public)
-    DeleteTransform = (47, AdminStatus.Yes, ServerlessStatus.Public)
-    CreateDataStream = (48, AdminStatus.Yes, ServerlessStatus.Public)
-    DeleteDataStream = (49, AdminStatus.Yes, ServerlessStatus.Public)
-    CreateComposableTemplate = (50, AdminStatus.Yes, ServerlessStatus.Public)
-    DeleteComposableTemplate = (51, AdminStatus.Yes, ServerlessStatus.Public)
-    CreateComponentTemplate = (52, AdminStatus.Yes, ServerlessStatus.Public)
-    DeleteComponentTemplate = (53, AdminStatus.Yes, ServerlessStatus.Public)
-    TransformStats = (54, AdminStatus.Yes, ServerlessStatus.Public)
-    CreateIlmPolicy = (55, AdminStatus.Yes, ServerlessStatus.Blocked)
-    DeleteIlmPolicy = (56, AdminStatus.Yes, ServerlessStatus.Blocked)
+    ForceMerge = (21, AdminStatus.Yes, serverless.Status.Internal)
+    ClusterHealth = (22, AdminStatus.Yes, serverless.Status.Internal)
+    PutPipeline = (23, AdminStatus.Yes, serverless.Status.Public)
+    Refresh = (24, AdminStatus.Yes, serverless.Status.Public)
+    CreateIndex = (25, AdminStatus.Yes, serverless.Status.Public)
+    DeleteIndex = (26, AdminStatus.Yes, serverless.Status.Public)
+    CreateIndexTemplate = (27, AdminStatus.Yes, serverless.Status.Blocked)
+    DeleteIndexTemplate = (28, AdminStatus.Yes, serverless.Status.Blocked)
+    ShrinkIndex = (29, AdminStatus.Yes, serverless.Status.Blocked)
+    CreateMlDatafeed = (30, AdminStatus.Yes, serverless.Status.Public)
+    DeleteMlDatafeed = (31, AdminStatus.Yes, serverless.Status.Public)
+    StartMlDatafeed = (32, AdminStatus.Yes, serverless.Status.Public)
+    StopMlDatafeed = (33, AdminStatus.Yes, serverless.Status.Public)
+    CreateMlJob = (34, AdminStatus.Yes, serverless.Status.Public)
+    DeleteMlJob = (35, AdminStatus.Yes, serverless.Status.Public)
+    OpenMlJob = (36, AdminStatus.Yes, serverless.Status.Public)
+    CloseMlJob = (37, AdminStatus.Yes, serverless.Status.Public)
+    Sleep = (38, AdminStatus.Yes, serverless.Status.Public)
+    DeleteSnapshotRepository = (39, AdminStatus.Yes, serverless.Status.Internal)
+    CreateSnapshotRepository = (40, AdminStatus.Yes, serverless.Status.Internal)
+    CreateSnapshot = (41, AdminStatus.Yes, serverless.Status.Internal)
+    RestoreSnapshot = (42, AdminStatus.Yes, serverless.Status.Internal)
+    PutSettings = (43, AdminStatus.Yes, serverless.Status.Internal)
+    CreateTransform = (44, AdminStatus.Yes, serverless.Status.Public)
+    StartTransform = (45, AdminStatus.Yes, serverless.Status.Public)
+    WaitForTransform = (46, AdminStatus.Yes, serverless.Status.Public)
+    DeleteTransform = (47, AdminStatus.Yes, serverless.Status.Public)
+    CreateDataStream = (48, AdminStatus.Yes, serverless.Status.Public)
+    DeleteDataStream = (49, AdminStatus.Yes, serverless.Status.Public)
+    CreateComposableTemplate = (50, AdminStatus.Yes, serverless.Status.Public)
+    DeleteComposableTemplate = (51, AdminStatus.Yes, serverless.Status.Public)
+    CreateComponentTemplate = (52, AdminStatus.Yes, serverless.Status.Public)
+    DeleteComponentTemplate = (53, AdminStatus.Yes, serverless.Status.Public)
+    TransformStats = (54, AdminStatus.Yes, serverless.Status.Public)
+    CreateIlmPolicy = (55, AdminStatus.Yes, serverless.Status.Blocked)
+    DeleteIlmPolicy = (56, AdminStatus.Yes, serverless.Status.Blocked)
 
-    def __init__(self, id: int, admin_status: AdminStatus, serverless_status: ServerlessStatus):
+    def __init__(self, id: int, admin_status: AdminStatus, serverless_status: serverless.Status):
         self.id = id
         self.admin_status = admin_status
         self.serverless_status = serverless_status

--- a/esrally/utils/serverless.py
+++ b/esrally/utils/serverless.py
@@ -1,0 +1,26 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from enum import IntEnum, unique
+
+
+@unique
+class Status(IntEnum):
+    # We rely on the order (least access to most access) in several places
+    Blocked = 1
+    Internal = 2
+    Public = 3

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -19,6 +19,7 @@ import pytest
 
 from esrally import exceptions
 from esrally.track import track
+from esrally.utils import serverless
 
 
 class TestTrack:
@@ -274,15 +275,15 @@ class TestOperationType:
     def test_attributes(self):
         create_ilm_policy = track.OperationType.CreateIlmPolicy
         assert create_ilm_policy.admin_op is True
-        assert create_ilm_policy.serverless_status == track.ServerlessStatus.Blocked
+        assert create_ilm_policy.serverless_status == serverless.Status.Blocked
 
         node_stats = track.OperationType.NodeStats
         assert node_stats.admin_op is False
-        assert node_stats.serverless_status == track.ServerlessStatus.Internal
+        assert node_stats.serverless_status == serverless.Status.Internal
 
         bulk = track.OperationType.Bulk
         assert bulk.admin_op is False
-        assert bulk.serverless_status == track.ServerlessStatus.Public
+        assert bulk.serverless_status == serverless.Status.Public
 
 
 class TestTaskFilter:


### PR DESCRIPTION
Can be tested using:

```
esrally race --track-path=$HOME/src/rally-tracks/geonames --test-mode --target-hosts=... --pipeline=benchmark-only --client-options=serverless.json --on-error=abort --telemetry=ccr-stats
```

This will run the race and print:

```
[INFO] Excluding telemetry device [ccr-stats] as it is unavailable on serverless.                                                         
```

To test without operator status, you should either include https://github.com/elastic/rally/pull/1768 or set `serverless.operator` to `false` in the rally.ini `[driver]` section.

TODO:

- [x] Tests
- [x] Figure out why the message is printed twice