### PR TITLE
Add ability to get access to test mode from custom runner

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -175,9 +175,11 @@ class Runner:
         self.logger = logging.getLogger(__name__)
         self.serverless_mode = False
         self.serverless_operator = False
+        self.test_mode = False
         if config:
             self.serverless_mode = convert.to_bool(config.opts("driver", "serverless.mode", mandatory=False, default_value=False))
             self.serverless_operator = convert.to_bool(config.opts("driver", "serverless.operator", mandatory=False, default_value=False))
+            self.test_mode = convert.to_bool(config.opts("track", "test.mode.enabled", mandatory=False, default_value=False))
 
     async def __aenter__(self):
         return self

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -277,7 +277,7 @@ def load_track_plugins(
     repo = track_repo(cfg, fetch=force_update, update=force_update)
     track_plugin_path = repo.track_dir(track_name)
     logging.getLogger(__name__).debug("Invoking plugin_reader with name [%s] resolved to path [%s]", track_name, track_plugin_path)
-    plugin_reader = TrackPluginReader(track_plugin_path, register_runner, register_scheduler, register_track_processor)
+    plugin_reader = TrackPluginReader(track_plugin_path, register_runner, register_scheduler, register_track_processor, cfg)
 
     if plugin_reader.can_load():
         plugin_reader.load()
@@ -1221,11 +1221,12 @@ class TrackPluginReader:
     Loads track plugins
     """
 
-    def __init__(self, track_plugin_path, runner_registry=None, scheduler_registry=None, track_processor_registry=None):
+    def __init__(self, track_plugin_path, runner_registry=None, scheduler_registry=None, track_processor_registry=None, config=None):
         self.runner_registry = runner_registry
         self.scheduler_registry = scheduler_registry
         self.track_processor_registry = track_processor_registry
         self.loader = modules.ComponentLoader(root_path=track_plugin_path, component_entry_point="track")
+        self.config = config
 
     def can_load(self):
         return self.loader.can_load()


### PR DESCRIPTION
We currently cant know if a track is in test mode within custom runner code. This adds the information for runners - I am still working on for ParamSources.

