### PR TITLE
Fix snapshot restore

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -2461,9 +2461,7 @@ Properties
 .. note::
     In order to ensure that the track execution only continues after a snapshot has been restored, set ``wait-for-completion`` to ``true`` **and** increase the request timeout. In the example below we set it to 7200 seconds (or 2 hours)::
 
-        "request-params": {
-            "request_timeout": 7200
-        }
+        "request-timeout": 7200
 
     However, this might not work if a proxy is in between the client and Elasticsearch and the proxy has a shorter request timeout configured than the client. In this case, keep the default value for ``wait-for-completion`` and instead add a ``wait-for-recovery`` runner in the next step.
 

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -4902,25 +4902,28 @@ class TestRestoreSnapshot:
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_restore_snapshot_with_wait(self, es):
+        es.options.return_value = es
         es.perform_request = mock.AsyncMock()
 
         params = {
             "repository": "backups",
             "snapshot": "snapshot-001",
             "wait-for-completion": True,
-            "request-params": {"request_timeout": 7200},
+            "request-timeout": 600.0,
         }
 
         r = runner.RestoreSnapshot()
         await r(es, params)
 
+        es.options.assert_called_once_with(request_timeout=600.0)
         es.perform_request.assert_awaited_once_with(
-            method="POST", path="/_snapshot/backups/snapshot-001/_restore", params={"request_timeout": 7200, "wait_for_completion": True}
+            method="POST", path="/_snapshot/backups/snapshot-001/_restore", headers={}, body={}, params={"wait_for_completion": True}
         )
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio
     async def test_restore_snapshot_with_body(self, es):
+        es.options.return_value = es
         es.perform_request = mock.AsyncMock()
         params = {
             "repository": "backups",
@@ -4933,7 +4936,6 @@ class TestRestoreSnapshot:
                 },
             },
             "wait-for-completion": True,
-            "request-params": {"request_timeout": 7200},
         }
 
         r = runner.RestoreSnapshot()
@@ -4942,6 +4944,7 @@ class TestRestoreSnapshot:
         es.perform_request.assert_awaited_once_with(
             method="POST",
             path="/_snapshot/backups/snapshot-001/_restore",
+            headers={},
             body={
                 "indices": "index1,index2",
                 "include_global_state": False,
@@ -4949,7 +4952,7 @@ class TestRestoreSnapshot:
                     "index.number_of_replicas": 0,
                 },
             },
-            params={"request_timeout": 7200, "wait_for_completion": True},
+            params={"wait_for_completion": True},
         )
 
 


### PR DESCRIPTION
This fixes the following problems in snapshot restore runner:
* `wait-for-completion` is ignored and not passed as request parameter
* client-side timeout is not a request parameter, but transport-level setting of Python client

