### PR TITLE
Upgrade gh-action-pypi-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,4 @@ jobs:
           name: "dist"
           path: "dist/"
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450  # v1.8.14
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4


### PR DESCRIPTION
Publishing esrally 2.12.0 to PyPI failed because our tooling wrote metadata version 2.4, and it appears the prior version of this action only understands up to version 2.3.