### PR TITLE
Fix optional version branch regex

### DIFF
--- a/esrally/utils/versions.py
+++ b/esrally/utils/versions.py
@@ -22,7 +22,7 @@ from esrally import exceptions
 
 VERSIONS = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$")
 
-VERSIONS_OPTIONAL = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-(.+))?$")
+VERSIONS_OPTIONAL = re.compile(r"^(\d+)(?:\.(\d+)?(?:\.(\d+)?(?:-(.+))?)?)?$")
 
 
 def _versions_pattern(strict):

--- a/tests/utils/versions_test.py
+++ b/tests/utils/versions_test.py
@@ -44,6 +44,8 @@ class TestsVersions:
         assert versions.is_version_identifier("5", strict=False)
         assert versions.is_version_identifier("23", strict=False)
         assert versions.is_version_identifier("20.3.7-SNAPSHOT", strict=False)
+        assert versions.is_version_identifier("9.2-test", strict=False) is False
+        assert versions.is_version_identifier("9-test", strict=False) is False
 
     def test_is_serverless(self):
         assert versions.is_serverless("serverless")


### PR DESCRIPTION
Closes https://github.com/elastic/rally/issues/1982.

The intention was to match the following:
```
6
6.6
6.6.6
6.6.6-whatever
```

But not the following:
```
6-whatever
6.6-whatever
```

This change nests regex groups 2-4 to achieve a better match vs intentions.