### PR TITLE
Inject serverless_operator in track templates

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -88,6 +88,7 @@ Assuming we pass ``--track-params="es_snapshot_restore_recovery_max_bytes_per_se
 The parameter ``default_value`` controls the value to use for the setting if it is undefined. If the setting is undefined and there is no default value, nothing will be added.
 
 * ``build_flavor``: a global variable that holds build flavor reported by Elasticsearch cluster targetted by Rally.
+* ``serverless_operator``: a global variable that holds ``true`` when Rally targets serverless cluster with operator privileges, and ``false`` otherwise.
 
 .. _adding_tracks_custom_param_sources:
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,14 @@
 Migration Guide
 ===============
 
+Migrating to Rally 2.10.0
+-------------------------
+
+``serverless_operator`` becomes a global variable in track templates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Rally now treats ``serverless_operator`` as a :ref:`global variable<advanced_extensions>` in Jinja2 templates. The variable equals ``true`` if Rally targets serverless cluster with operator privileges, and ``false`` otherwise. The ``serverless_operator`` becomes a reserved name so user-supplied track parameters must be named differently. Rename your track parameters before upgrade if needed.
+
 Migrating to Rally 2.9.0
 ------------------------
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -16,7 +16,7 @@ Migrating to Rally 2.9.0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Rally now treats ``build_flavor`` as a :ref:`global variable<advanced_extensions>` in Jinja2 templates. The value of the variable depends on the build flavor reported by Elasticsearch cluster targetted by Rally.
-The ``build_flavor`` becomes a reserved name so user-supplied track parameters must be named differently. Rename your track parameters before upgrade if needed.
+The ``build_flavor`` becomes a reserved name so user-supplied track parameters must be named differently. Rename your track parameters before upgrading if needed.
 
 Example error when running with ``--track-params="build_flavor:test"``::
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -7,7 +7,7 @@ Migrating to Rally 2.10.0
 ``serverless_operator`` becomes a global variable in track templates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Rally now treats ``serverless_operator`` as a :ref:`global variable<advanced_extensions>` in Jinja2 templates. The variable equals ``true`` if Rally targets serverless cluster with operator privileges, and ``false`` otherwise. The ``serverless_operator`` becomes a reserved name so user-supplied track parameters must be named differently. Rename your track parameters before upgrade if needed.
+Rally now treats ``serverless_operator`` as a :ref:`global variable<advanced_extensions>` in Jinja2 templates. The variable equals ``true`` if Rally targets serverless cluster with operator privileges, and ``false`` otherwise. The ``serverless_operator`` becomes a reserved name so user-supplied track parameters must be named differently. Rename your track parameters before upgrading if needed.
 
 Migrating to Rally 2.9.0
 ------------------------

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -956,14 +956,17 @@ def assert_equal_ignore_whitespace(expected, actual):
 
 
 class TestTemplateRender:
-    unittest_template_internal_vars = loader.default_internal_template_vars(clock=StaticClock, build_flavor="test")
+    unittest_template_internal_vars = loader.default_internal_template_vars(
+        clock=StaticClock, build_flavor="test", serverless_operator=False
+    )
 
     def test_render_simple_template(self):
         template = """
         {
             "key": {{'01-01-2000' | days_ago(now)}},
             "key2": "static value",
-            "key3": "{{build_flavor}}"
+            "key3": "{{build_flavor}}",
+            "key4": {{serverless_operator}}
         }
         """
 
@@ -973,7 +976,8 @@ class TestTemplateRender:
         {
             "key": 5864,
             "key2": "static value",
-            "key3": "test"
+            "key3": "test",
+            "key4": False
         }
         """
         assert rendered == expected
@@ -1071,6 +1075,8 @@ class TestTemplateRender:
         {
             {%- if build_flavor != "test" %}
             "key1": "build_flavor"
+            {%- elif serverless_operator %}
+            "key1": "serverless_operator"
             {%- elif lifecycle == "ilm" %}
             "key1": "ilm"
             {%- else %}


### PR DESCRIPTION
Logical continuation of https://github.com/elastic/rally/pull/1750 with additional global variable `serverless_operator`. The variable holds `true` if Rally detects serverless cluster and operator privileges, and `false` otherwise.

I've extended unit tests to cover the addition. For manual tests I've used custom track definition with the following bits:
```
# track json
{% import "rally.helpers" as rally with context %}
{
  "version": 2,
  [..]
  "indices": [
    {
      "name": "test-index",
      "body": "test-index.json"
    }
  ],
[..]

# test-index.json
{
    "mappings": {
      [..]
    },
    "settings": {
        "index": {
{% if build_flavor != "serverless" or serverless_operator %}
            "number_of_replicas": "{{number_of_replicas | default(0)}}",
            "number_of_shards": "{{number_of_shards | default(2)}}"
{% endif %}
        }
    }
}
```
