### PR TITLE
Handle raw response exceptions

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -2053,28 +2053,51 @@ async def execute_single(runner, es, params, on_error):
         total_ops = 0
         total_ops_unit = "ops"
         request_meta_data = {"success": False, "error-type": "api"}
+        error_message = ""
 
-        if isinstance(e.error, bytes):
-            error_message = e.error.decode("utf-8")
-        elif isinstance(e.error, BytesIO):
-            error_message = e.error.read().decode("utf-8")
+        # Some runners return a raw response, causing the 'error' property to be a string literal of the bytes/BytesIO object,
+        # we should avoid bubbling that up
+        # e.g. ApiError(413, '<_io.BytesIO object at 0xffffaf146a70>')
+        if isinstance(e.body, bytes):
+            # could be an empty body
+            if error_body := e.body.decode("utf-8"):
+                error_message = error_body
+            else:
+                # to be consistent with an empty 'e.error'
+                error_message = str(None)
+        elif isinstance(e.body, BytesIO):
+            # could be an empty body
+            if error_body := e.body.read().decode("utf-8"):
+                error_message = error_body
+            else:
+                # to be consistent with an empty 'e.error'
+                error_message = str(None)
+        # fallback to 'error' property if the body isn't bytes/BytesIO
         else:
-            error_message = e.error
+            if isinstance(e.error, bytes):
+                error_message = e.error.decode("utf-8")
+            elif isinstance(e.error, BytesIO):
+                error_message = e.error.read().decode("utf-8")
+            else:
+                # if the 'error' is empty, we get back str(None)
+                error_message = e.error
 
         if isinstance(e.info, bytes):
-            error_body = e.info.decode("utf-8")
+            error_info = e.info.decode("utf-8")
         elif isinstance(e.info, BytesIO):
-            error_body = e.info.read().decode("utf-8")
+            error_info = e.info.read().decode("utf-8")
         else:
-            error_body = e.info
+            error_info = e.info
 
-        if error_body:
-            error_message += f" ({error_body})"
+        if error_info:
+            error_message += f" ({error_info})"
+
         error_description = error_message
 
         request_meta_data["error-description"] = error_description
         if e.status_code:
             request_meta_data["http-status"] = e.status_code
+
     except KeyError as e:
         logging.getLogger(__name__).exception("Cannot execute runner [%s]; most likely due to missing parameters.", str(runner))
         msg = "Cannot execute [%s]. Provided parameters are: %s. Error: [%s]." % (str(runner), list(params.keys()), str(e))
@@ -2083,10 +2106,15 @@ async def execute_single(runner, es, params, on_error):
     if not request_meta_data["success"]:
         if on_error == "abort" or fatal_error:
             msg = "Request returned an error. Error type: %s" % request_meta_data.get("error-type", "Unknown")
-            description = request_meta_data.get("error-description")
-            if description:
-                msg += ", Description: %s" % description
+
+            if description := request_meta_data.get("error-description"):
+                msg += f", Description: {description}"
+
+            if http_status := request_meta_data.get("http-status"):
+                msg += f", HTTP Status: {http_status}"
+
             raise exceptions.RallyAssertionError(msg)
+
     return total_ops, total_ops_unit, request_meta_data
 
 

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1901,8 +1901,35 @@ class TestAsyncExecutor:
         with pytest.raises(exceptions.RallyAssertionError) as exc:
             await driver.execute_single(self.context_managed(runner), es, params, on_error="abort")
         assert exc.value.args[0] == (
-            "Request returned an error. Error type: api, Description: not found (the requested document could not be found)"
+            "Request returned an error. Error type: api, Description: not found (the requested document could not be found),"
+            " HTTP Status: 404"
         )
+
+    @pytest.mark.asyncio
+    async def test_execute_single_with_http_400_with_empty_raw_response_body(self):
+        es = None
+        params = None
+        empty_body = io.BytesIO(b"")
+        str_literal_empty_body = str(empty_body)
+        error_meta = elastic_transport.ApiResponseMeta(status=413, http_version="1.1", headers={}, duration=0.0, node=None)
+        runner = mock.AsyncMock(side_effect=elasticsearch.ApiError(message=str_literal_empty_body, meta=error_meta, body=empty_body))
+
+        with pytest.raises(exceptions.RallyAssertionError) as exc:
+            await driver.execute_single(self.context_managed(runner), es, params, on_error="abort")
+        assert exc.value.args[0] == ("Request returned an error. Error type: api, Description: None, HTTP Status: 413")
+
+    @pytest.mark.asyncio
+    async def test_execute_single_with_http_400_with_raw_response_body(self):
+        es = None
+        params = None
+        body = io.BytesIO(b"Huge error")
+        str_literal = str(body)
+        error_meta = elastic_transport.ApiResponseMeta(status=499, http_version="1.1", headers={}, duration=0.0, node=None)
+        runner = mock.AsyncMock(side_effect=elasticsearch.ApiError(message=str_literal, meta=error_meta, body=body))
+
+        with pytest.raises(exceptions.RallyAssertionError) as exc:
+            await driver.execute_single(self.context_managed(runner), es, params, on_error="abort")
+        assert exc.value.args[0] == ("Request returned an error. Error type: api, Description: Huge error, HTTP Status: 499")
 
     @pytest.mark.asyncio
     async def test_execute_single_with_http_400(self):


### PR DESCRIPTION
Some runners set the context manager to return a 'raw' response to avoid the unnecessary client side overhead of deserialising the response body. For example, the Bulk runner selectively parses the response body to check whether the overall HTTP request contains any failed bulk items, but discards the rest of the body.

This works well for failures _within_ the bulk request, but it doesn't solve for situations where the entire request fails. The recent Wikipedia track has been encountered difficult and vague errors during execution that look like this:
```

2023-11-21 01:01:28,169 -not-actor-/PID:15028 elastic_transport.transport INFO PUT https://10.10.12.39:9200/_bulk [status:413 duration:0.429s]

Running initial-documents-indexing                                             [  0% done]
[ERROR] Cannot race. Error in load generator [0]
        Cannot run task [initial-documents-indexing]: Request returned an error. Error type: api, Description: <_io.BytesIO object at 0xffff99199cb0>
```

Even if `detailed-results: true` is set for the operation, we still get back the above vague error message that is including a string literal representation of the error body. 

This commit ensures that we properly handle raw request exceptions, and those that return empty bodies. Testing with the Wikipedia track (as above) now returns:
```
Running initial-documents-indexing                                             [  0% done]
[ERROR] Cannot race. Error in load generator [0]
        Cannot run task [initial-documents-indexing]: Request returned an error. Error type: api, Description: None, HTTP Status: 413
```



