### PR TITLE
Adds an ESQL profile runner to rally

### DIFF
--- a/docs/track.rst
+++ b/docs/track.rst
@@ -3171,6 +3171,50 @@ Meta-data
 * ``unit``: The unit in which to interpret ``weight``, in this case ``pages``.
 * ``success``: A boolean indicating whether the query has succeeded.
 
+esql-profile
+~~~~~~~~~~~~~
+
+With the operation type ``esql-profile`` you can execute an `ES|QL query <https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html>`_ with profiling enabled (``profile: true``). This captures detailed timing information across all phases of query execution.
+
+Properties
+""""""""""
+
+* ``query`` (mandatory): An ES|QL query which starts with a source command followed by processing commands.
+* ``filter`` (optional): A query filter defined in `Elasticsearch query DSL <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html>`_.
+* ``body`` (optional): The query body.
+
+Example::
+
+    {
+      "name": "profile-query",
+      "operation-type": "esql-profile",
+      "query": "FROM logs-* | STATS count=count(*) BY agent.hostname | SORT count DESC | LIMIT 20"
+    }
+
+Meta-data
+"""""""""
+
+* ``weight``: Number of operations, always ``1``.
+* ``unit``: Always ``ops``.
+* ``success``: A boolean indicating whether the query has succeeded.
+
+The following metrics are included when profile data is present:
+
+* ``query.took_ms``: Total query execution time in milliseconds.
+* ``planning.took_ms``: Total planning time (includes parsing, preanalysis, and analysis).
+* ``parsing.took_ms``: Time to parse the ES|QL query.
+* ``preanalysis.took_ms``: Preanalysis time (field_caps, enrich policies, lookup indices).
+* ``dependency_resolution.took_ms``: Dependency resolution time.
+* ``analysis.took_ms``: Analysis time before optimizations.
+* ``<driver>.number``: Count of driver instances for the given driver.
+* ``<driver>.took_ms``: Maximum took time across all driver instances (milliseconds).
+* ``<driver>.cpu_ms``: Maximum CPU time across all driver instances (milliseconds).
+* ``<driver>.took_total_ms``: Sum of took times across all driver instances (milliseconds).
+* ``<driver>.cpu_total_ms``: Sum of CPU times across all driver instances (milliseconds).
+* ``<driver>.<operator>.process_ms``: Cumulative processing time for an operator across all driver instances (milliseconds).
+* ``<driver>.<operator>.processed_slices``: Cumulative processed slices for an operator across all driver instances.
+* ``<plan>.<optimization>.took_ms``: Time spent on a plan optimization step (``logical_optimization``, ``physical_optimization``, or ``reduction``), in milliseconds.
+
 .. _track_dependencies:
 
 dependencies

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -63,6 +63,7 @@ def register_default_runners(config: Optional[types.Config] = None):
     register_runner(track.OperationType.Sql, Sql(), async_runner=True)
     register_runner(track.OperationType.FieldCaps, FieldCaps(), async_runner=True)
     register_runner(track.OperationType.Esql, Esql(), async_runner=True)
+    register_runner(track.OperationType.EsqlProfile, EsqlProfile(), async_runner=True)
 
     # This is an administrative operation but there is no need for a retry here as we don't issue a request
     register_runner(track.OperationType.Sleep, Sleep(), async_runner=True)
@@ -3037,6 +3038,81 @@ class Esql(Runner):
 
     def __repr__(self, *args, **kwargs):
         return "esql"
+
+
+class EsqlProfile(Runner):
+    """
+    Runs an ES|QL query using profile: true, and adds the profile information to the result:
+
+    - query.took_ms: Total query time
+    - planning.took_ms: Planning time (includes parsing, preanalysis, analysis)
+    - parsing.took_ms: Time to parse the ES|QL query
+    - preanalysis.took_ms: Preanalysis time (field_caps, enrich policies, lookup indices)
+    - analysis.took_ms: Analysis time before optimizations
+    - <driver>.number: Count of driver instances
+    - <driver>.took_ms: Maximum took time across all driver instances
+    - <driver>.cpu_ms: Maximum CPU time across all driver instances
+    - <driver>.took_total_ms: Sum of took times across all driver instances
+    - <driver>.cpu_total_ms: Sum of CPU times across all driver instances
+    - <driver>.<operator>.process_ms: Processing time for each operator
+    - <driver>.<operator>.processed_slices: Processed slices per operator
+    - <plan>.<optimization>.took_ms: Plan optimization timing
+    """
+
+    async def __call__(self, es, params):
+        params, request_params, transport_params, headers = self._transport_request_params(params)
+        es = es.options(**transport_params)
+        query = mandatory(params, "query", self)
+        body = params.get("body", {})
+        body["query"] = query
+        body["profile"] = True
+        query_filter = params.get("filter")
+        if query_filter:
+            body["filter"] = query_filter
+        if not bool(headers):
+            headers = None
+        response = await es.perform_request(method="POST", path="/_query", headers=headers, body=body, params=request_params)
+        profile = response["profile"]
+        result = {"weight": 1, "unit": "ops", "success": True}
+        if profile:
+            for phase_name in ["query", "planning", "parsing", "preanalysis", "dependency_resolution", "analysis"]:
+                if phase_name in profile:
+                    took_nanos = profile.get(phase_name, {}).get("took_nanos", 0)
+                    if took_nanos > 0:
+                        result[f"{phase_name}.took_ms"] = took_nanos / 1_000_000
+            for driver in profile.get("drivers", []):
+                driver_name = driver.get("description", "unknown")
+                took_ms = driver.get("took_nanos", 0) / 1_000_000
+                cpu_ms = driver.get("cpu_nanos", 0) / 1_000_000
+                result[f"{driver_name}.number"] = result.get(f"{driver_name}.number", 0) + 1
+                result[f"{driver_name}.took_ms"] = max(result.get(f"{driver_name}.took_ms", 0), took_ms)
+                result[f"{driver_name}.cpu_ms"] = max(result.get(f"{driver_name}.cpu_ms", 0), cpu_ms)
+                result[f"{driver_name}.took_total_ms"] = result.get(f"{driver_name}.took_total_ms", 0) + took_ms
+                result[f"{driver_name}.cpu_total_ms"] = result.get(f"{driver_name}.cpu_total_ms", 0) + cpu_ms
+                for idx, operator in enumerate(driver.get("operators", [])):
+                    operator_name = operator.get("operator", f"operator_{idx}")
+                    safe_operator_name = operator_name.split("[")[0] if "[" in operator_name else operator_name
+                    status = operator.get("status", {})
+                    process_nanos = status.get("process_nanos", 0)
+                    if process_nanos > 0:
+                        key = f"{driver_name}.{safe_operator_name}.process_ms"
+                        result[key] = result.get(key, 0) + process_nanos / 1_000_000
+                    processed_slices = status.get("processed_slices", 0)
+                    if processed_slices > 0:
+                        key = f"{driver_name}.{safe_operator_name}.processed_slices"
+                        result[key] = result.get(key, 0) + processed_slices
+            for plan in profile.get("plans", []):
+                plan_name = plan.get("description", "unknown")
+                for optimization in ["logical_optimization_nanos", "physical_optimization_nanos", "reduction_nanos"]:
+                    nanos = plan.get(optimization, 0)
+                    if nanos > 0:
+                        metric_name = optimization.replace("_nanos", "")
+                        key = f"{plan_name}.{metric_name}.took_ms"
+                        result[key] = result.get(key, 0) + nanos / 1_000_000
+        return result
+
+    def __repr__(self, *args, **kwargs):
+        return "esql-profile"
 
 
 class RequestTiming(Runner, Delegator):

--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -703,6 +703,7 @@ class OperationType(Enum):
     WaitForCurrentSnapshotsCreate = (19, AdminStatus.No, serverless.Status.Internal)
     Downsample = (20, AdminStatus.No, serverless.Status.Internal)
     Esql = (21, AdminStatus.No, serverless.Status.Public)
+    EsqlProfile = (59, AdminStatus.No, serverless.Status.Public)
 
     # administrative actions
     ForceMerge = (22, AdminStatus.Yes, serverless.Status.Internal)
@@ -876,6 +877,8 @@ class OperationType(Enum):
             return OperationType.Downsample
         elif v == "esql":
             return OperationType.Esql
+        elif v == "esql-profile":
+            return OperationType.EsqlProfile
         elif v == "run-until":
             return OperationType.RunUntil
         else:

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -8273,4 +8273,3 @@ class TestEsqlProfileRunner:
         assert result["node_reduction.logical_optimization.took_ms"] == 1.0
         assert result["node_reduction.physical_optimization.took_ms"] == 2.0
         assert result["node_reduction.reduction.took_ms"] == 0.5
-

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -8153,3 +8153,124 @@ class TestEsqlRunner:
 
         expected_body = {"pragma": pragma, "query": "from * | limit 1"}
         es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})
+
+
+class TestEsqlProfileRunner:
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_profile_without_filter(self, es):
+        es.options.return_value = es
+        es.perform_request = mock.AsyncMock(return_value={"profile": {}})
+        esql_profile = runner.EsqlProfile()
+        result = await esql_profile(es, params={"query": "from logs-* | stats c = count(*)"})
+        assert result == {"weight": 1, "unit": "ops", "success": True}
+        expected_body = {"query": "from logs-* | stats c = count(*)", "profile": True}
+        es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_profile_with_filter(self, es):
+        es.options.return_value = es
+        es.perform_request = mock.AsyncMock(return_value={"profile": {}})
+        esql_profile = runner.EsqlProfile()
+        query_filter = {"range": {"@timestamp": {"gte": "2023"}}}
+        result = await esql_profile(es, params={"query": "from * | limit 1", "filter": query_filter})
+        assert result == {"weight": 1, "unit": "ops", "success": True}
+        expected_body = {"query": "from * | limit 1", "profile": True, "filter": query_filter}
+        es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_profile_with_body(self, es):
+        es.options.return_value = es
+        es.perform_request = mock.AsyncMock(return_value={"profile": {}})
+        esql_profile = runner.EsqlProfile()
+        pragma = {"data_partitioning": "doc"}
+        result = await esql_profile(es, params={"query": "from * | limit 1", "body": {"pragma": pragma}})
+        assert result == {"weight": 1, "unit": "ops", "success": True}
+        expected_body = {"pragma": pragma, "query": "from * | limit 1", "profile": True}
+        es.perform_request.assert_awaited_once_with(method="POST", path="/_query", headers=None, body=expected_body, params={})
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_profile_extracts_phase_metrics(self, es):
+        es.options.return_value = es
+        profile_response = {
+            "profile": {
+                "query": {"took_nanos": 5_000_000},
+                "planning": {"took_nanos": 2_000_000},
+                "parsing": {"took_nanos": 500_000},
+                "drivers": [],
+                "plans": [],
+            }
+        }
+        es.perform_request = mock.AsyncMock(return_value=profile_response)
+        esql_profile = runner.EsqlProfile()
+        result = await esql_profile(es, params={"query": "from logs-* | limit 10"})
+        assert result["weight"] == 1
+        assert result["unit"] == "ops"
+        assert result["success"] is True
+        assert result["query.took_ms"] == 5.0
+        assert result["planning.took_ms"] == 2.0
+        assert result["parsing.took_ms"] == 0.5
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_profile_extracts_driver_metrics(self, es):
+        es.options.return_value = es
+        profile_response = {
+            "profile": {
+                "drivers": [
+                    {
+                        "description": "data",
+                        "took_nanos": 10_000_000,
+                        "cpu_nanos": 8_000_000,
+                        "operators": [
+                            {"operator": "LuceneSourceOperator[...]", "status": {"process_nanos": 3_000_000, "processed_slices": 5}},
+                        ],
+                    },
+                    {
+                        "description": "data",
+                        "took_nanos": 12_000_000,
+                        "cpu_nanos": 6_000_000,
+                        "operators": [],
+                    },
+                ],
+                "plans": [],
+            }
+        }
+        es.perform_request = mock.AsyncMock(return_value=profile_response)
+        esql_profile = runner.EsqlProfile()
+        result = await esql_profile(es, params={"query": "from logs-* | limit 10"})
+        assert result["data.number"] == 2
+        assert result["data.took_ms"] == 12.0  # max
+        assert result["data.cpu_ms"] == 8.0  # max
+        assert result["data.took_total_ms"] == 22.0  # sum
+        assert result["data.cpu_total_ms"] == 14.0  # sum
+        assert result["data.LuceneSourceOperator.process_ms"] == 3.0
+        assert result["data.LuceneSourceOperator.processed_slices"] == 5
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_esql_profile_extracts_plan_metrics(self, es):
+        es.options.return_value = es
+        profile_response = {
+            "profile": {
+                "drivers": [],
+                "plans": [
+                    {
+                        "description": "node_reduction",
+                        "logical_optimization_nanos": 1_000_000,
+                        "physical_optimization_nanos": 2_000_000,
+                        "reduction_nanos": 500_000,
+                    }
+                ],
+            }
+        }
+        es.perform_request = mock.AsyncMock(return_value=profile_response)
+        esql_profile = runner.EsqlProfile()
+        result = await esql_profile(es, params={"query": "from logs-* | limit 10"})
+        assert result["node_reduction.logical_optimization.took_ms"] == 1.0
+        assert result["node_reduction.physical_optimization.took_ms"] == 2.0
+        assert result["node_reduction.reduction.took_ms"] == 0.5
+


### PR DESCRIPTION
 Adds EsqlProfile as a built-in Rally runner (`esql-profile` operation type).

This runner is already in use in 4 different tracks in rally-tracks: wikipeda, so_vector, msmarco-v2-vector and elastic/logs. With this change, we can perform changes to the runner in a single place.

The `esql-profile` runner executes an ES|QL query with `profile: true` and extracts detailed timing metrics from the profile response, returning them as measurable Rally metrics:

  - Query phase timings: query.took_ms, planning.took_ms, parsing.took_ms, preanalysis.took_ms, analysis.took_ms
  - Driver metrics (per named driver, aggregated across instances):
    - <driver>.number — count of driver instances
    - <driver>.took_ms / <driver>.cpu_ms — max across instances
    - <driver>.took_total_ms / <driver>.cpu_total_ms — sum across instances
  - Operator metrics (per operator within each driver):
    - <driver>.<operator>.process_ms
    - <driver>.<operator>.processed_slices
  - Plan optimization timings:
    - <plan>.logical_optimization.took_ms
    - <plan>.physical_optimization.took_ms
    - <plan>.reduction.took_ms

  Usage in a track

  {
    "operation-type": "esql-profile",
    "query": "FROM logs-* | STATS count = COUNT(*) BY host.name"
  }