### PR TITLE
Fix Docker build revisisted

### DIFF
--- a/.buildkite/dev-docker/pipeline.yml
+++ b/.buildkite/dev-docker/pipeline.yml
@@ -45,7 +45,7 @@ steps:
       zone: "us-central1-a"
       provider: "gcp"
   - label: ":docker: build docker manifest"
-    command: bash .buildkite/dev-docker/run.sh manifest both
+    command: bash .buildkite/dev-docker/run.sh manifest
     key: "manifest"
     depends_on:
       - "amd64"

--- a/.buildkite/dev-docker/pipeline.yml
+++ b/.buildkite/dev-docker/pipeline.yml
@@ -45,7 +45,7 @@ steps:
       zone: "us-central1-a"
       provider: "gcp"
   - label: ":docker: build docker manifest"
-    command: bash .buildkite/dev-docker/run.sh manifest
+    command: bash .buildkite/dev-docker/run.sh manifest both
     key: "manifest"
     depends_on:
       - "amd64"

--- a/build-dev-docker-manifest.sh
+++ b/build-dev-docker-manifest.sh
@@ -63,7 +63,7 @@ else
 fi
 
 echo "======================================================="
-echo "Creating Docker manifest image for Rally $RALLY_VERSION"
+echo "Creating Docker manifest list for Rally $RALLY_VERSION"
 echo "======================================================="
 
 docker manifest create ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION} \
@@ -72,14 +72,14 @@ docker manifest create ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION} \
 
 trap push_failed ERR
 echo "======================================================="
-echo "Publishing Docker image ${RALLY_DOCKER_IMAGE}:$RALLY_VERSION   "
+echo "Publishing Docker manifest list ${RALLY_DOCKER_IMAGE}:$RALLY_VERSION   "
 echo "======================================================="
 docker manifest push ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}
 trap - ERR
 
 if [[ $PUSH_LATEST == "true" ]]; then
     echo "======================================================="
-    echo "Creating Docker manifest image for Rally $DOCKER_TAG_LATEST"
+    echo "Creating Docker manifest list for Rally $DOCKER_TAG_LATEST"
     echo "======================================================="
 
     docker manifest create ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST} \
@@ -88,7 +88,7 @@ if [[ $PUSH_LATEST == "true" ]]; then
 
     trap push_failed ERR
     echo "======================================================="
-    echo "Publishing Docker image ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}"
+    echo "Publishing Docker manifest list ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}"
     echo "======================================================="
     docker manifest push ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}
     trap - ERR

--- a/build-dev-docker-manifest.sh
+++ b/build-dev-docker-manifest.sh
@@ -62,24 +62,43 @@ else
     export DOCKER_TAG_LATEST="${branch_name}-latest"
 fi
 
-echo "===================================================================="
-echo "Creating Docker manifest list ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}"
-echo "===================================================================="
+echo "========================================================"
+echo "Pulling Docker images for Rally $RALLY_VERSION          "
+echo "========================================================"
+
+docker pull "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-amd64"
+docker pull "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-arm64"
+
+echo "======================================================="
+echo "Creating Docker manifest image for Rally $RALLY_VERSION"
+echo "======================================================="
+
+docker manifest create ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION} \
+    --amend ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-amd64 \
+    --amend ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-arm64
 
 trap push_failed ERR
-docker buildx imagetools create --tag "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}" \
-    "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-amd64" \
-    "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-arm64"
+echo "======================================================="
+echo "Publishing Docker image ${RALLY_DOCKER_IMAGE}:$RALLY_VERSION   "
+echo "======================================================="
+docker manifest push ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}
+
 trap - ERR
 
 if [[ $PUSH_LATEST == "true" ]]; then
-    echo "===================================================================="
-    echo "Creating Docker manifest list ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}"
-    echo "===================================================================="
+    echo "======================================================="
+    echo "Creating Docker manifest image for Rally $DOCKER_TAG_LATEST"
+    echo "======================================================="
+
+    docker manifest create ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST} \
+        --amend ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}-amd64 \
+        --amend ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}-arm64
 
     trap push_failed ERR
-    docker buildx imagetools create --tag "${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}" \
-        "${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}-amd64" \
-        "${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}-arm64"
-    trap - ERR
+    echo "======================================================="
+    echo "Publishing Docker image ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}"
+    echo "======================================================="
+    docker manifest push ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}
 fi
+
+trap - ERR

--- a/build-dev-docker-manifest.sh
+++ b/build-dev-docker-manifest.sh
@@ -82,7 +82,6 @@ echo "======================================================="
 echo "Publishing Docker image ${RALLY_DOCKER_IMAGE}:$RALLY_VERSION   "
 echo "======================================================="
 docker manifest push ${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}
-
 trap - ERR
 
 if [[ $PUSH_LATEST == "true" ]]; then
@@ -99,6 +98,5 @@ if [[ $PUSH_LATEST == "true" ]]; then
     echo "Publishing Docker image ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}"
     echo "======================================================="
     docker manifest push ${RALLY_DOCKER_IMAGE}:${DOCKER_TAG_LATEST}
+    trap - ERR
 fi
-
-trap - ERR

--- a/build-dev-docker-manifest.sh
+++ b/build-dev-docker-manifest.sh
@@ -62,13 +62,6 @@ else
     export DOCKER_TAG_LATEST="${branch_name}-latest"
 fi
 
-echo "========================================================"
-echo "Pulling Docker images for Rally $RALLY_VERSION          "
-echo "========================================================"
-
-docker pull "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-amd64"
-docker pull "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}-arm64"
-
 echo "======================================================="
 echo "Creating Docker manifest image for Rally $RALLY_VERSION"
 echo "======================================================="

--- a/build-dev-docker.sh
+++ b/build-dev-docker.sh
@@ -92,7 +92,7 @@ echo "========================================================"
 echo "Building Docker image for Rally $RALLY_VERSION          "
 echo "========================================================"
 
-docker build -t "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}" --build-arg RALLY_VERSION --build-arg RALLY_LICENSE -f docker/Dockerfiles/dev/Dockerfile "${rally_dir}"
+docker build --provenance=false -t "${RALLY_DOCKER_IMAGE}:${RALLY_VERSION}" --build-arg RALLY_VERSION --build-arg RALLY_LICENSE -f docker/Dockerfiles/dev/Dockerfile "${rally_dir}"
 
 echo "======================================================="
 echo "Testing Docker image for Rally release $RALLY_VERSION  "

--- a/release-docker-manifest.sh
+++ b/release-docker-manifest.sh
@@ -76,14 +76,12 @@ if [[ $PUSH_LATEST == "true" ]]; then
         --amend elastic/rally:${RALLY_VERSION_TAG}-amd64 \
         --amend elastic/rally:${RALLY_VERSION_TAG}-arm64
 
+    trap push_failed ERR
     echo "======================================================="
     echo "Publishing Docker manifest list elastic/rally:${DOCKER_TAG_LATEST}"
     echo "======================================================="
-
-    trap push_failed ERR
     docker manifest push elastic/rally:${DOCKER_TAG_VERSION}
     docker manifest push elastic/rally:${DOCKER_TAG_LATEST}
+    trap - ERR
 fi
-
-trap - ERR
 

--- a/release-docker-manifest.sh
+++ b/release-docker-manifest.sh
@@ -44,34 +44,53 @@ export RALLY_VERSION_TAG="${RALLY_VERSION}-${DATE}"
 export DOCKER_TAG_VERSION="${RALLY_VERSION}"
 export DOCKER_TAG_LATEST="latest"
 
-echo "================================================================"
-echo "Creating Docker manifest list elastic/rally:${RALLY_VERSION_TAG}"
-echo "================================================================"
+echo "========================================================"
+echo "Pulling Docker images for Rally $RALLY_VERSION_TAG          "
+echo "========================================================"
+
+docker pull elastic/rally:${RALLY_VERSION_TAG}-amd64
+docker pull elastic/rally:${RALLY_VERSION_TAG}-arm64
+
+echo "======================================================="
+echo "Creating Docker manifest image for Rally $RALLY_VERSION_TAG"
+echo "======================================================="
+
+docker manifest create elastic/rally:${RALLY_VERSION_TAG} \
+    --amend elastic/rally:${RALLY_VERSION_TAG}-amd64 \
+    --amend elastic/rally:${RALLY_VERSION_TAG}-arm64
 
 trap push_failed ERR
-docker buildx imagetools create --tag "elastic/rally:${RALLY_VERSION_TAG}" \
-    "elastic/rally:${RALLY_VERSION_TAG}-amd64" \
-    "elastic/rally:${RALLY_VERSION_TAG}-arm64"
+echo "======================================================="
+echo "Publishing Docker image elastic/rally:$RALLY_VERSION_TAG"
+echo "======================================================="
+docker manifest push elastic/rally:${RALLY_VERSION_TAG}
 trap - ERR
 
 if [[ $PUSH_LATEST == "true" ]]; then
-    echo "================================================================"
-    echo "Creating Docker manifest list elastic/rally:${DOCKER_TAG_VERSION}"
-    echo "================================================================"
+    echo "======================================================="
+    echo "Creating Docker manifest image for Rally $DOCKER_TAG_VERSION"
+    echo "======================================================="
+
+    docker manifest create elastic/rally:${DOCKER_TAG_VERSION} \
+        --amend elastic/rally:${RALLY_VERSION_TAG}-amd64 \
+        --amend elastic/rally:${RALLY_VERSION_TAG}-arm64
+
+    echo "======================================================="
+    echo "Creating Docker manifest image for Rally $DOCKER_TAG_LATEST"
+    echo "======================================================="
+
+    docker manifest create elastic/rally:${DOCKER_TAG_LATEST} \
+        --amend elastic/rally:${RALLY_VERSION_TAG}-amd64 \
+        --amend elastic/rally:${RALLY_VERSION_TAG}-arm64
+
+    echo "======================================================="
+    echo "Publishing Docker image elastic/rally:${DOCKER_TAG_LATEST}"
+    echo "======================================================="
 
     trap push_failed ERR
-    docker buildx imagetools create --tag "elastic/rally:${DOCKER_TAG_VERSION}" \
-        "elastic/rally:${RALLY_VERSION_TAG}-amd64" \
-        "elastic/rally:${RALLY_VERSION_TAG}-arm64"
-    trap - ERR
-
-    echo "================================================================"
-    echo "Creating Docker manifest list elastic/rally:${DOCKER_TAG_LATEST}"
-    echo "================================================================"
-
-    trap push_failed ERR
-    docker buildx imagetools create --tag "elastic/rally:${DOCKER_TAG_LATEST}" \
-        "elastic/rally:${RALLY_VERSION_TAG}-amd64" \
-        "elastic/rally:${RALLY_VERSION_TAG}-arm64"
-    trap - ERR
+    docker manifest push elastic/rally:${DOCKER_TAG_VERSION}
+    docker manifest push elastic/rally:${DOCKER_TAG_LATEST}
 fi
+
+trap - ERR
+

--- a/release-docker-manifest.sh
+++ b/release-docker-manifest.sh
@@ -45,7 +45,7 @@ export DOCKER_TAG_VERSION="${RALLY_VERSION}"
 export DOCKER_TAG_LATEST="latest"
 
 echo "======================================================="
-echo "Creating Docker manifest image for Rally $RALLY_VERSION_TAG"
+echo "Creating Docker manifest list for Rally $RALLY_VERSION_TAG"
 echo "======================================================="
 
 docker manifest create elastic/rally:${RALLY_VERSION_TAG} \
@@ -54,14 +54,14 @@ docker manifest create elastic/rally:${RALLY_VERSION_TAG} \
 
 trap push_failed ERR
 echo "======================================================="
-echo "Publishing Docker image elastic/rally:$RALLY_VERSION_TAG"
+echo "Publishing Docker manifest list elastic/rally:$RALLY_VERSION_TAG"
 echo "======================================================="
 docker manifest push elastic/rally:${RALLY_VERSION_TAG}
 trap - ERR
 
 if [[ $PUSH_LATEST == "true" ]]; then
     echo "======================================================="
-    echo "Creating Docker manifest image for Rally $DOCKER_TAG_VERSION"
+    echo "Creating Docker manifest list for Rally $DOCKER_TAG_VERSION"
     echo "======================================================="
 
     docker manifest create elastic/rally:${DOCKER_TAG_VERSION} \
@@ -69,7 +69,7 @@ if [[ $PUSH_LATEST == "true" ]]; then
         --amend elastic/rally:${RALLY_VERSION_TAG}-arm64
 
     echo "======================================================="
-    echo "Creating Docker manifest image for Rally $DOCKER_TAG_LATEST"
+    echo "Creating Docker manifest list for Rally $DOCKER_TAG_LATEST"
     echo "======================================================="
 
     docker manifest create elastic/rally:${DOCKER_TAG_LATEST} \
@@ -77,7 +77,7 @@ if [[ $PUSH_LATEST == "true" ]]; then
         --amend elastic/rally:${RALLY_VERSION_TAG}-arm64
 
     echo "======================================================="
-    echo "Publishing Docker image elastic/rally:${DOCKER_TAG_LATEST}"
+    echo "Publishing Docker manifest list elastic/rally:${DOCKER_TAG_LATEST}"
     echo "======================================================="
 
     trap push_failed ERR

--- a/release-docker-manifest.sh
+++ b/release-docker-manifest.sh
@@ -44,13 +44,6 @@ export RALLY_VERSION_TAG="${RALLY_VERSION}-${DATE}"
 export DOCKER_TAG_VERSION="${RALLY_VERSION}"
 export DOCKER_TAG_LATEST="latest"
 
-echo "========================================================"
-echo "Pulling Docker images for Rally $RALLY_VERSION_TAG          "
-echo "========================================================"
-
-docker pull elastic/rally:${RALLY_VERSION_TAG}-amd64
-docker pull elastic/rally:${RALLY_VERSION_TAG}-arm64
-
 echo "======================================================="
 echo "Creating Docker manifest image for Rally $RALLY_VERSION_TAG"
 echo "======================================================="

--- a/release-docker.sh
+++ b/release-docker.sh
@@ -47,7 +47,7 @@ echo "========================================================"
 echo "Building Docker image Rally release $RALLY_VERSION_TAG  "
 echo "========================================================"
 
-docker build -t elastic/rally:${RALLY_VERSION_TAG} --build-arg RALLY_VERSION --build-arg RALLY_LICENSE -f docker/Dockerfiles/release/Dockerfile $PWD
+docker build --provenance=false -t elastic/rally:${RALLY_VERSION_TAG} --build-arg RALLY_VERSION --build-arg RALLY_LICENSE -f docker/Dockerfiles/release/Dockerfile $PWD
 
 echo "======================================================="
 echo "Testing Docker image Rally release $RALLY_VERSION_TAG  "


### PR DESCRIPTION
Follow-up to https://github.com/elastic/rally/pull/2035

The `docker buildx imagetools create` does not work well with internal Elastic Docker repository when used to update existing manifests (e.g. `dev-latest`).

As a workaround, this PR restores the previous experimental `docker manifest` commands and previous `docker build` behavior with `--provenance=false`.

Test run against `master` branch: [here](https://buildkite.com/elastic/rally-dev-docker-build/builds/907)