### PR TITLE
Add props to prevent typos in config properties

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -33,7 +33,7 @@ from enum import Enum, IntEnum
 
 import tabulate
 
-from esrally import client, config, exceptions, paths, time, version
+from esrally import client, config, exceptions, paths, props, time, version
 from esrally.utils import console, convert, io, versions
 
 
@@ -1595,13 +1595,13 @@ class RaceStore:
         raise NotImplementedError("abstract method")
 
     def _max_results(self):
-        return int(self.cfg.opts("system", "list.max_results"))
+        return int(self.cfg.opts(*props.SYSTEM.LIST.MAX_RESULTS))
 
     def _track(self):
-        return self.cfg.opts("system", "admin.track", mandatory=False)
+        return self.cfg.opts(*props.SYSTEM.ADMIN.TRACK, mandatory=False)
 
     def _benchmark_name(self):
-        return self.cfg.opts("system", "list.races.benchmark_name", mandatory=False)
+        return self.cfg.opts(*props.SYSTEM.LIST.RACES.BANCHMARK_NAME, mandatory=False)
 
     def _race_timestamp(self):
         return self.cfg.opts("system", "add.race_timestamp")
@@ -1616,10 +1616,10 @@ class RaceStore:
         return self.cfg.opts("system", "add.chart_name", mandatory=False)
 
     def _from_date(self):
-        return self.cfg.opts("system", "list.from_date", mandatory=False)
+        return self.cfg.opts(*props.SYSTEM.LIST.FROM_DATE, mandatory=False)
 
     def _to_date(self):
-        return self.cfg.opts("system", "list.to_date", mandatory=False)
+        return self.cfg.opts(*props.SYSTEM.LIST.TO_DATE, mandatory=False)
 
     def _dry_run(self):
         return self.cfg.opts("system", "admin.dry_run", mandatory=False)

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1601,7 +1601,7 @@ class RaceStore:
         return self.cfg.opts(*props.SYSTEM.ADMIN.TRACK, mandatory=False)
 
     def _benchmark_name(self):
-        return self.cfg.opts(*props.SYSTEM.LIST.RACES.BANCHMARK_NAME, mandatory=False)
+        return self.cfg.opts(*props.SYSTEM.LIST.RACES.BENCHMARK_NAME, mandatory=False)
 
     def _race_timestamp(self):
         return self.cfg.opts("system", "add.race_timestamp")

--- a/esrally/props.py
+++ b/esrally/props.py
@@ -38,7 +38,7 @@ class PropEnum(str, Enum, metaclass=PropEnumType):
         if isinstance(value, PropEnumType):
             return value  # Nested Enum should stay original
         elif isinstance(value, str):
-            # This prefixing lets A.B.C.D values not just "d" but "a.b.c.d"
+            # This prefixing lets A.B.C.D value not just "d" but "a.b.c.d"
             value = f"{cls.__qualname__.lower()}.{value}"
             member = str.__new__(cls, value)
             member._value_ = value

--- a/esrally/props.py
+++ b/esrally/props.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from enum import auto, EnumType, member, StrEnum
+from enum import EnumType, StrEnum, auto, member
 
 
 class PropEnumType(EnumType):
@@ -38,7 +38,7 @@ class PropEnum(StrEnum, metaclass=PropEnumType):
 class Property(PropEnum):
     def __sections(self):
         node = globals()
-        for name in type(self).__qualname__.split('.'):
+        for name in type(self).__qualname__.split("."):
             node = node[name]
             if issubclass(node, Section):
                 yield name
@@ -54,7 +54,12 @@ class Property(PropEnum):
         return self.value.replace(f"{self.__section}.", "", 1)
 
     def __iter__(self):
-        return iter((self.__section, self.__key, ))
+        return iter(
+            (
+                self.__section,
+                self.__key,
+            )
+        )
 
     def __repr__(self):
         return f"<{type(self).__qualname__}.{self.name}: {self.value}>"

--- a/esrally/props.py
+++ b/esrally/props.py
@@ -1,0 +1,93 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from enum import auto, EnumType, member, StrEnum
+
+
+class PropEnumType(EnumType):
+    __iter__ = None
+
+
+class PropEnum(StrEnum, metaclass=PropEnumType):
+    def __new__(cls, value):
+        if isinstance(value, PropEnumType):
+            return value
+        elif isinstance(value, str):
+            value = f"{cls.__qualname__.lower()}.{value}"
+            member = str.__new__(cls, value)
+            member._value_ = value
+            return member
+        else:
+            raise TypeError(f"{value!r} is not a string or enum")
+
+
+class Property(PropEnum):
+    def __sections(self):
+        node = globals()
+        for name in type(self).__qualname__.split('.'):
+            node = node[name]
+            if issubclass(node, Section):
+                yield name
+            else:
+                break
+
+    @property
+    def __section(self):
+        return '.'.join(map(str.lower, self.__sections()))
+
+    @property
+    def __key(self):
+        return self.value.replace(f"{self.__section}.", "", 1)
+
+    def __iter__(self):
+        return iter((self.__section, self.__key, ))
+
+    def __repr__(self):
+        return f"<{type(self).__qualname__}.{self.name}: {self.value}>"
+
+
+class Section(Property):
+    pass
+
+
+class Key(Property):
+    pass
+
+
+def desc(*_):
+    return auto()
+
+
+class SYSTEM(Section):
+
+    @member
+    class ADMIN(Key):
+        TRACK = desc()
+
+    @member
+    class LIST(Key):
+        FROM_DATE = desc()
+        MAX_RESULTS = desc()
+        TO_DATE = desc()
+
+        @member
+        class CONFIG(Key):
+            OPTION = desc()
+
+        @member
+        class RACES(Key):
+            BANCHMARK_NAME = desc()

--- a/esrally/props.py
+++ b/esrally/props.py
@@ -38,7 +38,7 @@ class PropEnum(str, Enum, metaclass=PropEnumType):
         if isinstance(value, PropEnumType):
             return value  # Nested Enum should stay original
         elif isinstance(value, str):
-            # This prefixing lets A.B.C.D value not just "d" but "a.b.c.d"
+            # String member A.B.C.D value is prefixed to obtain "a.b.c.d" instead of "d"
             value = f"{cls.__qualname__.lower()}.{value}"
             member = str.__new__(cls, value)
             member._value_ = value

--- a/esrally/props.py
+++ b/esrally/props.py
@@ -111,23 +111,9 @@ class SYSTEM(Section):
 
     @member
     class LIST(Key):
-        FROM_DATE = desc(
-            """
-            list records only from this date
-            """
-        )
-
-        MAX_RESULTS = desc(
-            """
-            the limit of the number of records to return
-            """
-        )
-
-        TO_DATE = desc(
-            """
-            list records only to this date
-            """
-        )
+        FROM_DATE = desc("list records only from this date")
+        MAX_RESULTS = desc("the limit of the number of records to return")
+        TO_DATE = desc("list records only to this date")
 
         @member
         class CONFIG(Key):

--- a/esrally/props.py
+++ b/esrally/props.py
@@ -17,28 +17,28 @@
 
 from enum import Enum, auto
 
+# TODO remove ImportError fallback when we drop support for Python 3.10
 try:
-    from enum import EnumType
+    from enum import EnumType, member
 except ImportError:
     from enum import EnumMeta as EnumType
-
-try:
-    from enum import member
-except ImportError:
 
     def member(enum):
         return enum
 
 
 class PropEnumType(EnumType):
-    __iter__ = None
+    __iter__ = None  # Disallows unintentional dot notation
 
 
 class PropEnum(str, Enum, metaclass=PropEnumType):
+    """StrEnum-like Enum but supports multi-level nesting"""
+
     def __new__(cls, value):
         if isinstance(value, PropEnumType):
-            return value
+            return value  # Nested Enum should stay original
         elif isinstance(value, str):
+            # This prefixing lets A.B.C.D values not just "d" but "a.b.c.d"
             value = f"{cls.__qualname__.lower()}.{value}"
             member = str.__new__(cls, value)
             member._value_ = value
@@ -53,6 +53,7 @@ class PropEnum(str, Enum, metaclass=PropEnumType):
 
 class Property(PropEnum):
     def __sections(self):
+        """Yields section names from the top level to the bottom"""
         node = globals()
         for name in type(self).__qualname__.split("."):
             node = node[name]
@@ -70,6 +71,7 @@ class Property(PropEnum):
         return self.value.replace(f"{self.__section}.", "", 1)
 
     def __iter__(self):
+        """Allows to unpack pair of section and key names by star expansion"""
         return iter(
             (
                 self.__section,
@@ -90,6 +92,15 @@ class Key(Property):
 
 
 def desc(*_):
+    """Just a blank function to write a description for each key as a string
+
+    The usage of this function is open-ended for future enhancements. By main-
+    taining descriptions as (list of) str in the source code, it may be
+    possible to reuse them as e.g. help texts for users in the future.
+
+    Returns `enum.auto()` to let Enum populate an appropriate value to the
+    member.
+    """
     return auto()
 
 
@@ -100,9 +111,23 @@ class SYSTEM(Section):
 
     @member
     class LIST(Key):
-        FROM_DATE = desc()
-        MAX_RESULTS = desc()
-        TO_DATE = desc()
+        FROM_DATE = desc(
+            """
+            list records only from this date
+            """
+        )
+
+        MAX_RESULTS = desc(
+            """
+            the limit of the number of records to return
+            """
+        )
+
+        TO_DATE = desc(
+            """
+            list records only to this date
+            """
+        )
 
         @member
         class CONFIG(Key):

--- a/esrally/props.py
+++ b/esrally/props.py
@@ -28,7 +28,7 @@ except ImportError:
 
 
 class PropEnumType(EnumType):
-    __iter__ = None  # Disallows unintentional dot notation
+    __iter__ = None  # Disallows erroneous unpack by star expansion
 
 
 class PropEnum(str, Enum, metaclass=PropEnumType):

--- a/esrally/props.py
+++ b/esrally/props.py
@@ -111,4 +111,4 @@ class SYSTEM(Section):
 
         @member
         class RACES(Key):
-            BANCHMARK_NAME = desc()
+            BENCHMARK_NAME = desc()

--- a/esrally/props.py
+++ b/esrally/props.py
@@ -15,14 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from enum import StrEnum, auto
+from enum import Enum, auto
 
 try:
     from enum import EnumType
 except ImportError:
     from enum import EnumMeta as EnumType
-finally:
-    assert EnumType
 
 try:
     from enum import member
@@ -31,15 +29,12 @@ except ImportError:
     def member(enum):
         return enum
 
-finally:
-    assert member
-
 
 class PropEnumType(EnumType):
     __iter__ = None
 
 
-class PropEnum(StrEnum, metaclass=PropEnumType):
+class PropEnum(str, Enum, metaclass=PropEnumType):
     def __new__(cls, value):
         if isinstance(value, PropEnumType):
             return value
@@ -50,6 +45,10 @@ class PropEnum(StrEnum, metaclass=PropEnumType):
             return member
         else:
             raise TypeError(f"{value!r} is not a string or enum")
+
+    @staticmethod
+    def _generate_next_value_(name, *_):
+        return name.lower()
 
 
 class Property(PropEnum):

--- a/esrally/props.py
+++ b/esrally/props.py
@@ -15,7 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from enum import EnumType, StrEnum, auto, member
+from enum import StrEnum, auto
+
+try:
+    from enum import EnumType
+except ImportError:
+    from enum import EnumMeta as EnumType
+finally:
+    assert EnumType
+
+try:
+    from enum import member
+except ImportError:
+
+    def member(enum):
+        return enum
+
+finally:
+    assert member
 
 
 class PropEnumType(EnumType):
@@ -47,7 +64,7 @@ class Property(PropEnum):
 
     @property
     def __section(self):
-        return '.'.join(map(str.lower, self.__sections()))
+        return ".".join(map(str.lower, self.__sections()))
 
     @property
     def __key(self):
@@ -78,7 +95,6 @@ def desc(*_):
 
 
 class SYSTEM(Section):
-
     @member
     class ADMIN(Key):
         TRACK = desc()

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -1090,7 +1090,7 @@ def dispatch_sub_command(arg_parser, args, cfg):
             cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.CONFIG.OPTION, args.configuration)
             cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.MAX_RESULTS, args.limit)
             cfg.add(config.Scope.applicationOverride, *props.SYSTEM.ADMIN.TRACK, args.track)
-            cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.RACES.BANCHMARK_NAME, args.benchmark_name)
+            cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.RACES.BENCHMARK_NAME, args.benchmark_name)
             cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.FROM_DATE, args.from_date)
             cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.TO_DATE, args.to_date)
             configure_mechanic_params(args, cfg, command_requires_car=False)

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -41,6 +41,7 @@ from esrally import (
     log,
     metrics,
     paths,
+    props,
     racecontrol,
     reporter,
     telemetry,
@@ -1086,12 +1087,12 @@ def dispatch_sub_command(arg_parser, args, cfg):
             configure_reporting_params(args, cfg)
             reporter.compare(cfg, args.baseline, args.contender)
         elif sub_command == "list":
-            cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
-            cfg.add(config.Scope.applicationOverride, "system", "list.max_results", args.limit)
-            cfg.add(config.Scope.applicationOverride, "system", "admin.track", args.track)
-            cfg.add(config.Scope.applicationOverride, "system", "list.races.benchmark_name", args.benchmark_name)
-            cfg.add(config.Scope.applicationOverride, "system", "list.from_date", args.from_date)
-            cfg.add(config.Scope.applicationOverride, "system", "list.to_date", args.to_date)
+            cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.CONFIG.OPTION, args.configuration)
+            cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.MAX_RESULTS, args.limit)
+            cfg.add(config.Scope.applicationOverride, *props.SYSTEM.ADMIN.TRACK, args.track)
+            cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.RACES.BANCHMARK_NAME, args.benchmark_name)
+            cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.FROM_DATE, args.from_date)
+            cfg.add(config.Scope.applicationOverride, *props.SYSTEM.LIST.TO_DATE, args.to_date)
             configure_mechanic_params(args, cfg, command_requires_car=False)
             configure_track_params(arg_parser, args, cfg, command_requires_track=False)
             dispatch_list(cfg)


### PR DESCRIPTION
This PR will eliminate numerous strings around config by typo-proof enums.

In short,
`cfg.opts("benchmarks", "local.dataset.cache")`
will be rewritten to
`cfg.opts(*props.BENCKMARKS.LOCAL.DATASET.CACHE)`

The following points are aimed in the implementation:

1. Not require any changes in section and key names.
2. Support auto-completion by IDEs.
3. Keep the existing code width the same as possible.
4. Prepare the way to describe config properties in the code.
5. Enable to express both dot-notated sections and keys.
6. Make unpreferable unpacking fail on properties in the middle of dot notation.
  -> i.e. With `props.SECTION.DOT.NOTATED.KEY`, `func(*props.SECTION.DOT.NOTATED)` raises `TypeError`.

In return, the following restrictions are introduced:

- No way to declare the below kind of config keys.
  ```ini
  [section]
  spam = many
  spam.eggs = a few
  ```
  -> i.e. `func(*props.SECTION.SPAM)` raises `TypeError`; you can still write `func("section", "spam")`, though.
- Can't also express `camelCase`, `PascalCase`, `MACRO_CASE`, `kebab-case`, `COBOL-CASE`, and `bracket[notation]`.
- (possibly more)

Closes #1646

**TODOs**:

- [ ] Write unit tests.
- [ ] Write script to check typos between before and after strings elimination.
- [ ] Replace the rest of config `(section, key)` pairs.