### PR TITLE
Fix Docker build

### DIFF
--- a/.buildkite/dev-docker/pipeline.yml
+++ b/.buildkite/dev-docker/pipeline.yml
@@ -45,7 +45,7 @@ steps:
       zone: "us-central1-a"
       provider: "gcp"
   - label: ":docker: build docker manifest"
-    command: bash .buildkite/dev-docker/run.sh manifest both
+    command: bash .buildkite/dev-docker/run.sh manifest
     key: "manifest"
     depends_on:
       - "amd64"

--- a/build-dev-docker-manifest.sh
+++ b/build-dev-docker-manifest.sh
@@ -62,43 +62,24 @@ else
     export DOCKER_TAG_LATEST="${branch_name}-latest"
 fi
 
-echo "========================================================"
-echo "Pulling Docker images for Rally $RALLY_VERSION          "
-echo "========================================================"
-
-docker pull --platform=linux/amd64 "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-amd64"
-docker pull --platform=linux/arm64 "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-arm64"
-
-echo "======================================================="
-echo "Creating Docker manifest image for Rally $RALLY_VERSION"
-echo "======================================================="
-
-docker manifest create ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION} \
-    --amend ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-amd64 \
-    --amend ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-arm64
+echo "======================================================"
+echo "Creating Docker manifest list for Rally $RALLY_VERSION"
+echo "======================================================"
 
 trap push_failed ERR
-echo "======================================================="
-echo "Publishing Docker image ${RALLY_DOCKER_IMAGE}:$RALLY_VERSION   "
-echo "======================================================="
-docker manifest push ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}
-
+docker buildx imagetools create --tag "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}" \
+    "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-amd64" \
+    "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-arm64"
 trap - ERR
 
 if [[ $PUSH_LATEST == "true" ]]; then
-    echo "======================================================="
-    echo "Creating Docker manifest image for Rally $DOCKER_TAG_LATEST"
-    echo "======================================================="
-
-    docker manifest create ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST} \
-        --amend ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}-amd64 \
-        --amend ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}-arm64
+    echo "======================================================"
+    echo "Creating Docker manifest list for Rally $DOCKER_TAG_LATEST"
+    echo "======================================================"
 
     trap push_failed ERR
-    echo "======================================================="
-    echo "Publishing Docker image ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}"
-    echo "======================================================="
-    docker manifest push ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}
+    docker buildx imagetools create --tag "${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}" \
+        "${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}-amd64" \
+        "${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}-arm64"
+    trap - ERR
 fi
-
-trap - ERR

--- a/build-dev-docker-manifest.sh
+++ b/build-dev-docker-manifest.sh
@@ -66,8 +66,8 @@ echo "========================================================"
 echo "Pulling Docker images for Rally $RALLY_VERSION          "
 echo "========================================================"
 
-docker pull "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-amd64"
-docker pull "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-arm64"
+docker pull --platform=linux/amd64 "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-amd64"
+docker pull --platform=linux/arm64 "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-arm64"
 
 echo "======================================================="
 echo "Creating Docker manifest image for Rally $RALLY_VERSION"

--- a/build-dev-docker-manifest.sh
+++ b/build-dev-docker-manifest.sh
@@ -62,9 +62,9 @@ else
     export DOCKER_TAG_LATEST="${branch_name}-latest"
 fi
 
-echo "======================================================"
-echo "Creating Docker manifest list for Rally $RALLY_VERSION"
-echo "======================================================"
+echo "===================================================================="
+echo "Creating Docker manifest list ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}"
+echo "===================================================================="
 
 trap push_failed ERR
 docker buildx imagetools create --tag "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}" \
@@ -73,9 +73,9 @@ docker buildx imagetools create --tag "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}" \
 trap - ERR
 
 if [[ $PUSH_LATEST == "true" ]]; then
-    echo "======================================================"
-    echo "Creating Docker manifest list for Rally $DOCKER_TAG_LATEST"
-    echo "======================================================"
+    echo "===================================================================="
+    echo "Creating Docker manifest list ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}"
+    echo "===================================================================="
 
     trap push_failed ERR
     docker buildx imagetools create --tag "${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}" \

--- a/release-docker-manifest.sh
+++ b/release-docker-manifest.sh
@@ -44,9 +44,9 @@ export RALLY_VERSION_TAG="${RALLY_VERSION}-${DATE}"
 export DOCKER_TAG_VERSION="${RALLY_VERSION}"
 export DOCKER_TAG_LATEST="latest"
 
-echo "======================================================="
-echo "Creating Docker manifest list for Rally $RALLY_VERSION_TAG"
-echo "======================================================="
+echo "================================================================"
+echo "Creating Docker manifest list elastic/rally:${RALLY_VERSION_TAG}"
+echo "================================================================"
 
 trap push_failed ERR
 docker buildx imagetools create --tag "elastic/rally:${RALLY_VERSION_TAG}" \
@@ -55,9 +55,9 @@ docker buildx imagetools create --tag "elastic/rally:${RALLY_VERSION_TAG}" \
 trap - ERR
 
 if [[ $PUSH_LATEST == "true" ]]; then
-    echo "======================================================="
-    echo "Creating Docker manifest list for Rally $DOCKER_TAG_VERSION"
-    echo "======================================================="
+    echo "================================================================"
+    echo "Creating Docker manifest list elastic/rally:${DOCKER_TAG_VERSION}"
+    echo "================================================================"
 
     trap push_failed ERR
     docker buildx imagetools create --tag "elastic/rally:${DOCKER_TAG_VERSION}" \
@@ -65,9 +65,9 @@ if [[ $PUSH_LATEST == "true" ]]; then
         "elastic/rally:${RALLY_VERSION_TAG}-arm64"
     trap - ERR
 
-    echo "======================================================="
-    echo "Creating Docker manifest list for Rally $DOCKER_TAG_LATEST"
-    echo "======================================================="
+    echo "================================================================"
+    echo "Creating Docker manifest list elastic/rally:${DOCKER_TAG_LATEST}"
+    echo "================================================================"
 
     trap push_failed ERR
     docker buildx imagetools create --tag "elastic/rally:${DOCKER_TAG_LATEST}" \

--- a/release-docker-manifest.sh
+++ b/release-docker-manifest.sh
@@ -44,53 +44,34 @@ export RALLY_VERSION_TAG="${RALLY_VERSION}-${DATE}"
 export DOCKER_TAG_VERSION="${RALLY_VERSION}"
 export DOCKER_TAG_LATEST="latest"
 
-echo "========================================================"
-echo "Pulling Docker images for Rally $RALLY_VERSION_TAG          "
-echo "========================================================"
-
-docker pull elastic/rally:${RALLY_VERSION_TAG}-amd64
-docker pull elastic/rally:${RALLY_VERSION_TAG}-arm64
-
 echo "======================================================="
-echo "Creating Docker manifest image for Rally $RALLY_VERSION_TAG"
+echo "Creating Docker manifest list for Rally $RALLY_VERSION_TAG"
 echo "======================================================="
-
-docker manifest create elastic/rally:${RALLY_VERSION_TAG} \
-    --amend elastic/rally:${RALLY_VERSION_TAG}-amd64 \
-    --amend elastic/rally:${RALLY_VERSION_TAG}-arm64
 
 trap push_failed ERR
-echo "======================================================="
-echo "Publishing Docker image elastic/rally:$RALLY_VERSION_TAG"
-echo "======================================================="
-docker manifest push elastic/rally:${RALLY_VERSION_TAG}
+docker buildx imagetools create --tag "elastic/rally:${RALLY_VERSION_TAG}" \
+    "elastic/rally:${RALLY_VERSION_TAG}-amd64" \
+    "elastic/rally:${RALLY_VERSION_TAG}-arm64"
 trap - ERR
 
 if [[ $PUSH_LATEST == "true" ]]; then
     echo "======================================================="
-    echo "Creating Docker manifest image for Rally $DOCKER_TAG_VERSION"
-    echo "======================================================="
-
-    docker manifest create elastic/rally:${DOCKER_TAG_VERSION} \
-        --amend elastic/rally:${RALLY_VERSION_TAG}-amd64 \
-        --amend elastic/rally:${RALLY_VERSION_TAG}-arm64
-
-    echo "======================================================="
-    echo "Creating Docker manifest image for Rally $DOCKER_TAG_LATEST"
-    echo "======================================================="
-
-    docker manifest create elastic/rally:${DOCKER_TAG_LATEST} \
-        --amend elastic/rally:${RALLY_VERSION_TAG}-amd64 \
-        --amend elastic/rally:${RALLY_VERSION_TAG}-arm64
-
-    echo "======================================================="
-    echo "Publishing Docker image elastic/rally:${DOCKER_TAG_LATEST}"
+    echo "Creating Docker manifest list for Rally $DOCKER_TAG_VERSION"
     echo "======================================================="
 
     trap push_failed ERR
-    docker manifest push elastic/rally:${DOCKER_TAG_VERSION}
-    docker manifest push elastic/rally:${DOCKER_TAG_LATEST}
+    docker buildx imagetools create --tag "elastic/rally:${DOCKER_TAG_VERSION}" \
+        "elastic/rally:${RALLY_VERSION_TAG}-amd64" \
+        "elastic/rally:${RALLY_VERSION_TAG}-arm64"
+    trap - ERR
+
+    echo "======================================================="
+    echo "Creating Docker manifest list for Rally $DOCKER_TAG_LATEST"
+    echo "======================================================="
+
+    trap push_failed ERR
+    docker buildx imagetools create --tag "elastic/rally:${DOCKER_TAG_LATEST}" \
+        "elastic/rally:${RALLY_VERSION_TAG}-amd64" \
+        "elastic/rally:${RALLY_VERSION_TAG}-arm64"
+    trap - ERR
 fi
-
-trap - ERR
-


### PR DESCRIPTION
It looks like Docker tools were updated in OS images used by Buildkite agents which disrupted periodic Docker builds. In more recent Docker versions `docker build` produces not a single image but a manifest list, which affected subsequent `docker pull` and `docker manifest create/push` commands in manifest scripts.

To fix this, manifest scripts are modified as follows:
* `docker pull` is removed alltogether; it was never required as `docker manifest` operates on the Docker repository; perhaps this was an extra safety measure to make sure prior builds actually pushed the image,
* `docker manifest create/push` experimental pair is replaced with a single `docker buildx imagetools create`

Test run: [here](https://buildkite.com/elastic/rally-dev-docker-build/builds/894)

The PR changes both dev and release manifest scripts, but only dev script was tested. The release manifest script will be tested during the next release.