### PR TITLE
Retrieve cluster info in serverless public mode

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -718,10 +718,11 @@ class Driver:
             self.logger.info("Skipping REST API check as requested explicitly.")
         elif uses_static_responses:
             self.logger.info("Skipping REST API check as static responses are used.")
-        elif serverless_mode and not serverless_operator:
-            self.logger.info("Skipping REST API check while targetting serverless cluster with a public user.")
         else:
-            self.wait_for_rest_api(es_clients)
+            if serverless_mode and not serverless_operator:
+                self.logger.info("Skipping REST API check while targetting serverless cluster with a public user.")
+            else:
+                self.wait_for_rest_api(es_clients)
             self.driver_actor.cluster_details = self.retrieve_cluster_info(es_clients)
             if serverless_mode and serverless_operator:
                 build_hash = self.retrieve_build_hash_from_nodes_info(es_clients)


### PR DESCRIPTION
https://github.com/elastic/rally/pull/1785 bypassed `client.wait_for_rest_layer()` call in `driver.Driver.prepare_benchmark()` but unnecessarily also bypassed `retrieve_cluster_info()` method. This PR fixes this.

Before the change:
```
% esrally race --track=geonames --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --test-mode                                      
[..]
[INFO] Race id is [b109fef1-5f31-4e63-92c5-dc3a6a10c3a1]
[INFO] Detected Elasticsearch Serverless mode with operator=[False].
[INFO] Excluding [check-cluster-health], [force-merge], [wait-until-merges-finish], [index-stats], [node-stats] as challenge [append-no-conflicts] is run on serverless.
[INFO] Racing on track [geonames], challenge [append-no-conflicts] and car ['external'] with version [oss]. <--- HERE
```

After:
```
% esrally race --track=geonames --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --test-mode
[..]
[INFO] Race id is [b7a2f8a9-8c58-4690-aaa2-0d2424ee7f37]
[INFO] Detected Elasticsearch Serverless mode with operator=[False].
[INFO] Excluding [check-cluster-health], [force-merge], [wait-until-merges-finish], [index-stats], [node-stats] as challenge [append-no-conflicts] is run on serverless.
[INFO] Racing on track [geonames], challenge [append-no-conflicts] and car ['external'] with version [8.11.0]. <--- HERE
```