### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ install_pytest_rally_plugin: venv
 
 # Old legacy alias goals
 install: venv
+	uv sync --locked --extra=develop
 
 reinstall: clean-venv
 	$(MAKE) venv
@@ -158,14 +159,14 @@ format: lint
 
 # It build project documentation.
 docs: venv
-	$(VENV_ACTIVATE); $(MAKE) -C docs/ html
+	uv run $(MAKE) -C docs/ html
 
 serve-docs: venv
-	$(VENV_ACTIVATE); $(MAKE) -C docs/ serve
+	uv run $(MAKE) -C docs/ serve
 
 # It cleans project documentation.
 clean-docs: venv
-	$(VENV_ACTIVATE); $(MAKE) -C docs/ clean
+	uv run $(MAKE) -C docs/ clean
 
 
 # --- Unit tests goals ---
@@ -198,7 +199,7 @@ test-3.13:
 
 # It runs integration tests.
 it: venv
-	$(MAKE) test ARGS=it/
+	$(MAKE) test ARGS=$(or $(ARGS),it/)
 
 # It runs serverless integration tests.
 it_serverless: install_pytest_rally_plugin

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -113,8 +113,7 @@ def shell_cmd(command_line):
 
 def command_in_docker(command_line, python_version):
     docker_command = f"docker run --rm -v {ROOT_DIR}:/rally_ro:ro python:{python_version} bash -c '{command_line}'"
-
-    return shell_cmd(docker_command)
+    return subprocess.run(docker_command, shell=True, check=True).returncode
 
 
 def wait_until_port_is_free(port_number=39200, timeout=120):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,8 @@ develop = [
     "types-urllib3==1.26.19",
     "types-requests<2.32.0",
     "types-jsonschema==3.2.0",
+    # Python dead library removed in version 3.13 and used to build Rally docs.
+    "standard-imghdr==3.13.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -635,6 +635,7 @@ develop = [
     { name = "pytest-benchmark" },
     { name = "pytest-httpserver" },
     { name = "sphinx" },
+    { name = "standard-imghdr" },
     { name = "trustme" },
     { name = "types-jsonschema" },
     { name = "types-psutil" },
@@ -688,6 +689,7 @@ requires-dist = [
     { name = "python-json-logger", specifier = "==2.0.7" },
     { name = "requests", specifier = "<2.32.0" },
     { name = "sphinx", marker = "extra == 'develop'", specifier = "==5.1.1" },
+    { name = "standard-imghdr", marker = "extra == 'develop'", specifier = "==3.13.0" },
     { name = "tabulate", specifier = "==0.8.9" },
     { name = "thespian", specifier = "==4.0.1" },
     { name = "trustme", marker = "extra == 'develop'", specifier = "==0.9.0" },
@@ -2134,6 +2136,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "standard-imghdr"
+version = "3.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/8d/ab2620fbe2e348483c9cb776c3b7b3cc407899291a041d7fa026469b7cd1/standard_imghdr-3.13.0.tar.gz", hash = "sha256:8d9c68058d882f6fc3542a8d39ef9ff94d2187dc90bd0c851e0902776b7b7a42", size = 5511, upload-time = "2024-10-30T16:01:36.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/cb/e1da7e340586a078404c7e4328bfefc930867ace8a9a55916fd220cf9547/standard_imghdr-3.13.0-py3-none-any.whl", hash = "sha256:30a1bff5465605bb496f842a6ac3cc1f2131bf3025b0da28d4877d6d4b7cc8e9", size = 4639, upload-time = "2024-10-30T16:01:13.829Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
It fixes `Makefile`:

- It restores the old `make install` behavior.
- It allows passing arguments to `make it`
- It uses `uv run` to run `make` against the docs sub-folder.
- It fixes `make docs` dependency issue with Python v3.13
