### PR TITLE
Update pypi publish to 1.8.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,4 @@ jobs:
           name: "dist"
           path: "dist/"
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e  # v1.8.10
+        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450  # v1.8.14


### PR DESCRIPTION
During release of 2.11.0 I discovered our version of PyPi publish is no longer compatible with the latest metadata version, this updates the action version, which bundles a later pkginfo