### PR TITLE
Add run-until runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ check-all: all
 	lint \
 	format \
 	pre-commit \
+	precommit \
 	install-pre-commit \
 	docs \
 	serve-docs \
@@ -139,7 +140,7 @@ lint: venv
 	uv run -- pre-commit run --all-files
 
 # It run all linters on changed files using pre-commit.
-pre-commit: venv
+precommit pre-commit: venv
 	uv run -- pre-commit run
 
 # It install a pre-commit hook in the project .git dir so modified files are checked before creating every commit.

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -741,6 +741,8 @@ class OperationType(Enum):
     TransformStats = (55, AdminStatus.Yes, serverless.Status.Public)
     CreateIlmPolicy = (56, AdminStatus.Yes, serverless.Status.Blocked)
     DeleteIlmPolicy = (57, AdminStatus.Yes, serverless.Status.Blocked)
+    # this is classed the same as RawRequest, but could potentially be used to call endpoints that are blocked
+    RunUntil = (58, AdminStatus.No, serverless.Status.Public)
 
     def __init__(self, id: int, admin_status: AdminStatus, serverless_status: serverless.Status):
         self.id = id

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -876,6 +876,8 @@ class OperationType(Enum):
             return OperationType.Downsample
         elif v == "esql":
             return OperationType.Esql
+        elif v == "run-until":
+            return OperationType.RunUntil
         else:
             raise KeyError(f"No enum value for [{v}]")
 


### PR DESCRIPTION
This runner allows a user to make an API call and evaluate part of the JSON response. The aim is to include in e.g a parallel block - where you could loop a corpus and ingest until ingested size reaches X bytes, or Y documents

There needs to be some documentation added and tests, but a review on the initial approach would be appreciated