### PR TITLE
Removing negative duration constraint, it might be needed in comparing results

### DIFF
--- a/esrally/utils/convert.py
+++ b/esrally/utils/convert.py
@@ -139,7 +139,7 @@ class Duration(int):
         it = iter(Duration.Unit)
         last = next(it)
         for unit in it:
-            if self < unit:
+            if abs(self) < unit:
                 return last
             last = unit
         return last
@@ -198,8 +198,6 @@ class Duration(int):
 def duration(x: int | float, unit: Duration.Unit = Duration.Unit.S) -> Duration:
     if isinstance(x, Duration):
         return x
-    if x < 0:
-        raise TypeError("negative duration")
     return Duration(x * unit)
 
 

--- a/tests/utils/convert_test.py
+++ b/tests/utils/convert_test.py
@@ -167,6 +167,7 @@ DAY = 24 * HOUR
     hour=DurationCase(3600, HOUR, "1h"),
     day=DurationCase(86400, DAY, "1d"),
     milions=DurationCase(1e6, 1000000 * 1000000000, "11d 13h 46m 40s"),
+    negative=DurationCase(-1.23456789, -1234567890, "-1.23s", convert.Duration.Unit.S),
 )
 def test_duration(case: DurationCase):
     got = convert.duration(case.value, case.unit)


### PR DESCRIPTION
It removes -ve duration constraint.
Currently it is not possible to compare races where contender is having smaller duration in some cases.