### PR TITLE
Preserve pre-existing `rally-metrics` index templates by default

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -80,6 +80,8 @@ The following settings are applicable only if ``datastore.type`` is set to "elas
 * ``datastore.probe.cluster_version`` (default: true): Enables automatic detection of the metric store's version.
 * ``datastore.number_of_shards`` (default: `Elasticsearch default value <https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#_static_index_settings>`_): The number of primary shards that the ``rally-*`` indices should have. Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
 * ``datastore.number_of_replicas`` (default: `Elasticsearch default value <https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#_static_index_settings>`_): The number of replicas each primary shard has. Defaults to . Any updates to this setting after initial index creation will only be applied to new ``rally-*`` indices.
+* ``datastore.overwrite_existing_templates`` (default: ``false``): Existing Rally index templates are replaced only when this option is ``true``.
+
 
 **Examples**
 

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -9,6 +9,12 @@ Minimum Python version is 3.9.0
 
 Rally 2.12.0 requires Python 3.9.0 or above. Check the :ref:`updated installation instructions <install_python>` for more details.
 
+The metrics store keeps existing index templates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Existing Rally index templates are replaced only when option ``datastore.overwrite_existing_templates`` in section ``reporting`` is ``true``.
+
+
 Migrating to Rally 2.10.1
 -------------------------
 

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -66,6 +66,7 @@ Key = Literal[
     "datastore.host",
     "datastore.number_of_replicas",
     "datastore.number_of_shards",
+    "datastore.overwrite_existing_templates",
     "datastore.password",
     "datastore.port",
     "datastore.probe.cluster_version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ develop = [
     "black==24.10.0",
     # mypy
     "boto3-stubs==1.26.125",
-    "mypy==1.10.1",
+    "mypy==1.15.0",
     "types-psutil==5.9.4",
     "types-tabulate==0.8.9",
     "types-urllib3==1.26.19",

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -126,5 +126,5 @@ def assert_annotations(obj, ident, *expects):
 class TestConfigTypeHint:
     def test_esrally_module_annotations(self):
         for module in project_root.glob_modules("esrally/**/*.py"):
-            assert_annotations(module, "cfg", types.Config)
+            assert_annotations(module, "cfg", types.Config, "types.Config")
             assert_annotations(module, "config", types.Config, Optional[types.Config], ConfigParser)


### PR DESCRIPTION
It handles issue #1900: Rally should not overwrite pre existing templates by default

When opening an EsMetricsStore, it creates the index template if any of following is true:

- the index template doesn't exist
- `reporting/datastore.overwrite_existing_templates` option is true and there are differences
  between existing and requested template.

It will preserve existing template on all the other cases.
It logs a warning when an existing index template is being replaced.
It logs index template differences between the existing one (if any) and configured one.