### PR TITLE
Improve error messages regarding track syntax errors

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1122,8 +1122,8 @@ class TrackFileReader:
                 track_spec = json.loads(rendered)
             except jinja2.exceptions.TemplateSyntaxError as te:
                 self.logger.exception("Could not load [%s] due to Jinja Syntax Exception.", track_spec_file)
-                msg = f"Could not load '{track_spec_file}' due to Jinja Syntax Exception."
-                msg += f"The track file ({tmp.name}) likely hasn't been writen"
+                msg = f"Could not load '{track_spec_file}' due to Jinja Syntax Exception. "
+                msg += f"The track file ({tmp.name}) likely hasn't been written."
                 raise TrackSyntaxError(msg, te)
             except jinja2.exceptions.TemplateNotFound:
                 self.logger.exception("Could not load [%s]", track_spec_file)

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1122,7 +1122,8 @@ class TrackFileReader:
                 track_spec = json.loads(rendered)
             except jinja2.exceptions.TemplateSyntaxError as te:
                 self.logger.exception("Could not load [%s] due to Jinja Syntax Exception.", track_spec_file)
-                msg = f"Could not load '{track_spec_file}' due to Jinja Syntax Exception. The track file ({tmp.name}) likely hasn't been writen"
+                msg = f"Could not load '{track_spec_file}' due to Jinja Syntax Exception."
+                msg += f"The track file ({tmp.name}) likely hasn't been writen"
                 raise TrackSyntaxError(msg, te)
             except jinja2.exceptions.TemplateNotFound:
                 self.logger.exception("Could not load [%s]", track_spec_file)
@@ -1702,7 +1703,7 @@ class TrackSpecificationReader:
         completed_by_name=None,
     ):
         if "operation" not in task_spec:
-            raise TrackSyntaxError("Operation missing from task spec %s in challenge '%s'.", task_spec, challenge_name)
+            raise TrackSyntaxError("Operation missing from task spec %s in challenge '%s'." % (task_spec, challenge_name))
         op_spec = task_spec["operation"]
         if isinstance(op_spec, str) and op_spec in ops:
             op = ops[op_spec]

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1120,6 +1120,10 @@ class TrackFileReader:
                     f.write(rendered)
                 self.logger.info("Final rendered track for '%s' has been written to '%s'.", track_spec_file, tmp.name)
                 track_spec = json.loads(rendered)
+            except jinja2.exceptions.TemplateSyntaxError as te:
+                self.logger.exception("Could not load [%s] due to Jinja Syntax Exception.", track_spec_file)
+                msg = f"Could not load '{track_spec_file}' due to Jinja Syntax Exception. The track file ({tmp.name}) likely hasn't been writen"
+                raise TrackSyntaxError(msg, te)
             except jinja2.exceptions.TemplateNotFound:
                 self.logger.exception("Could not load [%s]", track_spec_file)
                 raise exceptions.SystemSetupError(f"Track {track_name} does not exist")
@@ -1697,6 +1701,8 @@ class TrackSpecificationReader:
         default_ramp_up_time_period=None,
         completed_by_name=None,
     ):
+        if "operation" not in task_spec:
+            raise TrackSyntaxError("Operation missing from task spec %s in challenge '%s'.", task_spec, challenge_name)
         op_spec = task_spec["operation"]
         if isinstance(op_spec, str) and op_spec in ops:
             op = ops[op_spec]


### PR DESCRIPTION
I've encountered a few cryptic error messages whilst tweeking a track.

Issues this solves:
- If we fail to transform the templates completely due to a syntax error, we write that the full output is listed XXXX - it isnt, we never get round to writing it, so I am catching the TemplateSyntaxError and writing another error message. It would be nice if we can say _what_ the error is, or at least where, but we can't yet. If I find a way I will add that to the PR / a new PR
- If you don't include "operation", you get an Attribute error, but no information where in the track. Now we include a more helpful message that should help users see where the issue may be. 