### PR TITLE
Update Yappi to latest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     # License: MPL 2.0
     "certifi",
     # License: MIT
-    "yappi==1.4.0",
+    "yappi==1.5.1",
     # License: BSD
     "ijson==2.6.1",
     # License: Apache 2.0


### PR DESCRIPTION
I'm using Python 3.12, and I was unable to install this without upgrading to the latest version of yappi. When I didn't have the latest yappi, I got: 

```
Building wheels for collected packages: yappi
  Building wheel for yappi (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for yappi (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build/lib.linux-x86_64-cpython-312
      copying yappi/yappi.py -> build/lib.linux-x86_64-cpython-312
      running build_ext
      building '_yappi' extension
      creating build/temp.linux-x86_64-cpython-312
      creating build/temp.linux-x86_64-cpython-312/yappi
      gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -DLIB_RT_AVAILABLE=1 -I/usr/local/include/python3.12 -c yappi/_yappi.c -o build/temp.linux-x86_64-cpython-312/yappi/_yappi.o
      yappi/_yappi.c: In function ‘IS_SUSPENDED’:
      yappi/_yappi.c:240:18: error: invalid use of incomplete typedef ‘PyFrameObject’ {aka ‘struct _frame’}
        240 |     return (frame->f_stacktop != NULL);
            |                  ^~
      yappi/_yappi.c: In function ‘_code2pit’:
      yappi/_yappi.c:697:29: error: ‘PyCodeObject’ has no member named ‘co_varnames’; did you mean ‘co_names’?
        697 |         co_varnames = cobj->co_varnames;
            |                             ^~~~~~~~~~~
            |                             co_names
      yappi/_yappi.c: In function ‘IS_SUSPENDED’:
      yappi/_yappi.c:242:1: warning: control reaches end of non-void function [-Wreturn-type]
        242 | }
            | ^
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for yappi
Failed to build yappi
ERROR: Could not build wheels for yappi, which is required to install pyproject.toml-based projects
```

That's not your problem, but it was a showstopper for me! 

This is just a small change that pulls the latest yappi into rally.