### PR TITLE
Add client ID to metrics

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1025,12 +1025,14 @@ class SamplePostprocessor:
         for idx, sample in enumerate(raw_samples):
             if idx % self.downsample_factor == 0:
                 final_sample_count += 1
+                client_id_meta_data = {"client_id": sample.client_id}
                 meta_data = self.merge(
                     self.track_meta_data,
                     self.challenge_meta_data,
                     sample.operation_meta_data,
                     sample.task.meta_data,
                     sample.request_meta_data,
+                    client_id_meta_data,
                 )
 
                 self.metrics_store.put_value_cluster_level(
@@ -1083,7 +1085,7 @@ class SamplePostprocessor:
                         sample_type=timing.sample_type,
                         absolute_time=timing.absolute_time,
                         relative_time=timing.relative_time,
-                        meta_data=timing.request_meta_data,
+                        meta_data=self.merge(timing.request_meta_data, client_id_meta_data),
                     )
 
         end = time.perf_counter()

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -407,14 +407,14 @@ class TestSamplePostprocessor:
         ]
 
         post_process(samples)
-
+        meta_data = {"client_id": 0}
         calls = [
-            self.latency(38598, 24, 10.0),
-            self.service_time(38598, 24, 7.0),
-            self.processing_time(38598, 24, 9.0),
-            self.latency(38599, 25, 10.0),
-            self.service_time(38599, 25, 7.0),
-            self.processing_time(38599, 25, 9.0),
+            self.latency(38598, 24, 10.0, meta_data),
+            self.service_time(38598, 24, 7.0, meta_data),
+            self.processing_time(38598, 24, 9.0, meta_data),
+            self.latency(38599, 25, 10.0, meta_data),
+            self.service_time(38599, 25, 7.0, meta_data),
+            self.processing_time(38599, 25, 9.0, meta_data),
             self.throughput(38598, 24, 5000),
             self.throughput(38599, 25, 5000),
         ]
@@ -432,12 +432,12 @@ class TestSamplePostprocessor:
         ]
 
         post_process(samples)
-
+        meta_data = {"client_id": 0}
         calls = [
             # only the first out of two request samples is included, throughput metrics are still complete
-            self.latency(38598, 24, 10.0),
-            self.service_time(38598, 24, 7.0),
-            self.processing_time(38598, 24, 9.0),
+            self.latency(38598, 24, 10.0, meta_data),
+            self.service_time(38598, 24, 7.0, meta_data),
+            self.processing_time(38598, 24, 9.0, meta_data),
             self.throughput(38598, 24, 5000),
             self.throughput(38599, 25, 5000),
         ]
@@ -491,14 +491,15 @@ class TestSamplePostprocessor:
         ]
 
         post_process(samples)
-        meta_data = {"meta_key": "meta_value"}
+        meta_data = {"client_id": 0}
+        meta_data_with_key = {"client_id": 0, "meta_key": "meta_value"}
         calls = [
-            self.latency(38598, 24, 10.0),
-            self.service_time(38598, 24, 7.0),
-            self.processing_time(38598, 24, 9.0),
+            self.latency(38598, 24, 10.0, meta_data),
+            self.service_time(38598, 24, 7.0, meta_data),
+            self.processing_time(38598, 24, 9.0, meta_data),
             # dependent timings
-            self.service_time(38601, 25, 50.0, meta_data),
-            self.service_time(38602, 26, 80.0, meta_data),
+            self.service_time(38601, 25, 50.0, meta_data_with_key),
+            self.service_time(38602, 26, 80.0, meta_data_with_key),
             # we don't currently calculate dependent throughput
             self.throughput(38598, 24, 5000),
         ]


### PR DESCRIPTION
When analyzing Rally metrics with runs with multiple clients it is impossible to filter for a specific client ID. This PR adds new `meta.client_id` field to every metric record which can be attributed to a specific client, i.e. is not aggregated like throughput.
