### PR TITLE
Apply persist-credentials: false to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v4
         with:
           python-version: "3.13"
@@ -35,6 +37,7 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel: ${{ secrets.SLACK_CHANNEL }}
           status: FAILED
+          persist-credentials: false
 
   test:
     strategy:
@@ -49,6 +52,8 @@ jobs:
     name: unit ${{ fromJson('{"macos-latest":"macOS","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -64,6 +69,7 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel: ${{ secrets.SLACK_CHANNEL }}
           status: FAILED
+          persist-credentials: false
 
   rally-tracks-compat:
     runs-on: ubuntu-22.04
@@ -73,6 +79,8 @@ jobs:
         run: curl -4s ifconfig.me
         continue-on-error: true
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v4
         with:
           python-version: "3.13"
@@ -114,6 +122,7 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel: ${{ secrets.SLACK_CHANNEL }}
           status: FAILED
+          persist-credentials: false
       # Artifact will show up under "Artifacts" in the "Summary" page of runs
       - uses: actions/upload-artifact@v4
         if: always()
@@ -144,3 +153,4 @@ jobs:
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel: ${{ secrets.SLACK_CHANNEL }}
           status: FAILED
+          persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:


### PR DESCRIPTION
By default, credentials are persisted, which can be a security issue.

This was highlighted by the excellent [zizmor](https://github.com/zizmorcore/zizmor) tool. There are other issues, but this seemed like a good first step.