### PR TITLE
Replace deprecate use of resources.read_text() function.

### DIFF
--- a/esrally/version.py
+++ b/esrally/version.py
@@ -68,4 +68,4 @@ def minimum_es_version():
     """
     :return: A string identifying the minimum version of Elasticsearch that is supported by Rally.
     """
-    return resources.read_text("esrally", "min-es-version.txt").strip()
+    return resources.files("esrally").joinpath("min-es-version.txt").read_text().strip()

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -1,0 +1,32 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+from esrally import version
+
+MIN_ES_VERSION_PATH = os.path.join(os.path.dirname(version.__file__), "min-es-version.txt")
+
+
+class TestVersion:
+
+    def test_minimum_es_version(self):
+        assert os.path.exists(MIN_ES_VERSION_PATH)
+        got = version.minimum_es_version()
+        with open(MIN_ES_VERSION_PATH) as f:
+            want = f.read().strip()
+        assert want == got


### PR DESCRIPTION
This fixes the issue by replacing the deprecated function with the code suggested by Python documentation.

