### PR TITLE
Make Jit telelmetry compatible with JDK 9+

### DIFF
--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -149,7 +149,7 @@ class ProcessLauncher:
         telemetry_params = self.cfg.opts("telemetry", "params")
         node_telemetry = [
             telemetry.FlightRecorder(telemetry_params, node_telemetry_dir, java_major_version),
-            telemetry.JitCompiler(node_telemetry_dir),
+            telemetry.JitCompiler(node_telemetry_dir, java_major_version),
             telemetry.Gc(telemetry_params, node_telemetry_dir, java_major_version),
             telemetry.Heapdump(node_telemetry_dir),
             telemetry.DiskIo(node_count_on_host),

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -283,21 +283,31 @@ class JitCompiler(TelemetryDevice):
     human_name = "JIT Compiler Profiler"
     help = "Enables JIT compiler logs."
 
-    def __init__(self, log_root):
+    def __init__(self, log_root, java_major_version):
         super().__init__()
         self.log_root = log_root
+        self.java_major_version = java_major_version
 
     def instrument_java_opts(self):
         io.ensure_dir(self.log_root)
         log_file = os.path.join(self.log_root, "jit.log")
         console.info("%s: Writing JIT compiler log to [%s]" % (self.human_name, log_file), logger=self.logger)
-        return [
-            "-XX:+UnlockDiagnosticVMOptions",
-            "-XX:+TraceClassLoading",
-            "-XX:+LogCompilation",
-            f"-XX:LogFile={log_file}",
-            "-XX:+PrintAssembly",
-        ]
+        if self.java_major_version < 9:
+            return [
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+TraceClassLoading",
+                "-XX:+LogCompilation",
+                f"-XX:LogFile={log_file}",
+                "-XX:+PrintAssembly",
+            ]
+        else:
+            return [
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-Xlog:class+load=info",
+                "-XX:+LogCompilation",
+                f"-XX:LogFile={log_file}",
+                "-XX:+PrintAssembly",
+            ]
 
 
 class Gc(TelemetryDevice):


### PR DESCRIPTION

I found that the JIT telemetry device doesn't work with JDK > 16 - in JDK 9 the -XX:+TraceClassLoading option was replaced with -Xlog:class+load=info , JDK 9-15 it was changed for the user if they supplied the older one, in jdk16 + the option is rejected and the JVM fails to start.