### PR TITLE
Sort files to make deterministic

### DIFF
--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -772,7 +772,7 @@ class TemplateSource:
 
     def read_glob_files(self, pattern):
         source = []
-        files = self.fileglobber(pattern)
+        files = sorted(self.fileglobber(pattern))
         for fname in files:
             with self.source(fname, mode="rt", encoding="utf-8") as fp:
                 source.append(fp.read())


### PR DESCRIPTION
When using glob.glob (which is what is used when we use rally.collect) it seems the list of files is not always in the same order -this probably isnt an issue in most cases, but for an issue I am currently investigating I would like to remove this element of uncertainty. 
Using sorted will give us the order alphabetically, which seems a sensible order