### PR TITLE
Add render-track command

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -73,6 +73,23 @@ This will print::
 
 It is also possible to use task filters (e.g. ``--include-tasks``) or to refer to a track via its path (``--track-path``) or use a different track repository (``--track-repository``).
 
+``render-track``
+~~~~~~~~~~~~~~~~
+
+The ``render-track`` subcommand renders a track's Jinja2 templates and outputs the resulting JSON. This is useful for debugging track templates or inspecting the final track definition after template variables have been substituted. Example::
+
+    esrally render-track --track=geonames --quiet
+
+This will print the fully rendered track JSON to stdout. To write the output to a file instead::
+
+    esrally render-track --track=geonames --output-path=rendered-track.json
+
+You can also pass track parameters to see how they affect the rendered output::
+
+    esrally render-track --track=geonames --quiet --track-params='bulk_indexing_clients:100'
+
+It is also possible to refer to a track via its path (``--track-path``) or use a different track repository (``--track-repository``).
+
 ``compare``
 ~~~~~~~~~~~
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -78,7 +78,7 @@ It is also possible to use task filters (e.g. ``--include-tasks``) or to refer t
 
 The ``render-track`` subcommand renders a track's Jinja2 templates and outputs the resulting JSON. This is useful for debugging track templates or inspecting the final track definition after template variables have been substituted. Example::
 
-    esrally render-track --track=geonames --quiet
+    esrally render-track --track=geonames
 
 This will print the fully rendered track JSON to stdout. To write the output to a file instead::
 
@@ -86,7 +86,7 @@ This will print the fully rendered track JSON to stdout. To write the output to 
 
 You can also pass track parameters to see how they affect the rendered output::
 
-    esrally render-track --track=geonames --quiet --track-params='bulk_indexing_clients:100'
+    esrally render-track --track=geonames --track-params='bulk_indexing_clients:100'
 
 It is also possible to refer to a track via its path (``--track-path``) or use a different track repository (``--track-repository``).
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -255,6 +255,17 @@ def create_arg_parser():
         default="",
     )
     render_track_parser.add_argument(
+        "--build-flavor",
+        help="Define the build flavor to render the track for. This is used to render tracks differently based on the build flavor of the Elasticsearch nodes that will be benchmarked. List possible build flavors with `{PROGRAM_NAME} list tracks`.",
+        choices=["default", "serverless"],
+    )
+    render_track_parser.add_argument(
+        "--serverless-operator",
+        help="Whether to render the track for a serverless operator.",
+        default=False,
+        action="store_true",
+    )
+    render_track_parser.add_argument(
         "--output-path",
         help="Path to the output file. If not specified, the rendered track is written to stdout.",
         default=None,
@@ -1283,7 +1294,9 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             if args.track:
                 cfg.add(config.Scope.applicationOverride, "track", "track.name", args.track)
             cfg.add(config.Scope.applicationOverride, "track", "params", opts.to_dict(args.track_params))
-            track.render_track(cfg, output_path=args.output_path)
+            track.render_track(
+                cfg, build_flavor=args.build_flavor, serverless_operator=args.serverless_operator, output_path=args.output_path
+            )
         else:
             raise exceptions.SystemSetupError(f"Unknown subcommand [{sub_command}]")
         return ExitStatus.SUCCESSFUL

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -901,7 +901,7 @@ def create_arg_parser():
         p.add_argument(
             "--quiet",
             help="Suppress as much as output as possible (default: false).",
-            default=p is not render_track_parser,
+            default=p is render_track_parser,  # disable output for render-track
             action="store_true",
         )
         p.add_argument(

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -901,7 +901,7 @@ def create_arg_parser():
         p.add_argument(
             "--quiet",
             help="Suppress as much as output as possible (default: false).",
-            default=False,
+            default=p is not render_track_parser,
             action="store_true",
         )
         p.add_argument(

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -911,7 +911,7 @@ def create_arg_parser():
         )
         p.add_argument(
             "--quiet",
-            help=f"Suppress as much as output as possible (default: {str(p is render_track_parser).lower()}).",
+            help=f"Suppress as much output as possible (default: {str(p is render_track_parser).lower()}).",
             default=p is render_track_parser,  # disable output for render-track
             action=argparse.BooleanOptionalAction,
         )

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -243,6 +243,23 @@ def create_arg_parser():
         help="Defines a comma-separated list of tasks not to run. By default all tasks of a challenge are run.",
     )
 
+    render_track_parser = subparsers.add_parser("render-track", help="Render a track's Jinja2 templates into a single JSON output")
+    add_track_source(render_track_parser)
+    render_track_parser.add_argument(
+        "--track",
+        help=f"Define the track to use. List possible tracks with `{PROGRAM_NAME} list tracks`.",
+    )
+    render_track_parser.add_argument(
+        "--track-params",
+        help="Define a comma-separated list of key:value pairs that are injected verbatim to the track as variables.",
+        default="",
+    )
+    render_track_parser.add_argument(
+        "--output-path",
+        help="Path to the output file. If not specified, the rendered track is written to stdout.",
+        default=None,
+    )
+
     create_track_parser = subparsers.add_parser("create-track", help="Create a Rally track from existing data")
     create_track_parser.add_argument(
         "--track",
@@ -872,6 +889,7 @@ def create_arg_parser():
         start_parser,
         stop_parser,
         info_parser,
+        render_track_parser,
         create_track_parser,
     ]:
         # This option is needed to support a separate configuration for the integration tests on the same machine
@@ -1064,7 +1082,7 @@ def configure_telemetry_params(args, cfg: types.Config):
     cfg.add(config.Scope.applicationOverride, "telemetry", "params", opts.to_dict(args.telemetry_params))
 
 
-def configure_track_params(arg_parser, args, cfg: types.Config, command_requires_track=True):
+def configure_track_params(arg_parser, args, cfg: types.Config, command_requires_track=True, command_requires_track_details=True):
     cfg.add(config.Scope.applicationOverride, "track", "repository.revision", args.track_revision)
     # We can assume here that if a track-path is given, the user did not specify a repository either (although argparse sets it to
     # its default value)
@@ -1084,7 +1102,7 @@ def configure_track_params(arg_parser, args, cfg: types.Config, command_requires
                 raise arg_parser.error("argument --track is required")
             cfg.add(config.Scope.applicationOverride, "track", "track.name", args.track)
 
-    if command_requires_track:
+    if command_requires_track_details:
         cfg.add(config.Scope.applicationOverride, "track", "params", opts.to_dict(args.track_params))
         cfg.add(config.Scope.applicationOverride, "track", "challenge.name", args.challenge)
         cfg.add(config.Scope.applicationOverride, "track", "include.tasks", opts.csv_to_list(args.include_tasks))
@@ -1150,7 +1168,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "system", "list.to_date", args.to_date)
             cfg.add(config.Scope.applicationOverride, "system", "list.challenge", args.challenge)
             configure_mechanic_params(args, cfg, command_requires_car=False)
-            configure_track_params(arg_parser, args, cfg, command_requires_track=False)
+            configure_track_params(arg_parser, args, cfg, command_requires_track=False, command_requires_track_details=False)
             dispatch_list(cfg)
         elif sub_command == "delete":
             cfg.add(config.Scope.applicationOverride, "system", "delete.config.option", args.configuration)
@@ -1260,6 +1278,12 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
         elif sub_command == "info":
             configure_track_params(arg_parser, args, cfg)
             track.track_info(cfg)
+        elif sub_command == "render-track":
+            configure_track_params(arg_parser, args, cfg, command_requires_track_details=False)
+            if args.track:
+                cfg.add(config.Scope.applicationOverride, "track", "track.name", args.track)
+            cfg.add(config.Scope.applicationOverride, "track", "params", opts.to_dict(args.track_params))
+            track.render_track(cfg, output_path=args.output_path)
         else:
             raise exceptions.SystemSetupError(f"Unknown subcommand [{sub_command}]")
         return ExitStatus.SUCCESSFUL

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -911,9 +911,9 @@ def create_arg_parser():
         )
         p.add_argument(
             "--quiet",
-            help="Suppress as much as output as possible (default: false).",
+            help=f"Suppress as much as output as possible (default: {str(p is render_track_parser).lower()}).",
             default=p is render_track_parser,  # disable output for render-track
-            action="store_true",
+            action=argparse.BooleanOptionalAction,
         )
         p.add_argument(
             "--offline",

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -256,7 +256,7 @@ def create_arg_parser():
     )
     render_track_parser.add_argument(
         "--build-flavor",
-        help="Define the build flavor to render the track for. This is used to render tracks differently based on the build flavor of the Elasticsearch nodes that will be benchmarked. List possible build flavors with `{PROGRAM_NAME} list tracks`.",
+        help="Define the build flavor to render the track for.",
         choices=["default", "serverless"],
     )
     render_track_parser.add_argument(

--- a/esrally/track/__init__.py
+++ b/esrally/track/__init__.py
@@ -21,8 +21,8 @@ from .loader import (
     load_track,
     load_track_plugins,
     operation_parameters,
-    set_absolute_data_path,
     render_track,
+    set_absolute_data_path,
     track_info,
     track_repo,
 )

--- a/esrally/track/__init__.py
+++ b/esrally/track/__init__.py
@@ -22,6 +22,7 @@ from .loader import (
     load_track_plugins,
     operation_parameters,
     set_absolute_data_path,
+    render_track,
     track_info,
     track_repo,
 )

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -175,13 +175,18 @@ def list_tracks(cfg: types.Config):
     console.println(tabulate.tabulate(tabular_data=data, headers=headers))
 
 
-def render_track(cfg: types.Config, output_path=None):
+def render_track(cfg: types.Config, build_flavor=None, serverless_operator=False, output_path=None):
     repo = track_repo(cfg)
     track_name = repo.track_name
     track_spec_file = repo.track_file(track_name)
     track_params = cfg.opts("track", "params", default_value={})
 
-    rendered = render_template_from_file(track_spec_file, track_params)
+    rendered = render_template_from_file(
+        track_spec_file,
+        track_params,
+        build_flavor=build_flavor,
+        serverless_operator=serverless_operator,
+    )
     rendered_json = json.dumps(json.loads(rendered), indent=2)
 
     if output_path:

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -175,6 +175,23 @@ def list_tracks(cfg: types.Config):
     console.println(tabulate.tabulate(tabular_data=data, headers=headers))
 
 
+def render_track(cfg: types.Config, output_path=None):
+    repo = track_repo(cfg)
+    track_name = repo.track_name
+    track_spec_file = repo.track_file(track_name)
+    track_params = cfg.opts("track", "params", default_value={})
+
+    rendered = render_template_from_file(track_spec_file, track_params)
+    rendered_json = json.dumps(json.loads(rendered), indent=2)
+
+    if output_path:
+        with open(output_path, "w") as f:
+            print(rendered_json, file=f)
+        console.println(f"Rendered track [{track_name}] has been written to [{output_path}].")
+    else:
+        print(rendered_json)
+
+
 def track_info(cfg: types.Config):
     def format_task(t, indent="", num="", suffix=""):
         msg = f"{indent}{num}{str(t)}"

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -163,6 +163,56 @@ class TestGitRepository:
         assert repo.track_file("unittest") == "/tmp/tracks/default/unittest/track.json"
 
 
+class TestRenderTrack:
+    @mock.patch("esrally.track.loader.track_repo")
+    @mock.patch("esrally.track.loader.render_template_from_file")
+    def test_render_track_to_stdout(self, mock_render, mock_repo, capsys):
+        mock_repo.return_value.track_name = "unittest"
+        mock_repo.return_value.track_file.return_value = "/path/to/track/unittest/track.json"
+        mock_render.return_value = '{"short-description": "test", "indices": [{"name": "test"}]}'
+
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "track", "params", {})
+
+        loader.render_track(cfg)
+
+        mock_render.assert_called_once_with("/path/to/track/unittest/track.json", {})
+        captured = capsys.readouterr()
+        assert '"short-description": "test"' in captured.out
+        assert '"indices"' in captured.out
+
+    @mock.patch("esrally.track.loader.track_repo")
+    @mock.patch("esrally.track.loader.render_template_from_file")
+    def test_render_track_to_file(self, mock_render, mock_repo, tmp_path):
+        mock_repo.return_value.track_name = "unittest"
+        mock_repo.return_value.track_file.return_value = "/path/to/track/unittest/track.json"
+        mock_render.return_value = '{"short-description": "test"}'
+
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "track", "params", {})
+
+        output_file = tmp_path / "rendered.json"
+        loader.render_track(cfg, output_path=str(output_file))
+
+        assert output_file.exists()
+        contents = output_file.read_text()
+        assert '"short-description": "test"' in contents
+        assert contents.endswith("\n")
+
+    @mock.patch("esrally.track.loader.track_repo")
+    @mock.patch("esrally.track.loader.render_template_from_file")
+    def test_render_track_invalid_json_raises(self, mock_render, mock_repo):
+        mock_repo.return_value.track_name = "unittest"
+        mock_repo.return_value.track_file.return_value = "/path/to/track/unittest/track.json"
+        mock_render.return_value = "not valid json {{"
+
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "track", "params", {})
+
+        with pytest.raises(Exception):
+            loader.render_track(cfg)
+
+
 class TestTrackPreparation:
     @mock.patch("esrally.utils.io.prepare_file_offset_table")
     @mock.patch("os.path.getsize")

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -176,7 +176,12 @@ class TestRenderTrack:
 
         loader.render_track(cfg)
 
-        mock_render.assert_called_once_with("/path/to/track/unittest/track.json", {})
+        mock_render.assert_called_once_with(
+            "/path/to/track/unittest/track.json",
+            {},
+            build_flavor=None,
+            serverless_operator=False,
+        )
         captured = capsys.readouterr()
         assert '"short-description": "test"' in captured.out
         assert '"indices"' in captured.out


### PR DESCRIPTION
The `render-track` command renders a track's Jinja2 templates and outputs the resulting JSON. This is useful for debugging track templates or inspecting the final track definition after template variables have been substituted.