### PR TITLE
Add missing JSON logs

### DIFF
--- a/esrally/resources/logging.json
+++ b/esrally/resources/logging.json
@@ -65,7 +65,8 @@
   "loggers": {
     "elasticsearch": {
       "handlers": [
-        "rally_log_handler"
+        "rally_log_handler",
+        "rally_json_handler"
       ],
       "level": "WARNING",
       "propagate": false
@@ -79,7 +80,8 @@
     },
     "elastic_transport": {
       "handlers": [
-        "rally_log_handler"
+        "rally_log_handler",
+        "rally_json_handler"
       ],
       "level": "WARNING",
       "propagate": false


### PR DESCRIPTION
JSON logs are missing `elastic_transport` events, and exception stack traces forwarded by Thespian. This PR fixes it.
