### PR TITLE
Fix: Respect --offline flag for all track operations

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -382,7 +382,7 @@ class GitTrackRepository:
         tracks_dir = os.path.join(root, track_repositories)
 
         self.repo = repo_class(remote_url, tracks_dir, repo_name, "tracks", offline, fetch)
-        if update:
+        if update and not offline:
             if repo_revision:
                 # skip checkout if already on correct version.  this is helpful in case of multiple actors loading simultaneously.
                 if not self.repo.correct_revision(repo_revision):


### PR DESCRIPTION
When using the --offline flag with any Rally command that loads tracks (list, race, info, etc.), Rally was still attempting to update track repositories from git, causing failures.

This fix adds a check for offline mode before attempting repository updates in GitTrackRepository.__init__().

Affected operations:
- list tracks - listing available tracks
- race - running benchmarks
- info - showing track information
- Driver operations - track loading during execution

<!--
Thank you for your interest in and contributing to Rally! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

This should fix #1993 

