### PR TITLE
Fixes best_match versions algorithm in case of no major version

### DIFF
--- a/esrally/utils/versions.py
+++ b/esrally/utils/versions.py
@@ -177,9 +177,9 @@ def best_match(available_alternatives, distribution_version):
             if version in available_alternatives:
                 return version
             # match nearest prior minor
-            if version_type == "with_minor" and (latest_minor := latest_bounded_minor(available_alternatives, versions)):
-                if latest_minor:
-                    return f"{versions.major}.{latest_minor}"
+            latest_minor = latest_bounded_minor(available_alternatives, versions)
+            if version_type == "with_minor" and latest_minor is not None:
+                return f"{versions.major}.{latest_minor}"
         # not found in the available alternatives, it could still be a master version
         major, _, _, _ = components(distribution_version)
         if major > _latest_major(available_alternatives):
@@ -217,7 +217,7 @@ def latest_bounded_minor(alternatives, target_version):
             if patch is not None or suffix is not None:
                 # branches containing patch or patch-suffix aren't supported
                 continue
-            if major == target_version.major and minor and minor <= target_version.minor:
+            if major == target_version.major and minor is not None and minor <= target_version.minor:
                 eligible_minors.append(minor)
 
     # no matching minor version
@@ -225,5 +225,5 @@ def latest_bounded_minor(alternatives, target_version):
         return None
 
     eligible_minors.sort()
-
-    return min(eligible_minors, key=lambda x: abs(x - target_version.minor))
+    result = min(eligible_minors, key=lambda x: abs(x - target_version.minor))
+    return result

--- a/esrally/utils/versions.py
+++ b/esrally/utils/versions.py
@@ -225,5 +225,4 @@ def latest_bounded_minor(alternatives, target_version):
         return None
 
     eligible_minors.sort()
-    result = min(eligible_minors, key=lambda x: abs(x - target_version.minor))
-    return result
+    return min(eligible_minors, key=lambda x: abs(x - target_version.minor))

--- a/esrally/utils/versions.py
+++ b/esrally/utils/versions.py
@@ -177,8 +177,7 @@ def best_match(available_alternatives, distribution_version):
             if version in available_alternatives:
                 return version
             # match nearest prior minor
-            latest_minor = latest_bounded_minor(available_alternatives, versions)
-            if version_type == "with_minor" and latest_minor is not None:
+            if version_type == "with_minor" and (latest_minor := latest_bounded_minor(available_alternatives, versions)) is not None:
                 return f"{versions.major}.{latest_minor}"
         # not found in the available alternatives, it could still be a master version
         major, _, _, _ = components(distribution_version)

--- a/tests/utils/versions_test.py
+++ b/tests/utils/versions_test.py
@@ -148,6 +148,14 @@ class TestsVersions:
             versions.best_match(["7", "7.11", "7.2", "5", "6", "master"], "7.1.0") == "7"
         ), "If no exact match and no minor match, next best match is major version"
 
+        assert (
+            versions.best_match(["8.15", "9.2", "master"], "9.3.5") == "9.2"
+        ), "If no exact match best match is the nearest prior minor, even if major does not exist"
+
+        assert (
+            versions.best_match(["8.15", "9.0", "master"], "9.1.0") == "9.0"
+        ), "If no exact match and x.0 minor is nearest prior minor, next best match selects it, even if major does not exist"
+
     def test_version_comparison(self):
         assert versions.Version.from_string("7.10.2") < versions.Version.from_string("7.11.0")
         assert versions.Version.from_string("7.10.2") == versions.Version.from_string("7.10.2")


### PR DESCRIPTION
- Fixed a best_match case where X.0 was not selected if X major is absent in the alternatives
