### PR TITLE
ci: Fix lint errors due to mypy with python 3.12

### DIFF
--- a/esrally/client/asynchronous.py
+++ b/esrally/client/asynchronous.py
@@ -77,7 +77,7 @@ class StaticRequest(aiohttp.ClientRequest):
         self.response = self.response_class(
             self.method,
             self.original_url,
-            writer=self._writer,  # type: ignore[arg-type]  # TODO remove this ignore when introducing type hints
+            writer=self._writer,
             continue100=self._continue,
             timer=self._timer,
             request_info=self.request_info,

--- a/esrally/client/asynchronous.py
+++ b/esrally/client/asynchronous.py
@@ -77,7 +77,7 @@ class StaticRequest(aiohttp.ClientRequest):
         self.response = self.response_class(
             self.method,
             self.original_url,
-            writer=self._writer,
+            writer=self._writer,  # type: ignore[arg-type]  # TODO remove this ignore when introducing type hints
             continue100=self._continue,
             timer=self._timer,
             request_info=self.request_info,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     # License: MIT
     "urllib3==1.26.19",
     # License: Apache 2.0
-    "aiohttp==3.11.0",
+    "aiohttp==3.10.8",
     "docker==6.0.0",
     # avoid specific requests version to fix bug in docker-py
     "requests<2.32.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,12 @@ classifiers = [
 ################################################################################################
 dependencies = [
     # License: Apache 2.0
-    # transitive dependencies:
-    #   urllib3: MIT
-    #   aiohttp: Apache 2.0
-
     "elasticsearch[async]==8.6.1",
     "elastic-transport==8.4.1",
+    # License: MIT
     "urllib3==1.26.19",
+    # License: Apache 2.0
+    "aiohttp==3.11.0",
     "docker==6.0.0",
     # avoid specific requests version to fix bug in docker-py
     "requests<2.32.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     # License: MIT
     "urllib3==1.26.19",
     # License: Apache 2.0
-    "aiohttp==3.10.8",
+    "aiohttp==3.10.11",
     "docker==6.0.0",
     # avoid specific requests version to fix bug in docker-py
     "requests<2.32.0",


### PR DESCRIPTION
Now that we're using python 3.12 for the `lint` github action, we need to fix the errors that it is reporting.

[Lint errors in question](https://github.com/elastic/rally/actions/runs/11823806034/job/32943896624)


* Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
* Have you followed the [contributor guidelines](https://github.com/elastic/rally/blob/master/CONTRIBUTING.md)?
* Have you run `make check-all` successfully?
* Did you choose a [descriptive title and description](https://chris.beams.io/posts/git-commit/) for your PR?
* (Only for maintainers) Did you apply appropriate labels and a milestone?
