### PR TITLE
Set the pbzip2 -m flag to the highest supported limit of 2000MB

### DIFF
--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -337,7 +337,7 @@ def decompress(zip_name: str, target_directory: str) -> None:
     if extension == ".zip":
         _do_zip_decompress(target_directory, zipfile.ZipFile(zip_name))
     elif extension == ".bz2":
-        decompressor_args = ["pbzip2", "-d", "-k", "-m10000", "-c"]
+        decompressor_args = ["pbzip2", "-d", "-k", "-m2000", "-c"]
         decompressor_lib_bz2 = bz2.open
         _do_decompress_manually(target_directory, zip_name, decompressor_args, decompressor_lib_bz2)
     elif extension == ".zst":


### PR DESCRIPTION
Set the maximum memory flag (`-m`) to a supported value supported by pbzip2. Fixes a warning when decompressing `bz2` corpus files:

```
2026-01-26 20:00:17,22 ActorAddr-(T|:56141)/PID:34824 esrally.utils.io WARNING Failed to decompress [/Users/jbryan/.rally/benchmarks/data/github_archive0/documents-20211001-1k.json.bz2] with [['pbzip2', '-d', '-k', '-m10000', '-c', '/Users/jbryan/.rally/benchmarks/data/github_archive0/documents-20211001-1k.json.bz2']]. Error [b'pbzip2: *ERROR: Memory usage size Min: 1MB and Max: 2000MB!  Aborting...\n']. Falling back to standard library.
```

The upper limit according to `pbzip2.cpp` [source](https://compression.great-site.net/pbzip2/?i=1) is 2000MB.

```
3569                                         if ((maxMemory < 1000000) || (maxMemory > 2000000000))
3570                                         {
3571                                                 fprintf(stderr,"pbzip2: *ERROR: Memory usage size Min: 1MB and Max: 2000MB!  Aborting...\n");
3572                                                 return 1;
3573                                         } 
```