### PR TITLE
issue #1931: `create-track` command supports serverless.

### DIFF
--- a/esrally/tracker/index.py
+++ b/esrally/tracker/index.py
@@ -73,7 +73,7 @@ def extract_index_mapping_and_settings(client, index_pattern):
         valid, reason = is_valid(index, index_pattern)
         if valid:
             mappings = details["mappings"]
-            index_settings = filter_ephemeral_index_settings(details["settings"]["index"])
+            index_settings = filter_ephemeral_index_settings(details.get("settings", {}).get("index", {}))
             update_index_setting_parameters(index_settings)
             results[index] = {"mappings": mappings, "settings": {"index": index_settings}}
         else:


### PR DESCRIPTION
Support Serverless ES project with existing index when running the `create-track` command. Serverless might not have entries like settings and index.

<!--
Thank you for your interest in and contributing to Rally! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
 https://github.com/elastic/rally/issues/1931
