### PR TITLE
Skip abort on transport, increase retry count

### DIFF
--- a/esrally/client/asynchronous.py
+++ b/esrally/client/asynchronous.py
@@ -366,7 +366,7 @@ class RallyAsyncElasticsearch(AsyncElasticsearch, RequestContextHolder):
             headers=request_headers,
             body=body,
             request_timeout=self._request_timeout,
-            max_retries=self._max_retries,
+            max_retries=10,
             retry_on_status=self._retry_on_status,
             retry_on_timeout=self._retry_on_timeout,
             client_meta=self._client_meta,

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -2046,7 +2046,14 @@ async def execute_single(runner, es, params, on_error):
         # we *specifically* want to distinguish connection refused (a node died?) from connection timeouts
         # pylint: disable=unidiomatic-typecheck
         if type(e) is elasticsearch.ConnectionError:
-            fatal_error = True
+            # fatal_error = True temporarily disabled
+            logging.getLogger(__name__).warning(
+                "Connection error while executing runner [%s]. Full exception: "
+                "[%s]"
+                "Please check the logs of the node for more details.",
+                str(runner),
+                str(e),
+            )
 
         total_ops = 0
         total_ops_unit = "ops"


### PR DESCRIPTION
Not to be merged yet.

This extends the number of retries, as well as disabling abort on transport errors.