### PR TITLE
[Metrics store] Add support for custom templates

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -6,6 +6,34 @@ Metrics Records
 
 At the end of a race, Rally stores all metrics records in its metrics store. Metrics can be kept in memory or written to a dedicated Elasticsearch cluster (not the cluster where Rally ran its benchmarks). This can be configured in the `[reporting] section <https://esrally.readthedocs.io/en/stable/configuration.html#reporting>`_.
 
+Rally writes data to the following indices in the Elasticsearch metrics store:
+
+* ``rally-races-*``: Contains the metadata of a benchmark. This is a subset of the metrics records but only contains the metadata of a benchmark.
+* ``rally-metrics-*``: Contains all metrics records.
+* ``rally-results-*``: Contains the results of a benchmark. This is a subset of the metrics records but only contains the final results of a benchmark.
+* ``rally-annotations-*``: Contains annotations that can be added to a benchmark. This is a subset of the metrics records but only contains the annotations of a benchmark.
+
+Changing index settings, like number of shards and `ILM policies <https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-management.html#index-lifecycle-management>`_, can be performed by creating component templates matching the index template name with the ``@custom`` suffix. For example, to add an ILM policy named ``rally-metrics`` to ``rally-metrics-*`` indices, create a component template named ``rally-metrics@custom``:
+
+
+    PUT /_index_template/rally-metrics@custom
+    {
+      "template": {
+        "settings": {
+          "index.lifecycle.name": "rally-metrics"
+        }
+      }
+    }
+
+Supported metrics store custom component template names:
+
+* ``rally-races@custom``
+* ``rally-metrics@custom``
+* ``rally-results@custom``
+* ``rally-annotations@custom``
+
+Custom component templates with the ``@custom`` suffix will not be overwritten by Rally. Settings in custom component templates will override datastore shard settings in rally.ini.
+
 Rally stores the metrics in the indices ``rally-metrics-*``. It will create a new index for each month. Here is a typical metrics record::
 
 

--- a/esrally/resources/annotation-template.json
+++ b/esrally/resources/annotation-template.json
@@ -2,6 +2,8 @@
   "index_patterns": [
     "rally-annotations"
   ],
+  "composed_of": ["rally-annotations@custom"],
+  "ignore_missing_component_templates": ["rally-annotations@custom"],
   "template": {
     "settings": {
       "index": {}

--- a/esrally/resources/metrics-template.json
+++ b/esrally/resources/metrics-template.json
@@ -2,6 +2,8 @@
   "index_patterns": [
     "rally-metrics-*"
   ],
+  "composed_of": ["rally-metrics@custom"],
+  "ignore_missing_component_templates": ["rally-metrics@custom"],
   "template": {
     "settings": {
       "index": {

--- a/esrally/resources/races-template.json
+++ b/esrally/resources/races-template.json
@@ -2,6 +2,8 @@
   "index_patterns": [
     "rally-races-*"
   ],
+  "composed_of": ["rally-races@custom"],
+  "ignore_missing_component_templates": ["rally-races@custom"],
   "template": {
     "settings": {
       "index": {}

--- a/esrally/resources/results-template.json
+++ b/esrally/resources/results-template.json
@@ -1,108 +1,111 @@
 {
-  "index_patterns": ["rally-results-*"],
+  "index_patterns": [
+    "rally-results-*"
+  ],
+  "composed_of": ["rally-results@custom"],
+  "ignore_missing_component_templates": ["rally-results@custom"],
   "template": {
-  "settings": {
-    "index": {
-    }
-  },
-  "mappings": {
-    "date_detection": false,
-    "dynamic_templates": [
-      {
-        "strings": {
-          "match": "*",
-          "match_mapping_type": "string",
-          "mapping": {
-            "type": "keyword"
-          }
-        }
-      }
-    ],
-    "_source": {
-      "enabled": true
+    "settings": {
+      "index": {}
     },
-    "properties": {
-      "race-id": {
-        "type": "keyword"
-      },
-      "race-timestamp": {
-        "type": "date",
-        "format": "basic_date_time_no_millis",
-        "fields": {
-          "raw": {
-            "type": "keyword"
+    "mappings": {
+      "date_detection": false,
+      "dynamic_templates": [
+        {
+          "strings": {
+            "match": "*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword"
+            }
           }
         }
+      ],
+      "_source": {
+        "enabled": true
       },
-      "active": {
-        "type": "boolean"
-      },
-      "rally-version": {
-        "type": "keyword"
-      },
-      "rally-revision": {
-        "type": "keyword"
-      },
-      "environment": {
-        "type": "keyword"
-      },
-      "track": {
-        "type": "keyword"
-      },
-      "challenge": {
-        "type": "keyword"
-      },
-      "car": {
-        "type": "keyword"
-      },
-      "node-count": {
-        "type": "short"
-      },
-      "plugins": {
-        "type": "keyword"
-      },
-      "distribution-flavor": {
-        "type": "keyword"
-      },
-      "distribution-version": {
-        "type": "keyword"
-      },
-      "distribution-major-version": {
-        "type": "short"
-      },
-      "task": {
-        "type": "keyword"
-      },
-      "operation": {
-        "type": "keyword"
-      },
-      "job": {
-        "type": "keyword"
-      },
-      "name": {
-        "type": "keyword"
-      },
-      "value": {
-        "type": "object",
-        "properties": {
-          "single": {
-            "type": "double"
-          },
-          "min": {
-            "type": "double"
-          },
-          "mean": {
-            "type": "double"
-          },
-          "median": {
-            "type": "double"
-          },
-          "max": {
-            "type": "double"
+      "properties": {
+        "race-id": {
+          "type": "keyword"
+        },
+        "race-timestamp": {
+          "type": "date",
+          "format": "basic_date_time_no_millis",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "rally-version": {
+          "type": "keyword"
+        },
+        "rally-revision": {
+          "type": "keyword"
+        },
+        "environment": {
+          "type": "keyword"
+        },
+        "track": {
+          "type": "keyword"
+        },
+        "challenge": {
+          "type": "keyword"
+        },
+        "car": {
+          "type": "keyword"
+        },
+        "node-count": {
+          "type": "short"
+        },
+        "plugins": {
+          "type": "keyword"
+        },
+        "distribution-flavor": {
+          "type": "keyword"
+        },
+        "distribution-version": {
+          "type": "keyword"
+        },
+        "distribution-major-version": {
+          "type": "short"
+        },
+        "task": {
+          "type": "keyword"
+        },
+        "operation": {
+          "type": "keyword"
+        },
+        "job": {
+          "type": "keyword"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "object",
+          "properties": {
+            "single": {
+              "type": "double"
+            },
+            "min": {
+              "type": "double"
+            },
+            "mean": {
+              "type": "double"
+            },
+            "median": {
+              "type": "double"
+            },
+            "max": {
+              "type": "double"
+            }
           }
         }
       }
     }
   }
-}
 }


### PR DESCRIPTION
This change adds the ability to customize indices in the metrics store. The goal is to support ILM policies and eventually shift to using data streams.

* Support the addition of component templates having the `@custom` suffix.
* Add documentation.