### PR TITLE
Add ability to continue on network issues

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -842,14 +842,17 @@ Save the above responses as ``responses.json`` and execute a benchmark as follow
 ``on-error``
 ~~~~~~~~~~~~
 
+
 This option controls how Rally behaves when a response error occurs. The following values are possible:
 
 * ``continue``: (default) only records that an error has happened and will continue with the benchmark unless there is a fatal error. At the end of a race, errors show up in the "error rate" metric.
 * ``abort``: aborts the benchmark on the first request error with a detailed error message. It is possible to permit *individual* tasks to ignore non-fatal errors using :ref:`ignore-response-error-level <track_schedule>`.
+* ``continue-on-network``: As with ``continue``, but also continues on network errors (such as connection refused).
 
 .. attention::
 
-    The only error that is considered fatal is "Connection Refused" (`ECONNREFUSED <http://man7.org/linux/man-pages/man2/connect.2.html>`_).
+  With ``continue-on-network``, Rally continues on network errors (e.g., "Connection Refused"/`ECONNREFUSED <http://man7.org/linux/man-pages/man2/connect.2.html>`_). For other errors, behavior is the same as ``continue``. 
+  Use this option if you want Rally to be resilient to temporary network issues during a benchmark. Note that this will impact rally aborting in the case of a target Elasticsearch cluster being down.
 
 ``load-driver-hosts``
 ~~~~~~~~~~~~~~~~~~~~~

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -34,7 +34,18 @@ from typing import Callable, Optional
 
 import thespian.actors
 
-from esrally import PROGRAM_NAME, actor, client, config, exceptions, metrics, paths, telemetry, track, types
+from esrally import (
+    PROGRAM_NAME,
+    actor,
+    client,
+    config,
+    exceptions,
+    metrics,
+    paths,
+    telemetry,
+    track,
+    types,
+)
 from esrally.client import delete_api_keys
 from esrally.driver import runner, scheduler
 from esrally.track import TrackProcessorRegistry, load_track, load_track_plugins

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -50,15 +50,7 @@ from esrally.client import delete_api_keys
 from esrally.driver import runner, scheduler
 from esrally.track import TrackProcessorRegistry, load_track, load_track_plugins
 from esrally.utils import console, convert, net
-
-
-class OnErrorBehavior(Enum):
-    ABORT = "abort"
-    CONTINUE = "continue"
-    CONTINUE_ON_NETWORK = "continue-on-network"
-
-    def __str__(self):
-        return self.value
+from esrally.utils.error_behavior import OnErrorBehavior
 
 
 ##################################

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -694,10 +694,11 @@ def create_arg_parser():
     )
     race_parser.add_argument(
         "--on-error",
+        type=OnErrorBehavior,
         choices=list(OnErrorBehavior),
         help="Controls how Rally behaves on response errors (default: continue). 'continue-on-network' will retry on network errors"
         "(e.g., connection refused).",
-        default="continue",
+        default=OnErrorBehavior.CONTINUE,
     )
     race_parser.add_argument(
         "--telemetry",

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -48,10 +48,10 @@ from esrally import (
     types,
     version,
 )
+from esrally.driver.driver import OnErrorBehavior
 from esrally.mechanic import mechanic, team
 from esrally.tracker import tracker
 from esrally.utils import console, convert, io, net, opts, process, versions
-from esrally.driver.driver import OnErrorBehavior
 
 LOG = logging.getLogger(__name__)
 
@@ -695,7 +695,8 @@ def create_arg_parser():
     race_parser.add_argument(
         "--on-error",
         choices=list(OnErrorBehavior),
-        help="Controls how Rally behaves on response errors (default: continue). 'continue-on-network' will retry on network errors (e.g., connection refused).",
+        help="Controls how Rally behaves on response errors (default: continue). 'continue-on-network' will retry on network errors"
+        "(e.g., connection refused).",
         default="continue",
     )
     race_parser.add_argument(

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -51,6 +51,7 @@ from esrally import (
 from esrally.mechanic import mechanic, team
 from esrally.tracker import tracker
 from esrally.utils import console, convert, io, net, opts, process, versions
+from esrally.driver.driver import OnErrorBehavior
 
 LOG = logging.getLogger(__name__)
 
@@ -693,8 +694,8 @@ def create_arg_parser():
     )
     race_parser.add_argument(
         "--on-error",
-        choices=["continue", "abort"],
-        help="Controls how Rally behaves on response errors (default: continue).",
+        choices=list(OnErrorBehavior),
+        help="Controls how Rally behaves on response errors (default: continue). 'continue-on-network' will retry on network errors (e.g., connection refused).",
         default="continue",
     )
     race_parser.add_argument(

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -22,6 +22,7 @@ from enum import Enum, auto, unique
 
 from esrally import exceptions
 from esrally.utils import serverless
+from esrally.utils.error_behavior import OnErrorBehavior
 
 
 class Index:
@@ -1083,7 +1084,7 @@ class Task:
 
         return ignore_response_error_level
 
-    def error_behavior(self, default_error_behavior):
+    def error_behavior(self, default_error_behavior: OnErrorBehavior) -> OnErrorBehavior:
         """
         Returns the desired behavior when encountering errors during task execution.
 
@@ -1094,10 +1095,10 @@ class Task:
             "continue-on-network": will continue for non-fatal errors and network errors
         """
 
-        behavior = default_error_behavior if default_error_behavior in ("abort", "continue", "continue-on-network") else "continue"
-        if behavior == "abort":
+        behavior = default_error_behavior if default_error_behavior in list(OnErrorBehavior) else OnErrorBehavior.CONTINUE
+        if behavior == OnErrorBehavior.ABORT:
             if self.ignore_response_error_level == "non-fatal":
-                behavior = "continue"
+                behavior = OnErrorBehavior.CONTINUE
         return behavior
 
     def __hash__(self):

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -1090,14 +1090,14 @@ class Task:
         :param default_error_behavior: (str) the default error behavior for the benchmark
         :return: (str) prescribing error handling when a non-fatal error occurs:
             "abort": will fail when any error gets encountered
-            "continue": will continue for non fatal errors
+            "continue": will continue for non-fatal errors
+            "continue-on-network": will continue for non-fatal errors and network errors
         """
 
-        behavior = "continue"
-        if default_error_behavior == "abort":
-            if self.ignore_response_error_level != "non-fatal":
-                behavior = "abort"
-
+        behavior = default_error_behavior if default_error_behavior in ("abort", "continue", "continue-on-network") else "continue"
+        if behavior == "abort":
+            if self.ignore_response_error_level == "non-fatal":
+                behavior = "continue"
         return behavior
 
     def __hash__(self):

--- a/esrally/utils/error_behavior.py
+++ b/esrally/utils/error_behavior.py
@@ -1,0 +1,27 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from enum import Enum
+
+
+class OnErrorBehavior(Enum):
+    ABORT = "abort"
+    CONTINUE = "continue"
+    CONTINUE_ON_NETWORK = "continue-on-network"
+
+    def __str__(self):
+        return self.value

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -28,8 +28,9 @@ import pytest
 
 from esrally import config, exceptions, metrics, track
 from esrally.driver import driver, runner, scheduler
-from esrally.driver.driver import ApiKey, ClientContext, OnErrorBehavior
+from esrally.driver.driver import ApiKey, ClientContext
 from esrally.track import params
+from esrally.utils.error_behavior import OnErrorBehavior
 
 
 class DriverTestParamSource:

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -28,7 +28,7 @@ import pytest
 
 from esrally import config, exceptions, metrics, track
 from esrally.driver import driver, runner, scheduler
-from esrally.driver.driver import ApiKey, ClientContext
+from esrally.driver.driver import ApiKey, ClientContext, OnErrorBehavior
 from esrally.track import params
 
 
@@ -1506,7 +1506,7 @@ class TestAsyncExecutor:
             sampler=sampler,
             cancel=cancel,
             complete=complete,
-            on_error="continue",
+            on_error=OnErrorBehavior.CONTINUE,
         )
         await execute_schedule()
 
@@ -1570,7 +1570,7 @@ class TestAsyncExecutor:
             sampler=sampler,
             cancel=cancel,
             complete=complete,
-            on_error="continue",
+            on_error=OnErrorBehavior.CONTINUE,
         )
         await execute_schedule()
 
@@ -1639,7 +1639,7 @@ class TestAsyncExecutor:
             sampler=sampler,
             cancel=cancel,
             complete=complete,
-            on_error="continue",
+            on_error=OnErrorBehavior.CONTINUE,
         )
         await execute_schedule()
 
@@ -1713,7 +1713,7 @@ class TestAsyncExecutor:
                 sampler=sampler,
                 cancel=cancel,
                 complete=complete,
-                on_error="continue",
+                on_error=OnErrorBehavior.CONTINUE,
             )
             await execute_schedule()
 
@@ -1765,7 +1765,7 @@ class TestAsyncExecutor:
                 sampler=sampler,
                 cancel=cancel,
                 complete=complete,
-                on_error="continue",
+                on_error=OnErrorBehavior.CONTINUE,
             )
 
             cancel.set()
@@ -1824,7 +1824,7 @@ class TestAsyncExecutor:
             sampler=sampler,
             cancel=cancel,
             complete=complete,
-            on_error="continue",
+            on_error=OnErrorBehavior.CONTINUE,
         )
 
         with pytest.raises(exceptions.RallyError, match=r"Cannot run task \[no-op\]: expected unit test exception"):
@@ -1838,7 +1838,9 @@ class TestAsyncExecutor:
         params = None
         runner = mock.AsyncMock()
 
-        ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
 
         assert ops == 1
         assert unit == "ops"
@@ -1850,7 +1852,9 @@ class TestAsyncExecutor:
         params = None
         runner = mock.AsyncMock(return_value=(500, "MB"))
 
-        ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
 
         assert ops == 500
         assert unit == "MB"
@@ -1869,7 +1873,9 @@ class TestAsyncExecutor:
             }
         )
 
-        ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
 
         assert ops == 50
         assert unit == "docs"
@@ -1879,7 +1885,7 @@ class TestAsyncExecutor:
             "success": True,
         }
 
-    @pytest.mark.parametrize("on_error", ["abort", "continue"])
+    @pytest.mark.parametrize("on_error", ["abort", OnErrorBehavior.CONTINUE])
     @pytest.mark.asyncio
     async def test_execute_single_with_connection_error_always_aborts(self, on_error):
         es = None
@@ -1906,7 +1912,7 @@ class TestAsyncExecutor:
         )
 
         with pytest.raises(exceptions.RallyAssertionError) as exc:
-            await driver.execute_single(self.context_managed(runner), es, params, on_error="abort")
+            await driver.execute_single(self.context_managed(runner), es, params, on_error=OnErrorBehavior.ABORT)
         assert exc.value.args[0] == (
             "Request returned an error. Error type: api, Description: not found (the requested document could not be found),"
             " HTTP Status: 404"
@@ -1928,7 +1934,7 @@ class TestAsyncExecutor:
         runner = mock.AsyncMock(side_effect=elasticsearch.ApiError(message=str_literal_empty_body, meta=error_meta, body=empty_body))
 
         with pytest.raises(exceptions.RallyAssertionError) as exc:
-            await driver.execute_single(self.context_managed(runner), es, params, on_error="abort")
+            await driver.execute_single(self.context_managed(runner), es, params, on_error=OnErrorBehavior.ABORT)
         assert exc.value.args[0] == ("Request returned an error. Error type: api, Description: None, HTTP Status: 413")
 
     @pytest.mark.asyncio
@@ -1947,7 +1953,7 @@ class TestAsyncExecutor:
         runner = mock.AsyncMock(side_effect=elasticsearch.ApiError(message=str_literal, meta=error_meta, body=body))
 
         with pytest.raises(exceptions.RallyAssertionError) as exc:
-            await driver.execute_single(self.context_managed(runner), es, params, on_error="abort")
+            await driver.execute_single(self.context_managed(runner), es, params, on_error=OnErrorBehavior.ABORT)
         assert exc.value.args[0] == ("Request returned an error. Error type: api, Description: Huge error, HTTP Status: 499")
 
     @pytest.mark.asyncio
@@ -1965,7 +1971,9 @@ class TestAsyncExecutor:
             side_effect=elasticsearch.NotFoundError(message="not found", meta=error_meta, body="the requested document could not be found")
         )
 
-        ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
 
         assert ops == 0
         assert unit == "ops"
@@ -1989,7 +1997,9 @@ class TestAsyncExecutor:
         )
         runner = mock.AsyncMock(side_effect=elasticsearch.NotFoundError(message="", meta=error_meta, body=""))
 
-        ops, unit, request_meta_data = await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
 
         assert ops == 0
         assert unit == "ops"
@@ -2017,7 +2027,7 @@ class TestAsyncExecutor:
         runner = FailingRunner()
 
         with pytest.raises(exceptions.SystemSetupError) as exc:
-            await driver.execute_single(self.context_managed(runner), es, params, on_error="continue")
+            await driver.execute_single(self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE)
         assert exc.value.args[0] == (
             "Cannot execute [failing_mock_runner]. Provided parameters are: ['bulk', 'mode']. Error: ['bulk-size missing']."
         )

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -379,10 +379,20 @@ class TestTask:
         effective_on_error = task.error_behavior(default_error_behavior="continue")
         assert effective_on_error == "continue"
 
+    def test_task_continues_with_global_continue_on_network(self):
+        task = self.task()
+        effective_on_error = task.error_behavior(default_error_behavior="continue-on-network")
+        assert effective_on_error == "continue-on-network"
+
     def test_task_continues_with_global_abort_and_task_override(self):
         task = self.task(ignore_response_error_level="non-fatal")
         effective_on_error = task.error_behavior(default_error_behavior="abort")
         assert effective_on_error == "continue"
+
+    def test_task_continues_on_network_with_global_continue_on_network_and_task_override(self):
+        task = self.task(ignore_response_error_level="non-fatal")
+        effective_on_error = task.error_behavior(default_error_behavior="continue-on-network")
+        assert effective_on_error == "continue-on-network"
 
     def test_task_aborts_with_global_abort(self):
         task = self.task()

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -20,6 +20,7 @@ import pytest
 from esrally import exceptions
 from esrally.track import track
 from esrally.utils import serverless
+from esrally.utils.error_behavior import OnErrorBehavior
 
 
 class TestTrack:
@@ -376,25 +377,25 @@ class TestTask:
 
     def test_task_continues_with_global_continue(self):
         task = self.task()
-        effective_on_error = task.error_behavior(default_error_behavior="continue")
-        assert effective_on_error == "continue"
+        effective_on_error = task.error_behavior(default_error_behavior=OnErrorBehavior.CONTINUE)
+        assert effective_on_error is OnErrorBehavior.CONTINUE
 
     def test_task_continues_with_global_continue_on_network(self):
         task = self.task()
-        effective_on_error = task.error_behavior(default_error_behavior="continue-on-network")
-        assert effective_on_error == "continue-on-network"
+        effective_on_error = task.error_behavior(default_error_behavior=OnErrorBehavior.CONTINUE_ON_NETWORK)
+        assert effective_on_error is OnErrorBehavior.CONTINUE_ON_NETWORK
 
     def test_task_continues_with_global_abort_and_task_override(self):
         task = self.task(ignore_response_error_level="non-fatal")
-        effective_on_error = task.error_behavior(default_error_behavior="abort")
-        assert effective_on_error == "continue"
+        effective_on_error = task.error_behavior(default_error_behavior=OnErrorBehavior.ABORT)
+        assert effective_on_error is OnErrorBehavior.CONTINUE
 
     def test_task_continues_on_network_with_global_continue_on_network_and_task_override(self):
         task = self.task(ignore_response_error_level="non-fatal")
-        effective_on_error = task.error_behavior(default_error_behavior="continue-on-network")
-        assert effective_on_error == "continue-on-network"
+        effective_on_error = task.error_behavior(default_error_behavior=OnErrorBehavior.CONTINUE_ON_NETWORK)
+        assert effective_on_error is OnErrorBehavior.CONTINUE_ON_NETWORK
 
     def test_task_aborts_with_global_abort(self):
         task = self.task()
-        effective_on_error = task.error_behavior(default_error_behavior="abort")
-        assert effective_on_error == "abort"
+        effective_on_error = task.error_behavior(default_error_behavior=OnErrorBehavior.ABORT)
+        assert effective_on_error is OnErrorBehavior.ABORT


### PR DESCRIPTION
When running long tests we occasionally see network issues, seemingly arising from either the load driver instance or load balancers. This gives the option to be a little more leniant and not abort the whole test immediately. I haven't built in a retry mechanism, but that would probably be a good future improvement (along with back off). 