### PR TITLE
Log warning on BadRequestError

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -3039,6 +3039,9 @@ class Retry(Runner, Delegator):
                 if last_attempt or not retry_on_timeout:
                     raise
                 await asyncio.sleep(sleep_time)
+            except elasticsearch.BadRequestError as e:
+                self.logger.warning("[%s] %s", str(self.delegate), str(e))
+                raise e
             except elasticsearch.ApiError as e:
                 if last_attempt or not retry_on_timeout:
                     raise e


### PR DESCRIPTION
This PR updates the Retry runner to log a warning message when a delegate runner raises an `elasticsearch.BadRequestError`.

I was recently experimenting with a change to the elastic/logs track, and I spent several hours debugging why the `validate-package-template-installation` step was failing. It turns out I had a typo in my changes to one of the component index templates, but the bad request was being silently ignored. This PR should hopefully make it much easier to debug similar issues.