### PR TITLE
ESQL Profile operation - Retrieve timing information for operators that use receive_nanos and emit_nanos

### DIFF
--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -3156,7 +3156,7 @@ class EsqlProfile(Runner):
                     operator_name = operator.get("operator", f"operator_{idx}")
                     safe_operator_name = operator_name.split("[")[0] if "[" in operator_name else operator_name
                     status = operator.get("status", {})
-                    process_nanos = status.get("process_nanos", 0)
+                    process_nanos = status.get("process_nanos", 0) + status.get("receive_nanos", 0) + status.get("emit_nanos", 0)
                     if process_nanos > 0:
                         key = f"{driver_name}.{safe_operator_name}.process_ms"
                         result[key] = result.get(key, 0) + process_nanos / 1_000_000

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -8337,6 +8337,7 @@ class TestEsqlProfileRunner:
                         "cpu_nanos": 8_000_000,
                         "operators": [
                             {"operator": "LuceneSourceOperator[...]", "status": {"process_nanos": 3_000_000, "processed_slices": 5}},
+                            {"operator": "TopNOperator[...]", "status": {"emit_nanos": 1_000_000, "receive_nanos": 1_500_000}},
                         ],
                     },
                     {
@@ -8359,6 +8360,7 @@ class TestEsqlProfileRunner:
         assert result["data.cpu_total_ms"] == 14.0  # sum
         assert result["data.LuceneSourceOperator.process_ms"] == 3.0
         assert result["data.LuceneSourceOperator.processed_slices"] == 5
+        assert result["data.TopNOperator.process_ms"] == 2.5
 
     @mock.patch("elasticsearch.Elasticsearch")
     @pytest.mark.asyncio


### PR DESCRIPTION
Follow up to https://github.com/elastic/rally/pull/2047

Adds timing information for operators like TopNOpeartor, that does not use `process_nanos`