### PR TITLE
Override serverless cluster version

### DIFF
--- a/docs/serverless.rst
+++ b/docs/serverless.rst
@@ -42,7 +42,7 @@ The Serverless detection and the skip manifests through the following messages o
   [INFO] Race id is [d9d82d3f-dd74-4af0-90ea-8bdd449c824c]
   [INFO] Detected Elasticsearch Serverless mode with operator=[False].
   [INFO] Excluding [check-cluster-health], [force-merge], [wait-until-merges-finish], [index-stats], [node-stats] as challenge [append-no-conflicts] is run on serverless.
-  [INFO] Racing on track [geonames], challenge [append-no-conflicts] and car ['external'] with version [8.11.0].
+  [INFO] Racing on track [geonames], challenge [append-no-conflicts] and car ['external'] with version [serverless].
   [..]
 
 The automatic skip does not apply to the following tasks:

--- a/esrally/client/factory.py
+++ b/esrally/client/factory.py
@@ -349,13 +349,15 @@ def cluster_distribution_version(hosts, client_options, client_factory=EsClientF
     version = es.info()["version"]
 
     version_build_flavor = version.get("build_flavor", "oss")
-    # build hash will only be available for serverless if the client has operator privs
+    # if build hash is not available default to build flavor
     version_build_hash = version.get("build_hash", version_build_flavor)
-    # version number does not exist for serverless
+    # if version number is not available default to build flavor
     version_number = version.get("number", version_build_flavor)
 
     serverless_operator = False
     if versions.is_serverless(version_build_flavor):
+        # overwrite static serverless version number
+        version_number = "serverless"
         authentication_info = es.perform_request(method="GET", path="/_security/_authenticate")
         serverless_operator = authentication_info.body.get("operator", False)
 

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -724,10 +724,14 @@ class Driver:
             else:
                 self.wait_for_rest_api(es_clients)
             self.driver_actor.cluster_details = self.retrieve_cluster_info(es_clients)
-            if serverless_mode and serverless_operator:
-                build_hash = self.retrieve_build_hash_from_nodes_info(es_clients)
-                self.logger.info("Retrieved actual build hash [%s] from serverless cluster.", build_hash)
-                self.driver_actor.cluster_details["version"]["build_hash"] = build_hash
+            if serverless_mode:
+                # overwrite static serverless version number
+                self.driver_actor.cluster_details["version"]["number"] = "serverless"
+                if serverless_operator:
+                    # overwrite build hash if running as operator
+                    build_hash = self.retrieve_build_hash_from_nodes_info(es_clients)
+                    self.logger.info("Retrieved actual build hash [%s] from serverless cluster.", build_hash)
+                    self.driver_actor.cluster_details["version"]["build_hash"] = build_hash
 
         # Avoid issuing any requests to the target cluster when static responses are enabled. The results
         # are not useful and attempts to connect to a non-existing cluster just lead to exception traces in logs.

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -35,6 +35,7 @@ from typing import List, Optional
 import ijson
 
 from esrally import exceptions, track
+from esrally.utils import convert
 from esrally.utils.versions import Version
 
 # Mapping from operation type to specific runner
@@ -175,8 +176,8 @@ class Runner:
         self.serverless_mode = False
         self.serverless_operator = False
         if config:
-            self.serverless_mode = config.opts("driver", "serverless.mode", mandatory=False, default_value=False)
-            self.serverless_operator = config.opts("driver", "serverless.operator", mandatory=False, default_value=False)
+            self.serverless_mode = convert.to_bool(config.opts("driver", "serverless.mode", mandatory=False, default_value=False))
+            self.serverless_operator = convert.to_bool(config.opts("driver", "serverless.operator", mandatory=False, default_value=False))
 
     async def __aenter__(self):
         return self

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -197,13 +197,13 @@ class TestDriver:
         d = driver.Driver(driver_actor, self.cfg, es_client_factory_class=self.StaticServerlessClientFactory)
         d.prepare_benchmark(t=self.track)
 
-        # was build hash determined correctly?
+        # was build hash and version determined correctly?
         assert driver_actor.cluster_details == {
             "name": "serverless",
             "cluster_name": "serverless",
             "cluster_uuid": "4bbPT0Z6SsuODSz_vG1umA",
             "version": {
-                "number": "8.10.0",
+                "number": "serverless",  # <--- THIS
                 "build_flavor": "serverless",
                 "build_type": "docker",
                 "build_hash": "5f626ea4014dc029b8ae3f0bca06944975bf2d80",  # <--- THIS


### PR DESCRIPTION
Early Elastic Serverless versions returned no `version.number` and no `version.build_hash` fields under root API endpoint (`/`). Initial Rally adjustment for Serverless had taken this into account, see https://github.com/elastic/rally/pull/1738.

Later, due to BWC with clients, `version.number` and `version.build_hash` returned in static/pinned form.

```
{
	"name": "serverless",
	"cluster_name": "e4ba38a16a19425e9eac79c868c2afc5",
	"cluster_uuid": "btqR_bqJTPqvbV4Rgn_Z5Q",
	"version": {
		"number": "8.11.0", <--- HERE
		"build_flavor": "serverless",
		"build_type": "docker",
		"build_hash": "00000000", <--- HERE
		"build_date": "2023-10-31",
		"build_snapshot": false,
		"lucene_version": "9.7.0",
		"minimum_wire_compatibility_version": "8.11.0",
		"minimum_index_compatibility_version": "8.11.0"
	},
	"tagline": "You Know, for Search"
}
```

To address dummy build hash, when running with operator privileges the actual build hash is retrieved using nodes info API (see https://github.com/elastic/rally/pull/1756). The version number, however, remains at `8.11.0`. As a consequence, Rally checks out `8.11.0` Rally track branch which is fine today as it's kept in sync with `master`, but does not allow us to move to a newer track branch.

This PR restores the original concept of reporting the version of `serverless` when run against Elastic Serverless clusters. With `serverless` version, Rally track branch selection defaults to `master`, see here: https://github.com/elastic/rally/blob/6611f677cf6e6019bad8dc45e4452b91b3be745e/esrally/utils/versions.py#L187-L188