### PR TITLE
 Recover old silenced loggers instantiated before actor start is complete.

### DIFF
--- a/esrally/actor.py
+++ b/esrally/actor.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+import os
 import socket
 import traceback
 import typing
@@ -112,6 +113,7 @@ class RallyActor(thespian.actors.ActorTypeDispatcher):
         log.post_configure_actor_logging()
         self.logger = logging.getLogger(__name__)
         console.set_assume_tty(assume_tty=False)
+        LOG.info("Actor initialized: cls=%s, pid=%s", type(self).__name__, os.getpid())
 
     # The method name is required by the actor framework
     # noinspection PyPep8Naming

--- a/esrally/log.py
+++ b/esrally/log.py
@@ -14,18 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import importlib
 import json
 import logging
 import logging.config
 import os
 import time
 import typing
+from copy import deepcopy
 
 import ecs_logging
 
 from esrally import paths
 from esrally.utils import collections, io
+
+LOG = logging.getLogger(__name__)
 
 
 # pylint: disable=unused-argument
@@ -113,7 +116,7 @@ CONFIG_PATH = log_config_path()
 TEMPLATE_PATH = io.normalize_path(os.path.join(os.path.dirname(__file__), "resources", "logging.json"))
 
 
-def add_missing_loggers_to_config(
+def update_logger_config(
     *,
     config_path: str = CONFIG_PATH,
     template_path: str = TEMPLATE_PATH,
@@ -121,19 +124,26 @@ def add_missing_loggers_to_config(
     """It appends any missing top level loggers found in resources/logging.json to current log configuration."""
 
     with open(template_path, encoding="UTF-8") as fd:
-        missing_loggers: dict[str, typing.Any] = json.load(fd)["loggers"]
+        template: dict[str, typing.Any] = json.load(fd)
 
     with open(config_path, encoding="UTF-8") as fd:
-        config: dict[str, typing.Any] = json.load(fd)
+        original: dict[str, typing.Any] = json.load(fd)
 
-    config_loggers = config.setdefault("loggers", {})
-    for found_logger in config_loggers:
-        missing_loggers.pop(found_logger, None)
+    if original == template:
+        return
 
-    if missing_loggers:
-        config_loggers.update(missing_loggers)
+    updated = deepcopy(original)
+    updated.setdefault("disable_existing_loggers", template.get("disable_existing_loggers", False))
+
+    template_loggers = template.get("loggers", {})
+    config_loggers = updated.setdefault("loggers", template_loggers)
+    for name, logger in template_loggers.items():
+        config_loggers.setdefault(name, logger)
+
+    if original != updated:
+        LOG.info("Update logging configuration file with new values from template: '%s' -> '%s'", template_path, config_path)
         with open(config_path, "w", encoding="UTF-8") as fd:
-            json.dump(config, fd, indent=2)
+            json.dump(updated, fd, indent=2)
 
 
 def install_default_log_config():
@@ -152,7 +162,7 @@ def install_default_log_config():
             with open(source_path, encoding="UTF-8") as src:
                 contents = src.read()
                 target.write(contents)
-    add_missing_loggers_to_config()
+    update_logger_config()
     io.ensure_dir(paths.logs())
 
 
@@ -203,6 +213,32 @@ def post_configure_actor_logging():
         for lgr, cfg in load_configuration()["loggers"].items():
             if "level" in cfg:
                 logging.getLogger(lgr).setLevel(cfg["level"])
+
+    if LOG is not logging.getLogger(__name__):
+        updated: list[str] = []
+        # It just detected that all pre-existing loggers have been forgotten after changing manager.
+        # Here we try to replace them with those created from the new manager.
+        lost: set[str] = set()
+        for name, old_logger in LOG.manager.loggerDict.items():
+            if isinstance(old_logger, logging.PlaceHolder):
+                continue
+            lost.add(name)
+            try:
+                module = importlib.import_module(name)
+            except ImportError:
+                continue
+            for attribute_name in dir(module):
+                value = getattr(module, attribute_name, None)
+                if value is old_logger:
+                    setattr(module, attribute_name, logging.getLogger(name))
+                    lost.remove(name)
+                    updated.append(name)
+                    continue
+
+        if lost:
+            LOG.debug("Old per-module logger references lost: %s", lost)
+        if updated:
+            LOG.debug("Old per-module logger references updated: %s", updated)
 
 
 def configure_logging():

--- a/esrally/resources/logging.json
+++ b/esrally/resources/logging.json
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "disable_existing_loggers": false,
   "formatters": {
     "normal": {
       "format": "%(asctime)s,%(msecs)d %(actorAddress)s/PID:%(process)d %(name)s %(levelname)s %(message)s",

--- a/tests/log_test.py
+++ b/tests/log_test.py
@@ -50,8 +50,8 @@ def config_path(tmpdir, config: dict[str, Any]) -> str:
     return path
 
 
-def test_add_missing_loggers_to_config_missing(template: dict[str, Any], config: dict[str, Any], config_path: str) -> None:
-    log.add_missing_loggers_to_config(config_path=config_path)
+def test_update_logger_config(template: dict[str, Any], config: dict[str, Any], config_path: str) -> None:
+    log.update_logger_config(config_path=config_path)
 
     with open(config_path) as fd:
         got = json.load(fd)


### PR DESCRIPTION
It is convenient to use global references to loggers in python modules so they are available to the module functions without having to pass them as variables. This is a very common use case that is not working in rally because for some reason the logging system is squashed once the actors are being initialized, so those loggers get lost in a old logger manager not more used. When used they send messages to stderr instead of the logging forwarding mechanism implemented in thespian.

This patch implements a workaround to be executed during actors initialization to fix old logger references created by the old manager, with new ones created using the new logger manager. To perform it, it first check the issue checking if the module logger is not the one provided by the new manager. On such case it look at all modules referenced by the old manager and tries to replace their per-module references with new loggers provided by the new manager. The tricky part is to found the old references. The method used is looking for the modules by the name of lost loggers, and then look for the first reference to the logger interacting all the module attributes. The method is not optimal because it requires, after every actor iteration, to iterate tens of modules and for each tens of attributes to see if they refer to the logger.

A better solution has to be found, may be understanding what is going wrong during logging setup.