### PR TITLE
Add FS metrics to node-stats telemetry device

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -120,6 +120,7 @@ The node-stats telemetry device regularly calls the `cluster node-stats API <htt
 * Circuit breaker stats (key ``breakers`` in the node-stats API)
 * Network-related stats (key ``transport`` in the node-stats API)
 * Process cpu stats (key ``process.cpu`` in the node-stats API)
+* Filesystem stats (key ``fs`` in the node-stats API)
 
 Supported telemetry parameters:
 
@@ -136,7 +137,8 @@ Supported telemetry parameters:
 * ``node-stats-include-cgroup`` (default: ``true``): A boolean to include operating system cgroup stats. Memory stats are omitted since Elasticsearch emits them as string values. Use ``os_mem_*`` fields instead.
 * ``node-stats-include-network`` (default: ``true``): A boolean indicating whether network-related stats should be included.
 * ``node-stats-include-process`` (default: ``true``): A boolean indicating whether process cpu stats should be included.
-* ``node-stats-include-indexing-pressure`` (default: ``true``): A boolean indicating whether indexing pressuer stats should be included.
+* ``node-stats-include-indexing-pressure`` (default: ``true``): A boolean indicating whether indexing pressure stats should be included.
+* ``node-stats-include-fs`` (default: ``true``): A boolean indicating whether overall filesystem stats should be included. Per-device filesystem metrics are not included.
 
 recovery-stats
 --------------

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -846,6 +846,7 @@ class NodeStatsRecorder:
         self.include_cgroup_stats = telemetry_params.get("node-stats-include-cgroup", True)
         self.include_gc_stats = telemetry_params.get("node-stats-include-gc", True)
         self.include_indexing_pressure = telemetry_params.get("node-stats-include-indexing-pressure", True)
+        self.include_fs_stats = telemetry_params.get("node-stats-include-fs", True)
         self.client = client
         self.metrics_store = metrics_store
         self.cluster_name = cluster_name
@@ -883,6 +884,8 @@ class NodeStatsRecorder:
                 collected_node_stats.update(self.process_stats(node_name, node_stats))
             if self.include_indexing_pressure:
                 collected_node_stats.update(self.indexing_pressure(node_name, node_stats))
+            if self.include_fs_stats:
+                collected_node_stats.update(self.fs_stats(node_name, node_stats))
 
             self.metrics_store.put_doc(
                 dict(collected_node_stats), level=MetaInfoScope.node, node_name=node_name, meta_data=metrics_store_meta_data
@@ -931,6 +934,9 @@ class NodeStatsRecorder:
 
     def indexing_pressure(self, node_name, node_stats):
         return flatten_stats_fields(prefix="indexing_pressure", stats=node_stats["indexing_pressure"])
+
+    def fs_stats(self, node_name, node_stats):
+        return flatten_stats_fields(prefix="fs", stats=node_stats.get("fs"))
 
     def sample(self):
         # pylint: disable=import-outside-toplevel

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -2087,6 +2087,41 @@ class TestNodeStatsRecorder:
                         },
                     }
                 },
+                "fs": {
+                    "timestamp": 1704343978936,
+                    "total": {"total_in_bytes": 1055735832576, "free_in_bytes": 105574690816, "available_in_bytes": 105557913600},
+                    "data": [
+                        {
+                            "path": "/usr/share/elasticsearch/data",
+                            "mount": "/usr/share/elasticsearch/data (/dev/sdc)",
+                            "type": "ext4",
+                            "total_in_bytes": 1055735832576,
+                            "free_in_bytes": 105574690816,
+                            "available_in_bytes": 105557913600,
+                        }
+                    ],
+                    "io_stats": {
+                        "devices": [
+                            {
+                                "device_name": "sdc",
+                                "operations": 31184,
+                                "read_operations": 6,
+                                "write_operations": 31178,
+                                "read_kilobytes": 104,
+                                "write_kilobytes": 30343968,
+                                "io_time_in_millis": 58668,
+                            }
+                        ],
+                        "total": {
+                            "operations": 31184,
+                            "read_operations": 6,
+                            "write_operations": 31178,
+                            "read_kilobytes": 104,
+                            "write_kilobytes": 30343968,
+                            "io_time_in_millis": 58668,
+                        },
+                    },
+                },
             }
         },
     }
@@ -2197,6 +2232,16 @@ class TestNodeStatsRecorder:
             "indexing_pressure_memory_total_coordinating_rejections": 0,
             "indexing_pressure_memory_total_primary_rejections": 0,
             "indexing_pressure_memory_total_replica_rejections": 0,
+            "fs_timestamp": 1704343978936,
+            "fs_total_total_in_bytes": 1055735832576,
+            "fs_total_free_in_bytes": 105574690816,
+            "fs_total_available_in_bytes": 105557913600,
+            "fs_io_stats_total_operations": 31184,
+            "fs_io_stats_total_read_operations": 6,
+            "fs_io_stats_total_write_operations": 31178,
+            "fs_io_stats_total_read_kilobytes": 104,
+            "fs_io_stats_total_write_kilobytes": 30343968,
+            "fs_io_stats_total_io_time_in_millis": 58668,
         }
     )
 
@@ -2471,6 +2516,41 @@ class TestNodeStatsRecorder:
                             },
                         }
                     },
+                    "fs": {
+                        "timestamp": 1704343978936,
+                        "total": {"total_in_bytes": 1055735832576, "free_in_bytes": 105574690816, "available_in_bytes": 105557913600},
+                        "data": [
+                            {
+                                "path": "/usr/share/elasticsearch/data",
+                                "mount": "/usr/share/elasticsearch/data (/dev/sdc)",
+                                "type": "ext4",
+                                "total_in_bytes": 1055735832576,
+                                "free_in_bytes": 105574690816,
+                                "available_in_bytes": 105557913600,
+                            }
+                        ],
+                        "io_stats": {
+                            "devices": [
+                                {
+                                    "device_name": "sdc",
+                                    "operations": 31184,
+                                    "read_operations": 6,
+                                    "write_operations": 31178,
+                                    "read_kilobytes": 104,
+                                    "write_kilobytes": 30343968,
+                                    "io_time_in_millis": 58668,
+                                }
+                            ],
+                            "total": {
+                                "operations": 31184,
+                                "read_operations": 6,
+                                "write_operations": 31178,
+                                "read_kilobytes": 104,
+                                "write_kilobytes": 30343968,
+                                "io_time_in_millis": 58668,
+                            },
+                        },
+                    },
                 }
             },
         }
@@ -2596,6 +2676,16 @@ class TestNodeStatsRecorder:
                 "indexing_pressure_memory_total_coordinating_rejections": 0,
                 "indexing_pressure_memory_total_primary_rejections": 0,
                 "indexing_pressure_memory_total_replica_rejections": 0,
+                "fs_timestamp": 1704343978936,
+                "fs_total_total_in_bytes": 1055735832576,
+                "fs_total_free_in_bytes": 105574690816,
+                "fs_total_available_in_bytes": 105557913600,
+                "fs_io_stats_total_operations": 31184,
+                "fs_io_stats_total_read_operations": 6,
+                "fs_io_stats_total_write_operations": 31178,
+                "fs_io_stats_total_read_kilobytes": 104,
+                "fs_io_stats_total_write_kilobytes": 30343968,
+                "fs_io_stats_total_io_time_in_millis": 58668,
             },
             level=MetaInfoScope.node,
             node_name="rally0",


### PR DESCRIPTION
Adds overall (total) FS metrics to the default list of stats collected by the `node-stats` telemetry device. 

Note that we ignore the per-device stats here, as that'd require some remodelling of the `node-stats` document structure to support having per-device documents.

