### PR TITLE
Enable a release build of an Elasticsearch revision from sources (source.build.release) 

### DIFF
--- a/docs/car.rst
+++ b/docs/car.rst
@@ -71,9 +71,12 @@ The top-level directory "v1" denotes the configuration format in version 1. Belo
 This defines the variable ``clean_command`` for all cars that reference this configuration. Rally will treat the following variable names specially:
 
 * `clean_command`: The command to clean the Elasticsearch project directory.
-* `build_command`: The command to build an Elasticsearch source distribution.
-* `artifact_path_pattern`: A glob pattern to find a previously built source distribution within the project directory.
-* `release_url`: A download URL for Elasticsearch distributions. The placeholder ``{{VERSION}}`` is replaced by Rally with the actual Elasticsearch version.
+* `system.build_command`: The command to build an Elasticsearch x86_64 source distribution.
+* `system.build_command.no-snapshot`: The command to build an Elasticsearch x86_64 source distribution creating a release-like build.
+* `system.build_command.arch`: The command to build an Elasticsearch a source distribution based on the target.arch architecture.
+* `system.build_command.arch.no-snapshot`: The command to build an Elasticsearch source distribution creating a release-like build based on the target.arch architecture.
+* `system.artifact_path_pattern`: A glob pattern to find a previously built source distribution within the project directory.
+* `jdk.bundled.release_url`: A download URL for Elasticsearch distributions. The placeholder ``{{VERSION}}`` is replaced by Rally with the actual Elasticsearch version.
 
 Let's have a look at the ``1gheap`` car by inspecting ``1gheap.ini``::
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -667,6 +667,17 @@ You can use this distribution repository with the name "in_house_snapshot" as fo
 
 This will benchmark the latest 7.0.0 snapshot build of Elasticsearch.
 
+``source-build-method``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Method with which to build Elasticsearch and plugins from sources. Supported values are: ``default`` and ``docker``.
+
+``source-build-release``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Determines whether to build a release version of Elasticsearch. By default, Rally builds a snapshot version. Default: ``false``.
+Provide the ``--source-build-release`` flag to build a release version.
+
 ``report-format``
 ~~~~~~~~~~~~~~~~~
 

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -56,9 +56,7 @@ def create(cfg: types.Config, sources, distribution, car, plugins=None):
         es_src_dir = os.path.join(_src_dir(cfg), _config_value(src_config, "elasticsearch.src.subdir"))
 
         if source_build_method == "docker":
-            builder = DockerBuilder(
-                src_dir=es_src_dir, release_build=source_build_release, log_dir=paths.logs(), client=docker.from_env()
-            )
+            builder = DockerBuilder(src_dir=es_src_dir, release_build=source_build_release, log_dir=paths.logs(), client=docker.from_env())
         else:
             raw_build_jdk = car.mandatory_var("build.jdk")
             try:
@@ -418,7 +416,7 @@ class ElasticsearchSourceSupplier:
             system_build_command_var = "system.build_command.arch" if self.template_renderer.arch != "x86_64" else "system.build_command"
             if getattr(self.builder, "release_build", None) and self.builder.release_build is True:
                 system_build_command_var += ".no-snapshot"
-            else: 
+            else:
                 console.warn("Building a SNAPSHOT version of Elasticsearch, source.build.release was not set")
 
             commands.append(self.template_renderer.render(self.car.mandatory_var(system_build_command_var)))

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -416,8 +416,10 @@ class ElasticsearchSourceSupplier:
 
             # There are no 'x86_64' specific gradle build commands
             system_build_command_var = "system.build_command.arch" if self.template_renderer.arch != "x86_64" else "system.build_command"
-            if self.builder.release_build is True:
+            if getattr(self.builder, "release_build", None) and self.builder.release_build is True:
                 system_build_command_var += ".no-snapshot"
+            else: 
+                console.warn("Building a SNAPSHOT version of Elasticsearch, source.build.release was not set")
 
             commands.append(self.template_renderer.render(self.car.mandatory_var(system_build_command_var)))
 

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -415,9 +415,10 @@ class ElasticsearchSourceSupplier:
             # There are no 'x86_64' specific gradle build commands
             system_build_command_var = "system.build_command.arch" if self.template_renderer.arch != "x86_64" else "system.build_command"
             if getattr(self.builder, "release_build", None) and self.builder.release_build is True:
+                self.logger.info("Building a release version of Elasticsearch, source.build.release was set")
                 system_build_command_var += ".no-snapshot"
             else:
-                console.warn("Building a SNAPSHOT version of Elasticsearch, source.build.release was not set")
+                self.logger.info("Building a SNAPSHOT version of Elasticsearch, source.build.release was not set")
 
             commands.append(self.template_renderer.render(self.car.mandatory_var(system_build_command_var)))
 

--- a/esrally/mechanic/supplier.py
+++ b/esrally/mechanic/supplier.py
@@ -40,6 +40,7 @@ def create(cfg: types.Config, sources, distribution, car, plugins=None):
     caching_enabled = cfg.opts("source", "cache", mandatory=False, default_value=True)
     revisions = _extract_revisions(cfg.opts("mechanic", "source.revision", mandatory=sources))
     source_build_method = cfg.opts("mechanic", "source.build.method", mandatory=False, default_value="default")
+    source_build_snapshot = cfg.opts("mechanic", "source.build.snapshot", mandatory=False, default_value=True)
     distribution_version = cfg.opts("mechanic", "distribution.version", mandatory=False)
     supply_requirements = _supply_requirements(sources, distribution, plugins, revisions, distribution_version)
     build_needed = any(build for _, _, build in supply_requirements.values())
@@ -55,7 +56,9 @@ def create(cfg: types.Config, sources, distribution, car, plugins=None):
         es_src_dir = os.path.join(_src_dir(cfg), _config_value(src_config, "elasticsearch.src.subdir"))
 
         if source_build_method == "docker":
-            builder = DockerBuilder(src_dir=es_src_dir, log_dir=paths.logs(), client=docker.from_env())
+            builder = DockerBuilder(
+                src_dir=es_src_dir, build_snapshot=source_build_snapshot, log_dir=paths.logs(), client=docker.from_env()
+            )
         else:
             raw_build_jdk = car.mandatory_var("build.jdk")
             try:
@@ -64,6 +67,7 @@ def create(cfg: types.Config, sources, distribution, car, plugins=None):
                 raise exceptions.SystemSetupError(f"Car config key [build.jdk] is invalid: [{raw_build_jdk}] (must be int)")
             builder = Builder(
                 build_jdk=build_jdk,
+                build_snapshot=source_build_snapshot,
                 src_dir=es_src_dir,
                 log_dir=paths.logs(),
             )
@@ -407,17 +411,15 @@ class ElasticsearchSourceSupplier:
         if self.builder:
             self.builder.build_jdk = self.resolve_build_jdk_major(self.src_dir)
 
+            commands = []
+            commands.append(self.template_renderer.render(self.car.mandatory_var("clean_command")))
+
             # There are no 'x86_64' specific gradle build commands
-            if self.template_renderer.arch != "x86_64":
-                commands = [
-                    self.template_renderer.render(self.car.mandatory_var("clean_command")),
-                    self.template_renderer.render(self.car.mandatory_var("system.build_command.arch")),
-                ]
-            else:
-                commands = [
-                    self.template_renderer.render(self.car.mandatory_var("clean_command")),
-                    self.template_renderer.render(self.car.mandatory_var("system.build_command")),
-                ]
+            system_build_variable = "system.build_command.arch" if self.template_renderer.arch != "x86_64" else "system.build_command"
+            if self.builder.build_snapshot is False:
+                system_build_variable += ".no-snapshot"
+
+            commands.append(self.template_renderer.render(self.car.mandatory_var(system_build_variable)))
 
             self.builder.build(commands)
 
@@ -782,9 +784,10 @@ class Builder:
     It is not intended to be used directly but should be triggered by its mechanic.
     """
 
-    def __init__(self, src_dir, build_jdk=None, log_dir=None):
+    def __init__(self, src_dir, build_jdk=None, build_snapshot=None, log_dir=None):
         self.src_dir = src_dir
         self.build_jdk = build_jdk
+        self.build_snapshot = build_snapshot
         self._java_home = None
         self.log_dir = log_dir
         self.logger = logging.getLogger(__name__)
@@ -823,11 +826,12 @@ class Builder:
 
 
 class DockerBuilder:
-    def __init__(self, src_dir, build_jdk=None, log_dir=None, client=None):
+    def __init__(self, src_dir, build_jdk=None, build_snapshot=None, log_dir=None, client=None):
         self.client = client
         self.src_dir = src_dir
         self.build_jdk = build_jdk
         self.log_dir = log_dir
+        self.build_snapshot = build_snapshot
         io.ensure_dir(self.log_dir)
         self.log_file = os.path.join(self.log_dir, "build.log")
         self.logger = logging.getLogger(__name__)

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -377,7 +377,7 @@ def create_arg_parser():
     )
     build_parser.add_argument(
         "--source-build-release",
-        help=f"Build a release version of Elasticsearch from sources.",
+        help="Build a release version of Elasticsearch from sources.",
         default=False,
         action="store_true",
     )

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -128,10 +128,8 @@ def create_arg_parser():
     if cfg.config_present():
         cfg.load_config()
         preserve_install = cfg.opts("defaults", "preserve_benchmark_candidate", default_value=False, mandatory=False)
-        snapshot_build = cfg.opts("defaults", "source.build.snapshot", default_value=True, mandatory=False)
     else:
         preserve_install = False
-        snapshot_build = True
 
     parser = argparse.ArgumentParser(
         prog=PROGRAM_NAME,
@@ -378,9 +376,10 @@ def create_arg_parser():
         default="default",
     )
     build_parser.add_argument(
-        "--source-build-snapshot",
-        help="Decides whether installing Elasticsearch as a release version (enabling feature flags for example) or a snapshot version.",
-        default=snapshot_build,
+        "--source-build-release",
+        help=f"Build a release version of Elasticsearch from sources.",
+        default=False,
+        action="store_true",
     )
 
     download_parser = subparsers.add_parser("download", help="Downloads an artifact")
@@ -532,9 +531,10 @@ def create_arg_parser():
         default="default",
     )
     install_parser.add_argument(
-        "--source-build-snapshot",
-        help="Decides whether installing Elasticsearch as a release version (enabling feature flags for example) or a snapshot version.",
-        default=snapshot_build,
+        "--source-build-release",
+        help="Build a release version of Elasticsearch from sources.",
+        default=False,
+        action="store_true",
     )
     install_parser.add_argument(
         "--installation-id",
@@ -800,11 +800,6 @@ def create_arg_parser():
         help="Method with which to build Elasticsearch and plugins from source",
         choices=["docker", "default"],
         default="default",
-    )
-    race_parser.add_argument(
-        "--source-build-snapshot",
-        help="Decides whether installing Elasticsearch as a release version (enabling feature flags for example) or a snapshot version.",
-        default=snapshot_build,
     )
 
     ###############################################################################
@@ -1173,7 +1168,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", opts.to_dict(args.plugin_params))
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.method", args.source_build_method)
-            cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.snapshot", args.source_build_snapshot)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.release", args.source_build_release)
             cfg.add(config.Scope.applicationOverride, "mechanic", "target.os", args.target_os)
             cfg.add(config.Scope.applicationOverride, "mechanic", "target.arch", args.target_arch)
             configure_mechanic_params(args, cfg)
@@ -1189,7 +1184,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "mechanic", "network.http.port", args.http_port)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.method", args.source_build_method)
-            cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.snapshot", args.source_build_snapshot)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.release", args.source_build_release)
             cfg.add(config.Scope.applicationOverride, "mechanic", "build.type", args.build_type)
             cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
             cfg.add(config.Scope.applicationOverride, "mechanic", "node.name", args.node_name)
@@ -1235,7 +1230,6 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.method", args.source_build_method)
-            cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.snapshot", args.source_build_snapshot)
             cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", opts.csv_to_list(args.elasticsearch_plugins))
             cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", opts.to_dict(args.plugin_params))
             cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -128,8 +128,10 @@ def create_arg_parser():
     if cfg.config_present():
         cfg.load_config()
         preserve_install = cfg.opts("defaults", "preserve_benchmark_candidate", default_value=False, mandatory=False)
+        snapshot_build = cfg.opts("defaults", "source.build.snapshot", default_value=True, mandatory=False)
     else:
         preserve_install = False
+        snapshot_build = True
 
     parser = argparse.ArgumentParser(
         prog=PROGRAM_NAME,
@@ -375,6 +377,11 @@ def create_arg_parser():
         choices=["docker", "default"],
         default="default",
     )
+    build_parser.add_argument(
+        "--source-build-snapshot",
+        help="Decides whether installing Elasticsearch as a release version (enabling feature flags for example) or a snapshot version.",
+        default=True,
+    )
 
     download_parser = subparsers.add_parser("download", help="Downloads an artifact")
     download_parser.add_argument(
@@ -523,6 +530,11 @@ def create_arg_parser():
         help="Method with which to build Elasticsearch and plugins from source",
         choices=["docker", "default"],
         default="default",
+    )
+    install_parser.add_argument(
+        "--source-build-snapshot",
+        help="Decides whether installing Elasticsearch as a release version (enabling feature flags for example) or a snapshot version.",
+        default=True,
     )
     install_parser.add_argument(
         "--installation-id",
@@ -789,6 +801,11 @@ def create_arg_parser():
         choices=["docker", "default"],
         default="default",
     )
+    race_parser.add_argument(
+        "--source-build-snapshot",
+        help="Decides whether installing Elasticsearch as a release version (enabling feature flags for example) or a snapshot version.",
+        default=snapshot_build,
+    )
 
     ###############################################################################
     #
@@ -815,7 +832,7 @@ def create_arg_parser():
     add_parser.add_argument(
         "configuration",
         metavar="configuration",
-        help="The configuration for which Rally should add records. " "Possible values are: annotation",
+        help="The configuration for which Rally should add records. Possible values are: annotation",
         choices=["annotation"],
     )
     add_parser.add_argument(
@@ -1156,6 +1173,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", opts.to_dict(args.plugin_params))
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.method", args.source_build_method)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.snapshot", args.source_build_snapshot)
             cfg.add(config.Scope.applicationOverride, "mechanic", "target.os", args.target_os)
             cfg.add(config.Scope.applicationOverride, "mechanic", "target.arch", args.target_arch)
             configure_mechanic_params(args, cfg)
@@ -1171,6 +1189,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "mechanic", "network.http.port", args.http_port)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.method", args.source_build_method)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.snapshot", args.source_build_snapshot)
             cfg.add(config.Scope.applicationOverride, "mechanic", "build.type", args.build_type)
             cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
             cfg.add(config.Scope.applicationOverride, "mechanic", "node.name", args.node_name)
@@ -1216,6 +1235,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.method", args.source_build_method)
+            cfg.add(config.Scope.applicationOverride, "mechanic", "source.build.snapshot", args.source_build_snapshot)
             cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", opts.csv_to_list(args.elasticsearch_plugins))
             cfg.add(config.Scope.applicationOverride, "mechanic", "plugin.params", opts.to_dict(args.plugin_params))
             cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -380,7 +380,7 @@ def create_arg_parser():
     build_parser.add_argument(
         "--source-build-snapshot",
         help="Decides whether installing Elasticsearch as a release version (enabling feature flags for example) or a snapshot version.",
-        default=True,
+        default=snapshot_build,
     )
 
     download_parser = subparsers.add_parser("download", help="Downloads an artifact")
@@ -534,7 +534,7 @@ def create_arg_parser():
     install_parser.add_argument(
         "--source-build-snapshot",
         help="Decides whether installing Elasticsearch as a release version (enabling feature flags for example) or a snapshot version.",
-        default=True,
+        default=snapshot_build,
     )
     install_parser.add_argument(
         "--installation-id",

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -153,6 +153,7 @@ Key = Literal[
     "skip.telemetry",
     "snapshot.cache",
     "source.build.method",
+    "source.build.snapshot",
     "source.revision",
     "src.root.dir",
     "storage.adapters",

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -153,7 +153,7 @@ Key = Literal[
     "skip.telemetry",
     "snapshot.cache",
     "source.build.method",
-    "source.build.snapshot",
+    "source.build.release",
     "source.revision",
     "src.root.dir",
     "storage.adapters",

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -692,21 +692,21 @@ class TestElasticsearchSourceSupplier:
 
         builder.build.assert_called_once_with(["./gradlew clean", "./gradlew assemble"])
 
-    def test_build_no_snapshot(self):
+    def test_build_release(self):
         car = team.Car(
             "default",
             root_path=None,
             config_paths=[],
-            variables={"clean_command": "./gradlew clean", "system.build_command.no-snapshot": "./gradlew assemble"},
+            variables={"clean_command": "./gradlew clean", "system.build_command.no-snapshot": "./gradlew -Dbuild.snapshot=false assemble"},
         )
-        builder = mock.create_autospec(supplier.Builder)
+        builder = mock.create_autospec(supplier.Builder, release_build=True)
         renderer = supplier.TemplateRenderer(version="abc", arch="x86_64")
         es = supplier.ElasticsearchSourceSupplier(
             revision="abc", es_src_dir="/src", remote_url="", car=car, builder=builder, template_renderer=renderer
         )
         es.prepare()
 
-        builder.build.assert_called_once_with(["./gradlew clean", "./gradlew assemble"])
+        builder.build.assert_called_once_with(["./gradlew clean", "./gradlew -Dbuild.snapshot=false assemble"])
 
     def test_build_arm(self):
         car = team.Car(
@@ -724,21 +724,21 @@ class TestElasticsearchSourceSupplier:
 
         builder.build.assert_called_once_with(["./gradlew clean", "./gradlew assemble"])
 
-    def test_build_arm_no_snapshot(self):
+    def test_build_arm_release(self):
         car = team.Car(
             "default",
             root_path=None,
             config_paths=[],
-            variables={"clean_command": "./gradlew clean", "system.build_command.arch.no-snapshot": "./gradlew assemble"},
+            variables={"clean_command": "./gradlew clean", "system.build_command.arch.no-snapshot": "./gradlew -Dbuild.snapshot=false assemble"},
         )
-        builder = mock.create_autospec(supplier.Builder)
+        builder = mock.create_autospec(supplier.Builder, release_build=True)
         renderer = supplier.TemplateRenderer(version="abc", arch="aarch64")
         es = supplier.ElasticsearchSourceSupplier(
             revision="abc", es_src_dir="/src", remote_url="", car=car, builder=builder, template_renderer=renderer
         )
         es.prepare()
 
-        builder.build.assert_called_once_with(["./gradlew clean", "./gradlew assemble"])
+        builder.build.assert_called_once_with(["./gradlew clean", "./gradlew -Dbuild.snapshot=false assemble"])
 
     def test_raises_error_on_missing_car_variable(self):
         car = team.Car(

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -692,12 +692,44 @@ class TestElasticsearchSourceSupplier:
 
         builder.build.assert_called_once_with(["./gradlew clean", "./gradlew assemble"])
 
+    def test_build_no_snapshot(self):
+        car = team.Car(
+            "default",
+            root_path=None,
+            config_paths=[],
+            variables={"clean_command": "./gradlew clean", "system.build_command.no-snapshot": "./gradlew assemble"},
+        )
+        builder = mock.create_autospec(supplier.Builder)
+        renderer = supplier.TemplateRenderer(version="abc", arch="x86_64")
+        es = supplier.ElasticsearchSourceSupplier(
+            revision="abc", es_src_dir="/src", remote_url="", car=car, builder=builder, template_renderer=renderer
+        )
+        es.prepare()
+
+        builder.build.assert_called_once_with(["./gradlew clean", "./gradlew assemble"])
+
     def test_build_arm(self):
         car = team.Car(
             "default",
             root_path=None,
             config_paths=[],
             variables={"clean_command": "./gradlew clean", "system.build_command.arch": "./gradlew assemble"},
+        )
+        builder = mock.create_autospec(supplier.Builder)
+        renderer = supplier.TemplateRenderer(version="abc", arch="aarch64")
+        es = supplier.ElasticsearchSourceSupplier(
+            revision="abc", es_src_dir="/src", remote_url="", car=car, builder=builder, template_renderer=renderer
+        )
+        es.prepare()
+
+        builder.build.assert_called_once_with(["./gradlew clean", "./gradlew assemble"])
+
+    def test_build_arm_no_snapshot(self):
+        car = team.Car(
+            "default",
+            root_path=None,
+            config_paths=[],
+            variables={"clean_command": "./gradlew clean", "system.build_command.arch.no-snapshot": "./gradlew assemble"},
         )
         builder = mock.create_autospec(supplier.Builder)
         renderer = supplier.TemplateRenderer(version="abc", arch="aarch64")

--- a/tests/mechanic/supplier_test.py
+++ b/tests/mechanic/supplier_test.py
@@ -729,7 +729,10 @@ class TestElasticsearchSourceSupplier:
             "default",
             root_path=None,
             config_paths=[],
-            variables={"clean_command": "./gradlew clean", "system.build_command.arch.no-snapshot": "./gradlew -Dbuild.snapshot=false assemble"},
+            variables={
+                "clean_command": "./gradlew clean",
+                "system.build_command.arch.no-snapshot": "./gradlew -Dbuild.snapshot=false assemble",
+            },
         )
         builder = mock.create_autospec(supplier.Builder, release_build=True)
         renderer = supplier.TemplateRenderer(version="abc", arch="aarch64")


### PR DESCRIPTION
Introducing --source-build-release argument along with source.build.release parameter which defaults to false.

This parameter is designed to build a release version of an Elasticsearch revision when user builds from sources.
Being built as a "release" version Elasticsearch will enable all the feature flags that would be imposed in a regular release build.