### PR TITLE
Use composable index templates for metric indices

### DIFF
--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -7,7 +7,7 @@ Migrating to Rally 2.10.1
 The metrics store now uses composable templates 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* Existing legacy index templates will are not removed, however, composable templates take precedence (applies to races, results, and metrics).
+* Existing legacy index templates are not removed, however, composable templates take precedence (applies to races, results, and metrics).
 * The new templates will be applied when new races, results, and metrics indices are created.
 * The index template for annotations will only be applied if the ``rally-annotations`` index is not present.
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,6 +1,16 @@
 Migration Guide
 ===============
 
+Migrating to Rally 2.10.1
+-------------------------
+
+The metrics store now uses composable templates 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Existing legacy index templates will are not removed, however, composable templates take precedence (applies to races, results, and metrics).
+* The new templates will be applied when new races, results, and metrics indices are created.
+* The index template for annotations will only be applied if the ``rally-annotations`` index is not present.
+
 Migrating to Rally 2.10.0
 -------------------------
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -50,7 +50,7 @@ class EsClient:
 
     def put_template(self, name, template):
         tmpl = json.loads(template)
-        return self.guarded(self._client.indices.put_template, name=name, **tmpl)
+        return self.guarded(self._client.indices.put_index_template, name=name, **tmpl)
 
     def template_exists(self, name):
         return self.guarded(self._client.indices.exists_template, name=name)

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -55,9 +55,6 @@ class EsClient:
     def template_exists(self, name):
         return self.guarded(self._client.indices.exists_index_template, name=name)
 
-    def delete_template(self, name):
-        self.guarded(self._client.indices.delete_index_template, name=name)
-
     def delete_by_query(self, index, body):
         return self.guarded(self._client.delete_by_query, index=index, body=body)
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -314,9 +314,9 @@ class IndexTemplateProvider:
                         f"The setting: datastore.number_of_shards must be >= 1. Please "
                         f"check the configuration in {self._config.config_file.location}"
                     )
-                template["settings"]["index"]["number_of_shards"] = int(self._number_of_shards)
+                template["template"]["settings"]["index"]["number_of_shards"] = int(self._number_of_shards)
             if self._number_of_replicas is not None:
-                template["settings"]["index"]["number_of_replicas"] = int(self._number_of_replicas)
+                template["template"]["settings"]["index"]["number_of_replicas"] = int(self._number_of_replicas)
             return json.dumps(template)
 
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -53,10 +53,10 @@ class EsClient:
         return self.guarded(self._client.indices.put_index_template, name=name, **tmpl)
 
     def template_exists(self, name):
-        return self.guarded(self._client.indices.exists_template, name=name)
+        return self.guarded(self._client.indices.exists_index_template, name=name)
 
     def delete_template(self, name):
-        self.guarded(self._client.indices.delete_template, name=name)
+        self.guarded(self._client.indices.delete_index_template, name=name)
 
     def delete_by_query(self, index, body):
         return self.guarded(self._client.delete_by_query, index=index, body=body)

--- a/esrally/resources/annotation-template.json
+++ b/esrally/resources/annotation-template.json
@@ -1,48 +1,51 @@
 {
-  "index_patterns": ["rally-annotations"],
-  "settings": {
-    "index":{
-    }
-  },
-  "mappings": {
-    "dynamic_templates": [
-      {
-        "strings": {
-          "match": "*",
-          "match_mapping_type": "string",
-          "mapping": {
-            "type": "keyword"
+  "index_patterns": [
+    "rally-annotations"
+  ],
+  "template": {
+    "settings": {
+      "index": {}
+    },
+    "mappings": {
+      "dynamic_templates": [
+        {
+          "strings": {
+            "match": "*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword"
+            }
           }
         }
-      }
-    ],
-    "properties": {
-      "environment": {
-        "type": "keyword"
-      },
-      "race-timestamp": {
-        "type": "date",
-        "fields": {
-          "raw": {
-            "type": "keyword"
-          }
+      ],
+      "properties": {
+        "environment": {
+          "type": "keyword"
         },
-        "format": "basic_date_time_no_millis"
-      },
-      "user-tag": {
-        "type": "keyword"
-      },
-      "track": {
-        "type": "keyword"
-      },
-      "chart": {
-        "type": "keyword"
-      },
-      "chart-name": {
-        "type": "keyword"
-      },
-      "message": {
-        "type": "keyword"
+        "race-timestamp": {
+          "type": "date",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          },
+          "format": "basic_date_time_no_millis"
+        },
+        "user-tag": {
+          "type": "keyword"
+        },
+        "track": {
+          "type": "keyword"
+        },
+        "chart": {
+          "type": "keyword"
+        },
+        "chart-name": {
+          "type": "keyword"
+        },
+        "message": {
+          "type": "keyword"
+        }
       }
     }
   }

--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -1,93 +1,97 @@
 {
-  "index_patterns": ["rally-metrics-*"],
-  "settings": {
-    "index": {
-      "mapping.total_fields.limit": 2000
-    }
-  },
-  "mappings": {
-    "date_detection": false,
-    "dynamic_templates": [
-      {
-        "strings": {
-          "match": "*",
-          "match_mapping_type": "string",
-          "mapping": {
-            "type": "keyword"
-          }
-        }
+  "index_patterns": [
+    "rally-metrics-*"
+  ],
+  "template": {
+    "settings": {
+      "index": {
+        "mapping.total_fields.limit": 2000
       }
-    ],
-    "_source": {
-      "enabled": true
     },
-    "properties": {
-      "@timestamp": {
-        "type": "date",
-        "format": "epoch_millis"
-      },
-      "relative-time": {
-        "type": "float"
-      },
-      "race-id": {
-        "type": "keyword"
-      },
-      "race-timestamp": {
-        "type": "date",
-        "format": "basic_date_time_no_millis",
-        "fields": {
-          "raw": {
-            "type": "keyword"
+    "mappings": {
+      "date_detection": false,
+      "dynamic_templates": [
+        {
+          "strings": {
+            "match": "*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword"
+            }
           }
         }
+      ],
+      "_source": {
+        "enabled": true
       },
-      "environment": {
-        "type": "keyword"
-      },
-      "track": {
-        "type": "keyword"
-      },
-      "challenge": {
-        "type": "keyword"
-      },
-      "car": {
-        "type": "keyword"
-      },
-      "name": {
-        "type": "keyword"
-      },
-      "value": {
-        "type": "float"
-      },
-      "min": {
-        "type": "float"
-      },
-      "max": {
-        "type": "float"
-      },
-      "mean": {
-        "type": "float"
-      },
-      "median": {
-        "type": "float"
-      },
-      "unit": {
-        "type": "keyword"
-      },
-      "sample-type": {
-        "type": "keyword"
-      },
-      "task": {
-        "type": "keyword"
-      },
-      "operation": {
-        "type": "keyword"
-      },
-      "operation-type": {
-        "type": "keyword"
-      },
-      "job": {
-        "type": "keyword"
+      "properties": {
+        "@timestamp": {
+          "type": "date",
+          "format": "epoch_millis"
+        },
+        "relative-time": {
+          "type": "float"
+        },
+        "race-id": {
+          "type": "keyword"
+        },
+        "race-timestamp": {
+          "type": "date",
+          "format": "basic_date_time_no_millis",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "environment": {
+          "type": "keyword"
+        },
+        "track": {
+          "type": "keyword"
+        },
+        "challenge": {
+          "type": "keyword"
+        },
+        "car": {
+          "type": "keyword"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "float"
+        },
+        "min": {
+          "type": "float"
+        },
+        "max": {
+          "type": "float"
+        },
+        "mean": {
+          "type": "float"
+        },
+        "median": {
+          "type": "float"
+        },
+        "unit": {
+          "type": "keyword"
+        },
+        "sample-type": {
+          "type": "keyword"
+        },
+        "task": {
+          "type": "keyword"
+        },
+        "operation": {
+          "type": "keyword"
+        },
+        "operation-type": {
+          "type": "keyword"
+        },
+        "job": {
+          "type": "keyword"
+        }
       }
     }
   }

--- a/esrally/resources/races-template.json
+++ b/esrally/resources/races-template.json
@@ -1,69 +1,72 @@
 {
-  "index_patterns": ["rally-races-*"],
-  "settings": {
-    "index": {
-    }
-  },
-  "mappings": {
-    "date_detection": false,
-    "dynamic_templates": [
-      {
-        "strings": {
-          "match": "*",
-          "match_mapping_type": "string",
-          "mapping": {
-            "type": "keyword"
-          }
-        }
-      }
-    ],
-    "_source": {
-      "enabled": true
+  "index_patterns": [
+    "rally-races-*"
+  ],
+  "template": {
+    "settings": {
+      "index": {}
     },
-    "properties": {
-      "race-id": {
-        "type": "keyword"
-      },
-      "race-timestamp": {
-        "type": "date",
-        "format": "basic_date_time_no_millis",
-        "fields": {
-          "raw": {
-            "type": "keyword"
+    "mappings": {
+      "date_detection": false,
+      "dynamic_templates": [
+        {
+          "strings": {
+            "match": "*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword"
+            }
           }
         }
+      ],
+      "_source": {
+        "enabled": true
       },
-      "rally-version": {
-        "type": "keyword"
-      },
-      "rally-revision": {
-        "type": "keyword"
-      },
-      "environment": {
-        "type": "keyword"
-      },
-      "pipeline": {
-        "type": "keyword"
-      },
-      "track": {
-        "type": "keyword"
-      },
-      "challenge": {
-        "type": "keyword"
-      },
-      "car": {
-        "type": "keyword"
-      },
-      "node-count": {
-        "type": "short"
-      },
-      "plugins": {
-        "type": "keyword"
-      },
-      "results": {
-        "properties": {
-          "op_metrics": {
-            "type": "nested"
+      "properties": {
+        "race-id": {
+          "type": "keyword"
+        },
+        "race-timestamp": {
+          "type": "date",
+          "format": "basic_date_time_no_millis",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "rally-version": {
+          "type": "keyword"
+        },
+        "rally-revision": {
+          "type": "keyword"
+        },
+        "environment": {
+          "type": "keyword"
+        },
+        "pipeline": {
+          "type": "keyword"
+        },
+        "track": {
+          "type": "keyword"
+        },
+        "challenge": {
+          "type": "keyword"
+        },
+        "car": {
+          "type": "keyword"
+        },
+        "node-count": {
+          "type": "short"
+        },
+        "plugins": {
+          "type": "keyword"
+        },
+        "results": {
+          "properties": {
+            "op_metrics": {
+              "type": "nested"
+            }
           }
         }
       }

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -1,5 +1,6 @@
 {
   "index_patterns": ["rally-results-*"],
+  "template": {
   "settings": {
     "index": {
     }
@@ -103,4 +104,5 @@
       }
     }
   }
+}
 }

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -2615,8 +2615,8 @@ class TestIndexTemplateProvider:
 
         for template in templates:
             t = json.loads(template)
-            assert t["settings"]["index"]["number_of_shards"] == _datastore_number_of_shards
-            assert t["settings"]["index"]["number_of_replicas"] == _datastore_number_of_replicas
+            assert t["template"]["settings"]["index"]["number_of_shards"] == _datastore_number_of_shards
+            assert t["template"]["settings"]["index"]["number_of_replicas"] == _datastore_number_of_replicas
 
     def test_primary_shard_count_specified_index_template_update(self):
         _datastore_type = "elasticsearch"
@@ -2636,10 +2636,10 @@ class TestIndexTemplateProvider:
 
         for template in templates:
             t = json.loads(template)
-            assert t["settings"]["index"]["number_of_shards"] == _datastore_number_of_shards
+            assert t["template"]["settings"]["index"]["number_of_shards"] == _datastore_number_of_shards
             with pytest.raises(KeyError):
                 # pylint: disable=unused-variable
-                number_of_replicas = t["settings"]["index"]["number_of_replicas"]
+                number_of_replicas = t["template"]["settings"]["index"]["number_of_replicas"]
 
     def test_replica_shard_count_specified_index_template_update(self):
         _datastore_type = "elasticsearch"
@@ -2659,10 +2659,10 @@ class TestIndexTemplateProvider:
 
         for template in templates:
             t = json.loads(template)
-            assert t["settings"]["index"]["number_of_replicas"] == _datastore_number_of_replicas
+            assert t["template"]["settings"]["index"]["number_of_replicas"] == _datastore_number_of_replicas
             with pytest.raises(KeyError):
                 # pylint: disable=unused-variable
-                number_of_shards = t["settings"]["index"]["number_of_shards"]
+                number_of_shards = t["template"]["settings"]["index"]["number_of_shards"]
 
     def test_primary_shard_count_less_than_one(self):
         _datastore_type = "elasticsearch"
@@ -2705,5 +2705,5 @@ class TestIndexTemplateProvider:
 
         for template in templates:
             t = json.loads(template)
-            assert t["settings"]["index"]["number_of_shards"] == 200
-            assert t["settings"]["index"]["number_of_replicas"] == 1
+            assert t["template"]["settings"]["index"]["number_of_shards"] == 200
+            assert t["template"]["settings"]["index"]["number_of_replicas"] == 1


### PR DESCRIPTION
In this commit, Rally is being switched from using legacy index templates to newer composable templates for metrics indices. [Legacy index templates](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html) have been deprecated since ES 7.8 in favor of composable templates, and are not supported in ES Serverless. Rally metrics index templates have just one modification to make them composable templates. No other modifications have been made.

* Elasticsearch favors composable templates over legacy index templates when both have matching index patterns. After this change, new metrics indices will use the new index templates.

Closes https://github.com/elastic/rally/issues/1810.