### PR TITLE
Skip metrics that are missing in either contender or baseline

### DIFF
--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -666,7 +666,6 @@ class ComparisonReporter:
         totals.sort()
 
         lines = []
-        skip = 0
         for index, _total, field in totals:
             for stat in disk_usage_fields(baseline_stats):
                 if index in collated_baseline and index in collated_contender:
@@ -675,7 +674,6 @@ class ComparisonReporter:
                     if baseline_value == 0 and contender_value == 0:
                         continue
                 else:
-                    skip += 1
                     continue
                 unit = convert.bytes_to_human_unit(min(baseline_value, contender_value))
                 lines.append(
@@ -689,8 +687,6 @@ class ComparisonReporter:
                         formatter=partial(convert.bytes_to_unit, unit),
                     )
                 )
-        if total > 0:
-            print_internal(f"Skipped {skip} statistics as missing from either baseline or contender")
         return lines
 
     def _report_total_times(self, baseline_stats, contender_stats):

--- a/esrally/reporter.py
+++ b/esrally/reporter.py
@@ -666,11 +666,16 @@ class ComparisonReporter:
         totals.sort()
 
         lines = []
+        skip = 0
         for index, _total, field in totals:
             for stat in disk_usage_fields(baseline_stats):
-                baseline_value = collated_baseline[index].get(field, {}).get(stat, 0)
-                contender_value = collated_contender[index].get(field, {}).get(stat, 0)
-                if baseline_value == 0 and contender_value == 0:
+                if index in collated_baseline and index in collated_contender:
+                    baseline_value = collated_baseline[index].get(field, {}).get(stat, 0)
+                    contender_value = collated_contender[index].get(field, {}).get(stat, 0)
+                    if baseline_value == 0 and contender_value == 0:
+                        continue
+                else:
+                    skip += 1
                     continue
                 unit = convert.bytes_to_human_unit(min(baseline_value, contender_value))
                 lines.append(
@@ -684,6 +689,8 @@ class ComparisonReporter:
                         formatter=partial(convert.bytes_to_unit, unit),
                     )
                 )
+        if total > 0:
+            print_internal(f"Skipped {skip} statistics as missing from either baseline or contender")
         return lines
 
     def _report_total_times(self, baseline_stats, contender_stats):


### PR DESCRIPTION
Fixes: #1802 

This fixes compare failing if a metric is missing from one of baseline or contender. It seems this functionality was partly thought about already via e.g #1482 though this adds further protection.
