### PR TITLE
Suppress a flaky internal mypy error appearing randomly when executing `make lint`.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,8 @@ repos:
           "--config",
           "pyproject.toml"
         ]
+        # Suppress a flaky internal mypy error appearing randomly when executing make lint.
+        require_serial: true
 
   - repo: local
     hooks:


### PR DESCRIPTION
Fixes Rally issue #1918.
