### PR TITLE
Add detailed results support for ES|QL queries

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3147,6 +3147,7 @@ Properties
 * ``query`` (mandatory): An ES|QL query which starts with a source command followed by processing commands.
 * ``filter`` (optional): A query filter defined in `Elasticsearch query DSL <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html>`_.
 * ``body`` (optional): The query body.
+* ``detailed-results`` (optional, defaults to ``false``): Records more detailed meta-data about queries. As it analyzes the corresponding response in more detail, this might incur additional overhead which can skew measurement results.
 
 Example::
 
@@ -3167,9 +3168,19 @@ Example::
 Meta-data
 """""""""
 
-* ``weight``: "weight" of an operation, in this case the number of retrieved pages.
-* ``unit``: The unit in which to interpret ``weight``, in this case ``pages``.
-* ``success``: A boolean indicating whether the query has succeeded.
+The following meta-data are always returned:
+
+* ``success``: A boolean indicating whether the query has succeeded. This will be ``false`` if the response contains ``is_partial: true``.
+* ``is_partial``: Whether the query returned partial results. If ``true``, the operation is marked as failed and will cause the benchmark to abort if ``--on-error=abort`` is specified.
+
+If ``detailed-results`` is ``true`` the following meta-data are returned in addition:
+
+* ``took``: Value of the ``took`` property in the query response (in milliseconds).
+* ``documents_found``: Number of documents found by the query.
+* ``values_loaded``: Number of values loaded by the query.
+* ``completion_time_in_millis``: Timestamp when the query completed.
+* ``start_time_in_millis``: Timestamp when the query started.
+* ``expiration_time_in_millis``: Timestamp when the query results expire.
 
 .. _track_dependencies:
 

--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3170,6 +3170,8 @@ Meta-data
 
 The following meta-data are always returned:
 
+* ``weight``: The "weight" of an operation, always ``1`` for ES|QL queries.
+* ``unit``: The unit in which to interpret ``weight``, always ``ops``.
 * ``success``: A boolean indicating whether the query has succeeded. This will be ``false`` if the response contains ``is_partial: true``.
 * ``is_partial``: Whether the query returned partial results. If ``true``, the operation is marked as failed and will cause the benchmark to abort if ``--on-error=abort`` is specified.
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -3018,6 +3018,25 @@ class FieldCaps(Runner):
 
 
 class Esql(Runner):
+    """
+    Runs an ES|QL query against Elasticsearch.
+
+    It expects at least the following keys in the `params` hash:
+
+    * `query`: The ES|QL query string to execute.
+
+    The following parameters are optional:
+
+    * `body`: Additional body parameters to include in the request.
+    * `filter`: A filter to apply to the query.
+    * `detailed-results` (default: ``False``): Records more detailed meta-data about queries. As it analyzes the
+                                               corresponding response in more detail, this might incur additional
+                                               overhead which can skew measurement results.
+
+    If the response contains ``is_partial: true``, the operation is marked as failed. This will cause the benchmark
+    to abort if ``--on-error=abort`` is specified, or record an error and continue otherwise.
+    """
+
     async def __call__(self, es, params):
         params, request_params, transport_params, headers = self._transport_request_params(params)
         es = es.options(**transport_params)
@@ -3030,10 +3049,54 @@ class Esql(Runner):
         if not bool(headers):
             # counter-intuitive, but preserves prior behavior
             headers = None
+        detailed_results = params.get("detailed-results", False)
         # disable eager response parsing - responses might be huge thus skewing results
         es.return_raw_response()
-        await es.perform_request(method="POST", path="/_query", headers=headers, body=body, params=request_params)
-        return {"success": True, "unit": "ops", "weight": 1}
+        r = await es.perform_request(method="POST", path="/_query", headers=headers, body=body, params=request_params)
+
+        if detailed_results:
+            props = parse(
+                r,
+                [
+                    "took",
+                    "is_partial",
+                    "documents_found",
+                    "values_loaded",
+                    "completion_time_in_millis",
+                    "start_time_in_millis",
+                    "expiration_time_in_millis",
+                ],
+            )
+            is_partial = props.get("is_partial", False)
+            result = {
+                "weight": 1,
+                "unit": "ops",
+                "success": not is_partial,
+                "is_partial": is_partial,
+                "took": props.get("took"),
+                "documents_found": props.get("documents_found"),
+                "values_loaded": props.get("values_loaded"),
+                "completion_time_in_millis": props.get("completion_time_in_millis"),
+                "start_time_in_millis": props.get("start_time_in_millis"),
+                "expiration_time_in_millis": props.get("expiration_time_in_millis"),
+            }
+            if is_partial:
+                result["error-type"] = "esql"
+                result["error-description"] = "ES|QL query returned partial results"
+            return result
+        else:
+            props = parse(r, ["is_partial"])
+            is_partial = props.get("is_partial", False)
+            result = {
+                "weight": 1,
+                "unit": "ops",
+                "success": not is_partial,
+                "is_partial": is_partial,
+            }
+            if is_partial:
+                result["error-type"] = "esql"
+                result["error-description"] = "ES|QL query returned partial results"
+            return result
 
     def __repr__(self, *args, **kwargs):
         return "esql"

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -8122,10 +8122,11 @@ class TestEsqlRunner:
     @pytest.mark.asyncio
     async def test_esql_without_query_filter(self, es):
         es.options.return_value = es
-        es.perform_request = mock.AsyncMock()
+        response = {"is_partial": False, "columns": [], "values": []}
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
         esql = runner.Esql()
         result = await esql(es, params={"query": "from logs-* | stats c = count(*)"})
-        assert result == {"weight": 1, "unit": "ops", "success": True}
+        assert result == {"weight": 1, "unit": "ops", "success": True, "is_partial": False}
         expected_body = {"query": "from logs-* | stats c = count(*)"}
         es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})
 
@@ -8133,11 +8134,12 @@ class TestEsqlRunner:
     @pytest.mark.asyncio
     async def test_esql_with_query_filter(self, es):
         es.options.return_value = es
-        es.perform_request = mock.AsyncMock()
+        response = {"is_partial": False, "columns": [], "values": []}
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
         esql = runner.Esql()
         query_filter = {"range": {"@timestamp": {"gte": "2023"}}}
         result = await esql(es, params={"query": "from * | limit 1", "filter": query_filter})
-        assert result == {"weight": 1, "unit": "ops", "success": True}
+        assert result == {"weight": 1, "unit": "ops", "success": True, "is_partial": False}
         expected_body = {"query": "from * | limit 1", "filter": query_filter}
         es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})
 
@@ -8145,11 +8147,119 @@ class TestEsqlRunner:
     @pytest.mark.asyncio
     async def test_esql_with_body(self, es):
         es.options.return_value = es
-        es.perform_request = mock.AsyncMock()
+        response = {"is_partial": False, "columns": [], "values": []}
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
         esql = runner.Esql()
         pragma = {"data_partitioning": "doc"}
         result = await esql(es, params={"query": "from * | limit 1", "body": {"pragma": pragma}})
-        assert result == {"weight": 1, "unit": "ops", "success": True}
+        assert result == {"weight": 1, "unit": "ops", "success": True, "is_partial": False}
 
         expected_body = {"pragma": pragma, "query": "from * | limit 1"}
         es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_is_partial_false(self, es):
+        es.options.return_value = es
+        response = {"is_partial": False, "columns": [], "values": []}
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
+        esql = runner.Esql()
+        result = await esql(es, params={"query": "from * | limit 1"})
+        assert result["success"] is True
+        assert result["is_partial"] is False
+        assert "error-type" not in result
+        assert "error-description" not in result
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_is_partial_true(self, es):
+        es.options.return_value = es
+        response = {"is_partial": True, "columns": [], "values": []}
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
+        esql = runner.Esql()
+        result = await esql(es, params={"query": "from * | limit 1"})
+        assert result["success"] is False
+        assert result["is_partial"] is True
+        assert result["error-type"] == "esql"
+        assert result["error-description"] == "ES|QL query returned partial results"
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_detailed_results(self, es):
+        es.options.return_value = es
+        response = {
+            "took": 14,
+            "is_partial": False,
+            "completion_time_in_millis": 1772217296434,
+            "documents_found": 1,
+            "values_loaded": 4,
+            "start_time_in_millis": 1772217296420,
+            "expiration_time_in_millis": 1772649296247,
+            "columns": [{"name": "@timestamp", "type": "date"}],
+            "values": [["2026-02-13T11:49:58.810Z"]],
+        }
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
+        esql = runner.Esql()
+        result = await esql(es, params={"query": "from * | limit 1", "detailed-results": True})
+        assert result == {
+            "weight": 1,
+            "unit": "ops",
+            "success": True,
+            "is_partial": False,
+            "took": 14,
+            "documents_found": 1,
+            "values_loaded": 4,
+            "completion_time_in_millis": 1772217296434,
+            "start_time_in_millis": 1772217296420,
+            "expiration_time_in_millis": 1772649296247,
+        }
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_detailed_results_with_partial(self, es):
+        es.options.return_value = es
+        response = {
+            "took": 14,
+            "is_partial": True,
+            "completion_time_in_millis": 1772217296434,
+            "documents_found": 1,
+            "values_loaded": 4,
+            "start_time_in_millis": 1772217296420,
+            "expiration_time_in_millis": 1772649296247,
+            "columns": [{"name": "@timestamp", "type": "date"}],
+            "values": [["2026-02-13T11:49:58.810Z"]],
+        }
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
+        esql = runner.Esql()
+        result = await esql(es, params={"query": "from * | limit 1", "detailed-results": True})
+        assert result["success"] is False
+        assert result["is_partial"] is True
+        assert result["took"] == 14
+        assert result["documents_found"] == 1
+        assert result["values_loaded"] == 4
+        assert result["completion_time_in_millis"] == 1772217296434
+        assert result["start_time_in_millis"] == 1772217296420
+        assert result["expiration_time_in_millis"] == 1772649296247
+        assert result["error-type"] == "esql"
+        assert result["error-description"] == "ES|QL query returned partial results"
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_detailed_results_missing_optional_fields(self, es):
+        es.options.return_value = es
+        response = {
+            "is_partial": False,
+            "columns": [],
+            "values": [],
+        }
+        es.perform_request = mock.AsyncMock(return_value=io.BytesIO(json.dumps(response).encode()))
+        esql = runner.Esql()
+        result = await esql(es, params={"query": "from * | limit 1", "detailed-results": True})
+        assert result["success"] is True
+        assert result["is_partial"] is False
+        assert result["took"] is None
+        assert result["documents_found"] is None
+        assert result["values_loaded"] is None
+        assert result["completion_time_in_millis"] is None
+        assert result["start_time_in_millis"] is None
+        assert result["expiration_time_in_millis"] is None


### PR DESCRIPTION
* Enhances the Esql runner to include an optional `detailed-results` parameter. When set to true additional meta-data is returned about the query execution.

* Updates the documentation and tests to ensure proper handling of both detailed and standard results, including scenarios for partial results.

Key updates:
- Introduced `detailed-results` parameter in the Esql class.
- Updated response structure to include additional fields when detailed results are requested.
- Enhanced tests to cover various cases for detailed results and partial responses.