### PR TITLE
[ES-12520] Add --user-tags to list races

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -965,6 +965,15 @@ When you run ``esrally list races``, this will show up again::
 
 This will help you recognize a specific race when running ``esrally compare``.
 
+You can also filter races with user tags.
+
+**Example**
+
+ ::
+
+   esrally list races --track=pmc --user-tags="intention:github-issue-1234-baseline,gc:cms"
+
+
 .. note::
    This option used to be named `--user-tag` without an s, which was confusing as multiple tags are supported. While users are now encouraged to use `--user-tags` for clarity, Rally will continue to honor `--user-tag` in the future to avoid breaking backwards-compatibility.
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -193,6 +193,7 @@ def create_arg_parser():
     )
     list_parser.add_argument(
         "--user-tags",
+        "--user-tag",
         help="Show only races with user-specific key-value pairs (separated by ':'). When multiple tags provided all need to match.",
         default="",
     )
@@ -721,8 +722,8 @@ def create_arg_parser():
         help="Defines a comma-separated list of tasks not to run. By default all tasks of a challenge are run.",
     )
     race_parser.add_argument(
-        "--user-tag",
         "--user-tags",
+        "--user-tag",
         help="Define a user-specific key-value pair (separated by ':'). It is added to each metric record as meta info. "
         "Example: intention:baseline-ticket-12345",
         default="",
@@ -1192,7 +1193,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             # use the race id implicitly also as the install id.
             cfg.add(config.Scope.applicationOverride, "system", "install.id", args.race_id)
             cfg.add(config.Scope.applicationOverride, "race", "pipeline", args.pipeline)
-            cfg.add(config.Scope.applicationOverride, "race", "user.tags", opts.to_dict(args.user_tag))
+            cfg.add(config.Scope.applicationOverride, "race", "user.tags", opts.to_dict(args.user_tags))
             cfg.add(config.Scope.applicationOverride, "driver", "profiling", args.enable_driver_profiling)
             cfg.add(config.Scope.applicationOverride, "driver", "assertions", args.enable_assertions)
             cfg.add(config.Scope.applicationOverride, "driver", "on.error", args.on_error)

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -185,6 +185,17 @@ def create_arg_parser():
         help="Show only records from this challenge",
         default=None,
     )
+    list_parser.add_argument(
+        "--format",
+        help="Races output format, defaults to text.",
+        choices=["text", "json"],
+        default="text",
+    )
+    list_parser.add_argument(
+        "--user-tags",
+        help="Show only races with user-specific key-value pairs (separated by ':'). When multiple tags provided all need to match.",
+        default="",
+    )
     add_track_source(list_parser)
 
     delete_parser = subparsers.add_parser("delete", help="Delete records")
@@ -1107,6 +1118,8 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "system", "list.max_results", args.limit)
             cfg.add(config.Scope.applicationOverride, "system", "admin.track", args.track)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.benchmark_name", args.benchmark_name)
+            cfg.add(config.Scope.applicationOverride, "system", "list.races.format", args.format)
+            cfg.add(config.Scope.applicationOverride, "system", "list.races.user_tags", opts.to_dict(args.user_tags))
             cfg.add(config.Scope.applicationOverride, "system", "list.from_date", args.from_date)
             cfg.add(config.Scope.applicationOverride, "system", "list.to_date", args.to_date)
             cfg.add(config.Scope.applicationOverride, "system", "list.challenge", args.challenge)
@@ -1250,6 +1263,7 @@ def main():
     # Early init of console output so we start to show everything consistently.
     console.init(quiet=False)
 
+    logger.debug("Command line: %s", " ".join(sys.argv))
     arg_parser = create_arg_parser()
     args = arg_parser.parse_args()
 
@@ -1258,7 +1272,8 @@ def main():
         sys.exit(0)
 
     console.init(quiet=args.quiet)
-    console.println(BANNER)
+    if (not hasattr(args, "format")) or args.format == "text":
+        console.println(BANNER)
 
     cfg = config.Config(config_name=args.configuration_name)
     if not cfg.config_present():
@@ -1300,18 +1315,19 @@ def main():
 
     result = dispatch_sub_command(arg_parser, args, cfg)
 
-    end = time.time()
-    if result == ExitStatus.SUCCESSFUL:
-        console.println("")
-        console.info("SUCCESS (took %d seconds)" % (end - start), overline="-", underline="-")
-    elif result == ExitStatus.INTERRUPTED:
-        console.println("")
-        console.info("ABORTED (took %d seconds)" % (end - start), overline="-", underline="-")
-        sys.exit(130)
-    elif result == ExitStatus.ERROR:
-        console.println("")
-        console.info("FAILURE (took %d seconds)" % (end - start), overline="-", underline="-")
-        sys.exit(64)
+    if (not hasattr(args, "format")) or args.format == "text":
+        end = time.time()
+        if result == ExitStatus.SUCCESSFUL:
+            console.println("")
+            console.info("SUCCESS (took %d seconds)" % (end - start), overline="-", underline="-")
+        elif result == ExitStatus.INTERRUPTED:
+            console.println("")
+            console.info("ABORTED (took %d seconds)" % (end - start), overline="-", underline="-")
+            sys.exit(130)
+        elif result == ExitStatus.ERROR:
+            console.println("")
+            console.info("FAILURE (took %d seconds)" % (end - start), overline="-", underline="-")
+            sys.exit(64)
 
 
 if __name__ == "__main__":

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -96,6 +96,8 @@ Key = Literal[
     "list.from_date",
     "list.max_results",
     "list.races.benchmark_name",
+    "list.races.format",
+    "list.races.user_tags",
     "list.to_date",
     "load_driver_hosts",
     "local.dataset.cache",

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1329,7 +1329,9 @@ class TestEsRaceStore:
     def test_filter_race(self):
         self.es_mock.search.return_value = {"hits": {"total": 0}}
         self.cfg.add(config.Scope.application, "system", "admin.track", "unittest")
+        self.cfg.add(config.Scope.application, "system", "list.challenge", "unittest-challenge")
         self.cfg.add(config.Scope.application, "system", "list.races.benchmark_name", "unittest-test")
+        self.cfg.add(config.Scope.application, "system", "list.races.user_tags", {"env-id": "123", "name": "unittest-test2"})
         self.cfg.add(config.Scope.application, "system", "list.to_date", "20160131")
         self.cfg.add(config.Scope.application, "system", "list.from_date", "20160230")
         self.race_store.list()
@@ -1348,6 +1350,9 @@ class TestEsRaceStore:
                                 ]
                             }
                         },
+                        {"term": {"challenge": "unittest-challenge"}},
+                        {"term": {"user-tags.env-id": "123"}},
+                        {"term": {"user-tags.name": "unittest-test2"}},
                     ]
                 }
             },
@@ -2002,7 +2007,7 @@ class TestFileRaceStore:
             race_id=self.RACE_ID,
             race_timestamp=self.RACE_TIMESTAMP,
             pipeline="from-sources",
-            user_tags={"name": "unittest-test"},
+            user_tags={"name": "unittest-test", "env-id": "123"},
             track=t,
             track_params={"clients": 12},
             challenge=t.default_challenge,
@@ -2020,6 +2025,10 @@ class TestFileRaceStore:
         self.cfg.add(config.Scope.application, "system", "list.races.benchmark_name", "unittest-test-2")
         assert len(self.race_store.list()) == 0
         self.cfg.add(config.Scope.application, "system", "list.races.benchmark_name", "unittest-test")
+        assert len(self.race_store.list()) == 1
+        self.cfg.add(config.Scope.application, "system", "list.races.user_tags", {"env-id": "321", "name": "unittest-test"})
+        assert len(self.race_store.list()) == 0
+        self.cfg.add(config.Scope.application, "system", "list.races.user_tags", {"env-id": "123", "name": "unittest-test"})
         assert len(self.race_store.list()) == 1
         self.cfg.add(config.Scope.application, "system", "list.to_date", "20160129")
         assert len(self.race_store.list()) == 0


### PR DESCRIPTION
This allows to filter races based on arbitrary user tags. It is a generalization of `--benchmark-name` option which matches either `name` or `benchmark-name` tags today.

Additionally, list races command gets new `--format {text,json}` option to make automated parsing easier. The JSON format provides full race document as persisted in the metric store.
