### PR TITLE
Avoid immense term error in metrics metadata fields

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -659,13 +659,28 @@ class BulkIndex(Runner):
             error_details.add((data["status"], None))
 
     def error_description(self, error_details):
+        """
+        Generates error description with an arbitrary limit of 5 errors.
+
+        :param error_details: accumulated error details
+        :return: error description
+        """
         error_descriptions = []
-        for status, reason in error_details:
-            if reason:
-                error_descriptions.append(f"HTTP status: {status}, message: {reason}")
+        is_truncated = False
+        for count, error_detail in enumerate(error_details):
+            status, reason = error_detail
+            if count < 5:
+                if reason:
+                    error_descriptions.append(f"HTTP status: {status}, message: {reason}")
+                else:
+                    error_descriptions.append(f"HTTP status: {status}")
             else:
-                error_descriptions.append(f"HTTP status: {status}")
-        return " | ".join(sorted(error_descriptions))
+                is_truncated = True
+                break
+        description = " | ".join(sorted(error_descriptions))
+        if is_truncated:
+            description = description + " | <TRUNCATED>"
+        return description
 
     def __repr__(self, *args, **kwargs):
         return "bulk-index"

--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -16,7 +16,8 @@
             "match": "*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 32766
             }
           }
         }
@@ -29,8 +30,45 @@
           "type": "date",
           "format": "epoch_millis"
         },
-        "relative-time": {
+        "car": {
+          "type": "keyword"
+        },
+        "challenge": {
+          "type": "keyword"
+        },
+        "environment": {
+          "type": "keyword"
+        },
+        "job": {
+          "type": "keyword"
+        },
+        "max": {
           "type": "float"
+        },
+        "mean": {
+          "type": "float"
+        },
+        "median": {
+          "type": "float"
+        },
+        "meta": {
+          "properties": {
+            "error-description": {
+              "type": "wildcard"
+            }
+          }
+        },
+        "min": {
+          "type": "float"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "operation": {
+          "type": "keyword"
+        },
+        "operation-type": {
+          "type": "keyword"
         },
         "race-id": {
           "type": "keyword"
@@ -44,38 +82,8 @@
             }
           }
         },
-        "environment": {
-          "type": "keyword"
-        },
-        "track": {
-          "type": "keyword"
-        },
-        "challenge": {
-          "type": "keyword"
-        },
-        "car": {
-          "type": "keyword"
-        },
-        "name": {
-          "type": "keyword"
-        },
-        "value": {
+        "relative-time": {
           "type": "float"
-        },
-        "min": {
-          "type": "float"
-        },
-        "max": {
-          "type": "float"
-        },
-        "mean": {
-          "type": "float"
-        },
-        "median": {
-          "type": "float"
-        },
-        "unit": {
-          "type": "keyword"
         },
         "sample-type": {
           "type": "keyword"
@@ -83,14 +91,14 @@
         "task": {
           "type": "keyword"
         },
-        "operation": {
+        "track": {
           "type": "keyword"
         },
-        "operation-type": {
+        "unit": {
           "type": "keyword"
         },
-        "job": {
-          "type": "keyword"
+        "value": {
+          "type": "float"
         }
       }
     }


### PR DESCRIPTION
To avoid immense term error in metrics metadata fields:
* `meta.error-description` field mapping changes from `keyword` to `wildcard` which fits this type of content better while still allowing the search,
* remaining dynamically mapped text fields get `"ignore_above": 32766` parameter (see [doc](https://www.elastic.co/guide/en/elasticsearch/reference/8.12/ignore-above.html)),
* `meta.error-description` field generated in `BulkIndex` runner gets limited to 5 unique errors only for better log readability - currently, in the worst case the field is concatenated from errors from _all_ bulk documents.

Addresses https://github.com/elastic/rally/issues/1834.
