### PR TITLE
Simplify test mode with small document sets

### DIFF
--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -299,12 +299,14 @@ Congratulations, you have created your first track! You can test it with ``esral
 Adding support for test mode
 ----------------------------
 
-You can check your track very quickly for syntax errors when you invoke Rally with ``--test-mode``. Rally postprocesses its internal track representation as follows:
+You can check your track very quickly for syntax errors when you invoke Rally with ``--test-mode``.
+
+In test mode Rally postprocesses its internal track representation as follows:
 
 * Iteration-based tasks run at most one warmup iteration and one measurement iteration.
 * Time-period-based tasks run at most for 10 seconds without warmup.
 
-Rally also post-processes all data file names in the internal track representation:
+In test mode Rally also post-processes all data file names:
 
 * If ``documents.json`` has 1000 documents or fewer, Rally uses it (no modifications).
 * If ``documents.json`` has more than 1000 documents, Rally assumes an additional ``documents-1k.json`` file is present and uses it. You need to prepare these additional files manually. Pick 1000 documents for every data file in your track and store them in a file with the ``-1k`` suffix. On Linux you can do it as follows: ``head -n 1000 documents.json > documents-1k.json``.

--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -304,9 +304,10 @@ You can check your track very quickly for syntax errors when you invoke Rally wi
 * Iteration-based tasks run at most one warmup iteration and one measurement iteration.
 * Time-period-based tasks run at most for 10 seconds without warmup.
 
-Rally also post-processes all data file names. Instead of ``documents.json``, Rally expects ``documents-1k.json`` and assumes the file contains 1.000 documents. You need to prepare these data files though. Pick 1.000 documents for every data file in your track and store them in a file with the suffix ``-1k``. We choose the first 1.000 with ``head -n 1000 documents.json > documents-1k.json``.
+Rally also post-processes all data file names in the internal track representation:
 
-If your file has 1000 or fewer documents, you can skip creating the ``-1k`` variant. Rally will use the original file in such case.
+* If ``documents.json`` has 1000 documents or fewer, Rally uses it (no modifications).
+* If ``documents.json`` has more than 1000 documents, Rally assumes an additional ``documents-1k.json`` file is present and uses it. You need to prepare these additional files manually. Pick 1000 documents for every data file in your track and store them in a file with the ``-1k`` suffix. On Linux you can do it as follows: ``head -n 1000 documents.json > documents-1k.json``.
 
 Challenges
 ----------

--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -306,7 +306,7 @@ You can check your track very quickly for syntax errors when you invoke Rally wi
 
 Rally also post-processes all data file names. Instead of ``documents.json``, Rally expects ``documents-1k.json`` and assumes the file contains 1.000 documents. You need to prepare these data files though. Pick 1.000 documents for every data file in your track and store them in a file with the suffix ``-1k``. We choose the first 1.000 with ``head -n 1000 documents.json > documents-1k.json``.
 
-If your file has 1000 and less documents, you can skip creation of ``-1k`` variant. Rally will use the original file in such case.
+If your file has 1000 or fewer documents, you can skip creating the ``-1k`` variant. Rally will use the original file in such case.
 
 Challenges
 ----------

--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -304,7 +304,9 @@ You can check your track very quickly for syntax errors when you invoke Rally wi
 * Iteration-based tasks run at most one warmup iteration and one measurement iteration.
 * Time-period-based tasks run at most for 10 seconds without warmup.
 
-Rally also postprocesses all data file names. Instead of ``documents.json``, Rally expects ``documents-1k.json`` and assumes the file contains 1.000 documents. You need to prepare these data files though. Pick 1.000 documents for every data file in your track and store them in a file with the suffix ``-1k``. We choose the first 1.000 with ``head -n 1000 documents.json > documents-1k.json``.
+Rally also post-processes all data file names. Instead of ``documents.json``, Rally expects ``documents-1k.json`` and assumes the file contains 1.000 documents. You need to prepare these data files though. Pick 1.000 documents for every data file in your track and store them in a file with the suffix ``-1k``. We choose the first 1.000 with ``head -n 1000 documents.json > documents-1k.json``.
+
+If your file has 1000 and less documents, you can skip creation of ``-1k`` variant. Rally will use the original file in such case.
 
 Challenges
 ----------

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -962,30 +962,44 @@ class TestModeTrackProcessor(TrackProcessor):
             return track
         self.logger.info("Preparing track [%s] for test mode.", str(track))
         for corpus in track.corpora:
-            if self.logger.isEnabledFor(logging.DEBUG):
-                self.logger.debug("Reducing corpus size to 1000 documents for [%s]", corpus.name)
             for document_set in corpus.documents:
                 # TODO #341: Should we allow this for snapshots too?
                 if document_set.is_bulk:
-                    document_set.number_of_documents = 1000
+                    if document_set.number_of_documents > 1000:
+                        if self.logger.isEnabledFor(logging.DEBUG):
+                            self.logger.debug(
+                                "Reducing corpus size to 1000 documents in corpus [%s], uncompressed source file [%s]",
+                                corpus.name,
+                                document_set.document_file,
+                            )
 
-                    if document_set.has_compressed_corpus():
-                        path, ext = io.splitext(document_set.document_archive)
-                        path_2, ext_2 = io.splitext(path)
+                        document_set.number_of_documents = 1000
 
-                        document_set.document_archive = f"{path_2}-1k{ext_2}{ext}"
-                        document_set.document_file = f"{path_2}-1k{ext_2}"
-                    elif document_set.has_uncompressed_corpus():
-                        path, ext = io.splitext(document_set.document_file)
-                        document_set.document_file = f"{path}-1k{ext}"
+                        if document_set.has_compressed_corpus():
+                            path, ext = io.splitext(document_set.document_archive)
+                            path_2, ext_2 = io.splitext(path)
+
+                            document_set.document_archive = f"{path_2}-1k{ext_2}{ext}"
+                            document_set.document_file = f"{path_2}-1k{ext_2}"
+                        elif document_set.has_uncompressed_corpus():
+                            path, ext = io.splitext(document_set.document_file)
+                            document_set.document_file = f"{path}-1k{ext}"
+                        else:
+                            raise exceptions.RallyAssertionError(
+                                f"Document corpus [{corpus.name}] has neither compressed nor uncompressed corpus."
+                            )
+
+                        # we don't want to check sizes
+                        document_set.compressed_size_in_bytes = None
+                        document_set.uncompressed_size_in_bytes = None
                     else:
-                        raise exceptions.RallyAssertionError(
-                            f"Document corpus [{corpus.name}] has neither compressed nor uncompressed corpus."
-                        )
-
-                    # we don't want to check sizes
-                    document_set.compressed_size_in_bytes = None
-                    document_set.uncompressed_size_in_bytes = None
+                        if self.logger.isEnabledFor(logging.DEBUG):
+                            self.logger.debug(
+                                "Maintaining existing size of %d documents in corpus [%s], uncompressed source file [%s]",
+                                document_set.number_of_documents,
+                                corpus.name,
+                                document_set.document_file,
+                            )
 
         for challenge in track.challenges:
             for task in challenge.schedule:

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -1251,7 +1251,7 @@ class TestTrackPostProcessing:
             ],
             "corpora": [
                 {
-                    "name": "unittest-more-than-1k-documents",
+                    "name": "unittest-reduce-to-1k-documents",
                     "documents": [
                         {
                             "source-file": "documents.json.bz2",
@@ -1262,7 +1262,7 @@ class TestTrackPostProcessing:
                     ],
                 },
                 {
-                    "name": "unittest-less-than-1k-documents",
+                    "name": "unittest-keep-less-than-1k-documents",
                     "documents": [
                         {
                             "source-file": "documents.json.bz2",
@@ -1338,13 +1338,13 @@ class TestTrackPostProcessing:
             ],
             "corpora": [
                 {
-                    "name": "unittest-more-than-1k-documents",
+                    "name": "unittest-reduce-to-1k-documents",
                     "documents": [
                         {"source-file": "documents-1k.json.bz2", "document-count": 1000},
                     ],
                 },
                 {
-                    "name": "unittest-less-than-1k-documents",
+                    "name": "unittest-keep-less-than-1k-documents",
                     "documents": [
                         {
                             "source-file": "documents.json.bz2",

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -1251,7 +1251,18 @@ class TestTrackPostProcessing:
             ],
             "corpora": [
                 {
-                    "name": "unittest",
+                    "name": "unittest-more-than-1k-documents",
+                    "documents": [
+                        {
+                            "source-file": "documents.json.bz2",
+                            "document-count": 1001,
+                            "compressed-bytes": 100,
+                            "uncompressed-bytes": 10000,
+                        }
+                    ],
+                },
+                {
+                    "name": "unittest-less-than-1k-documents",
                     "documents": [
                         {
                             "source-file": "documents.json.bz2",
@@ -1260,7 +1271,7 @@ class TestTrackPostProcessing:
                             "uncompressed-bytes": 10000,
                         }
                     ],
-                }
+                },
             ],
             "operations": [
                 {
@@ -1327,9 +1338,20 @@ class TestTrackPostProcessing:
             ],
             "corpora": [
                 {
-                    "name": "unittest",
+                    "name": "unittest-more-than-1k-documents",
                     "documents": [
                         {"source-file": "documents-1k.json.bz2", "document-count": 1000},
+                    ],
+                },
+                {
+                    "name": "unittest-less-than-1k-documents",
+                    "documents": [
+                        {
+                            "source-file": "documents.json.bz2",
+                            "document-count": 10,
+                            "compressed-bytes": 100,
+                            "uncompressed-bytes": 10000,
+                        },
                     ],
                 },
             ],


### PR DESCRIPTION
https://github.com/elastic/rally-tracks/pull/469 adds very small indices for enrichment purposes. This scenario is not supported by test mode which requires `-1k` files with 1000 documents. This leads to an awkward workaround where original corpus gets dummy content just to reach 1000 documents in `-1k` files.

This PR addresses this limitation by skipping the `-1k` requirement for document sets with 1000 and less documents. In such case, original document set file is taken when running in test mode.
