### PR TITLE
Run Rally IT Serverless pipeline on pull requests

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -4,6 +4,11 @@
       "enabled": true,
       "pipeline_slug": "rally-it",
       "allow_org_users": true
+    },
+    {
+      "enabled": true,
+      "pipeline_slug": "rally-it-serverless",
+      "allow_org_users": true
     }
   ]
 }


### PR DESCRIPTION
Noticed in https://github.com/elastic/rally/pull/1782 that the pipeline does not run on pull requests from forks.