### PR TITLE
Add read timeout for retry

### DIFF
--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -224,7 +224,7 @@ def download_http(url, local_path, expected_size_in_bytes=None, progress_indicat
     for i in range(HTTP_DOWNLOAD_RETRIES + 1):
         try:
             return _download_http(url, local_path, expected_size_in_bytes, progress_indicator)
-        except urllib3.exceptions.ProtocolError as exc:
+        except (urllib3.exceptions.ProtocolError, urllib3.exceptions.ReadTimeoutError) as exc:
             if i == HTTP_DOWNLOAD_RETRIES:
                 raise
             logger.warning("Retrying after %s", exc)


### PR DESCRIPTION
This PR deals with the ReadTimeoutError when downloading track data. 
It is a transient error and it should be handled by retry mechanism.

Following is the stack trace
```
File "/home/esbench/.local/lib/python3.11/site-packages/urllib3/response.py", line 566, in read                                                                                                                                                    
    with self._error_catcher():                                                                                                                                                                                                                      
  File "/home/esbench/.pyenv/versions/3.11.7/lib/python3.11/contextlib.py", line 158, in __exit__                                                                                                                                                    
    self.gen.throw(typ, value, traceback)                                                                                                                                                                                                            
  File "/home/esbench/.local/lib/python3.11/site-packages/urllib3/response.py", line 449, in _error_catcher                                                                                                                                          
    raise ReadTimeoutError(self._pool, None, "Read timed out.")                                                                                                                                                                                      
urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='rally-tracks.elastic.co', port=443): Read timed out.
```