### PR TITLE
Checkout tag on Docker release

### DIFF
--- a/.buildkite/release-docker/run.sh
+++ b/.buildkite/release-docker/run.sh
@@ -22,3 +22,7 @@ set -x
 export TERM=dumb
 export LC_ALL=en_US.UTF-8
 ./release-docker.sh "$RELEASE_VERSION"
+
+popd
+popd
+rm -rf "$tmp_dir"

--- a/.buildkite/release-docker/run.sh
+++ b/.buildkite/release-docker/run.sh
@@ -17,7 +17,6 @@ git clone https://github.com/elastic/rally
 pushd rally
 git checkout "${RELEASE_VERSION}"
 git --no-pager show
-exit 0
 
 set -x
 export TERM=dumb

--- a/.buildkite/release-docker/run.sh
+++ b/.buildkite/release-docker/run.sh
@@ -11,6 +11,14 @@ DOCKER_PASSWORD=$(vault read -field token /secret/ci/elastic-rally/release/docke
 retry 5 docker login -u elasticmachine -p $DOCKER_PASSWORD
 unset DOCKER_PASSWORD
 
+tmp_dir=$(mktemp --directory)
+pushd "$tmp_dir"
+git clone https://github.com/elastic/rally
+pushd rally
+git checkout "${RELEASE_VERSION}"
+git --no-pager show
+exit 0
+
 set -x
 export TERM=dumb
 export LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Docker release workflow does not checkout the right tag before the Docker build.
This PR fixes this using approach taken from [eland](https://github.com/elastic/eland/blob/6cecb454e35890bd487f275e94f7c477c7acecd3/.buildkite/release-docker/run.sh#L18-L23).
