### PR TITLE
Remove esql version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Once your changes and tests are ready to submit for review:
 
     Ensure that all tests pass by running `make check-all`. This runs sequentially lint checks, unit tests and integration tests. These can be executed in isolation using `make lint`, `make test` and `make it` respectively, in case you need to iterate over a subset of tests.
 
-    Note: Integration tests are much slower than unit tests.
+    Note: Integration tests are much slower than unit tests and require `docker-compose`.
 
 3. Sign the Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Once your changes and tests are ready to submit for review:
 
     Ensure that all tests pass by running `make check-all`. This runs sequentially lint checks, unit tests and integration tests. These can be executed in isolation using `make lint`, `make test` and `make it` respectively, in case you need to iterate over a subset of tests.
 
-    Note: Integration tests are much slower than unit tests and require `docker-compose`.
+    Note: Integration tests are much slower than unit tests.
 
 3. Sign the Contributor License Agreement
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3138,13 +3138,12 @@ The operation returns no meta-data.
 esql
 ~~~~~~~~~~~~~
 
-With the operation type ``esql`` you can execute an `ES|QL query <https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html>`_.
+With the operation type ``esql`` you can execute `ES|QL query <https://www.elastic.co/guide/en/elasticsearch/reference/master/esql.html>`_.
 
 Properties
 """"""""""
 
-* ``query`` (mandatory): An ES|QL query which starts with a source command followed by processing commands.
-* ``version`` (optional): The version of the ES|QL query language. Defaults to the first released version, ``2024.04.01``. See the docs for `available versions <https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-version.html>`_.
+* ``query`` (mandatory): An ES|QL query starts with a source command followed processing commands.
 * ``filter`` (optional): A query filter defined in `Elasticsearch query DSL <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html>`_.
 * ``body`` (optional): The query body.
 
@@ -3154,7 +3153,6 @@ Example::
       "name": "default",
       "operation-type": "esql",
       "query": "FROM logs-* | STATS count=count(*) BY agent.hostname | SORT count DESC | LIMIT 20",
-      "version": "2024.04.01",
       "filter": {
         "range": {
           "timestamp": {

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3138,12 +3138,12 @@ The operation returns no meta-data.
 esql
 ~~~~~~~~~~~~~
 
-With the operation type ``esql`` you can execute `ES|QL query <https://www.elastic.co/guide/en/elasticsearch/reference/master/esql.html>`_.
+With the operation type ``esql`` you can execute an `ES|QL query <https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html>`_.
 
 Properties
 """"""""""
 
-* ``query`` (mandatory): An ES|QL query starts with a source command followed processing commands.
+* ``query`` (mandatory): An ES|QL query which starts with a source command followed by processing commands.
 * ``filter`` (optional): A query filter defined in `Elasticsearch query DSL <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html>`_.
 * ``body`` (optional): The query body.
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2892,7 +2892,6 @@ class Esql(Runner):
         query = mandatory(params, "query", self)
         body = params.get("body", {})
         body["query"] = query
-        body["version"] = params.get("version", "2024.04.01")
         query_filter = params.get("filter")
         if query_filter:
             body["filter"] = query_filter

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -7686,7 +7686,7 @@ class TestEsqlRunner:
         esql = runner.Esql()
         result = await esql(es, params={"query": "from logs-* | stats c = count(*)"})
         assert result == {"weight": 1, "unit": "ops", "success": True}
-        expected_body = {"query": "from logs-* | stats c = count(*)", "version": "2024.04.01"}
+        expected_body = {"query": "from logs-* | stats c = count(*)"}
         es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -7698,7 +7698,7 @@ class TestEsqlRunner:
         query_filter = {"range": {"@timestamp": {"gte": "2023"}}}
         result = await esql(es, params={"query": "from * | limit 1", "filter": query_filter})
         assert result == {"weight": 1, "unit": "ops", "success": True}
-        expected_body = {"query": "from * | limit 1", "version": "2024.04.01", "filter": query_filter}
+        expected_body = {"query": "from * | limit 1", "filter": query_filter}
         es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})
 
     @mock.patch("elasticsearch.Elasticsearch")
@@ -7711,16 +7711,5 @@ class TestEsqlRunner:
         result = await esql(es, params={"query": "from * | limit 1", "body": {"pragma": pragma}})
         assert result == {"weight": 1, "unit": "ops", "success": True}
 
-        expected_body = {"pragma": pragma, "query": "from * | limit 1", "version": "2024.04.01"}
-        es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})
-
-    @mock.patch("elasticsearch.Elasticsearch")
-    @pytest.mark.asyncio
-    async def test_esql_with_version(self, es):
-        es.options.return_value = es
-        es.perform_request = mock.AsyncMock()
-        esql = runner.Esql()
-        result = await esql(es, params={"query": "from * | limit 1", "version": "wow"})
-        assert result == {"weight": 1, "unit": "ops", "success": True}
-        expected_body = {"query": "from * | limit 1", "version": "wow"}
+        expected_body = {"pragma": pragma, "query": "from * | limit 1"}
         es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})


### PR DESCRIPTION
ES|QL in 8.14 will not require a `version` parameter in requests to `_query`, after all.

Remove the `version` parameter from the ES|QL runner, essentially reverting https://github.com/elastic/rally/pull/1841.

This should be merged only after https://github.com/elastic/elasticsearch/pull/108919 is merged to avoid breakage.