### PR TITLE
Avoid logging ES credentials from running Rally processes

### DIFF
--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -181,7 +181,7 @@ def find_all_other_rally_processes() -> List[psutil.Process]:
 
 def redact_cmdline(cmdline: list) -> List[str]:
     """
-    Redact client options in p.cmdline as it contains sensitive information like passwords
+    Redact client options in cmdline as it contains sensitive information like passwords
     """
 
     return ["=".join((value.split("=")[0], '"*****"')) if "--client-options" in value else value for value in cmdline]
@@ -189,7 +189,9 @@ def redact_cmdline(cmdline: list) -> List[str]:
 
 def kill_all(predicate: Callable[[psutil.Process], bool]) -> None:
     def kill(p: psutil.Process):
-        logging.getLogger(__name__).info("Killing lingering process with PID [%s] and command line [%s].", p.pid, redact_cmdline(p.cmdline))
+        logging.getLogger(__name__).info(
+            "Killing lingering process with PID [%s] and command line [%s].", p.pid, redact_cmdline(p.cmdline())
+        )
         p.kill()
         # wait until process has terminated, at most 3 seconds. Otherwise we might run into race conditions with actor system
         # sockets that are still open.

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -17,6 +17,7 @@
 
 import logging
 import os
+import re
 import shlex
 import subprocess
 import time
@@ -181,7 +182,13 @@ def find_all_other_rally_processes() -> List[psutil.Process]:
 
 def kill_all(predicate: Callable[[psutil.Process], bool]) -> None:
     def kill(p: psutil.Process):
-        logging.getLogger(__name__).info("Killing lingering process with PID [%s] and command line [%s].", p.pid, p.cmdline())
+        # Do not leak Elasticsearch authentication credentials to the log
+        p_cmdline = p.cmdline()
+        for i, s in enumerate(p_cmdline):
+            if "--client-options" in s:
+                p_cmdline[i] = re.sub(r"basic_auth_password:'.+'", "basic_auth_password:'*****'", s)
+                p_cmdline[i] = re.sub(r"api_key:'.+'", "api_key:'*****'", s)
+        logging.getLogger(__name__).info("Killing lingering process with PID [%s] and command line [%s].", p.pid, p_cmdline)
         p.kill()
         # wait until process has terminated, at most 3 seconds. Otherwise we might run into race conditions with actor system
         # sockets that are still open.

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -17,7 +17,6 @@
 
 import logging
 import os
-import re
 import shlex
 import subprocess
 import time


### PR DESCRIPTION
Replace the basic authentication password and API key with `'*****'` before creating the log entry when killing a running process.

Support both `--client-options` CLI formats:

- [x] name:value pairs
- [x] inline JSON

Closes https://github.com/elastic/rally/issues/1862
