### PR TITLE
Update create track

### DIFF
--- a/docs/adding_tracks.rst
+++ b/docs/adding_tracks.rst
@@ -27,11 +27,15 @@ The track generator will create a folder with the track's name in the specified 
 
     > find tracks/acme
     tracks/acme
+    tracks/acme/challenges
+    tracks/acme/challenges/default.json
     tracks/acme/companies-documents.json
     tracks/acme/companies-documents.json.bz2
     tracks/acme/companies-documents-1k.json
     tracks/acme/companies-documents-1k.json.bz2
     tracks/acme/companies.json
+    tracks/acme/operations
+    tracks/acme/operations/default.json
     tracks/acme/products-documents.json
     tracks/acme/products-documents.json.bz2
     tracks/acme/products-documents-1k.json
@@ -39,11 +43,15 @@ The track generator will create a folder with the track's name in the specified 
     tracks/acme/products.json
     tracks/acme/track.json
 
+
 The files are organized as follows:
 
 * ``track.json`` contains the actual Rally track. For details see the :doc:`track reference<track>`.
 * ``companies.json`` and ``products.json`` contain the mapping and settings for the extracted indices.
 * ``*-documents.json(.bz2)`` contains the sources of all the documents from the extracted indices. The files suffixed with ``-1k`` contain a smaller version of the document corpus to support :ref:`test mode <add_track_test_mode>`.
+* ``operations/default.json`` contains a sample operation that can be used when adding search requests to the track.
+* ``challenges/default.json`` contains the initial actions for the default challenge - delete index, create, and bulk-index.
+
 
 Creating a track from scratch
 -----------------------------

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -1002,7 +1002,7 @@ Use index patterns::
 .. note::
    If the cluster requires authentication specify credentials via ``--client-options`` as described in the :ref:`command line reference <clr_client_options>`.
 
-  ``batch-size``
+``batch-size``
 ~~~~~~~~~~~~~~~~
 
 The number of records to request per batch when generating a track with the ``create-track`` subcommand. The default value is 1000
@@ -1012,6 +1012,7 @@ The number of records to request per batch when generating a track with the ``cr
 Target a single data stream::
 
     esrally create-track --track=acme --batch-size 10000 --target-hosts=127.0.0.1:9200 --output-path=~/tracks
+
 
 .. note::
    The larger the batch size, the more data will be downloaded in one go. As such, you should ensure that you have a stable network connection between where you are running rally and the Elasticsearch cluster.

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -1009,13 +1009,13 @@ The number of records to request per batch when generating a track with the ``cr
 
 **Example**
 
-Target a single data stream::
+Run with 10000 records per batch::
 
     esrally create-track --track=acme --batch-size 10000 --target-hosts=127.0.0.1:9200 --output-path=~/tracks
 
 
 .. note::
-   The larger the batch size, the more data will be downloaded in one go. As such, you should ensure that you have a stable network connection between where you are running rally and the Elasticsearch cluster.
+   The larger the batch size, the more data will be downloaded per call to Elasticsearch. As such, you should ensure that you have a stable network connection between where you are running rally and the Elasticsearch cluster.
 
 .. _command_line_reference_advanced_topics:
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -1002,6 +1002,20 @@ Use index patterns::
 .. note::
    If the cluster requires authentication specify credentials via ``--client-options`` as described in the :ref:`command line reference <clr_client_options>`.
 
+  ``batch-size``
+~~~~~~~~~~~~~~~~
+
+The number of records to request per batch when generating a track with the ``create-track`` subcommand. The default value is 1000
+
+**Example**
+
+Target a single data stream::
+
+    esrally create-track --track=acme --batch-size 10000 --target-hosts=127.0.0.1:9200 --output-path=~/tracks
+
+.. note::
+   The larger the batch size, the more data will be downloaded in one go. As such, you should ensure that you have a stable network connection between where you are running rally and the Elasticsearch cluster.
+
 .. _command_line_reference_advanced_topics:
 
 Advanced topics

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -199,7 +199,7 @@ def create_arg_parser():
     add_track_source(info_parser)
     info_parser.add_argument(
         "--track",
-        help=f"Define the track to use. List possible tracks with `{PROGRAM_NAME} list tracks`."
+        help=f"Define the track to use. List possible tracks with `{PROGRAM_NAME} list tracks`.",
         # we set the default value later on because we need to determine whether the user has provided this value.
         # default="geonames"
     )
@@ -228,6 +228,11 @@ def create_arg_parser():
         "--track",
         required=True,
         help="Name of the generated track",
+    )
+    create_track_parser.add_argument(
+        "--batch-size",
+        default=1000,
+        help="Number of documents to collect per call to Elasticsearch.",
     )
     indices_or_data_streams_group = create_track_parser.add_mutually_exclusive_group(required=True)
     indices_or_data_streams_group.add_argument(
@@ -1188,11 +1193,13 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
                 cfg.add(config.Scope.applicationOverride, "generator", "data_streams", args.data_streams)
                 cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
                 cfg.add(config.Scope.applicationOverride, "track", "track.name", args.track)
+                cfg.add(config.Scope.applicationOverride, "generator", "batch_size", args.batch_size)
             elif args.indices is not None:
                 cfg.add(config.Scope.applicationOverride, "generator", "indices", args.indices)
                 cfg.add(config.Scope.applicationOverride, "generator", "data_streams", args.data_streams)
                 cfg.add(config.Scope.applicationOverride, "generator", "output.path", args.output_path)
                 cfg.add(config.Scope.applicationOverride, "track", "track.name", args.track)
+                cfg.add(config.Scope.applicationOverride, "generator", "batch_size", args.batch_size)
             configure_connection_params(arg_parser, args, cfg)
 
             tracker.create_track(cfg)

--- a/esrally/resources/challenges.json.j2
+++ b/esrally/resources/challenges.json.j2
@@ -1,0 +1,35 @@
+{
+    "name": "my-challenge",
+    "description": "My new challenge",
+    "default": true,
+    "schedule": [
+    {
+      "operation": "delete-index"
+    },{% raw %}
+    {
+      "operation": {
+        "operation-type": "create-index",
+        "settings": {{index_settings | default({}) | tojson}}
+      }
+    },{% endraw %}
+    {
+      "operation": {
+        "operation-type": "cluster-health",
+        "index": {{ indices | map(attribute='name') | list | join(',') | tojson }},{% raw %}
+        "request-params": {
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        },
+        "retry-until-success": true
+      }
+    },
+    {
+      "operation": {
+        "operation-type": "bulk",
+        "bulk-size": {{bulk_size | default(5000)}},
+        "ingest-percentage": {{ingest_percentage | default(100)}}
+      },
+      "clients": {{bulk_indexing_clients | default(8)}}
+    }
+  ]{% endraw %}
+}

--- a/esrally/resources/operations.json.j2
+++ b/esrally/resources/operations.json.j2
@@ -1,0 +1,11 @@
+{% raw %}
+    {
+      "name": "default",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "match_all": {}
+        }
+      }
+    }
+{% endraw %}

--- a/esrally/resources/track.json.j2
+++ b/esrally/resources/track.json.j2
@@ -22,34 +22,12 @@
       ]
     }{% endfor %}
   ],
-  "schedule": [
-    {
-      "operation": "delete-index"
-    },{% raw %}
-    {
-      "operation": {
-        "operation-type": "create-index",
-        "settings": {{index_settings | default({}) | tojson}}
-      }
-    },{% endraw %}
-    {
-      "operation": {
-        "operation-type": "cluster-health",
-        "index": {{ indices | map(attribute='name') | list | join(',') | tojson }},{% raw %}
-        "request-params": {
-          "wait_for_status": "{{cluster_health | default('green')}}",
-          "wait_for_no_relocating_shards": "true"
-        },
-        "retry-until-success": true
-      }
-    },
-    {
-      "operation": {
-        "operation-type": "bulk",
-        "bulk-size": {{bulk_size | default(5000)}},
-        "ingest-percentage": {{ingest_percentage | default(100)}}
-      },
-      "clients": {{bulk_indexing_clients | default(8)}}
-    }
-  ]{% endraw %}
+  {% raw %}
+  "operations": [
+    {{ rally.collect(parts="operations/*.json") }}
+  ],
+  "challenges": [
+    {{ rally.collect(parts="challenges/*.json") }}
+  ]
+   {% endraw %}
 }

--- a/esrally/tracker/corpus.py
+++ b/esrally/tracker/corpus.py
@@ -71,7 +71,7 @@ def dump_documents(client, index, out_path, total_docs, batch_size=1000, progres
     from elasticsearch import helpers
 
     logger = logging.getLogger(__name__)
-    freq = max(1, total_docs // 1000)
+    freq = max(1, total_docs // batch_size)
 
     progress = console.progress()
     compressor = DOCS_COMPRESSOR()

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -51,6 +51,7 @@ Key = Literal[
     "assertions",
     "async.debug",
     "available.cores",
+    "batch_size",
     "build.type",
     "cache",
     "cache.days",


### PR DESCRIPTION
I seem to mess up my old branch - this is the same as PR #1836 
Add option to increase batch size when creating a track to speed up download of data. Update track layout to adhere to best practices

Creating tracks from large corpus can take quite a bit of time, so I have added the option to increase the batch size of scan, so if a user is running with a stable enough network connection and enough hardware resources on the rally instance, they can increase the batch size to speed up download.

I have also updated the track layout to better match how we tend to layout our tracks

There was feedback to add more docs, so that's done too