### PR TITLE
Fix telemetry docs 

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -45,7 +45,7 @@ The remaining telemetry devices i.e. ``jit``, ``gc``, ``jfr`` and ``heapdump`` c
 
 .. note::
 
-    If you are using the experimental :doc:`cluster management commands </cluster_management>`_, setup level telemetry devices (and their parameters) should only be specified via the ``start`` subcommand and not via the ``race`` subcommand. For more details check ``esrally start --help``.
+    If you are using the experimental :doc:`cluster management commands </cluster_management>`, setup level telemetry devices (and their parameters) should only be specified via the ``start`` subcommand and not via the ``race`` subcommand. For more details check ``esrally start --help``.
 
 jfr
 ---

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -44,6 +44,7 @@ All telemetry devices with a ``-stats`` suffix can be used even with a cluster t
 The remaining telemetry devices i.e. ``jit``, ``gc``, ``jfr`` and ``heapdump`` can only be used when Rally provisions the cluster itself (i.e. won't work with ``--pipeline=benchmark-only``) and are **setup level** telemetry devices.
 
 .. note::
+
     If you are using the experimental :doc:`cluster management commands </cluster_management>`_, setup level telemetry devices (and their parameters) should only be specified via the ``start`` subcommand and not via the ``race`` subcommand. For more details check ``esrally start --help``.
 
 jfr

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -44,8 +44,7 @@ All telemetry devices with a ``-stats`` suffix can be used even with a cluster t
 The remaining telemetry devices i.e. ``jit``, ``gc``, ``jfr`` and ``heapdump`` can only be used when Rally provisions the cluster itself (i.e. won't work with ``--pipeline=benchmark-only``) and are **setup level** telemetry devices.
 
 .. note::
-
-    If you are using the experimental `cluster management commands <cluster_management>`_, setup level telemetry devices (and their parameters) should only be specified via the ``start`` subcommand and not via the ``race`` subcommand. For more details check ``esrally start --help``.
+    If you are using the experimental :doc:`cluster management commands </cluster_management>`_, setup level telemetry devices (and their parameters) should only be specified via the ``start`` subcommand and not via the ``race`` subcommand. For more details check ``esrally start --help``.
 
 jfr
 ---


### PR DESCRIPTION
Fix broken link in telemetry docs

I spotted the link back to cluster management was broken, so fixed it
