### PR TITLE
Initial commit for proxy support

### DIFF
--- a/esrally/client/asynchronous.py
+++ b/esrally/client/asynchronous.py
@@ -267,6 +267,7 @@ class RallyAiohttpHttpNode(AiohttpHttpNode):
             cookie_jar=aiohttp.DummyCookieJar(),
             request_class=self._request_class,
             response_class=self._response_class,
+            trust_env=True,
             connector=connector,
             trace_configs=self.trace_configs,
         )


### PR DESCRIPTION
Initial support for proxies.

The aim is to rely on existing support from requests or aiohttp.

Next steps:
- more thorough testing
- documentation