### PR TITLE
Track certain headers if present in error responses

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -2028,6 +2028,16 @@ async def execute_single(runner, es, params, on_error: OnErrorBehavior):
     # pylint: disable=import-outside-toplevel
     import elasticsearch
 
+    def _parse_headers(e):
+        tracked_headers = [{"request_id": "X-Cloud-Request-Id", "handling_node": "X-Found-Handling-Instance"}]
+        headers_meta = {}
+        if hasattr(e, "errors") and e.errors and len(e.errors) > 0 and hasattr(e.errors[0], "headers"):
+            for header in tracked_headers:
+                for key, value in header.items():
+                    if value in e.errors[0].headers:
+                        headers_meta[key] = e.errors[0].headers[value]
+        return headers_meta
+
     is_connection_error = False
 
     try:
@@ -2063,6 +2073,7 @@ async def execute_single(runner, es, params, on_error: OnErrorBehavior):
         if e.errors:
             if hasattr(e.errors[0], "status"):
                 request_meta_data["http-status"] = e.errors[0].status
+            request_meta_data.update(_parse_headers(e))
         # connection timeout errors don't provide a helpful description
         if isinstance(e, elasticsearch.ConnectionTimeout):
             request_meta_data["error-description"] = "network connection timed out"
@@ -2117,6 +2128,7 @@ async def execute_single(runner, es, params, on_error: OnErrorBehavior):
         request_meta_data["error-description"] = error_description
         if e.status_code:
             request_meta_data["http-status"] = e.status_code
+        request_meta_data.update(_parse_headers(e))
 
     except KeyError as e:
         logging.getLogger(__name__).exception("Cannot execute runner [%s]; most likely due to missing parameters.", str(runner))

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -2029,7 +2029,13 @@ async def execute_single(runner, es, params, on_error: OnErrorBehavior):
     import elasticsearch
 
     def _parse_headers(e):
-        tracked_headers = [{"request_id": "X-Cloud-Request-Id", "handling_node": "X-Found-Handling-Instance"}]
+        tracked_headers = [
+            {
+                "request_id": "X-Cloud-Request-Id",
+                "handling_node": "X-Found-Handling-Instance",
+                "handling_cluster": "X-Found-Handling-Cluster",
+            }
+        ]
         headers_meta = {}
         if hasattr(e, "errors") and e.errors and len(e.errors) > 0 and hasattr(e.errors[0], "headers"):
             for header in tracked_headers:

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -1391,6 +1391,7 @@ class TestScheduler:
             assert params == {"body": ["a"], "operation-type": "bulk", "size": 11}
 
 
+# pylint: disable=too-many-public-methods
 class TestAsyncExecutor:
     class NoopContextManager:
         def __init__(self, mock):
@@ -2032,6 +2033,249 @@ class TestAsyncExecutor:
         assert exc.value.args[0] == (
             "Cannot execute [failing_mock_runner]. Provided parameters are: ['bulk', 'mode']. Error: ['bulk-size missing']."
         )
+
+    @pytest.mark.asyncio
+    async def test_execute_single_transport_error_with_headers(self):
+        """Test that TransportError with headers correctly extracts tracking headers."""
+        es = None
+        params = None
+
+        # Create a mock error object with headers
+        mock_error = mock.Mock()
+        mock_error.headers = {"X-Cloud-Request-Id": "req-12345", "X-Found-Handling-Instance": "node-67890", "Other-Header": "other-value"}
+
+        # Create TransportError with mock errors containing headers
+        transport_error = elasticsearch.TransportError(message="Transport failed")
+        transport_error.errors = [mock_error]
+
+        runner = mock.AsyncMock(side_effect=transport_error)
+
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
+
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data["success"] is False
+        assert request_meta_data["error-type"] == "transport"
+        assert request_meta_data["request_id"] == "req-12345"
+        assert request_meta_data["handling_node"] == "node-67890"
+        # Verify other headers are not included
+        assert "other-header" not in request_meta_data
+        assert "Other-Header" not in request_meta_data
+
+    @pytest.mark.asyncio
+    async def test_execute_single_transport_error_with_partial_headers(self):
+        """Test that TransportError with only some tracking headers extracts what's available."""
+        es = None
+        params = None
+
+        # Create a mock error object with only one of the tracked headers
+        mock_error = mock.Mock()
+        mock_error.headers = {"X-Cloud-Request-Id": "req-54321", "Some-Other-Header": "ignored"}
+
+        transport_error = elasticsearch.TransportError(message="Transport failed")
+        transport_error.errors = [mock_error]
+
+        runner = mock.AsyncMock(side_effect=transport_error)
+
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
+
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data["success"] is False
+        assert request_meta_data["error-type"] == "transport"
+        assert request_meta_data["request_id"] == "req-54321"
+        # This header should not be present since it wasn't in the error
+        assert "handling_node" not in request_meta_data
+
+    @pytest.mark.asyncio
+    async def test_execute_single_transport_error_with_no_tracking_headers(self):
+        """Test that TransportError with no tracking headers doesn't add any extra fields."""
+        es = None
+        params = None
+
+        # Create a mock error object with headers but none of the tracked ones
+        mock_error = mock.Mock()
+        mock_error.headers = {"Content-Type": "application/json", "Some-Other-Header": "value"}
+
+        transport_error = elasticsearch.TransportError(message="Transport failed")
+        transport_error.errors = [mock_error]
+
+        runner = mock.AsyncMock(side_effect=transport_error)
+
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
+
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data["success"] is False
+        assert request_meta_data["error-type"] == "transport"
+        # None of the tracked headers should be present
+        assert "request_id" not in request_meta_data
+        assert "handling_node" not in request_meta_data
+
+    @pytest.mark.asyncio
+    async def test_execute_single_transport_error_without_headers_attribute(self):
+        """Test that TransportError without headers attribute doesn't cause errors."""
+        es = None
+        params = None
+
+        # Create a mock error object without headers attribute
+        mock_error = mock.Mock()
+        # Explicitly delete headers attribute to mimic an error object without it
+        del mock_error.headers
+
+        transport_error = elasticsearch.TransportError(message="Transport failed")
+        transport_error.errors = [mock_error]
+
+        runner = mock.AsyncMock(side_effect=transport_error)
+
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
+
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data["success"] is False
+        assert request_meta_data["error-type"] == "transport"
+        # None of the tracked headers should be present
+        assert "request_id" not in request_meta_data
+        assert "handling_node" not in request_meta_data
+
+    @pytest.mark.asyncio
+    async def test_execute_single_transport_error_without_errors_attribute(self):
+        """Test that TransportError without errors attribute doesn't cause errors."""
+        es = None
+        params = None
+
+        transport_error = elasticsearch.TransportError(message="Transport failed")
+        # Don't set the errors attribute or set it to None
+
+        runner = mock.AsyncMock(side_effect=transport_error)
+
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
+
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data["success"] is False
+        assert request_meta_data["error-type"] == "transport"
+        # None of the tracked headers should be present
+        assert "request_id" not in request_meta_data
+        assert "handling_node" not in request_meta_data
+
+    @pytest.mark.asyncio
+    async def test_execute_single_api_error_with_headers(self):
+        """Test that ApiError with headers correctly extracts tracking headers."""
+        es = None
+        params = None
+
+        # Create a mock error object with headers
+        mock_error = mock.Mock()
+        mock_error.headers = {
+            "X-Cloud-Request-Id": "api-req-98765",
+            "X-Found-Handling-Instance": "api-node-13579",
+            "Content-Type": "application/json",
+        }
+
+        error_meta = elastic_transport.ApiResponseMeta(
+            status=500,
+            http_version="1.1",
+            headers=elastic_transport.HttpHeaders(),
+            duration=0.0,
+            node=elastic_transport.NodeConfig(scheme="http", host="localhost", port=9200),
+        )
+
+        # Create ApiError with mock errors containing headers
+        api_error = elasticsearch.ApiError(message="API failed", meta=error_meta, body="Internal server error")
+        api_error.errors = [mock_error]
+
+        runner = mock.AsyncMock(side_effect=api_error)
+
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
+
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data["success"] is False
+        assert request_meta_data["error-type"] == "api"
+        assert request_meta_data["http-status"] == 500
+        assert request_meta_data["request_id"] == "api-req-98765"
+        assert request_meta_data["handling_node"] == "api-node-13579"
+
+    @pytest.mark.asyncio
+    async def test_execute_single_api_error_with_partial_headers(self):
+        """Test that ApiError with only some tracking headers extracts what's available."""
+        es = None
+        params = None
+
+        # Create a mock error object with only one tracked header
+        mock_error = mock.Mock()
+        mock_error.headers = {"X-Found-Handling-Instance": "api-node-only", "Authorization": "Bearer token"}
+
+        error_meta = elastic_transport.ApiResponseMeta(
+            status=403,
+            http_version="1.1",
+            headers=elastic_transport.HttpHeaders(),
+            duration=0.0,
+            node=elastic_transport.NodeConfig(scheme="http", host="localhost", port=9200),
+        )
+
+        api_error = elasticsearch.ApiError(message="Forbidden", meta=error_meta, body="Access denied")
+        api_error.errors = [mock_error]
+
+        runner = mock.AsyncMock(side_effect=api_error)
+
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
+
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data["success"] is False
+        assert request_meta_data["error-type"] == "api"
+        assert request_meta_data["http-status"] == 403
+        assert request_meta_data["handling_node"] == "api-node-only"
+        # This header should not be present since it wasn't in the error
+        assert "request_id" not in request_meta_data
+
+    @pytest.mark.asyncio
+    async def test_execute_single_api_error_without_errors_attribute(self):
+        """Test that ApiError without errors attribute doesn't cause errors."""
+        es = None
+        params = None
+
+        error_meta = elastic_transport.ApiResponseMeta(
+            status=400,
+            http_version="1.1",
+            headers=elastic_transport.HttpHeaders(),
+            duration=0.0,
+            node=elastic_transport.NodeConfig(scheme="http", host="localhost", port=9200),
+        )
+
+        # Create ApiError without setting errors attribute
+        api_error = elasticsearch.ApiError(message="Bad request", meta=error_meta, body="Invalid input")
+
+        runner = mock.AsyncMock(side_effect=api_error)
+
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
+
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data["success"] is False
+        assert request_meta_data["error-type"] == "api"
+        assert request_meta_data["http-status"] == 400
+        # None of the tracked headers should be present
+        assert "request_id" not in request_meta_data
+        assert "handling_node" not in request_meta_data
 
 
 class TestAsyncProfiler:

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -2042,7 +2042,12 @@ class TestAsyncExecutor:
 
         # Create a mock error object with headers
         mock_error = mock.Mock()
-        mock_error.headers = {"X-Cloud-Request-Id": "req-12345", "X-Found-Handling-Instance": "node-67890", "Other-Header": "other-value"}
+        mock_error.headers = {
+            "X-Cloud-Request-Id": "req-12345",
+            "X-Found-Handling-Instance": "node-67890",
+            "X-Found-Handling-Cluster": "cluster-abc123",
+            "Other-Header": "other-value",
+        }
 
         # Create TransportError with mock errors containing headers
         transport_error = elasticsearch.TransportError(message="Transport failed")
@@ -2060,6 +2065,7 @@ class TestAsyncExecutor:
         assert request_meta_data["error-type"] == "transport"
         assert request_meta_data["request_id"] == "req-12345"
         assert request_meta_data["handling_node"] == "node-67890"
+        assert request_meta_data["handling_cluster"] == "cluster-abc123"
         # Verify other headers are not included
         assert "other-header" not in request_meta_data
         assert "Other-Header" not in request_meta_data
@@ -2088,8 +2094,9 @@ class TestAsyncExecutor:
         assert request_meta_data["success"] is False
         assert request_meta_data["error-type"] == "transport"
         assert request_meta_data["request_id"] == "req-54321"
-        # This header should not be present since it wasn't in the error
+        # These headers should not be present since they weren't in the error
         assert "handling_node" not in request_meta_data
+        assert "handling_cluster" not in request_meta_data
 
     @pytest.mark.asyncio
     async def test_execute_single_transport_error_with_no_tracking_headers(self):
@@ -2117,6 +2124,7 @@ class TestAsyncExecutor:
         # None of the tracked headers should be present
         assert "request_id" not in request_meta_data
         assert "handling_node" not in request_meta_data
+        assert "handling_cluster" not in request_meta_data
 
     @pytest.mark.asyncio
     async def test_execute_single_transport_error_without_headers_attribute(self):
@@ -2145,6 +2153,7 @@ class TestAsyncExecutor:
         # None of the tracked headers should be present
         assert "request_id" not in request_meta_data
         assert "handling_node" not in request_meta_data
+        assert "handling_cluster" not in request_meta_data
 
     @pytest.mark.asyncio
     async def test_execute_single_transport_error_without_errors_attribute(self):
@@ -2168,6 +2177,7 @@ class TestAsyncExecutor:
         # None of the tracked headers should be present
         assert "request_id" not in request_meta_data
         assert "handling_node" not in request_meta_data
+        assert "handling_cluster" not in request_meta_data
 
     @pytest.mark.asyncio
     async def test_execute_single_api_error_with_headers(self):
@@ -2180,6 +2190,7 @@ class TestAsyncExecutor:
         mock_error.headers = {
             "X-Cloud-Request-Id": "api-req-98765",
             "X-Found-Handling-Instance": "api-node-13579",
+            "X-Found-Handling-Cluster": "api-cluster-xyz789",
             "Content-Type": "application/json",
         }
 
@@ -2208,6 +2219,7 @@ class TestAsyncExecutor:
         assert request_meta_data["http-status"] == 500
         assert request_meta_data["request_id"] == "api-req-98765"
         assert request_meta_data["handling_node"] == "api-node-13579"
+        assert request_meta_data["handling_cluster"] == "api-cluster-xyz789"
 
     @pytest.mark.asyncio
     async def test_execute_single_api_error_with_partial_headers(self):
@@ -2242,8 +2254,9 @@ class TestAsyncExecutor:
         assert request_meta_data["error-type"] == "api"
         assert request_meta_data["http-status"] == 403
         assert request_meta_data["handling_node"] == "api-node-only"
-        # This header should not be present since it wasn't in the error
+        # These headers should not be present since they weren't in the error
         assert "request_id" not in request_meta_data
+        assert "handling_cluster" not in request_meta_data
 
     @pytest.mark.asyncio
     async def test_execute_single_api_error_without_errors_attribute(self):
@@ -2276,6 +2289,7 @@ class TestAsyncExecutor:
         # None of the tracked headers should be present
         assert "request_id" not in request_meta_data
         assert "handling_node" not in request_meta_data
+        assert "handling_cluster" not in request_meta_data
 
 
 class TestAsyncProfiler:


### PR DESCRIPTION
When a race encounters issues, it would be beneficial to report some of the headers we get in the response. I have added two headers I am currently interested in, I am open to other headers if others are of interest too.

This will currently only add to failed requests - if a request succeeds, then we do not capture the headers in that case. If we wanted to track the headers in successful calls, we would need to tie into each runner, which currently seems quite convoluted. At the same time, I cannot see any value in capturing these headers for successful requests.