### PR TITLE
Add sampling method parameter to downsampling

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3077,11 +3077,12 @@ Properties
 * ``fixed_interval`` (optional, defaults to ``1h``): The aggregation interval key defined as in `https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals`.
 * ``source-index`` (optional): The index containing data to aggregate which includes a ``@timestamp`` field. Note that this index should be marked read-only prior to the execution of this operation. If there is only one index defined in the ``indices`` of the track definition, that will be used as the default.
 * ``target-index`` (optional, defaults to ``{source-index}-{fixed-interval}``): Tne new target index created by the downsampling operation and including aggregated data.
+* ``sampling-method`` (optional): The downsampling method used to aggregate metric data. It accepts values `aggregate` or `last_value`, when the value is missing downsampling defaults to `aggregate`.
 
 **Example**
 
 Executes a downsampling operation aggregating data in the source index (test-source-index) and creating a new target index (test-target-index) applying an aggregation
-interval of 1 minute on the @timestamp field::
+interval of 1 minute on the @timestamp field, keeping the last value of the metric fields::
 
     {
       "name": "downsample",
@@ -3089,7 +3090,8 @@ interval of 1 minute on the @timestamp field::
         "operation-type": "downsample",
         "fixed-interval": "1m",
         "source-index": "test-source-index",
-        "target-index": "tsdb-target-index"
+        "target-index": "tsdb-target-index",
+        "sampling-method": "last_value"
       }
     }
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3077,7 +3077,7 @@ Properties
 * ``fixed_interval`` (optional, defaults to ``1h``): The aggregation interval key defined as in `https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#fixed_intervals`.
 * ``source-index`` (optional): The index containing data to aggregate which includes a ``@timestamp`` field. Note that this index should be marked read-only prior to the execution of this operation. If there is only one index defined in the ``indices`` of the track definition, that will be used as the default.
 * ``target-index`` (optional, defaults to ``{source-index}-{fixed-interval}``): Tne new target index created by the downsampling operation and including aggregated data.
-* ``sampling-method`` (optional): The downsampling method used to aggregate metric data. It accepts values `aggregate` or `last_value`, when the value is missing downsampling defaults to `aggregate`.
+* ``sampling-method`` (optional): The downsampling method used to aggregate metric data. It accepts values ``aggregate`` or ``last_value``, when the value is missing downsampling defaults to ``aggregate``.
 
 **Example**
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -2857,12 +2857,14 @@ class Downsample(Runner):
                 "Parameter source for operation 'downsample' did not provide the mandatory parameter 'target-index'. "
                 "Add it to your parameter source and try again."
             )
+        sampling_method = params.get("sampling-method")
 
         path = f"/{source_index}/_downsample/{target_index}"
 
-        await es.perform_request(
-            method="POST", path=path, body={"fixed_interval": fixed_interval}, params=request_params, headers=request_headers
-        )
+        request_body = {"fixed_interval": fixed_interval}
+        if sampling_method:
+            request_body["sampling_method"] = sampling_method
+        await es.perform_request(method="POST", path=path, body=request_body, params=request_params, headers=request_headers)
 
         return {"weight": 1, "unit": "ops", "success": True}
 


### PR DESCRIPTION
As part of https://github.com/elastic/elasticsearch/issues/128357 we introduce a new downsampling method that can be configured via the request body. In order to performance test this method we want to expose this parameter in rally,