### PR TITLE
Remove 'aiohttp' pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,6 @@ dependencies = [
     "elasticsearch[async]==8.6.1",
     "elastic-transport==8.4.1",
     "urllib3==1.26.18",
-    # unpin once https://github.com/aio-libs/aiohttp/issues/7864 is fixed
-    "aiohttp==3.8.6",
     "docker==6.0.0",
     # License: BSD
     "psutil==5.9.4",


### PR DESCRIPTION
[3.9.1 was released this week](https://pypi.org/project/aiohttp/), which includes the fix for https://github.com/aio-libs/aiohttp/issues/7864, so removing the pin as installing will fetch the latest version.

Verified the fix with the reproduction script in https://github.com/elastic/rally/pull/1806