### PR TITLE
ingest-doc-count option should take the number of clients into account

### DIFF
--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -834,7 +834,7 @@ class PartitionBulkIndexParamSource:
             if docs_for_this_partition % self.bulk_size != 0:
                 raise exceptions.InvalidSyntax(
                     f"'ingest-doc-count' divided by the number of partitions ({self.total_partitions})"
-                    " must be a multiple of 'bulk-size' ({self.bulk_size}) but was {docs_for_this_partition}"
+                    f" must be a multiple of 'bulk-size' ({self.bulk_size}) but was {docs_for_this_partition}"
                 )
             self.total_bulks = docs_for_this_partition // self.bulk_size
         else:

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -833,7 +833,8 @@ class PartitionBulkIndexParamSource:
             docs_for_this_partition = self.ingest_doc_count // self.total_partitions
             if docs_for_this_partition % self.bulk_size != 0:
                 raise exceptions.InvalidSyntax(
-                    f"'ingest-doc-count' divided by the number of partitions ({self.total_partitions}) must be a multiple of 'bulk-size' ({self.bulk_size}) but was {docs_for_this_partition}"
+                    f"'ingest-doc-count' divided by the number of partitions ({self.total_partitions})"
+                    " must be a multiple of 'bulk-size' ({self.bulk_size}) but was {docs_for_this_partition}"
                 )
             self.total_bulks = docs_for_this_partition // self.bulk_size
         else:

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -742,7 +742,9 @@ class PartitionBulkIndexParamSource:
         :param batch_size: The number of documents to read in one go.
         :param bulk_size: The size of bulk index operations (number of documents per bulk).
         :param ingest_percentage: A number between (0.0, 100.0] that defines how much of the whole corpus should be ingested.
-        :param ingest_doc_count: An optional positive integer that defines the maximum number of documents to ingest.
+        :param ingest_doc_count: An optional positive integer that defines the total number of documents to ingest
+                                 across all partitions. Must be a multiple of bulk_size, and when divided by the
+                                 number of partitions must also be a multiple of bulk_size.
                                  Mutually exclusive with ingest_percentage (when not 100%).
         :param id_conflicts: The type of id conflicts.
         :param conflict_probability: A number between (0.0, 100.0] that defines the probability that a document is replaced by another one.
@@ -827,7 +829,13 @@ class PartitionBulkIndexParamSource:
 
         all_bulks = number_of_bulks(self.corpora, start_index, end_index, self.total_partitions, self.bulk_size)
         if self.ingest_doc_count is not None:
-            self.total_bulks = math.ceil(self.ingest_doc_count / self.bulk_size)
+            # ingest_doc_count is the total across all partitions, so divide by partition count
+            docs_for_this_partition = self.ingest_doc_count // self.total_partitions
+            if docs_for_this_partition % self.bulk_size != 0:
+                raise exceptions.InvalidSyntax(
+                    f"'ingest-doc-count' divided by the number of partitions ({self.total_partitions}) must be a multiple of 'bulk-size' ({self.bulk_size}) but was {docs_for_this_partition}"
+                )
+            self.total_bulks = docs_for_this_partition // self.bulk_size
         else:
             self.total_bulks = math.ceil((all_bulks * self.ingest_percentage) / 100)
 


### PR DESCRIPTION
Follow on from https://github.com/elastic/rally/pull/2033 which added the `ingest-doc-count` to specify the exact number of docs to upload. 

The problem is that the logic did not respect the number of clients used. If you have `ingest-doc-count: 1000` and `clients: 4` then 4000 docs will be uploaded which is not what I asked for. 