### PR TITLE
Esrally/stop params/fix #1957

### DIFF
--- a/docs/cluster_management.rst
+++ b/docs/cluster_management.rst
@@ -60,7 +60,7 @@ When the benchmark has finished, we can stop the node again::
 
 If you only want to shutdown the node but don't want to delete the node and the data, pass ``--preserve-install`` additionally.
 
-If you want to avoid telemetry data collection to the metrics store when stopping the node, you can also pass ``--skip-telemetry`` to the stop command:
+If you want to avoid telemetry data collection to the metrics store when stopping the node, you can also pass ``--skip-telemetry`` to the stop command::
 
     esrally stop --installation-id="${INSTALLATION_ID}" --preserve-install --skip-telemetry
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -576,14 +576,13 @@ and reference it when running Rally::
 ``skip-telemetry``
 ~~~~~~~~~~~~~~~~~~
 
+This command line flag is used to skip telemetry collection when running ``esrally stop`` for a node that has been started with the ``start`` subcommand. This is useful if you want to stop a node but don't want to collect telemetry data for it.
+
 **Example**
 
  ::
 
    esrally stop --installation-id=INSTALLATION_ID --skip-telemetry
-
-
-This command line flag is used to skip telemetry collection when running ``esrally stop`` for a node that has been started with the ``start`` subcommand. This is useful if you want to stop a node but don't want to collect telemetry data for it.
 
 ``runtime-jdk``
 ~~~~~~~~~~~~~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -67,7 +67,6 @@ This section defines how metrics are stored.
 * ``sample.queue.size`` (default: 2^20): The number of metrics samples that can be stored in Rally's in-memory queue.
 * ``metrics.request.downsample.factor`` (default: 1): Determines how many service time and latency samples should be kept in the metrics store. By default all values will be kept. To keep only e.g. every 100th sample, specify 100. This is useful to avoid overwhelming the metrics store in benchmarks with many clients (tens of thousands).
 * ``output.processingtime`` (default: false): If set to "true", Rally will show the additional metric :ref:`processing time <summary_report_processing_time>` in the command line report.
-* ``skip.telemetry`` (default: None): Determines whether telemetry data collection should be skipped when stopping a benchmark. Can be set through the command line flag ``--skip-telemetry``.
 
 The following settings are applicable only if ``datastore.type`` is set to "elasticsearch":
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -67,7 +67,7 @@ This section defines how metrics are stored.
 * ``sample.queue.size`` (default: 2^20): The number of metrics samples that can be stored in Rally's in-memory queue.
 * ``metrics.request.downsample.factor`` (default: 1): Determines how many service time and latency samples should be kept in the metrics store. By default all values will be kept. To keep only e.g. every 100th sample, specify 100. This is useful to avoid overwhelming the metrics store in benchmarks with many clients (tens of thousands).
 * ``output.processingtime`` (default: false): If set to "true", Rally will show the additional metric :ref:`processing time <summary_report_processing_time>` in the command line report.
-* ``skip.telemetry`` (default: None): Determines whether telemetry data collection should be skipped when stopping a benchmark. This can be set either via configuration param ``skip.telemetry`` the command line flag ``--skip-telemetry``.
+* ``skip.telemetry`` (default: None): Determines whether telemetry data collection should be skipped when stopping a benchmark. Can be set through the command line flag ``--skip-telemetry``.
 
 The following settings are applicable only if ``datastore.type`` is set to "elasticsearch":
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -324,10 +324,3 @@ When a benchmark is executed with ``--enable-assertions`` and this query returns
 
     [ERROR] Cannot race. Error in load generator [0]
         Cannot run task [geo_distance]: Expected [hits] to be > [0] but was [0].
-
-Skipping telemetry data collection when hitting an error.
---------------------------------------------------------------
-
-In some cases, you may want to skip telemetry data collection when Rally hits an error. This can be useful in cases you want to avoid storing telemetry results when a benchmark got unexpected results . To enable this behavior, you can pass the ``--skip-telemetry`` command line flag when executing `esrally stop`. This will prevent Rally from sending telemetry data to the metrics store. 
-
-	esrally stop --installation-id=INSTALLATION_ID  --skip-telemetry

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -328,6 +328,6 @@ When a benchmark is executed with ``--enable-assertions`` and this query returns
 Skipping telemetry data collection when hitting an error.
 --------------------------------------------------------------
 
-In some cases, you may want to skip telemetry data collection when Rally hits an error. This can be useful in cases you want to avoid storing telemetry results when a benchmark got unexpected results. To enable this behavior, you can either use the ``skip.telemetry`` configuration setting in your ``rally.ini`` file or pass the ``--skip-telemetry`` command line flag when stopping Rally. This will prevent Rally from sending telemetry data to the metrics store. 
+In some cases, you may want to skip telemetry data collection when Rally hits an error. This can be useful in cases you want to avoid storing telemetry results when a benchmark got unexpected results . To enable this behavior, you can pass the ``--skip-telemetry`` command line flag when executing `esrally stop`. This will prevent Rally from sending telemetry data to the metrics store. 
 
 	esrally stop --installation-id=INSTALLATION_ID  --skip-telemetry

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -1097,7 +1097,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
     cfg.add(config.Scope.application, "system", "quiet.mode", args.quiet)
     cfg.add(config.Scope.application, "system", "offline.mode", args.offline)
     logger = logging.getLogger(__name__)
-    
+
     try:
         if sub_command == "compare":
             configure_reporting_params(args, cfg)

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -573,7 +573,6 @@ def create_arg_parser():
         # default is None, since it can be set via config file
         "--skip-telemetry",
         help="Skip telemetry data collection. (default: None).",
-        default=None,
         action="store_true",
     )
 
@@ -1098,7 +1097,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
     cfg.add(config.Scope.application, "system", "quiet.mode", args.quiet)
     cfg.add(config.Scope.application, "system", "offline.mode", args.offline)
     logger = logging.getLogger(__name__)
-
+    
     try:
         if sub_command == "compare":
             configure_reporting_params(args, cfg)
@@ -1166,6 +1165,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             mechanic.start(cfg)
         elif sub_command == "stop":
             cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
+            cfg.add(config.Scope.applicationOverride, "mechanic", "skip.telemetry", args.skip_telemetry)
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
             mechanic.stop(cfg)
         elif sub_command == "race":


### PR DESCRIPTION
Load skip.telemetry from cli arguments
- #1957 was not loading skip.telemetry parameter correctly leaving 
skip.telemetry unused even if it was set as a cli flag.
- There is no value loading skip.telemetry parameter from cfg file
since setting this parameter statically to true is not a plausible option, 
so it should be set to true only when given in the cli args.