### PR TITLE
Speedup default s3 corpus downloader

### DIFF
--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -111,7 +111,7 @@ def _download_from_s3_bucket(bucket_name, bucket_path, local_path, expected_size
     if expected_size_in_bytes is None:
         expected_size_in_bytes = bucket.Object(bucket_path).content_length
     progress_callback = S3ProgressAdapter(expected_size_in_bytes, progress_indicator) if progress_indicator else None
-    bucket.download_file(bucket_path, local_path, Callback=progress_callback, Config=boto3.s3.transfer.TransferConfig(use_threads=False))
+    bucket.download_file(bucket_path, local_path, Callback=progress_callback, Config=boto3.s3.transfer.TransferConfig(use_threads=True))
 
 
 def _build_gcs_object_url(bucket_name, bucket_path):


### PR DESCRIPTION
Until the [CLI for Rally Storage Manager](https://github.com/elastic/rally/pull/1991) is more widely used, this PR improves the default S3 downloader by using multithreads for S3 corpus downloads. Using the default max_concurrency of S3ProgressAdapter (10).

