### PR TITLE
Disk usage stats timeout

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -301,6 +301,7 @@ The disk-usage-stats telemetry device runs the `_disk_usage <https://www.elastic
 Supported telemetry parameters:
 
 * ``disk-usage-stats-indices`` (default all indices in the track): Comma separated string or a list of indices who's disk usage to fetch.
+* ``disk-usage-stats-timeout`` (default 600s): A time value specifying the timeout for the disk usage API call.
 
 Example::
 

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -2354,7 +2354,6 @@ class DiskUsageStats(TelemetryDevice):
 
     def on_benchmark_stop(self):
         # pylint: disable=import-outside-toplevel
-        import elastic_transport
         import elasticsearch
 
         found = False
@@ -2370,7 +2369,7 @@ class DiskUsageStats(TelemetryDevice):
                 msg = f"Requested disk usage for missing index {index}"
                 self.logger.warning(msg)
                 continue
-            except elastic_transport.ConnectionTimeout:
+            except elasticsearch.ConnectionTimeout:
                 msg = f"Timeout occurred while collecting disk usage for {index}"
                 self.logger.warning(msg)
                 continue

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -4854,12 +4854,12 @@ class TestDiskUsageStats:
     def test_uses_indices_by_default(self, es):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
+        es.options.return_value.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         device = telemetry.DiskUsageStats({}, es, metrics_store, index_names=["foo", "bar"], data_stream_names=[])
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
         t.on_benchmark_stop()
-        es.indices.disk_usage.assert_has_calls(
+        es.options.return_value.indices.disk_usage.assert_has_calls(
             [
                 call(index="foo", run_expensive_tasks=True),
                 call(index="bar", run_expensive_tasks=True),
@@ -4869,13 +4869,13 @@ class TestDiskUsageStats:
     @mock.patch("elasticsearch.Elasticsearch")
     def test_uses_data_streams_by_default(self, es):
         cfg = create_config()
+        es.options.return_value.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         device = telemetry.DiskUsageStats({}, es, metrics_store, index_names=[], data_stream_names=["foo", "bar"])
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
         t.on_benchmark_stop()
-        es.indices.disk_usage.assert_has_calls(
+        es.options.return_value.indices.disk_usage.assert_has_calls(
             [
                 call(index="foo", run_expensive_tasks=True),
                 call(index="bar", run_expensive_tasks=True),
@@ -4885,15 +4885,15 @@ class TestDiskUsageStats:
     @mock.patch("elasticsearch.Elasticsearch")
     def test_uses_indices_param_if_specified_instead_of_index_names(self, es):
         cfg = create_config()
+        es.options.return_value.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         device = telemetry.DiskUsageStats(
             {"disk-usage-stats-indices": "foo,bar"}, es, metrics_store, index_names=["baz"], data_stream_names=[]
         )
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
         t.on_benchmark_stop()
-        es.indices.disk_usage.assert_has_calls(
+        es.options.return_value.indices.disk_usage.assert_has_calls(
             [
                 call(index="foo", run_expensive_tasks=True),
                 call(index="bar", run_expensive_tasks=True),
@@ -4903,15 +4903,15 @@ class TestDiskUsageStats:
     @mock.patch("elasticsearch.Elasticsearch")
     def test_uses_indices_param_as_csv_if_specified_instead_of_data_stream_names(self, es):
         cfg = create_config()
+        es.options.return_value.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         device = telemetry.DiskUsageStats(
             {"disk-usage-stats-indices": "foo,bar"}, es, metrics_store, index_names=[], data_stream_names=["baz"]
         )
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
         t.on_benchmark_stop()
-        es.indices.disk_usage.assert_has_calls(
+        es.options.return_value.indices.disk_usage.assert_has_calls(
             [
                 call(index="foo", run_expensive_tasks=True),
                 call(index="bar", run_expensive_tasks=True),
@@ -4921,15 +4921,15 @@ class TestDiskUsageStats:
     @mock.patch("elasticsearch.Elasticsearch")
     def test_uses_indices_param_as_list_if_specified_instead_of_data_stream_names(self, es):
         cfg = create_config()
+        es.options.return_value.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         device = telemetry.DiskUsageStats(
             {"disk-usage-stats-indices": ["foo", "bar"]}, es, metrics_store, index_names=[], data_stream_names=["baz"]
         )
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
         t.on_benchmark_stop()
-        es.indices.disk_usage.assert_has_calls(
+        es.options.return_value.indices.disk_usage.assert_has_calls(
             [
                 call(index="foo", run_expensive_tasks=True),
                 call(index="bar", run_expensive_tasks=True),
@@ -4940,8 +4940,7 @@ class TestDiskUsageStats:
     @mock.patch("elasticsearch.Elasticsearch")
     def test_error_on_retrieval_does_not_store_metrics(self, es, metrics_store_cluster_level, caplog):
         cfg = create_config()
-        metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.side_effect = elasticsearch.RequestError(
+        es.options.return_value.indices.disk_usage.side_effect = elasticsearch.RequestError(
             message="error",
             meta=elastic_transport.ApiResponseMeta(
                 status=400,
@@ -4952,6 +4951,7 @@ class TestDiskUsageStats:
             ),
             body=None,
         )
+        metrics_store = metrics.EsMetricsStore(cfg)
         device = telemetry.DiskUsageStats({}, es, metrics_store, index_names=["foo"], data_stream_names=[])
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
@@ -4964,8 +4964,8 @@ class TestDiskUsageStats:
     @mock.patch("elasticsearch.Elasticsearch")
     def test_no_indices_fails(self, es, metrics_store_cluster_level, caplog):
         cfg = create_config()
+        es.options.return_value.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         device = telemetry.DiskUsageStats({}, es, metrics_store, index_names=[], data_stream_names=[])
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         with pytest.raises(exceptions.RallyError):
@@ -4981,8 +4981,7 @@ class TestDiskUsageStats:
     @mock.patch("elasticsearch.Elasticsearch")
     def test_missing_all_fails(self, es, metrics_store_cluster_level, caplog):
         cfg = create_config()
-        metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.side_effect = elasticsearch.NotFoundError(
+        es.options.return_value.indices.disk_usage.side_effect = elasticsearch.NotFoundError(
             message="error",
             meta=elastic_transport.ApiResponseMeta(
                 status=404,
@@ -4993,6 +4992,7 @@ class TestDiskUsageStats:
             ),
             body=None,
         )
+        metrics_store = metrics.EsMetricsStore(cfg)
         device = telemetry.DiskUsageStats({}, es, metrics_store, index_names=["foo", "bar"], data_stream_names=[])
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
@@ -5032,7 +5032,7 @@ class TestDiskUsageStats:
                 }
             },
         }
-        es.indices.disk_usage.side_effect = [not_found_response, successful_response]
+        es.options.return_value.indices.disk_usage.side_effect = [not_found_response, successful_response]
         device = telemetry.DiskUsageStats({}, es, metrics_store, index_names=["foo", "bar"], data_stream_names=[])
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
@@ -5045,7 +5045,7 @@ class TestDiskUsageStats:
     def test_successful_shards(self, es, metrics_store_cluster_level):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {
+        es.options.return_value.indices.disk_usage.return_value = {
             "_shards": {"total": 1, "successful": 1, "failed": 0},
         }
         device = telemetry.DiskUsageStats({}, es, metrics_store, index_names=["foo"], data_stream_names=[])
@@ -5059,7 +5059,7 @@ class TestDiskUsageStats:
     def test_unsuccessful_shards(self, es, metrics_store_cluster_level):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {
+        es.options.return_value.indices.disk_usage.return_value = {
             "_shards": {"total": 1, "successful": 0, "failed": 1, "failures": "hello there!"},
         }
         device = telemetry.DiskUsageStats({}, es, metrics_store, index_names=["foo"], data_stream_names=[])
@@ -5074,7 +5074,7 @@ class TestDiskUsageStats:
     def test_source(self, es, metrics_store_cluster_level):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {
+        es.options.return_value.indices.disk_usage.return_value = {
             "_shards": {"failed": 0},
             "foo": {
                 "fields": {
@@ -5099,7 +5099,7 @@ class TestDiskUsageStats:
     def test_id(self, es, metrics_store_cluster_level):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {
+        es.options.return_value.indices.disk_usage.return_value = {
             "_shards": {"failed": 0},
             "foo": {
                 "fields": {
@@ -5131,7 +5131,7 @@ class TestDiskUsageStats:
         """
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {
+        es.options.return_value.indices.disk_usage.return_value = {
             "_shards": {"failed": 0},
             "foo": {
                 "fields": {
@@ -5158,7 +5158,7 @@ class TestDiskUsageStats:
     def test_number(self, es, metrics_store_cluster_level):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {
+        es.options.return_value.indices.disk_usage.return_value = {
             "_shards": {"failed": 0},
             "foo": {
                 "fields": {
@@ -5185,7 +5185,7 @@ class TestDiskUsageStats:
     def test_keyword(self, es, metrics_store_cluster_level):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {
+        es.options.return_value.indices.disk_usage.return_value = {
             "_shards": {"failed": 0},
             "foo": {
                 "fields": {
@@ -5212,7 +5212,7 @@ class TestDiskUsageStats:
     def test_indexed_vector(self, es, metrics_store_cluster_level):
         cfg = create_config()
         metrics_store = metrics.EsMetricsStore(cfg)
-        es.indices.disk_usage.return_value = {
+        es.options.return_value.indices.disk_usage.return_value = {
             "_shards": {"failed": 0},
             "foo": {"fields": {"title_vector": {"total_in_bytes": 64179820, "doc_values_in_bytes": 0, "knn_vectors_in_bytes": 64179820}}},
         }


### PR DESCRIPTION
If disk-usage-stats times out,then rally exits and you lose a whole run. This allows us to avoid a timeout by implementing the ability to override timeout, as well as avoids a Rally Error being raised. We then still exit, since if we fail to collect any stats we raise a RallyError - 

Should we change this so a fatal error in a telemetry device is not fatal for the whole run? 