### PR TITLE
Strip whitespace from 'revision' args

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -98,6 +98,9 @@ def create_arg_parser():
                 raise argparse.ArgumentTypeError(f"must be at least {min_es_version} but was {v}")
         return v
 
+    def strip_whitespace(v):
+        return str(v).strip()
+
     def add_track_source(subparser):
         track_source_group = subparser.add_mutually_exclusive_group()
         track_source_group.add_argument(
@@ -114,6 +117,7 @@ def create_arg_parser():
             "--track-revision",
             help="Define a specific revision in the track repository that Rally should use.",
             default=None,
+            type=strip_whitespace,
         )
 
     # try to preload configurable defaults, but this does not work together with `--configuration-name` (which is undocumented anyway)
@@ -295,6 +299,7 @@ def create_arg_parser():
         'e.g. "@2013-07-27T10:37:00Z" (default: current). A combination of branch and timestamp is also possible,'
         'e.g. "@feature-branch@2023-04-06T14:52:31Z".',
         default="current",
+        type=strip_whitespace,
     )  # optimized for local usage, don't fetch sources
     build_parser.add_argument(
         "--target-os",
@@ -313,6 +318,7 @@ def create_arg_parser():
         "--team-revision",
         help="Define a specific revision in the team repository that Rally should use.",
         default=None,
+        type=strip_whitespace,
     )
     build_parser.add_argument(
         "--team-path",
@@ -355,6 +361,7 @@ def create_arg_parser():
         "--team-revision",
         help="Define a specific revision in the team repository that Rally should use.",
         default=None,
+        type=strip_whitespace,
     )
     download_parser.add_argument(
         "--team-path",
@@ -399,6 +406,7 @@ def create_arg_parser():
         ' The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, '
         'e.g. "@2013-07-27T10:37:00Z" (default: current).',
         default="current",
+        type=strip_whitespace,
     )  # optimized for local usage, don't fetch sources
     # Intentionally undocumented as we do not consider Docker a fully supported option.
     install_parser.add_argument(
@@ -416,6 +424,7 @@ def create_arg_parser():
         "--team-revision",
         help="Define a specific revision in the team repository that Rally should use.",
         default=None,
+        type=strip_whitespace,
     )
     install_parser.add_argument(
         "--team-path",
@@ -571,6 +580,7 @@ def create_arg_parser():
             "--team-revision",
             help="Define a specific revision in the team repository that Rally should use.",
             default=None,
+            type=strip_whitespace,
         )
 
     race_parser.add_argument(
@@ -591,6 +601,7 @@ def create_arg_parser():
         ' The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, '
         'e.g. "@2013-07-27T10:37:00Z" (default: current).',
         default="current",
+        type=strip_whitespace,
     )  # optimized for local usage, don't fetch sources
     add_track_source(race_parser)
     race_parser.add_argument(

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -99,7 +99,7 @@ def create_arg_parser():
         return v
 
     def strip_whitespace(v):
-        return str(v).strip()
+        return v.strip()
 
     def add_track_source(subparser):
         track_source_group = subparser.add_mutually_exclusive_group()

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -98,7 +98,7 @@ def create_arg_parser():
                 raise argparse.ArgumentTypeError(f"must be at least {min_es_version} but was {v}")
         return v
 
-    def strip_whitespace(v):
+    def revision(v):
         return v.strip()
 
     def add_track_source(subparser):
@@ -117,7 +117,7 @@ def create_arg_parser():
             "--track-revision",
             help="Define a specific revision in the track repository that Rally should use.",
             default=None,
-            type=strip_whitespace,
+            type=revision,
         )
 
     # try to preload configurable defaults, but this does not work together with `--configuration-name` (which is undocumented anyway)
@@ -299,7 +299,7 @@ def create_arg_parser():
         'e.g. "@2013-07-27T10:37:00Z" (default: current). A combination of branch and timestamp is also possible,'
         'e.g. "@feature-branch@2023-04-06T14:52:31Z".',
         default="current",
-        type=strip_whitespace,
+        type=revision,
     )  # optimized for local usage, don't fetch sources
     build_parser.add_argument(
         "--target-os",
@@ -318,7 +318,7 @@ def create_arg_parser():
         "--team-revision",
         help="Define a specific revision in the team repository that Rally should use.",
         default=None,
-        type=strip_whitespace,
+        type=revision,
     )
     build_parser.add_argument(
         "--team-path",
@@ -361,7 +361,7 @@ def create_arg_parser():
         "--team-revision",
         help="Define a specific revision in the team repository that Rally should use.",
         default=None,
-        type=strip_whitespace,
+        type=revision,
     )
     download_parser.add_argument(
         "--team-path",
@@ -406,7 +406,7 @@ def create_arg_parser():
         ' The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, '
         'e.g. "@2013-07-27T10:37:00Z" (default: current).',
         default="current",
-        type=strip_whitespace,
+        type=revision,
     )  # optimized for local usage, don't fetch sources
     # Intentionally undocumented as we do not consider Docker a fully supported option.
     install_parser.add_argument(
@@ -424,7 +424,7 @@ def create_arg_parser():
         "--team-revision",
         help="Define a specific revision in the team repository that Rally should use.",
         default=None,
-        type=strip_whitespace,
+        type=revision,
     )
     install_parser.add_argument(
         "--team-path",
@@ -580,7 +580,7 @@ def create_arg_parser():
             "--team-revision",
             help="Define a specific revision in the team repository that Rally should use.",
             default=None,
-            type=strip_whitespace,
+            type=revision,
         )
 
     race_parser.add_argument(
@@ -601,7 +601,7 @@ def create_arg_parser():
         ' The timestamp must be specified as: "@ts" where "ts" must be a valid ISO 8601 timestamp, '
         'e.g. "@2013-07-27T10:37:00Z" (default: current).',
         default="current",
-        type=strip_whitespace,
+        type=revision,
     )  # optimized for local usage, don't fetch sources
     add_track_source(race_parser)
     race_parser.add_argument(


### PR DESCRIPTION
In https://github.com/elastic/rally/pull/1763 we added a new `Bootstrap` message handler to each Rally worker, which is responsible for ensuring the track and configuration is properly loaded on each worker before we attempt to execute the benchmark. Part of this work uncovered that there was a race condition if multiple workers tried to checkout the same underlying git repository in parallel, resulting in this error message:
```
2023-08-29 01:38:04,182 ActorAddr-(T|:58548)/PID:87195 esrally.utils.process INFO fatal: Unable to create '/Users/bradleydeam/perf/github.com/b-deam/rally-tracks/.git/index.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
```

To avoid this, we added a check as part of the repository loading process that skips the checkout if we're already on the correct revision/branch
https://github.com/elastic/rally/blob/8dae2c3f3c26f0dbfb2d9047cf0a622688dd57ab/esrally/track/loader.py#L360-L362

However, recent PRs to https://github.com/elastic/rally-tracks have been failing due to this race condition even with the above check in place. When we look at [the CI logs for an example of the failure](https://github.com/elastic/rally-tracks/actions/runs/5962856049?pr=451), we see that it's because the revision passed in contains whitespace at the end, meaning the `correction_revision()` function returns false, note the whitespace in the latter revision:
```
2023-08-24 11:21:15,408 ActorAddr-(T|:36487)/PID:3957 esrally.utils.repo INFO Checking current revision [96248077b03ae242a973b175244ac93eec0e0f9a] is equal to specified revision [96248077b03ae242a973b175244ac93eec0e0f9a
].
```

CI highlighted this bug, but it would be very confusing and difficult for any end users to debug. 

This commit adds a function that strips whitespace from any subcommand
that takes a revision argument.