### PR TITLE
Add check if headers is not None before treating it like a dict

### DIFF
--- a/esrally/client/common.py
+++ b/esrally/client/common.py
@@ -20,7 +20,7 @@ _COMPAT_MIMETYPE_SUB = _COMPAT_MIMETYPE_TEMPLATE % (r"\g<1>",)
 def _mimetype_header_to_compat(header, request_headers):
     # Converts all parts of a Accept/Content-Type headers
     # from application/X -> application/vnd.elasticsearch+X
-    mimetype = request_headers.get(header, None)
+    mimetype = request_headers.get(header, None) if request_headers else None
     if mimetype:
         request_headers[header] = _COMPAT_MIMETYPE_RE.sub(_COMPAT_MIMETYPE_SUB, mimetype)
 


### PR DESCRIPTION
Martijn came across an issue with ccr-stats, where we are updating headers, but we don't have any request headers set - so this bit of code blows up. In other cases (e.g blob-store-stats) we typically run against serverless, which we specifically don't try and update the headers for.

