### PR TITLE
Initalize all loggers in rally daemon

### DIFF
--- a/esrally/rallyd.py
+++ b/esrally/rallyd.py
@@ -21,6 +21,9 @@ import os
 import sys
 import time
 
+# the following import is needed for log.post_configure_actor_logging() to recover
+# all loggers from the old log manager
+from esrally import racecontrol  # pylint: disable=unused-import
 from esrally import (
     BANNER,
     PROGRAM_NAME,


### PR DESCRIPTION
Follow-up to https://github.com/elastic/rally/pull/1988.

The log recovery mechanism can only work when loggers are defined. When using rally daemon, actor processes are spawned from the daemon which has not enough imports to cover all the loggers. This fixes this problem.
