### PR TITLE
Simplify ClusterEnvironmentInfo telemetry device

### DIFF
--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1707,7 +1707,7 @@ class DiskIo(InternalTelemetryDevice):
 
 
 def store_node_attribute_metadata(metrics_store, nodes_info):
-    # push up all node level attributes to cluster level if the values are identical for all nodes
+    # push up all node level attributes to cluster level iff the values are identical for all nodes
     pseudo_cluster_attributes = {}
     for node in nodes_info:
         if "attributes" in node:

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -1707,7 +1707,7 @@ class DiskIo(InternalTelemetryDevice):
 
 
 def store_node_attribute_metadata(metrics_store, nodes_info):
-    # push up all node level attributes to cluster level iff the values are identical for all nodes
+    # push up all node level attributes to cluster level if the values are identical for all nodes
     pseudo_cluster_attributes = {}
     for node in nodes_info:
         if "attributes" in node:
@@ -1802,7 +1802,6 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
             return
         distribution_flavor = client_info["version"].get("build_flavor", "oss")
         # serverless returns dummy build hash which gets overridden when running with operator privileges
-        # TODO: refactor if config object gets included in telemetry base class (ES-6459)
         revision = client_info["version"].get("build_hash", distribution_flavor)
         if self.revision_override:
             revision = self.revision_override
@@ -1811,18 +1810,6 @@ class ClusterEnvironmentInfo(InternalTelemetryDevice):
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "source_revision", revision)
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "distribution_version", distribution_version)
         self.metrics_store.add_meta_info(metrics.MetaInfoScope.cluster, None, "distribution_flavor", distribution_flavor)
-
-        info = self.client.nodes.info(node_id="_all")
-        nodes_info = info["nodes"].values()
-        for node in nodes_info:
-            node_name = node["name"]
-            # while we could determine this for bare-metal nodes that are provisioned by Rally, there are other cases (Docker, externally
-            # provisioned clusters) where it's not that easy.
-            self.metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "jvm_vendor", extract_value(node, ["jvm", "vm_vendor"]))
-            self.metrics_store.add_meta_info(metrics.MetaInfoScope.node, node_name, "jvm_version", extract_value(node, ["jvm", "version"]))
-
-        store_plugin_metadata(self.metrics_store, nodes_info)
-        store_node_attribute_metadata(self.metrics_store, nodes_info)
 
 
 def add_metadata_for_node(metrics_store, node_name, host_name):

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -3336,16 +3336,6 @@ class TestClusterEnvironmentInfo:
             mock.call(metrics.MetaInfoScope.cluster, None, "source_revision", "abc123"),
             mock.call(metrics.MetaInfoScope.cluster, None, "distribution_version", "6.0.0-alpha1"),
             mock.call(metrics.MetaInfoScope.cluster, None, "distribution_flavor", "oss"),
-            mock.call(metrics.MetaInfoScope.node, "rally0", "jvm_vendor", "Oracle Corporation"),
-            mock.call(metrics.MetaInfoScope.node, "rally0", "jvm_version", "1.8.0_74"),
-            mock.call(metrics.MetaInfoScope.node, "rally1", "jvm_vendor", "Oracle Corporation"),
-            mock.call(metrics.MetaInfoScope.node, "rally1", "jvm_version", "1.8.0_102"),
-            mock.call(metrics.MetaInfoScope.node, "rally0", "plugins", ["ingest-geoip"]),
-            mock.call(metrics.MetaInfoScope.node, "rally1", "plugins", ["ingest-geoip"]),
-            # can push up to cluster level as all nodes have the same plugins installed
-            mock.call(metrics.MetaInfoScope.cluster, None, "plugins", ["ingest-geoip"]),
-            mock.call(metrics.MetaInfoScope.node, "rally0", "attribute_group", "cold_nodes"),
-            mock.call(metrics.MetaInfoScope.node, "rally1", "attribute_group", "hot_nodes"),
         ]
 
         metrics_store_add_meta_info.assert_has_calls(calls)


### PR DESCRIPTION
`ClusterEnvironmentInfo` telemetry device unnecessarily calls nodes stats API to populate metadata fields in a metric store which duplicates `ExternalEnvironmentInfo`. As `ClusterEnvironmentInfo` is not tagged with `serverless.Status.Internal` status, the additional bonus of the simplification is unblocking Rally when ran with public serverless privileges.

I've tested the change comparing metric store content (`rally-metrics-*`) with/without simplification. On each run the amount of documents with the following fields was equal:
* serverless cluster with operator privileges - `meta.jvm_vendor` field,
* stateful ESS cluster with superuser privileges - `meta.jvm_vendor` and `meta.attribute_region` fields.
