### PR TITLE
Switch to JDK 21

### DIFF
--- a/.buildkite/it/run.sh
+++ b/.buildkite/it/run.sh
@@ -30,9 +30,9 @@ retry 5 sudo apt-get update
 retry 5 sudo apt-get install -y \
     "python${PYTHON_VERSION}" "python${PYTHON_VERSION}-dev" "python${PYTHON_VERSION}-venv" \
     git make jq docker \
-    openjdk-17-jdk-headless openjdk-11-jdk-headless
+    openjdk-21-jdk-headless openjdk-11-jdk-headless
 export JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-export JAVA17_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+export JAVA21_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 
 echo "--- Run IT test :pytest:"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,11 @@ jobs:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4.3
         with:
           distribution: "temurin"
-          java-version: "17"
-      - run: echo "JAVA17_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+          java-version: "21"
+      - run: echo "JAVA21_HOME=$JAVA_HOME_21_X64" >> $GITHUB_ENV
       - run: echo "JAVA11_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
       - name: "Install dependencies"
         run: python -m pip install --upgrade nox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
-      - uses: actions/setup-java@v4.3
+      - uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "21"


### PR DESCRIPTION
This updates the build JDK to 21, since Elasticsearch@main now requires 21 to build. I bumped the github action versions too at the same time