### PR TITLE
Parse sampling value in DownsampleParamSource

### DIFF
--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -866,9 +866,12 @@ class DownsampleParamSource(ParamSource):
         params["index"] = params.get("source-index")
         self._source_index = get_target(track, params)
         self._target_index = params.get("target-index", f"{self._source_index}-{self._fixed_interval}")
+        self._sampling_method = params.get("sampling-method", None)
 
     def params(self):
         parsed_params = {"fixed-interval": self._fixed_interval, "source-index": self._source_index, "target-index": self._target_index}
+        if self._sampling_method:
+            parsed_params["sampling-method"] = self._sampling_method
         parsed_params.update(self._client_params())
         return parsed_params
 

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -866,7 +866,7 @@ class DownsampleParamSource(ParamSource):
         params["index"] = params.get("source-index")
         self._source_index = get_target(track, params)
         self._target_index = params.get("target-index", f"{self._source_index}-{self._fixed_interval}")
-        self._sampling_method = params.get("sampling-method", None)
+        self._sampling_method = params.get("sampling-method")
 
     def params(self):
         parsed_params = {"fixed-interval": self._fixed_interval, "source-index": self._source_index, "target-index": self._target_index}

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2958,6 +2958,7 @@ class TestDownsampleParamSource:
                 "source-index": "test-source-index",
                 "target-index": "test-target-index",
                 "fixed-interval": "1m",
+                "sampling-method": "last_value"
             },
         )
 
@@ -3010,3 +3011,4 @@ class TestDownsampleParamSource:
         p = source.params()
         assert p["fixed-interval"] == "1h"
         assert p["target-index"] == f"{p['source-index']}-{p['fixed-interval']}"
+        assert p.get("sampling-method") is None

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2966,6 +2966,7 @@ class TestDownsampleParamSource:
         assert p["fixed-interval"] == "1m"
         assert p["source-index"] == "test-source-index"
         assert p["target-index"] == "test-target-index"
+        assert p["sampling-method"] == "last_value"
 
     def test_downsample_default_index_param(self):
         source = params.DownsampleParamSource(
@@ -2983,6 +2984,7 @@ class TestDownsampleParamSource:
         assert p["fixed-interval"] == "1m"
         assert p["source-index"] == "test-source-index"
         assert p["target-index"] == "test-target-index"
+        assert p.get("sampling-method") is None
 
     def test_downsample_source_index_override_default_index_param(self):
         source = params.DownsampleParamSource(
@@ -3001,6 +3003,7 @@ class TestDownsampleParamSource:
         assert p["fixed-interval"] == "1m"
         assert p["source-index"] == "another-index"
         assert p["target-index"] == "test-target-index"
+        assert p.get("sampling-method") is None
 
     def test_downsample_empty_params(self):
         source = params.DownsampleParamSource(

--- a/tests/track/params_test.py
+++ b/tests/track/params_test.py
@@ -2958,7 +2958,7 @@ class TestDownsampleParamSource:
                 "source-index": "test-source-index",
                 "target-index": "test-target-index",
                 "fixed-interval": "1m",
-                "sampling-method": "last_value"
+                "sampling-method": "last_value",
             },
         )
 


### PR DESCRIPTION
In #2004 we introduced a new parameter to the downsampling operation but we did not parse it correctly in `DownsampleParamSource`