### PR TITLE
Pull non-default branch commits selectively

### DIFF
--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -750,7 +750,7 @@ class SourceRepository:
                 branch,
                 self.name,
             )
-            git.pull_ts(self.src_dir, git_ts_revision, remote="origin", branch=branch)
+            git.pull_ts(self.src_dir, git_ts_revision, remote="origin", branch=branch, default_branch=DEFAULT_ELASTICSEARCH_BRANCH)
         elif self.has_remote():  # we can have either a commit hash, branch name, or tag
             git.fetch(self.src_dir, remote="origin")
             if git.is_branch(self.src_dir, identifier=revision):

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -147,7 +147,7 @@ class TestSourceRepository:
         s.fetch("@2023-04-20T11:09:12Z")
 
         mock_is_working_copy.assert_called_with("/src")
-        mock_pull_ts.assert_called_with("/src", "2023-04-20T11:09:12Z", remote="origin", branch="main")
+        mock_pull_ts.assert_called_with("/src", "2023-04-20T11:09:12Z", remote="origin", branch="main", default_branch="main")
         mock_head_revision.assert_called_with("/src")
 
     @mock.patch("esrally.utils.git.fetch", autospec=True)


### PR DESCRIPTION
After switching nightlies to non-default branch it was observed commit IDs selected through `branch@timestamp` notation are not constant, and depend on subsequent merges of default branch (`main`) into non-default branch.

This PR mitigates this problem by filtering commit IDs of default branch from timestamp-based pulls of non-default branches using `main..branch` notation of `git rev-list` command.
