### PR TITLE
Update storage tools with last changes from `storage` branch.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -140,6 +140,8 @@ remote servers. Available options are:
 * ``storage.max_connections`` represents the maximum number of client connections to be made against the same server or
   bucket. The default value is 8.
 
+* ``storage.max_workers`` indicates the maximum number of worker threads used for making storage files transfers.
+
 * ``storage.mirror_files`` is used to provide a json file that specify the mapping for mirrors URLs resolution.
   Example::
 

--- a/esrally/storage/_adapter.py
+++ b/esrally/storage/_adapter.py
@@ -21,7 +21,6 @@ import importlib
 import logging
 import threading
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
@@ -39,13 +38,6 @@ class ServiceUnavailableError(Exception):
 class Writable(Protocol):
 
     def write(self, data: bytes) -> None:
-        pass
-
-
-@runtime_checkable
-class Readable(Protocol):
-
-    def read(self, size: int = -1) -> bytes:
         pass
 
 
@@ -120,13 +112,6 @@ class Adapter(ABC):
         """
 
     @abstractmethod
-    def list(self, url: str) -> Iterator[Head]:
-        """It gets list of file headers.
-        :return: the Head of the remote file.
-        :raises ServiceUnavailableError: in case on temporary service failure.
-        """
-
-    @abstractmethod
     def get(self, url: str, stream: Writable, head: Head | None = None) -> Head:
         """It downloads a remote bucket object to a local file path.
 
@@ -137,20 +122,6 @@ class Adapter(ABC):
             - document_length: the number of bytes to transfer.
             - crc32c the CRC32C checksum of the file.
             - date: the date the file has been modified.
-        :raises ServiceUnavailableError: in case on temporary service failure.
-        """
-
-    @abstractmethod
-    def put(self, stream: Readable, url: str, head: Head | None = None) -> Head:
-        """It uploads a local file object to a remote bucket.
-
-        :param stream: it represents the local file stream where to read data from.
-        :param url: it represents the URL of the remote file object.
-        :param head: it allows to specify optional parameters:
-            - range: the portion of the file to transfer (it must be empty or a continuous range).
-            - document_length: the number of bytes to transfer.
-            - crc32c the CRC32C checksum of the file.
-            - date: the date the file was modified.
         :raises ServiceUnavailableError: in case on temporary service failure.
         """
 

--- a/esrally/storage/_client.py
+++ b/esrally/storage/_client.py
@@ -17,13 +17,11 @@
 from __future__ import annotations
 
 import logging
-import os
 import threading
 import time
 import urllib.parse
 from collections import defaultdict, deque
 from collections.abc import Iterator
-from datetime import datetime
 from random import Random
 from typing import NamedTuple
 
@@ -116,10 +114,6 @@ class Client:
     def adapters(self) -> AdapterRegistry:
         return self._adapters
 
-    def list(self, url: str) -> Iterator[Head]:
-        adapter, url = self._adapters.get(url)
-        yield from adapter.list(url)
-
     def resolve(self, url: str, check: Head | None, ttl: float = 60.0) -> Iterator[Head]:
         """It looks up mirror list for given URL and yield mirror heads.
         :param url: the remote file URL at its mirrored source location.
@@ -201,30 +195,6 @@ class Client:
                 connections.done()
 
         raise ServiceUnavailableError(f"no service available for getting URL '{url}'")
-
-    def put(self, path: str, url: str, head: Head | None = None) -> Head:
-        if head is not None:
-            st = os.stat(path)
-            if head.date is None:
-                head.date = datetime.fromtimestamp(st.st_mtime)
-            file_size = st.st_size
-            if head.ranges:
-                if len(head.ranges) > 1:
-                    raise NotImplementedError("multiple ranges is not supported")
-                if head.ranges.end >= file_size:
-                    raise ValueError(f"ranges end must not exceed file size: {head.ranges.end} > {file_size}")
-            else:
-                if head.content_length is None:
-                    head.content_length = file_size
-                elif head.content_length != file_size:
-                    raise ValueError(f"unexpected file size: {file_size} != {head.document_length}, file '{path}'")
-
-        adapter, url = self._adapters.get(url)
-        with open(path, "rb") as stream:
-            if head is not None:
-                for r in head.ranges:
-                    stream.seek(r.start)
-            return adapter.put(stream, url, head=head)
 
     def _server_connections(self, url: str) -> WaitGroup:
         with self._lock:

--- a/esrally/storage/_client.py
+++ b/esrally/storage/_client.py
@@ -110,10 +110,6 @@ class Client:
 
         return _head_or_raise(value)
 
-    @property
-    def adapters(self) -> AdapterRegistry:
-        return self._adapters
-
     def resolve(self, url: str, check: Head | None, ttl: float = 60.0) -> Iterator[Head]:
         """It looks up mirror list for given URL and yield mirror heads.
         :param url: the remote file URL at its mirrored source location.

--- a/esrally/storage/_client.py
+++ b/esrally/storage/_client.py
@@ -93,7 +93,7 @@ class Client:
                     # cached value or error is enough recent to be used.
                     return _head_or_raise(value)
 
-        adapter, url = self._adapters.get(url)
+        adapter = self._adapters.get(url)
         try:
             value = adapter.head(url)
         except Exception as ex:
@@ -179,7 +179,7 @@ class Client:
             except WaitGroupLimitError:
                 LOG.debug("connection limit exceeded: url='%s'", url)
                 continue
-            adapter, url = self._adapters.get(got.url)
+            adapter = self._adapters.get(got.url)
             try:
                 return adapter.get(url, stream, head=head)
             except ServiceUnavailableError as ex:

--- a/esrally/storage/_executor.py
+++ b/esrally/storage/_executor.py
@@ -53,3 +53,28 @@ class ThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor, Executor):
         executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="esrally.storage.executor")
         assert isinstance(executor, Executor)
         return executor
+
+
+class DummyExecutor(Executor):
+
+    def __init__(self):
+        self.tasks: list[tuple] | None = []
+
+    def submit(self, fn, /, *args, **kwargs):
+        """Submits a callable to be executed with the given arguments.
+
+        Schedules the callable to be executed as fn(*args, **kwargs).
+        """
+        if self.tasks is None:
+            raise RuntimeError("Executor already closed")
+        self.tasks.append((fn, args, kwargs))
+
+    def execute_tasks(self):
+        if self.tasks is None:
+            raise RuntimeError("Executor already closed")
+        tasks, self.tasks = self.tasks, []
+        for fn, args, kwargs in tasks:
+            fn(*args, **kwargs)
+
+    def shutdown(self):
+        self.tasks = None

--- a/esrally/storage/_executor.py
+++ b/esrally/storage/_executor.py
@@ -1,0 +1,55 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import concurrent.futures
+from typing import Protocol, runtime_checkable
+
+from esrally.types import Config
+
+MAX_WORKERS = 32
+
+
+@runtime_checkable
+class Executor(Protocol):
+    """Executor protocol is used by Transfer class to submit tasks execution.
+
+    Notable implementation of this protocol is concurrent.futures.ThreadPoolExecutor[1] class.
+
+    [1] https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
+    """
+
+    def submit(self, fn, /, *args, **kwargs):
+        """Submits a callable to be executed with the given arguments.
+
+        Schedules the callable to be executed as fn(*args, **kwargs) and returns
+        a Future instance representing the execution of the callable.
+
+        Returns:
+            A Future representing the given call.
+        """
+        raise NotImplementedError()
+
+
+class ThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor, Executor):
+
+    @classmethod
+    def from_config(cls, cfg: Config) -> concurrent.futures.Executor:
+        max_workers = int(cfg.opts("storage", "storage.max_workers", MAX_WORKERS, mandatory=False))
+        executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="esrally.storage.executor")
+        assert isinstance(executor, Executor)
+        return executor

--- a/esrally/storage/_http.py
+++ b/esrally/storage/_http.py
@@ -136,8 +136,8 @@ class HTTPAdapter(Adapter):
         content_length = cls._content_length_from_headers(headers)
         accept_ranges = cls._accept_ranges_from_headers(headers)
         ranges, document_length = cls._content_range_from_headers(headers)
-        hashes = cls._hashes_from_headers(headers)
-        crc32c = hashes.get("crc32c")
+        crc32c = cls._hashes_from_headers(headers).get("crc32c")
+        # TODO: date header is not supported yet.
         return Head.create(
             url=url,
             content_length=content_length,

--- a/esrally/storage/_http.py
+++ b/esrally/storage/_http.py
@@ -26,13 +26,7 @@ import requests.adapters
 import urllib3
 from requests.structures import CaseInsensitiveDict
 
-from esrally.storage._adapter import (
-    Adapter,
-    Head,
-    Readable,
-    ServiceUnavailableError,
-    Writable,
-)
+from esrally.storage._adapter import Adapter, Head, ServiceUnavailableError, Writable
 from esrally.storage._range import NO_RANGE, RangeSet, rangeset
 from esrally.types import Config
 
@@ -112,15 +106,6 @@ class HTTPAdapter(Adapter):
             for chunk in res.iter_content(self.chunk_size):
                 if chunk:
                     stream.write(chunk)
-        return got
-
-    def put(self, stream: Readable, url: str, head: Head | None = None, headers: Mapping[str, str] | None = None) -> Head:
-        headers = self._headers(head, headers)
-        with self.session.put(url, data=stream, headers=headers) as res:
-            res.raise_for_status()
-            got = self._make_head(url, res.headers)
-            if head is not None:
-                head.check(got)
         return got
 
     @classmethod

--- a/esrally/storage/_http.py
+++ b/esrally/storage/_http.py
@@ -70,10 +70,8 @@ class HTTPAdapter(Adapter):
     """It implements the `Adapter` interface for http(s) protocols using the requests library."""
 
     @classmethod
-    def match_url(cls, url: str) -> str:
-        if url.startswith("http://") or url.startswith("https://"):
-            return url
-        raise NotImplementedError
+    def match_url(cls, url: str) -> bool:
+        return url.startswith("http://") or url.startswith("https://")
 
     @classmethod
     def from_config(cls, cfg: Config) -> Adapter:

--- a/esrally/storage/_mirror.py
+++ b/esrally/storage/_mirror.py
@@ -21,7 +21,7 @@ import os
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
 
-from esrally.config import Config
+from esrally.types import Config
 
 MIRRORS_FILES = ""
 

--- a/esrally/storage/testing.py
+++ b/esrally/storage/testing.py
@@ -1,0 +1,67 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import copy
+from collections.abc import Iterable, Iterator
+
+from esrally.storage._adapter import Adapter, Head, Readable, Writable
+from esrally.storage._range import NO_RANGE, RangeSet
+
+
+class DummyAdapter(Adapter):
+
+    HEADS: Iterable[Head] = tuple()
+    DATA: dict[str, bytes] = {}
+
+    @classmethod
+    def match_url(cls, url: str) -> str:
+        return url
+
+    def __init__(self, heads: Iterable[Head] | None = None, data: dict[str, bytes] | None = None) -> None:
+        if heads is None:
+            heads = self.HEADS
+        if data is None:
+            data = self.DATA
+        self.heads: dict[str, Head] = {h.url: h for h in heads if h.url is not None}
+        self.data: dict[str, bytes] = copy.deepcopy(data)
+
+    def head(self, url: str) -> Head:
+        try:
+            return copy.copy(self.heads[url])
+        except KeyError:
+            raise FileNotFoundError from None
+
+    def get(self, url: str, stream: Writable, head: Head | None = None) -> Head:
+        ranges: RangeSet = NO_RANGE
+        if head is not None:
+            ranges = head.ranges
+            if len(ranges) > 1:
+                raise NotImplementedError("len(head.ranges) > 1")
+        data = self.data[url]
+        if ranges:
+            stream.write(data[ranges.start : ranges.end])
+            return Head(url, content_length=ranges.size, ranges=ranges, document_length=len(data))
+
+        stream.write(data)
+        return Head(url, content_length=len(data))
+
+    def list(self, url: str) -> Iterator[Head]:
+        raise NotImplementedError()
+
+    def put(self, stream: Readable, url: str, head: Head | None = None) -> Head:
+        raise NotImplementedError()

--- a/esrally/storage/testing.py
+++ b/esrally/storage/testing.py
@@ -17,9 +17,9 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 
-from esrally.storage._adapter import Adapter, Head, Readable, Writable
+from esrally.storage._adapter import Adapter, Head, Writable
 from esrally.storage._range import NO_RANGE, RangeSet
 
 
@@ -59,9 +59,3 @@ class DummyAdapter(Adapter):
 
         stream.write(data)
         return Head(url, content_length=len(data))
-
-    def list(self, url: str) -> Iterator[Head]:
-        raise NotImplementedError()
-
-    def put(self, stream: Readable, url: str, head: Head | None = None) -> Head:
-        raise NotImplementedError()

--- a/esrally/storage/testing.py
+++ b/esrally/storage/testing.py
@@ -29,8 +29,8 @@ class DummyAdapter(Adapter):
     DATA: dict[str, bytes] = {}
 
     @classmethod
-    def match_url(cls, url: str) -> str:
-        return url
+    def match_url(cls, url: str) -> bool:
+        return True
 
     def __init__(self, heads: Iterable[Head] | None = None, data: dict[str, bytes] | None = None) -> None:
         if heads is None:

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -153,6 +153,7 @@ Key = Literal[
     "storage.http.chunk_size",
     "storage.http.max_retries",
     "storage.max_connections",
+    "storage.max_workers",
     "storage.mirrors_files",
     "storage.random_seed",
     "target.arch",

--- a/tests/storage/adapter_test.py
+++ b/tests/storage/adapter_test.py
@@ -38,37 +38,29 @@ class MockAdapter(Adapter, ABC):
 class HTTPAdapter(MockAdapter, ABC):
 
     @classmethod
-    def match_url(cls, url: str) -> str:
-        if url.startswith("http://"):
-            return url
-        raise NotImplementedError()
+    def match_url(cls, url: str) -> bool:
+        return url.startswith("http://")
 
 
 class HTTPSAdapter(MockAdapter, ABC):
 
     @classmethod
-    def match_url(cls, url: str) -> str:
-        if url.startswith("https://"):
-            return url
-        raise NotImplementedError()
+    def match_url(cls, url: str) -> bool:
+        return url.startswith("https://")
 
 
 class ExampleAdapter(MockAdapter, ABC):
 
     @classmethod
-    def match_url(cls, url: str) -> str:
-        if url.startswith("https://example.com/"):
-            return url
-        raise NotImplementedError()
+    def match_url(cls, url: str) -> bool:
+        return url.startswith("https://example.com/")
 
 
 class ExampleAdapterWithPath(MockAdapter, ABC):
 
     @classmethod
-    def match_url(cls, url: str) -> str:
-        if url.startswith("https://example.com/some/path/"):
-            return url
-        raise NotImplementedError()
+    def match_url(cls, url: str) -> bool:
+        return url.startswith("https://example.com/some/path/")
 
 
 @pytest.fixture()
@@ -105,18 +97,16 @@ class RegistryCase:
 )
 def test_adapter_registry_get(case: RegistryCase, registry: AdapterRegistry) -> None:
     try:
-        adapter, url = registry.get(case.url)
+        adapter = registry.get(case.url)
         error = None
     except Exception as ex:
-        adapter, url = None, None
+        adapter = None, None
         error = ex
 
     if case.want_type is not None:
         assert isinstance(adapter, case.want_type)
-        assert url == case.url
-        adapter2, url = registry.get(case.url)
+        adapter2 = registry.get(case.url)
         assert adapter2 is adapter
-        assert url == case.url
 
     if case.want_error is not None:
         assert isinstance(error, case.want_error)

--- a/tests/storage/adapter_test.py
+++ b/tests/storage/adapter_test.py
@@ -22,6 +22,7 @@ from unittest import mock
 
 import pytest
 
+from esrally import types
 from esrally.config import Config, Scope
 from esrally.storage._adapter import Adapter, AdapterRegistry
 from esrally.utils.cases import cases
@@ -30,27 +31,44 @@ from esrally.utils.cases import cases
 class MockAdapter(Adapter, ABC):
 
     @classmethod
-    def from_config(cls, cfg: Config) -> Adapter:
+    def from_config(cls, cfg: types.Config) -> Adapter:
         return mock.create_autospec(cls, spec_set=True, instance=True)
 
 
 class HTTPAdapter(MockAdapter, ABC):
 
-    __adapter_URL_prefixes__ = "http://"
+    @classmethod
+    def match_url(cls, url: str) -> str:
+        if url.startswith("http://"):
+            return url
+        raise NotImplementedError()
 
 
 class HTTPSAdapter(MockAdapter, ABC):
 
-    __adapter_URL_prefixes__ = "https://"
+    @classmethod
+    def match_url(cls, url: str) -> str:
+        if url.startswith("https://"):
+            return url
+        raise NotImplementedError()
 
 
 class ExampleAdapter(MockAdapter, ABC):
-    __adapter_URL_prefixes__ = "https://example.com/"
+
+    @classmethod
+    def match_url(cls, url: str) -> str:
+        if url.startswith("https://example.com/"):
+            return url
+        raise NotImplementedError()
 
 
 class ExampleAdapterWithPath(MockAdapter, ABC):
 
-    __adapter_URL_prefixes__ = "https://example.com/some/path/"
+    @classmethod
+    def match_url(cls, url: str) -> str:
+        if url.startswith("https://example.com/some/path/"):
+            return url
+        raise NotImplementedError()
 
 
 @pytest.fixture()
@@ -60,7 +78,7 @@ def cfg() -> Config:
         Scope.application,
         "storage",
         "storage.adapters",
-        f"{__name__}:HTTPSAdapter,{__name__}:HTTPAdapter,{__name__}:ExampleAdapter,{__name__}:ExampleAdapterWithPath",
+        f"{__name__}:ExampleAdapterWithPath,{__name__}:ExampleAdapter,{__name__}:HTTPSAdapter,{__name__}:HTTPAdapter",
     )
     return cfg
 
@@ -74,31 +92,31 @@ def registry(cfg: Config) -> AdapterRegistry:
 @dataclass()
 class RegistryCase:
     url: str
-    want: type[Adapter] | type[Exception]
+    want_type: type[Adapter] | None = None
+    want_error: type[Exception] | None = None
 
 
 @cases(
-    ftp=RegistryCase("ftp://example.com", ValueError),
-    http=RegistryCase("http://example.com", HTTPAdapter),
-    https=RegistryCase("https://example.com", HTTPSAdapter),
-    example=RegistryCase("https://example.com/", ExampleAdapter),
+    ftp=RegistryCase("ftp://example.com", want_error=ValueError),
+    http=RegistryCase("http://example.com", want_type=HTTPAdapter),
+    https=RegistryCase("https://example.com", want_type=HTTPSAdapter),
+    example=RegistryCase("https://example.com/", want_type=ExampleAdapter),
     example_with_path=RegistryCase("https://example.com/some/path/", ExampleAdapterWithPath),
 )
 def test_adapter_registry_get(case: RegistryCase, registry: AdapterRegistry) -> None:
     try:
-        got = registry.get(case.url)
+        adapter, url = registry.get(case.url)
+        error = None
     except Exception as ex:
-        got = ex
-    assert isinstance(got, case.want)
-    if isinstance(case.want, Adapter):
-        assert got is registry.get(case.url)
+        adapter, url = None, None
+        error = ex
 
+    if case.want_type is not None:
+        assert isinstance(adapter, case.want_type)
+        assert url == case.url
+        adapter2, url = registry.get(case.url)
+        assert adapter2 is adapter
+        assert url == case.url
 
-def test_adapter_registry_order(registry: AdapterRegistry) -> None:
-    registered_prefixes = [c.url_prefix for c in registry._classes]  # pylint: disable=protected-access
-    assert registered_prefixes == [
-        "https://example.com/some/path/",
-        "https://example.com/",
-        "https://",
-        "http://",
-    ], "prefixes are not sorted from the longest to the shortest"
+    if case.want_error is not None:
+        assert isinstance(error, case.want_error)

--- a/tests/storage/client_test.py
+++ b/tests/storage/client_test.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import copy
 import json
 import os
 import random
@@ -27,7 +28,7 @@ from unittest.mock import create_autospec
 import pytest
 
 from esrally.config import Config, Scope
-from esrally.storage._adapter import Adapter, Head, Writable
+from esrally.storage._adapter import Adapter, Head, Readable, Writable
 from esrally.storage._client import MAX_CONNECTIONS, Client
 from esrally.storage._range import NO_RANGE, RangeSet, rangeset
 from esrally.types import Key
@@ -78,24 +79,36 @@ MIRRORS = {
 
 class HTTPSAdapter(Adapter):
 
-    __adapter_URL_prefixes__ = "https://"
+    @classmethod
+    def match_url(cls, url: str) -> str:
+        """It returns a canonical URL in case this adapter accepts the URL, None otherwise."""
+        return url
 
     def head(self, url: str) -> Head:
         head = HEADS.get(url)
         if head is None:
             raise FileNotFoundError
-        return Head(*head)
+        return copy.copy(head)
 
-    def get(self, url: str, stream: Writable, ranges: RangeSet = NO_RANGE) -> Head:
-        head = HEADS.get(url)
-        if head is None:
+    def get(self, url: str, stream: Writable, head: Head | None = None) -> Head:
+        if url not in HEADS:
             raise FileNotFoundError
-        if ranges:
-            for r in ranges:
-                stream.write(SOME_BODY[r.start : r.end])
-            return Head.create(url=url, content_length=ranges.size, ranges=ranges, document_length=len(SOME_BODY))
-        stream.write(SOME_BODY)
-        return Head.create(url, content_length=len(SOME_BODY))
+        if head is None or not head.ranges:
+            stream.write(SOME_BODY)
+            accept_ranges = None
+            if head is not None:
+                accept_ranges = head.accept_ranges
+            return Head(url=url, content_length=len(SOME_BODY), document_length=len(SOME_BODY), accept_ranges=accept_ranges)
+
+        for r in head.ranges:
+            stream.write(SOME_BODY[r.start : r.end])
+        return Head(url=url, content_length=head.ranges.size, ranges=head.ranges, document_length=len(SOME_BODY), accept_ranges=True)
+
+    def put(self, stream: Readable, url: str, head: Head | None = None) -> Head:
+        raise NotImplementedError
+
+    def list(self, url: str) -> Iterator[Head]:
+        raise NotImplementedError
 
 
 @pytest.fixture(scope="function")
@@ -164,27 +177,30 @@ def test_head(case: HeadCase, client: Client) -> None:
 @dataclass()
 class ResolveCase:
     url: str
-    want: set[Head]
+    want: list[Head]
     document_length: int | None = None
-    accept_ranges: bool = False
+    accept_ranges: bool | None = None
     ttl: float = 60.0
 
 
 @cases(
-    unmirrored=ResolveCase(url=SOME_URL, want={SOME_HEAD}),
-    mirrored=ResolveCase(url=MIRRORING_URL, want={MIRRORED_HEAD, MIRRORED_NO_RANGE_HEAD, MIRRORING_HEAD}),
+    unmirrored=ResolveCase(url=SOME_URL, want=[SOME_HEAD]),
+    mirrored=ResolveCase(url=MIRRORING_URL, want=[MIRRORED_HEAD, MIRRORED_NO_RANGE_HEAD, MIRRORING_HEAD]),
     document_length=ResolveCase(
-        url=MIRRORING_URL, document_length=len(SOME_BODY), want={MIRRORED_HEAD, MIRRORED_NO_RANGE_HEAD, MIRRORING_HEAD}
+        url=MIRRORING_URL, document_length=len(SOME_BODY), want=[MIRRORED_HEAD, MIRRORED_NO_RANGE_HEAD, MIRRORING_HEAD]
     ),
-    mismatching_document_length=ResolveCase(url=MIRRORING_URL, document_length=10, want=set()),
-    accept_ranges=ResolveCase(url=MIRRORING_URL, accept_ranges=True, want={MIRRORED_HEAD, MIRRORING_HEAD}),
-    reject_ranges=ResolveCase(url=NO_RANGES_URL, accept_ranges=True, want=set()),
-    zero_ttl=ResolveCase(url=SOME_URL, ttl=0.0, want={SOME_HEAD}),
+    mismatching_document_length=ResolveCase(url=MIRRORING_URL, document_length=10, want=[]),
+    accept_ranges=ResolveCase(url=MIRRORING_URL, accept_ranges=True, want=[MIRRORING_HEAD, MIRRORED_HEAD]),
+    reject_ranges=ResolveCase(url=NO_RANGES_URL, accept_ranges=True, want=[]),
+    zero_ttl=ResolveCase(url=SOME_URL, ttl=0.0, want=[SOME_HEAD]),
 )
 def test_resolve(case: ResolveCase, client: Client) -> None:
-    got = set(client.resolve(case.url, document_length=case.document_length, accept_ranges=case.accept_ranges, ttl=case.ttl))
-    assert got == case.want, "unexpected resolve result"
+    check = Head(document_length=case.document_length, accept_ranges=case.accept_ranges)
+    got = sorted(client.resolve(case.url, check=check, ttl=case.ttl), key=lambda h: str(h.url))
+    want = sorted(case.want, key=lambda h: str(h.url))
+    assert got == want, "unexpected resolve result"
     for g in got:
+        assert g.url is not None, "unexpected resolve result"
         if case.ttl > 0.0:
             assert g is client.head(url=g.url, ttl=case.ttl), "obtained head wasn't cached"
         else:
@@ -194,7 +210,7 @@ def test_resolve(case: ResolveCase, client: Client) -> None:
 @dataclass()
 class GetCase:
     url: str
-    want_any: set[Head]
+    want_any: list[Head]
     ranges: RangeSet = NO_RANGE
     document_length: int = None
     want_data: bytes | None = None
@@ -203,27 +219,38 @@ class GetCase:
 @cases(
     regular=GetCase(
         SOME_URL,
-        {Head(url=SOME_URL, content_length=len(SOME_BODY), document_length=len(SOME_BODY), accept_ranges=False)},
+        [Head(url=SOME_URL, content_length=len(SOME_BODY), document_length=len(SOME_BODY))],
         want_data=SOME_BODY,
     ),
     range=GetCase(
         SOME_URL,
-        {Head(SOME_URL, content_length=30, accept_ranges=True, ranges=rangeset("0-29"), document_length=len(SOME_BODY))},
+        [Head(SOME_URL, content_length=30, accept_ranges=True, ranges=rangeset("0-29"), document_length=len(SOME_BODY))],
         ranges=rangeset("0-29"),
         want_data=SOME_BODY,
     ),
     mirrors=GetCase(
         MIRRORING_URL,
-        {
-            Head(url=MIRRORED_URL, content_length=len(SOME_BODY), document_length=len(SOME_BODY), accept_ranges=False),
-            Head(url=MIRRORED_NO_RANGE_URL, content_length=len(SOME_BODY), document_length=len(SOME_BODY), accept_ranges=False),
-        },
+        [
+            MIRRORED_HEAD,
+            MIRRORED_NO_RANGE_HEAD,
+        ],
         want_data=SOME_BODY,
     ),
 )
 def test_get(case: GetCase, client: Client) -> None:
     stream = create_autospec(Writable, spec_set=True, instance=True)
-    got = client.get(case.url, stream, case.ranges, document_length=case.document_length)
-    assert got in case.want_any
+    got = client.get(case.url, stream, head=Head(ranges=case.ranges, document_length=case.document_length))
+    assert [] != check_any(got, case.want_any)
     if case.want_data is not None:
         stream.write.assert_called_once_with(case.want_data)
+
+
+def check_any(head: Head, any_head: list[Head]) -> list[Head]:
+    ret: list[Head] = []
+    for h in any_head:
+        try:
+            h.check(head)
+        except ValueError:
+            continue
+        ret.append(h)
+    return ret

--- a/tests/storage/transfer_test.py
+++ b/tests/storage/transfer_test.py
@@ -27,6 +27,7 @@ import pytest
 from esrally.config import Config
 from esrally.storage._adapter import Head, Writable
 from esrally.storage._client import Client
+from esrally.storage._executor import DummyExecutor
 from esrally.storage._range import rangeset
 from esrally.storage._transfer import MAX_CONNECTIONS, Transfer
 from esrally.utils.cases import cases
@@ -36,33 +37,6 @@ MISMATCH_URL = "https://rally-tracks.elastic.co/apm/span.json.gz"
 DATA = b"\xff" * 1024
 CRC32C = "valid-crc32-checksum"
 MISMATCH_CRC32C = "invalid-crc32c-checksum"
-
-
-class DummyExecutor:
-
-    def __init__(self):
-        self.tasks: list[tuple] | None = []
-
-    def submit(self, fn, /, *args, **kwargs):
-        """Submits a callable to be executed with the given arguments.
-
-        Schedules the callable to be executed as fn(*args, **kwargs).
-        """
-        tasks = self.tasks
-        if tasks is None:
-            raise RuntimeError("Executor already closed")
-        self.tasks.append((fn, args, kwargs))
-
-    def execute_tasks(self):
-        tasks = self.tasks
-        if tasks is None:
-            raise RuntimeError("Executor already closed")
-        self.tasks = []
-        for fn, args, kwargs in tasks:
-            fn(*args, **kwargs)
-
-    def shutdown(self):
-        self.tasks = None
 
 
 class DummyClient(Client):

--- a/tests/storage/transfer_test.py
+++ b/tests/storage/transfer_test.py
@@ -27,7 +27,7 @@ import pytest
 from esrally.config import Config
 from esrally.storage._adapter import Head, Writable
 from esrally.storage._client import Client
-from esrally.storage._range import NO_RANGE, RangeSet, rangeset
+from esrally.storage._range import rangeset
 from esrally.storage._transfer import MAX_CONNECTIONS, Transfer
 from esrally.utils.cases import cases
 
@@ -70,15 +70,13 @@ class DummyClient(Client):
     def head(self, url: str, ttl: float | None = None) -> Head:
         return Head.create(url, content_length=len(DATA), accept_ranges=True, crc32c=CRC32C)
 
-    def get(
-        self, url: str, stream: Writable, ranges: RangeSet = NO_RANGE, document_length: int | None = None, crc32c: str | None = None
-    ) -> Head:
+    def get(self, url: str, stream: Writable, head: Head | None = None) -> Head:
         data = DATA
-        if ranges:
-            data = data[ranges.start : ranges.end]
+        if head is not None and head.ranges:
+            data = data[head.ranges.start : head.ranges.end]
         if data:
             stream.write(data)
-        return Head.create(url, ranges=ranges, content_length=len(data), document_length=len(DATA), crc32c=CRC32C)
+        return Head.create(url, ranges=head.ranges, content_length=len(data), document_length=len(DATA), crc32c=CRC32C)
 
 
 @pytest.fixture


### PR DESCRIPTION
This change introduces some improvements from this new feature development branch:
- `Head` class is now a `dataclass` used to pass parameters between methods and to verify responses with the requested parameters.
- It uses a generic `match_url` class method to maps URLS to adapter classes.
- `AdapterRegistry` class skips non-existing modules.
- It adds `list` and `put` methods to `Adapter` interface.
- It adds `MirrorList.from_config` factory method.
- It adds `put` method to `Client` class.
- It adds a `ThreadPoolExecutor` subclass with its `from_config` factory method.
- It makes the `HTTPAdapter` easier to extend.
