### PR TITLE
It always shows mirror failures when there is any.

### DIFF
--- a/esrally/storage/_cli.py
+++ b/esrally/storage/_cli.py
@@ -61,13 +61,13 @@ def main():
             "--local-dir", type=str, default=cfg.local_dir, help="It specifies local destination directory for downloading files."
         )
         p.add_argument("--base-url", type=str, default=None, help="It specifies the base URL for remote storage.")
-        p.add_argument("--mirror-failures", action="store_true", help="It considers only those files which have recorded mirror failures.")
 
     # It defines ls sub-command output options.
     for p in (parser, ls_parser):
         p.add_argument("--filebeat", action="store_true", help="It prints a JSON entry for each file, each separated by a newline.")
         p.add_argument("--json", action="store_true", help="It prints a pretty entry for each file.")
-        p.add_argument("--stats", action="store_true", help="It adds connectivity statistics to produced output.")
+        p.add_argument("--stats", action="store_true", help="It shows connectivity statistics in produced output.")
+        p.add_argument("--mirror-failures", action="store_true", help="It shows mirror failures in produced output.")
         p.add_argument("--filenames", action="store_true", help="It shows downloaded file names.")
         p.add_argument("--status-filenames", action="store_true", help="It shows status file names.")
 
@@ -131,12 +131,6 @@ def main():
         transfers = [tr for tr in transfers if tr.url.startswith(args.base_url.rstrip("/"))]
         if not transfers:
             LOG.info("No transfers with base URL: %s.", args.base_url)
-            return
-
-    if args.mirror_failures:
-        transfers = [tr for tr in transfers if tr.mirror_failures]
-        if not transfers:
-            LOG.info("No transfers with mirror failures.")
             return
 
     file_types: set[storage.TransferFileType] | None = None

--- a/esrally/storage/_transfer.py
+++ b/esrally/storage/_transfer.py
@@ -701,7 +701,7 @@ class Transfer:
             return 0.0
         return (done.size - self._resumed_size) / self.duration.s()
 
-    def pretty(self, *, stats: bool = False, mirror_failures: bool = False) -> dict[str, Any]:
+    def pretty(self, *, stats: bool = False) -> dict[str, Any]:
         details: dict[str, Any] = {
             "url": self.url,
             "path": self.path,
@@ -712,14 +712,14 @@ class Transfer:
             "duration": self.duration and pretty.duration(self.duration),
             "throughput": self.average_speed and pretty.throughput(self.average_speed),
         }
-        if mirror_failures:
+        if self.mirror_failures:
             details["mirror_failures"] = [dataclasses.asdict(f) for f in self.mirror_failures]
         if stats:
             details["stats"] = [s.pretty() for s in self.stats]
         return {k: v for k, v in details.items() if v}
 
-    def info(self, *, stats: bool = False, mirror_failures: bool = False) -> str:
-        return json.dumps(self.pretty(stats=stats, mirror_failures=mirror_failures), indent=2)
+    def info(self, *, stats: bool = False) -> str:
+        return json.dumps(self.pretty(stats=stats), indent=2)
 
     def wait(self, timeout: float | None = None) -> None:
         """It waits for transfer termination."""


### PR DESCRIPTION
In order to store connectivity statistics we would like to create a file to be consumed by `filebeat` with all the informations required for investigating corpora download issue and monitor its reliability and speed. With this purpose the `esrally-storage ls` sub-command now always shows mirror failures, without requiring `--mirror-failures` flag which is intended to ignore those transfers that have any mirror failure (for example in order to populate a mirror bucket using `esrally-storage put` sub-command). 