### PR TITLE
Reduce log volume forwarded through Thespian framework

### DIFF
--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -114,14 +114,11 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
     # noinspection PyPep8Naming
     @staticmethod
     def actorSystemCapabilityCheck(capabilities, requirements):
-        logger = logging.getLogger(__name__)
         for name, value in requirements.items():
             current = capabilities.get(name, None)
             if current != value:
                 # A mismatch by is not a problem by itself as long as at least one actor system instance matches the requirements.
-                logger.debug("Checking capabilities [%s] against requirements [%s] failed.", capabilities, requirements)
                 return False
-        logger.debug("Capabilities [%s] match requirements [%s].", capabilities, requirements)
         return True
 
     def transition_when_all_children_responded(self, sender, msg, expected_status, new_status, transition):

--- a/esrally/client/factory.py
+++ b/esrally/client/factory.py
@@ -78,7 +78,7 @@ class EsClientFactory:
                 self.ssl_context.verify_mode = ssl.CERT_NONE
                 self.client_options["ssl_show_warn"] = False
 
-                self.logger.warning(
+                self.logger.debug(
                     "User has enabled SSL but disabled certificate verification. This is dangerous but may be ok for a benchmark."
                 )
             else:

--- a/tests/client/factory_test.py
+++ b/tests/client/factory_test.py
@@ -238,6 +238,7 @@ class TestEsClientFactory:
             [
                 mock.call("SSL support: on"),
                 mock.call("SSL certificate verification: off"),
+                mock.call("User has enabled SSL but disabled certificate verification. This is dangerous but may be ok for a benchmark."),
                 mock.call("SSL client authentication: off"),
             ]
         )
@@ -278,6 +279,7 @@ class TestEsClientFactory:
         mocked_debug_logger.assert_has_calls(
             [
                 mock.call("SSL certificate verification: off"),
+                mock.call("User has enabled SSL but disabled certificate verification. This is dangerous but may be ok for a benchmark."),
                 mock.call("SSL client authentication: on"),
             ],
         )


### PR DESCRIPTION
This reduces the amount of Thespian messages containing forwarded logs contributing to https://github.com/elastic/rally/issues/1448.

I don't understand `actorSystemCapabilityCheck()` behavior, as `DEBUG` logs should not be forwarded. I've raised this with Thespian maintainer, but have not received additional explanations so far. As we cannot get lower than `DEBUG` I'm simply removing those logs.

The `WARNING` log about SSL verification being off being forwarded through Thespian is expected.

See https://github.com/thespianpy/Thespian/issues/82#issuecomment-2551853924 for additional context, and potential follow-up in the future.
