### PR TITLE
Support API key authentication

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -717,6 +717,7 @@ Here are a few common examples:
 
 * Enable HTTP compression: ``--client-options="http_compress:true"``
 * Enable basic authentication: ``--client-options="basic_auth_user:'user',basic_auth_password:'password'"``. Avoid the characters ``'``, ``,`` and ``:`` in user name and password as Rally's parsing of these options is currently really simple and there is no possibility to escape characters.
+* Enable API key authentication: ``--client-options="api_key:'a0V...2dw=='"``
 
 **TLS/SSL**
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -711,13 +711,16 @@ Rally recognizes the following client options in addition:
 * ``static_responses``: The path to a JSON file containing path patterns and the corresponding responses. When this value is set to ``true``, Rally will not send requests to Elasticsearch but return static responses as specified by the file. This is useful to diagnose performance issues in Rally itself. See below for a specific example.
 * ``create_api_key_per_client`` (default: ``false``): If set to ``true``, Rally will create a unique `Elasticsearch API key <https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html>`_ for each simulated client that issues requests against Elasticsearch during the benchmark. This is useful for simulating workloads where data is indexed by many distinct agents, each configured with its own API key, as is typical with Elastic Agent. Note that ``basic_auth_user`` and ``basic_auth_password`` must also be provided, and the ``basic_auth_user`` must have `sufficient privileges <https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html#security-api-create-api-key-prereqs>`_ to create API keys. These basic auth credentials are used to create the API keys at the start of the benchmark and delete them at the end, but only the generated API keys will be used during benchmark execution.
 
-**Examples**
+**Authentication**
 
-Here are a few common examples:
+You can choose between two authentication modes:
 
-* Enable HTTP compression: ``--client-options="http_compress:true"``
-* Enable basic authentication: ``--client-options="basic_auth_user:'user',basic_auth_password:'password'"``. Avoid the characters ``'``, ``,`` and ``:`` in user name and password as Rally's parsing of these options is currently really simple and there is no possibility to escape characters.
-* Enable API key authentication: ``--client-options="api_key:'a0V...2dw=='"``
+* API key authentication (preferred): ``--client-options="api_key:'a0V...2dw=='"``
+* Basic authentication: ``--client-options="basic_auth_user:'user',basic_auth_password:'password'"``. Avoid the characters ``'``, ``,`` and ``:`` in user name and password as Rally's parsing of these options is currently really simple and there is no possibility to escape characters.
+
+**HTTP compression**
+
+Enable HTTP compression using ``--client-options="http_compress:true"``.
 
 **TLS/SSL**
 

--- a/esrally/client/factory.py
+++ b/esrally/client/factory.py
@@ -52,6 +52,8 @@ class EsClientFactory:
             masked_client_options["basic_auth_password"] = "*****"
         if "http_auth" in masked_client_options:
             masked_client_options["http_auth"] = (masked_client_options["http_auth"][0], "*****")
+        if "api_key" in masked_client_options:
+            masked_client_options["api_key"] = "*****"
         self.logger.info("Creating ES client connected to %s with options [%s]", hosts, masked_client_options)
 
         # we're using an SSL context now and it is not allowed to have use_ssl present in client options anymore
@@ -139,6 +141,11 @@ class EsClientFactory:
             self.logger.debug("HTTP basic authentication: on")
         else:
             self.logger.debug("HTTP basic authentication: off")
+
+        if self._is_set(self.client_options, "api_key"):
+            self.logger.debug("API key authentication: on")
+        else:
+            self.logger.debug("API key authentication: off")
 
         if self._is_set(self.client_options, "compressed"):
             console.warn("You set the deprecated client option 'compressed‘. Please use 'http_compress' instead.", logger=self.logger)


### PR DESCRIPTION
Closes #1777, relates #1757 

Most of the work is done in the Elasticsearch Python client, so we do only three things:

 * document the option,
 * mask the API key in logs,
 * and log that it is enabled or not.

However:

 * We don't catch the case where `api_key`, `basic_auth_user` and `basic_auth_password` are all set, since we get a traceback with `ValueError: Can only set one of 'api_key', 'basic_auth', and 'bearer_auth'` in this case.
 * We don't try to support the combination of  `create_api_key_per_client` with `api_key`: `basic_auth` is still required for that use case, as documented.