### PR TITLE
Install dependencies when listing tracks

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -129,7 +129,7 @@ def tracks(cfg):
     :return: A list of tracks that are available for the provided distribution version or else for the main version.
     """
     repo = track_repo(cfg)
-    return [_load_single_track(cfg, repo, track_name) for track_name in repo.track_names]
+    return [_load_single_track(cfg, repo, track_name, install_dependencies=True) for track_name in repo.track_names]
 
 
 def list_tracks(cfg):


### PR DESCRIPTION
`esrally list tracks` attempts to load plugins for each track, and if a dependency is missing, Rally exits with an error.

Dependencies can be specified in track.json, however by default we don't install them every time we load a track, because doing so involves shelling out to pip.

This commit changes `list tracks` to install any necessary dependencies during track loading.

