### PR TITLE
Remove -m flag from pbzip2 decompression (fixes #2030)

### DIFF
--- a/esrally/utils/io.py
+++ b/esrally/utils/io.py
@@ -337,7 +337,7 @@ def decompress(zip_name: str, target_directory: str) -> None:
     if extension == ".zip":
         _do_zip_decompress(target_directory, zipfile.ZipFile(zip_name))
     elif extension == ".bz2":
-        decompressor_args = ["pbzip2", "-d", "-k", "-m2000", "-c"]
+        decompressor_args = ["pbzip2", "-d", "-k", "-c"]
         decompressor_lib_bz2 = bz2.open
         _do_decompress_manually(target_directory, zip_name, decompressor_args, decompressor_lib_bz2)
     elif extension == ".zst":

--- a/tests/utils/io_test.py
+++ b/tests/utils/io_test.py
@@ -110,7 +110,7 @@ class TestDecompression:
         archive_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "resources", "test.txt.bz2")
         tmp_dir = tempfile.mkdtemp()
         decompressor_bin = "pbzip2"
-        decompress_cmd = f"{decompressor_bin} -d -k -m10000 -c ${archive_path}"
+        decompress_cmd = f"{decompressor_bin} -d -k -c {archive_path}"
         stderr_msg = "Error details here"
         expected_err = "Failed to decompress [%s] with [%s]. Error [%s]. Falling back to standard library."
         mocked_run.side_effect = subprocess.CalledProcessError(cmd=decompress_cmd, returncode=1, stderr=stderr_msg)


### PR DESCRIPTION
`pbzip2` on some systems (e.g. macOS/Homebrew) has a hard-coded memory limit of 2000MB. Passing -m with a larger value caused decompression to fail and Rally to loop instead of falling back to the standard library. Dropping the `-m` flag lets `pbzip2` use its default memory limit.

Fixes #2030 
