### PR TITLE
Revert "Upgrade thespian to 4.0.0 to fix hang on macOS (#1653)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "Jinja2==3.1.5",
     "markupsafe==2.0.1",
     # License: MIT
-    "thespian==4.0.0",
+    "thespian==3.10.1",
     # recommended library for thespian to identify actors more easily with `ps`
     # "setproctitle==1.1.10",
     # always use the latest version, these are certificate files...


### PR DESCRIPTION
This reverts commit fa5fbe0bb9993b60e33eaa36c2e73da8a935cdab.

Thespian 4.0.0 is causing issues on systems with multiple interfaces / IP addresses. During convention registration, actors might be presenting unexpected IP address which leads to communication failures, if one IP path is filtered.