### PR TITLE
Introducing skip-telemetry parameter

### DIFF
--- a/docs/cluster_management.rst
+++ b/docs/cluster_management.rst
@@ -59,7 +59,8 @@ When the benchmark has finished, we can stop the node again::
     esrally stop --installation-id="${INSTALLATION_ID}"
 
 If you only want to shutdown the node but don't want to delete the node and the data, pass ``--preserve-install`` additionally.
-If you want to avoid telemetry data collection to the metrics store when stopping the node, you can also pass ``--skip-telemetry`` to the stop command.
+
+If you want to avoid telemetry data collection to the metrics store when stopping the node, you can also pass ``--skip-telemetry`` to the stop command:
 
     esrally stop --installation-id="${INSTALLATION_ID}" --preserve-install --skip-telemetry
 

--- a/docs/cluster_management.rst
+++ b/docs/cluster_management.rst
@@ -59,7 +59,9 @@ When the benchmark has finished, we can stop the node again::
     esrally stop --installation-id="${INSTALLATION_ID}"
 
 If you only want to shutdown the node but don't want to delete the node and the data, pass ``--preserve-install`` additionally.
+If you want to avoid telemetry data collection to the metrics store when stopping the node, you can also pass ``--skip-telemetry`` to the stop command.
 
+    esrally stop --installation-id="${INSTALLATION_ID}" --preserve-install --skip-telemetry
 
 Levelling Up: Benchmarking a Cluster
 ------------------------------------

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -574,7 +574,7 @@ and reference it when running Rally::
    esrally race --track=geonames --telemetry="node-stats" --telemetry-params="telemetry-params.json"
 
 ``skip-telemetry``
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 **Example**
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -583,7 +583,7 @@ and reference it when running Rally::
    esrally stop --installation-id=INSTALLATION_ID --skip-telemetry
 
 
-This command line flag is used to skip telemetry collection when stopping a node that has been started with the ``start`` subcommand. This is useful if you want to stop a node but don't want to collect telemetry data for it.
+This command line flag is used to skip telemetry collection when running ``esrally stop`` for a node that has been started with the ``start`` subcommand. This is useful if you want to stop a node but don't want to collect telemetry data for it.
 
 ``runtime-jdk``
 ~~~~~~~~~~~~~~~

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -573,6 +573,17 @@ and reference it when running Rally::
 
    esrally race --track=geonames --telemetry="node-stats" --telemetry-params="telemetry-params.json"
 
+``skip-telemetry``
+~~~~~~~~~~~~~
+
+**Example**
+
+ ::
+
+   esrally stop --installation-id=INSTALLATION_ID --skip-telemetry
+
+
+This command line flag is used to skip telemetry collection when stopping a node that has been started with the ``start`` subcommand. This is useful if you want to stop a node but don't want to collect telemetry data for it.
 
 ``runtime-jdk``
 ~~~~~~~~~~~~~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -207,6 +207,7 @@ defaults
 This section defines default values for certain command line parameters of Rally.
 
 * ``preserve_benchmark_candidate`` (default: false): Determines whether Elasticsearch installations will be preserved or wiped by default after a benchmark. For preserving an installation for a single benchmark, use the command line flag ``--preserve-install``.
+* ``skip.telemetry`` (default: None): Determines whether telemetry data collection should be skipped when stopping a benchmark. This can be set via the command line flag ``--skip-telemetry``.
 
 distributions
 ~~~~~~~~~~~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -67,6 +67,7 @@ This section defines how metrics are stored.
 * ``sample.queue.size`` (default: 2^20): The number of metrics samples that can be stored in Rally's in-memory queue.
 * ``metrics.request.downsample.factor`` (default: 1): Determines how many service time and latency samples should be kept in the metrics store. By default all values will be kept. To keep only e.g. every 100th sample, specify 100. This is useful to avoid overwhelming the metrics store in benchmarks with many clients (tens of thousands).
 * ``output.processingtime`` (default: false): If set to "true", Rally will show the additional metric :ref:`processing time <summary_report_processing_time>` in the command line report.
+* ``skip.telemetry`` (default: None): Determines whether telemetry data collection should be skipped when stopping a benchmark. This can be set either via configuration param ``skip.telemetry`` the command line flag ``--skip-telemetry``.
 
 The following settings are applicable only if ``datastore.type`` is set to "elasticsearch":
 
@@ -207,7 +208,6 @@ defaults
 This section defines default values for certain command line parameters of Rally.
 
 * ``preserve_benchmark_candidate`` (default: false): Determines whether Elasticsearch installations will be preserved or wiped by default after a benchmark. For preserving an installation for a single benchmark, use the command line flag ``--preserve-install``.
-* ``skip.telemetry`` (default: None): Determines whether telemetry data collection should be skipped when stopping a benchmark. This can be set via the command line flag ``--skip-telemetry``.
 
 distributions
 ~~~~~~~~~~~~~

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -325,3 +325,9 @@ When a benchmark is executed with ``--enable-assertions`` and this query returns
     [ERROR] Cannot race. Error in load generator [0]
         Cannot run task [geo_distance]: Expected [hits] to be > [0] but was [0].
 
+Skipping telemetry data collection when hitting an error.
+--------------------------------------------------------------
+
+In some cases, you may want to skip telemetry data collection when Rally hits an error. This can be useful in cases you want to avoid storing telemetry results when a benchmark got unexpected results. To enable this behavior, you can either use the ``skip.telemetry`` configuration setting in your ``rally.ini`` file or pass the ``--skip-telemetry`` command line flag when stopping Rally. This will prevent Rally from sending telemetry data to the metrics store. 
+
+	esrally stop --installation-id=INSTALLATION_ID  --skip-telemetry

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -84,15 +84,16 @@ class DockerLauncher:
         logging.error(msg)
         raise exceptions.LaunchError(msg)
 
-    def stop(self, nodes, metrics_store, skip_telemetry=False):
+    def stop(self, nodes, metrics_store=None):
         self.logger.info("Shutting down [%d] nodes running in Docker on this host.", len(nodes))
         for node in nodes:
             self.logger.info("Stopping node [%s].", node.node_name)
-            if metrics_store:
+            if metrics_store is not None:
                 telemetry.add_metadata_for_node(metrics_store, node.node_name, node.host_name)
                 node.telemetry.detach_from_node(node, running=True)
+
             process.run_subprocess_with_logging(self._docker_compose(node.binary_path, "down"))
-            if metrics_store and not skip_telemetry:
+            if metrics_store is not None:
                 node.telemetry.detach_from_node(node, running=False)
                 node.telemetry.store_system_metrics(node, metrics_store)
 
@@ -223,12 +224,12 @@ class ProcessLauncher:
 
         return wait_for_pidfile(pid_path)
 
-    def stop(self, nodes, metrics_store, skip_telemetry=False):
+    def stop(self, nodes, metrics_store=None):
         self.logger.info("Shutting down [%d] nodes on this host.", len(nodes))
         stopped_nodes = []
         for node in nodes:
             node_name = node.node_name
-            if metrics_store and not skip_telemetry:
+            if metrics_store is not None:
                 telemetry.add_metadata_for_node(metrics_store, node_name, node.host_name)
                 node.telemetry.detach_from_node(node, running=True)
             try:
@@ -255,9 +256,9 @@ class ProcessLauncher:
                     except psutil.NoSuchProcess:
                         self.logger.warning("No process found with PID [%s] for node [%s].", es.pid, node_name)
                 self.logger.info("Done shutting down node [%s] in [%.1f] s.", node_name, stop_watch.split_time())
-                if metrics_store and not skip_telemetry:
+                if metrics_store is not None:
                     node.telemetry.detach_from_node(node, running=False)
             # store system metrics in any case (telemetry devices may derive system metrics while the node is running)
-            if metrics_store and not skip_telemetry:
+            if metrics_store is not None:
                 node.telemetry.store_system_metrics(node, metrics_store)
         return stopped_nodes

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -128,28 +128,30 @@ def stop(cfg: types.Config):
         raise exceptions.SystemSetupError(f"Unknown build type [{node_config.build_type}]")
 
     nodes, race_id = _load_node_file(root_path)
+    skip_telemetry = cfg.opts("mechanic", "skip.telemetry", default_value=False, mandatory=False)
+    metrics_store = None
+    if not skip_telemetry:
+        cls = metrics.metrics_store_class(cfg)
+        metrics_store = cls(cfg)
+        race_store = metrics.race_store(cfg)
+        try:
+            current_race = race_store.find_by_race_id(race_id)
+            metrics_store.open(
+                race_id=current_race.race_id,
+                race_timestamp=current_race.race_timestamp,
+                track_name=current_race.track_name,
+                challenge_name=current_race.challenge_name,
+            )
+        except exceptions.NotFound:
+            logging.getLogger(__name__).info("Could not find race [%s] and will thus not persist system metrics.", race_id)
+            # Don't persist system metrics if we can't retrieve the race as we cannot derive the required meta-data.
+            current_race = None
+            metrics_store = None
 
-    cls = metrics.metrics_store_class(cfg)
-    metrics_store = cls(cfg)
-    race_store = metrics.race_store(cfg)
-    try:
-        current_race = race_store.find_by_race_id(race_id)
-        metrics_store.open(
-            race_id=current_race.race_id,
-            race_timestamp=current_race.race_timestamp,
-            track_name=current_race.track_name,
-            challenge_name=current_race.challenge_name,
-        )
-    except exceptions.NotFound:
-        logging.getLogger(__name__).info("Could not find race [%s] and will thus not persist system metrics.", race_id)
-        # Don't persist system metrics if we can't retrieve the race as we cannot derive the required meta-data.
-        current_race = None
-        metrics_store = None
-
-    node_launcher.stop(nodes, metrics_store, cfg.opts("mechanic", "skip.telemetry"))
+    node_launcher.stop(nodes, metrics_store)
     _delete_node_file(root_path)
 
-    if current_race:
+    if metrics_store is not None and current_race:
         metrics_store.flush(refresh=True)
         for node in nodes:
             results = metrics.calculate_system_results(metrics_store, node.node_name)

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -131,7 +131,6 @@ def stop(cfg: types.Config):
 
     cls = metrics.metrics_store_class(cfg)
     metrics_store = cls(cfg)
-
     race_store = metrics.race_store(cfg)
     try:
         current_race = race_store.find_by_race_id(race_id)
@@ -147,7 +146,7 @@ def stop(cfg: types.Config):
         current_race = None
         metrics_store = None
 
-    node_launcher.stop(nodes, metrics_store)
+    node_launcher.stop(nodes, metrics_store, cfg.opts("mechanic", "skip.telemetry"))
     _delete_node_file(root_path)
 
     if current_race:

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -570,10 +570,7 @@ def create_arg_parser():
         action="store_true",
     )
     stop_parser.add_argument(
-        "--skip-telemetry", 
-        help="Skip telemetry data collection. (default: false).", 
-        default=False, 
-        action="store_true"
+        "--skip-telemetry", help="Skip telemetry data collection. (default: false).", default=False, action="store_true"
     )
 
     for p in [list_parser, race_parser]:

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -570,7 +570,11 @@ def create_arg_parser():
         action="store_true",
     )
     stop_parser.add_argument(
-        "--skip-telemetry", help="Skip telemetry data collection. (default: false).", default=False, action="store_true"
+        # default is None, since it can be set via config file
+        "--skip-telemetry",
+        help="Skip telemetry data collection. (default: None).",
+        default=None,
+        action="store_true",
     )
 
     for p in [list_parser, race_parser]:
@@ -1162,7 +1166,6 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             mechanic.start(cfg)
         elif sub_command == "stop":
             cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
-            cfg.add(config.Scope.applicationOverride, "mechanic", "skip.telemetry", convert.to_bool(args.skip_telemetry))
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
             mechanic.stop(cfg)
         elif sub_command == "race":

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -569,6 +569,12 @@ def create_arg_parser():
         default=preserve_install,
         action="store_true",
     )
+    stop_parser.add_argument(
+        "--skip-telemetry", 
+        help="Skip telemetry data collection. (default: false).", 
+        default=False, 
+        action="store_true"
+    )
 
     for p in [list_parser, race_parser]:
         p.add_argument(
@@ -1159,6 +1165,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             mechanic.start(cfg)
         elif sub_command == "stop":
             cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
+            cfg.add(config.Scope.applicationOverride, "mechanic", "skip.telemetry", convert.to_bool(args.skip_telemetry))
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
             mechanic.stop(cfg)
         elif sub_command == "race":

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -145,6 +145,7 @@ Key = Literal[
     "serverless.mode",
     "serverless.operator",
     "skip.rest.api.check",
+    "skip.telemetry",
     "snapshot.cache",
     "source.build.method",
     "source.revision",


### PR DESCRIPTION
This PR introduces a new optional flag, `--skip-telemetry`, to the `esrally stop` command. When specified, Rally will skip running telemetry devices during the stop phase, preventing the collection of potentially invalid or irrelevant metrics.

### Motivation

- Avoids collecting and reporting telemetry from failed or incomplete benchmarks, which can pollute metrics dashboards and downstream analyses with unwanted irrelevant data.
- Provides users with more control over when telemetry is collected

### Usage
To skip telemetry collection during the stop phase, use:
`esrally stop --skip-telemetry`