### PR TITLE
Add esrally race --prepare-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ export UV_PROJECT_ENVIRONMENT := $(VIRTUAL_ENV)
 
 PRE_COMMIT_HOOK_PATH := .git/hooks/pre-commit
 
-LOG_CI_LEVEL := INFO
+DEBUG =
+LOG_CI_LEVEL = $(if $(DEBUG),DEBUG)
+PYTEST_FLAGS =
+PYTEST = pytest $(if $(DEBUG),-s -x --lf) $(if $(LOG_CI_LEVEL),-o log_cli=true --log-cli-level=$(LOG_CI_LEVEL)) $(PYTEST_FLAGS)
 
 # --- Global goals ---
 
@@ -174,7 +177,7 @@ clean-docs: venv
 
 # It runs unit tests using the default python interpreter version.
 test: venv
-	uv run -- pytest -s $(or $(ARGS), tests/)
+	uv run -- $(PYTEST) -- $(or $(ARGS), tests/)
 
 # It runs unit tests using all supported python versions.
 test-all: test-3.10 test-3.11 test-3.12 test-3.13
@@ -204,11 +207,11 @@ it: venv
 
 # It runs serverless integration tests.
 it_serverless: install_pytest_rally_plugin
-	uv run -- pytest -s --log-cli-level=$(LOG_CI_LEVEL) --track-repository-test-directory=it_tracks_serverless it/track_repo_compatibility $(ARGS)
+	$(MAKE) test PYTEST_FLAGS+=--track-repository-test-directory=it_tracks_serverless ARGS=it/track_repo_compatibility
 
 # It runs rally_tracks_compat integration tests.
 it_tracks_compat: install_pytest_rally_plugin
-	uv run -- pytest -s --log-cli-level=$(LOG_CI_LEVEL) it/track_repo_compatibility $(ARGS)
+	$(MAKE) test ARGS=it/track_repo_compatibility
 
 # It runs benchmark tests.
 benchmark: venv

--- a/docs/pipelines.rst
+++ b/docs/pipelines.rst
@@ -5,6 +5,8 @@ A pipeline is a series of steps that are performed to get benchmark results. Thi
 
 An example will clarify the concept: If you want to benchmark a binary distribution of Elasticsearch, Rally has to download a distribution archive, decompress it, start Elasticsearch and then run the benchmark. However, if you want to benchmark a source build of Elasticsearch, it first has to build a distribution using the Gradle Wrapper. So, in both cases, different steps are involved and that's what pipelines are for.
 
+For any pipeline, you can pass ``--prepare-only`` to ``esrally race`` to stop after provisioning (when the pipeline includes it) and track-data preparation, without running the workload or writing results. See :ref:`race_prepare_only`.
+
 You can get a list of all pipelines with ``esrally list pipelines``::
 
     Available pipelines:

--- a/docs/pipelines.rst
+++ b/docs/pipelines.rst
@@ -5,7 +5,7 @@ A pipeline is a series of steps that are performed to get benchmark results. Thi
 
 An example will clarify the concept: If you want to benchmark a binary distribution of Elasticsearch, Rally has to download a distribution archive, decompress it, start Elasticsearch and then run the benchmark. However, if you want to benchmark a source build of Elasticsearch, it first has to build a distribution using the Gradle Wrapper. So, in both cases, different steps are involved and that's what pipelines are for.
 
-For any pipeline, you can pass ``--prepare-only`` to ``esrally race`` to stop after provisioning (when the pipeline includes it) and track-data preparation, without running the workload or writing results. See :ref:`race_prepare_only`.
+For any pipeline, you can pass ``--prepare-only`` to ``esrally race`` to stop after local track-data preparation, without running the workload or writing results. Rally does not start Elasticsearch or connect to a cluster in this mode. See :ref:`race_prepare_only`.
 
 You can get a list of all pipelines with ``esrally list pipelines``::
 

--- a/docs/race.rst
+++ b/docs/race.rst
@@ -140,13 +140,13 @@ If you are curious about the operations that Rally has run, inspect the `geopoin
 Prepare only (no benchmark)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want Rally to provision Elasticsearch when your :doc:`pipeline </pipelines>` does so, download and prepare track data under your Rally root, and then exit successfully **without** running the challenge schedule or printing a benchmark summary, pass ``--prepare-only``::
+If you want Rally to download and prepare track data under your Rally root (corpora, generated documents, and other on-disk work defined by the track) and then exit successfully **without** running the challenge schedule or printing a benchmark summary, pass ``--prepare-only``. In this mode Rally does **not** start Elasticsearch and does **not** open connections to ``--target-hosts``::
 
     esrally race --track=geopoint --challenge=append-fast-with-conflicts --prepare-only
 
-With ``--pipeline=benchmark-only``, Rally only prepares track data against your existing cluster (no Elasticsearch provisioning)::
+With ``--pipeline=benchmark-only``, Rally performs the same local track preparation only; it does not contact a cluster. Pass ``--distribution-version`` (or pin the track repository revision) if you need a specific Elasticsearch version for track branch selection, because Rally will not probe a running cluster::
 
-    esrally race --pipeline=benchmark-only --target-hosts=127.0.0.1:9200 --track=geonames --prepare-only
+    esrally race --pipeline=benchmark-only --track=geonames --distribution-version=8.11.0 --prepare-only
 
-In this mode Rally prints a message that the track was prepared in prepare-only mode; it does **not** persist a race record or benchmark results. Elasticsearch is stopped the same way as after a normal race (see :doc:`cluster management </cluster_management>` and ``--preserve-install``).
+In this mode Rally prints a message that the track was prepared in prepare-only mode; it does **not** persist a race record or benchmark results. Rally does not stop Elasticsearch after prepare-only, because it does not start a benchmark candidate in this mode (see :doc:`cluster management </cluster_management>` if you manage a cluster yourself).
 

--- a/docs/race.rst
+++ b/docs/race.rst
@@ -142,7 +142,7 @@ Prepare only (no benchmark)
 
 If you want Rally to provision Elasticsearch when your :doc:`pipeline </pipelines>` does so, download and prepare track data under your Rally root, and then exit successfully **without** running the challenge schedule or printing a benchmark summary, pass ``--prepare-only``::
 
-    esrally race --distribution-version=6.0.0 --track=geopoint --challenge=append-fast-with-conflicts --prepare-only
+    esrally race --track=geopoint --challenge=append-fast-with-conflicts --prepare-only
 
 With ``--pipeline=benchmark-only``, Rally only prepares track data against your existing cluster (no Elasticsearch provisioning)::
 

--- a/docs/race.rst
+++ b/docs/race.rst
@@ -135,3 +135,18 @@ What did Rally just do?
 If you are curious about the operations that Rally has run, inspect the `geopoint track specification <https://github.com/elastic/rally-tracks/blob/5/geopoint/track.json>`_ or start to :doc:`write your own tracks </adding_tracks>`. You can also configure Rally to :doc:`store all data samples in Elasticsearch </configuration>` so you can analyze the results with Kibana. Finally, you may want to :doc:`change the Elasticsearch configuration </car>`.
 
 
+.. _race_prepare_only:
+
+Prepare only (no benchmark)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want Rally to provision Elasticsearch when your :doc:`pipeline </pipelines>` does so, download and prepare track data under your Rally root, and then exit successfully **without** running the challenge schedule or printing a benchmark summary, pass ``--prepare-only``::
+
+    esrally race --distribution-version=6.0.0 --track=geopoint --challenge=append-fast-with-conflicts --prepare-only
+
+With ``--pipeline=benchmark-only``, Rally only prepares track data against your existing cluster (no Elasticsearch provisioning)::
+
+    esrally race --pipeline=benchmark-only --target-hosts=127.0.0.1:9200 --track=geonames --prepare-only
+
+In this mode Rally prints a message that the track was prepared in prepare-only mode; it does **not** persist a race record or benchmark results. Elasticsearch is stopped the same way as after a normal race (see :doc:`cluster management </cluster_management>` and ``--preserve-install``).
+

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -45,6 +45,7 @@ from esrally import (
     telemetry,
     track,
     types,
+    version,
 )
 from esrally.client import delete_api_keys
 from esrally.driver import runner, scheduler
@@ -701,7 +702,7 @@ class Driver:
             self.logger.error("Unable to create API keys. Stopping benchmark.")
             raise exceptions.SystemSetupError(e.message)
 
-    def prepare_benchmark(self, t):
+    def prepare_benchmark(self, t: track.Track) -> None:
         self.track = t
         self.challenge = select_challenge(self.config, self.track)
         self.quiet = self.config.opts("system", "quiet.mode", mandatory=False, default_value=False)
@@ -712,44 +713,62 @@ class Driver:
             self.metrics_store, downsample_factor, self.track.meta_data, self.challenge.meta_data
         )
 
-        es_clients = self.create_es_clients()
-        self.default_sync_es_client = es_clients["default"]
+        prepare_only: bool = convert.to_bool(self.config.opts("race", "prepare.only", mandatory=False, default_value=False))
+        serverless_mode: bool = convert.to_bool(self.config.opts("driver", "serverless.mode", mandatory=False, default_value=False))
+        serverless_operator: bool = convert.to_bool(self.config.opts("driver", "serverless.operator", mandatory=False, default_value=False))
+        enabled_telemetry_devices = self.config.opts("telemetry", "devices")
 
-        skip_rest_api_check = self.config.opts("mechanic", "skip.rest.api.check")
-        uses_static_responses = self.config.opts("client", "options").uses_static_responses
-        serverless_mode = convert.to_bool(self.config.opts("driver", "serverless.mode", mandatory=False, default_value=False))
-        serverless_operator = convert.to_bool(self.config.opts("driver", "serverless.operator", mandatory=False, default_value=False))
-        build_hash = None
-        if skip_rest_api_check:
-            self.logger.info("Skipping REST API check as requested explicitly.")
-        elif uses_static_responses:
-            self.logger.info("Skipping REST API check as static responses are used.")
+        if prepare_only:
+            self.logger.info("Prepare-only mode: skipping Elasticsearch client and REST checks; preparing track on disk only.")
+            dist_flavor: str = self.config.opts("mechanic", "distribution.flavor", mandatory=False) or "default"
+            dist_ver: str = self.config.opts("mechanic", "distribution.version", mandatory=False) or version.minimum_es_version()
+            build_hash: str = dist_flavor
+            self.driver_actor.cluster_details = {
+                "version": {"build_flavor": dist_flavor, "number": dist_ver, "build_hash": build_hash},
+            }
+            self.telemetry = telemetry.Telemetry(
+                enabled_devices=enabled_telemetry_devices,
+                devices=[],
+                serverless_mode=serverless_mode,
+                serverless_operator=serverless_operator,
+            )
         else:
-            if serverless_mode and not serverless_operator:
-                self.logger.info("Skipping REST API check while targetting serverless cluster with a public user.")
-            else:
-                self.wait_for_rest_api(es_clients)
-            self.driver_actor.cluster_details = self.retrieve_cluster_info(es_clients)
-            if serverless_mode:
-                # overwrite static serverless version number
-                self.driver_actor.cluster_details["version"]["number"] = "serverless"
-                if serverless_operator:
-                    # overwrite build hash if running as operator
-                    build_hash = self.retrieve_build_hash_from_nodes_info(es_clients)
-                    self.logger.info("Retrieved actual build hash [%s] from serverless cluster.", build_hash)
-                    self.driver_actor.cluster_details["version"]["build_hash"] = build_hash
+            es_clients = self.create_es_clients()
+            self.default_sync_es_client = es_clients["default"]
 
-        # Avoid issuing any requests to the target cluster when static responses are enabled. The results
-        # are not useful and attempts to connect to a non-existing cluster just lead to exception traces in logs.
-        self.prepare_telemetry(
-            es_clients,
-            enable=not uses_static_responses,
-            index_names=self.track.index_names(),
-            data_stream_names=self.track.data_stream_names(),
-            build_hash=build_hash,
-            serverless_mode=serverless_mode,
-            serverless_operator=serverless_operator,
-        )
+            skip_rest_api_check = self.config.opts("mechanic", "skip.rest.api.check")
+            uses_static_responses = self.config.opts("client", "options").uses_static_responses
+            build_hash = None
+            if skip_rest_api_check:
+                self.logger.info("Skipping REST API check as requested explicitly.")
+            elif uses_static_responses:
+                self.logger.info("Skipping REST API check as static responses are used.")
+            else:
+                if serverless_mode and not serverless_operator:
+                    self.logger.info("Skipping REST API check while targetting serverless cluster with a public user.")
+                else:
+                    self.wait_for_rest_api(es_clients)
+                self.driver_actor.cluster_details = self.retrieve_cluster_info(es_clients)
+                if serverless_mode:
+                    # overwrite static serverless version number
+                    self.driver_actor.cluster_details["version"]["number"] = "serverless"
+                    if serverless_operator:
+                        # overwrite build hash if running as operator
+                        build_hash = self.retrieve_build_hash_from_nodes_info(es_clients)
+                        self.logger.info("Retrieved actual build hash [%s] from serverless cluster.", build_hash)
+                        self.driver_actor.cluster_details["version"]["build_hash"] = build_hash
+
+            # Avoid issuing any requests to the target cluster when static responses are enabled. The results
+            # are not useful and attempts to connect to a non-existing cluster just lead to exception traces in logs.
+            self.prepare_telemetry(
+                es_clients,
+                enable=not uses_static_responses,
+                index_names=self.track.index_names(),
+                data_stream_names=self.track.data_stream_names(),
+                build_hash=build_hash,
+                serverless_mode=serverless_mode,
+                serverless_operator=serverless_operator,
+            )
 
         for host in self.config.opts("driver", "load_driver_hosts"):
             host_config = {

--- a/esrally/log.py
+++ b/esrally/log.py
@@ -170,7 +170,6 @@ def install_default_log_config():
     io.ensure_dir(paths.logs())
 
 
-# pylint: disable=unused-argument
 def configure_file_handler(*, filename: str, encoding: str = "UTF-8", delay: bool = False, **kwargs: Any) -> logging.Handler:
     """
     Configures the WatchedFileHandler supporting expansion of `~` and `${LOG_PATH}` to the user's home and the log path respectively.

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -112,6 +112,16 @@ class BenchmarkActor(actor.RallyActor):
         assert self.cfg is not None
         self.coordinator = BenchmarkCoordinator(msg.cfg)
         self.coordinator.setup(sources=msg.sources)
+        prepare_only: bool = convert.to_bool(self.cfg.opts("race", "prepare.only", mandatory=False, default_value=False))
+        if prepare_only:
+            self.mechanic = None
+            team_revision: Optional[str] = self.cfg.opts("mechanic", "repository.revision", mandatory=False)
+            if team_revision:
+                self.coordinator.race.team_revision = team_revision
+            self.logger.info("Prepare-only mode: skipping engine; preparing track data only.")
+            self.main_driver = self.createActor(driver.DriverActor, targetActorRequirements={"coordinator": True})
+            self.send(self.main_driver, driver.PrepareBenchmark(self.cfg, self.coordinator.current_track))
+            return
         self.logger.info("Asking mechanic to start the engine.")
         self.mechanic = self.createActor(mechanic.MechanicActor, targetActorRequirements={"coordinator": True})
         self.send(
@@ -139,32 +149,35 @@ class BenchmarkActor(actor.RallyActor):
     def receiveMsg_PreparationComplete(self, msg, sender):
         self.coordinator.on_preparation_complete(msg.distribution_flavor, msg.distribution_version, msg.revision)
         # esrally race --prepare-only (race.prepare.only): exit after track prep instead of StartBenchmark.
-        prepare_only = convert.to_bool(self.cfg.opts("race", "prepare.only", mandatory=False, default_value=False))
+        prepare_only: bool = convert.to_bool(self.cfg.opts("race", "prepare.only", mandatory=False, default_value=False))
         if prepare_only:
-            self.logger.info("Prepare-only mode: skipping benchmark; shutting down driver and engine.")
+            self.logger.info("Prepare-only mode: skipping benchmark; shutting down driver%s.", " and engine" if self.mechanic else "")
             self._finish_prepare_only()
             return
         self.logger.info("Telling driver to start benchmark.")
         self.send(self.main_driver, driver.StartBenchmark())
 
-    def _finish_prepare_only(self):
+    def _finish_prepare_only(self) -> None:
         # Same teardown order as receiveMsg_BenchmarkComplete (exit driver, StopEngine -> EngineStopped -> Success),
         # but without running the challenge or on_benchmark_complete (no results, no summary).
         assert self.coordinator is not None
         assert self.main_driver is not None
-        assert self.mechanic is not None
         self.coordinator.on_prepare_only_complete()
         self.send(self.main_driver, thespian.actors.ActorExitRequest())
         self.main_driver = None
-        self.logger.info("Asking mechanic to stop the engine.")
-        self.send(self.mechanic, mechanic.StopEngine())
+        if self.mechanic is not None:
+            self.logger.info("Asking mechanic to stop the engine.")
+            self.send(self.mechanic, mechanic.StopEngine())
+        else:
+            self.send(self.start_sender, Success())
 
     @actor.no_retry("race control")  # pylint: disable=no-value-for-parameter
     def receiveMsg_TaskFinished(self, msg, sender):
         self.coordinator.on_task_finished(msg.metrics)
         # We choose *NOT* to reset our own metrics store's timer as this one is only used to collect complete metrics records from
         # other stores (used by driver and mechanic). Hence there is no need to reset the timer in our own metrics store.
-        self.send(self.mechanic, mechanic.ResetRelativeTime(msg.next_task_scheduled_in))
+        if self.mechanic is not None:
+            self.send(self.mechanic, mechanic.ResetRelativeTime(msg.next_task_scheduled_in))
 
     @actor.no_retry("race control")  # pylint: disable=no-value-for-parameter
     def receiveMsg_BenchmarkCancelled(self, msg, sender):
@@ -210,38 +223,48 @@ class BenchmarkCoordinator:
         # to load the track we need to know the correct cluster distribution version. Usually, this value should be set
         # but there are rare cases (external pipeline and user did not specify the distribution version) where we need
         # to derive it ourselves. For source builds we always assume "main"
+        prepare_only: bool = convert.to_bool(self.cfg.opts("race", "prepare.only", mandatory=False, default_value=False))
+        if prepare_only:
+            # Do not open reporting datastore (e.g. Elasticsearch metrics); prepare-only never persists benchmark metrics.
+            self.cfg.add(config.Scope.benchmark, "reporting", "datastore.type", "in-memory")
         if not sources and not self.cfg.exists("mechanic", "distribution.version"):
-            hosts = self.cfg.opts("client", "hosts").default
-            client_options = self.cfg.opts("client", "options").default
-            (
-                distribution_flavor,
-                distribution_version,
-                distribution_build_hash,
-                serverless_operator,
-            ) = client.factory.cluster_distribution_version(hosts, client_options)
-
-            self.logger.info(
-                "Automatically derived distribution flavor [%s], version [%s], and build hash [%s]",
-                distribution_flavor,
-                distribution_version,
-                distribution_build_hash,
-            )
-            self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", distribution_version)
-            self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.flavor", distribution_flavor)
-            if versions.is_serverless(distribution_flavor):
-                if not self.cfg.exists("driver", "serverless.mode"):
-                    self.cfg.add(config.Scope.benchmark, "driver", "serverless.mode", True)
-
-                if not self.cfg.exists("driver", "serverless.operator"):
-                    self.cfg.add(config.Scope.benchmark, "driver", "serverless.operator", serverless_operator)
-                console.info(f"Detected Elasticsearch Serverless mode with operator=[{serverless_operator}].")
+            if prepare_only:
+                # No cluster contact: seed version for track repo selection and messaging (see GitTrackRepository.update).
+                self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", version.minimum_es_version())
+                if not self.cfg.exists("mechanic", "distribution.flavor"):
+                    self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.flavor", "default")
             else:
-                min_es_version = versions.Version.from_string(version.minimum_es_version())
-                specified_version = versions.Version.from_string(distribution_version)
-                if specified_version < min_es_version:
-                    raise exceptions.SystemSetupError(
-                        f"Cluster version must be at least [{min_es_version}] but was [{distribution_version}]"
-                    )
+                hosts = self.cfg.opts("client", "hosts").default
+                client_options = self.cfg.opts("client", "options").default
+                (
+                    distribution_flavor,
+                    distribution_version,
+                    distribution_build_hash,
+                    serverless_operator,
+                ) = client.factory.cluster_distribution_version(hosts, client_options)
+
+                self.logger.info(
+                    "Automatically derived distribution flavor [%s], version [%s], and build hash [%s]",
+                    distribution_flavor,
+                    distribution_version,
+                    distribution_build_hash,
+                )
+                self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.version", distribution_version)
+                self.cfg.add(config.Scope.benchmark, "mechanic", "distribution.flavor", distribution_flavor)
+                if versions.is_serverless(distribution_flavor):
+                    if not self.cfg.exists("driver", "serverless.mode"):
+                        self.cfg.add(config.Scope.benchmark, "driver", "serverless.mode", True)
+
+                    if not self.cfg.exists("driver", "serverless.operator"):
+                        self.cfg.add(config.Scope.benchmark, "driver", "serverless.operator", serverless_operator)
+                    console.info(f"Detected Elasticsearch Serverless mode with operator=[{serverless_operator}].")
+                else:
+                    min_es_version = versions.Version.from_string(version.minimum_es_version())
+                    specified_version = versions.Version.from_string(distribution_version)
+                    if specified_version < min_es_version:
+                        raise exceptions.SystemSetupError(
+                            f"Cluster version must be at least [{min_es_version}] but was [{distribution_version}]"
+                        )
 
         self.current_track = track.load_track(self.cfg, install_dependencies=True)
         self.track_revision = self.cfg.opts("track", "repository.revision", mandatory=False)
@@ -268,7 +291,7 @@ class BenchmarkCoordinator:
         self.race.distribution_flavor = distribution_flavor
         self.race.distribution_version = distribution_version
         self.race.revision = revision
-        prepare_only = convert.to_bool(self.cfg.opts("race", "prepare.only", mandatory=False, default_value=False))
+        prepare_only: bool = convert.to_bool(self.cfg.opts("race", "prepare.only", mandatory=False, default_value=False))
         if not prepare_only:
             # store race initially (without any results) so other components can retrieve full metadata
             self.race_store.store_race(self.race)
@@ -279,33 +302,41 @@ class BenchmarkCoordinator:
                     "Prepared track [{}] and car {} with version [{}]; "
                     "prepare-only mode - not running the benchmark or persisting a race record.\n".format(
                         self.race.track_name, self.race.car, self.race.distribution_version
-                    )
+                    ),
+                    force=True,
+                    flush=True,
                 )
             else:
                 console.info(
                     "Prepared track [{}], challenge [{}] and car {} with version [{}]; "
                     "prepare-only mode - not running the benchmark or persisting a race record.\n".format(
                         self.race.track_name, self.race.challenge_name, self.race.car, self.race.distribution_version
-                    )
+                    ),
+                    force=True,
+                    flush=True,
                 )
         elif self.race.challenge.auto_generated:
             console.info(
                 "Racing on track [{}] and car {} with version [{}].\n".format(
                     self.race.track_name, self.race.car, self.race.distribution_version
-                )
+                ),
+                force=True,
+                flush=True,
             )
         else:
             console.info(
                 "Racing on track [{}], challenge [{}] and car {} with version [{}].\n".format(
                     self.race.track_name, self.race.challenge_name, self.race.car, self.race.distribution_version
-                )
+                ),
+                force=True,
+                flush=True,
             )
 
     def on_task_finished(self, new_metrics):
         self.logger.info("Bulk adding request metrics to metrics store.")
         self.metrics_store.bulk_add(new_metrics)
 
-    def on_prepare_only_complete(self):
+    def on_prepare_only_complete(self) -> None:
         # Close coordinator metrics store without flush/calculate_results/reporter.summarize (see on_benchmark_complete).
         self.logger.info("Prepare-only run finished; closing metrics store without benchmark results.")
         self.metrics_store.close()

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -39,7 +39,7 @@ from esrally import (
     types,
     version,
 )
-from esrally.utils import console, opts, versions
+from esrally.utils import console, convert, opts, versions
 
 pipelines = collections.OrderedDict()
 
@@ -138,8 +138,26 @@ class BenchmarkActor(actor.RallyActor):
     @actor.no_retry("race control")  # pylint: disable=no-value-for-parameter
     def receiveMsg_PreparationComplete(self, msg, sender):
         self.coordinator.on_preparation_complete(msg.distribution_flavor, msg.distribution_version, msg.revision)
+        # esrally race --prepare-only (race.prepare.only): exit after track prep instead of StartBenchmark.
+        prepare_only = convert.to_bool(self.cfg.opts("race", "prepare.only", mandatory=False, default_value=False))
+        if prepare_only:
+            self.logger.info("Prepare-only mode: skipping benchmark; shutting down driver and engine.")
+            self._finish_prepare_only()
+            return
         self.logger.info("Telling driver to start benchmark.")
         self.send(self.main_driver, driver.StartBenchmark())
+
+    def _finish_prepare_only(self):
+        # Same teardown order as receiveMsg_BenchmarkComplete (exit driver, StopEngine -> EngineStopped -> Success),
+        # but without running the challenge or on_benchmark_complete (no results, no summary).
+        assert self.coordinator is not None
+        assert self.main_driver is not None
+        assert self.mechanic is not None
+        self.coordinator.on_prepare_only_complete()
+        self.send(self.main_driver, thespian.actors.ActorExitRequest())
+        self.main_driver = None
+        self.logger.info("Asking mechanic to stop the engine.")
+        self.send(self.mechanic, mechanic.StopEngine())
 
     @actor.no_retry("race control")  # pylint: disable=no-value-for-parameter
     def receiveMsg_TaskFinished(self, msg, sender):
@@ -250,9 +268,27 @@ class BenchmarkCoordinator:
         self.race.distribution_flavor = distribution_flavor
         self.race.distribution_version = distribution_version
         self.race.revision = revision
-        # store race initially (without any results) so other components can retrieve full metadata
-        self.race_store.store_race(self.race)
-        if self.race.challenge.auto_generated:
+        prepare_only = convert.to_bool(self.cfg.opts("race", "prepare.only", mandatory=False, default_value=False))
+        if not prepare_only:
+            # store race initially (without any results) so other components can retrieve full metadata
+            self.race_store.store_race(self.race)
+        # Prepare-only: skip store_race here so no partial race.json is written when we never run the benchmark.
+        if prepare_only:
+            if self.race.challenge.auto_generated:
+                console.info(
+                    "Prepared track [{}] and car {} with version [{}]; "
+                    "prepare-only mode - not running the benchmark or persisting a race record.\n".format(
+                        self.race.track_name, self.race.car, self.race.distribution_version
+                    )
+                )
+            else:
+                console.info(
+                    "Prepared track [{}], challenge [{}] and car {} with version [{}]; "
+                    "prepare-only mode - not running the benchmark or persisting a race record.\n".format(
+                        self.race.track_name, self.race.challenge_name, self.race.car, self.race.distribution_version
+                    )
+                )
+        elif self.race.challenge.auto_generated:
             console.info(
                 "Racing on track [{}] and car {} with version [{}].\n".format(
                     self.race.track_name, self.race.car, self.race.distribution_version
@@ -268,6 +304,11 @@ class BenchmarkCoordinator:
     def on_task_finished(self, new_metrics):
         self.logger.info("Bulk adding request metrics to metrics store.")
         self.metrics_store.bulk_add(new_metrics)
+
+    def on_prepare_only_complete(self):
+        # Close coordinator metrics store without flush/calculate_results/reporter.summarize (see on_benchmark_complete).
+        self.logger.info("Prepare-only run finished; closing metrics store without benchmark results.")
+        self.metrics_store.close()
 
     def on_benchmark_complete(self, new_metrics):
         self.logger.info("Benchmark is complete.")

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -809,6 +809,13 @@ def create_arg_parser():
         action="store_true",
     )
     race_parser.add_argument(
+        "--prepare-only",
+        help="After provisioning (if applicable) and preparing the track on disk, exit successfully without running the challenge "
+        "schedule or writing benchmark results (default: false).",
+        default=False,
+        action="store_true",
+    )
+    race_parser.add_argument(
         "--enable-driver-profiling",
         help="Enables a profiler for analyzing the performance of calls in Rally's driver (default: false).",
         default=False,
@@ -1255,6 +1262,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "driver", "on.error", args.on_error)
             cfg.add(config.Scope.applicationOverride, "driver", "load_driver_hosts", opts.csv_to_list(args.load_driver_hosts))
             cfg.add(config.Scope.applicationOverride, "track", "test.mode.enabled", args.test_mode)
+            cfg.add(config.Scope.applicationOverride, "race", "prepare.only", args.prepare_only)
             configure_track_params(arg_parser, args, cfg)
             configure_connection_params(arg_parser, args, cfg)
             configure_telemetry_params(args, cfg)

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -127,6 +127,7 @@ Key = Literal[
     "plugin.community-plugin.src.dir",
     "plugin.community-plugin.src.subdir",
     "plugin.params",
+    "prepare.only",
     "preserve.install",
     "preserve_benchmark_candidate",
     "private.url",

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -138,9 +138,9 @@ class TestCluster:
     def __init__(self, cfg):
         self.cfg = cfg
         self.installation_id = None
-        self.http_port = None
+        self.http_port: int | None = None
 
-    def install(self, distribution_version, node_name, car, http_port):
+    def install(self, distribution_version, node_name, car, http_port: int):
         self.http_port = http_port
         transport_port = http_port + 100
         try:

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -32,7 +32,7 @@ from esrally.utils import process
 
 CONFIG_NAMES = ["in-memory-it", "es-it"]
 DISTRIBUTIONS = ["8.4.0"]
-# There are no ARM distribution artefacts for 6.8.0, which can't be tested on Apple Silicon
+# There are no ARM distribution artifacts for 6.8.0, which can't be tested on Apple Silicon
 if platform.machine() != "arm64":
     DISTRIBUTIONS.insert(0, "6.8.0")
 TRACKS = ["geonames", "nyc_taxis", "http_logs", "nested"]

--- a/it/prepare_only_test.py
+++ b/it/prepare_only_test.py
@@ -1,0 +1,320 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+import it
+from esrally.client import EsClientFactory
+from esrally.utils.cases import cases
+
+LOG = logging.getLogger(__name__)
+# Mirror ``rally.log`` lines from each esrally subprocess to stderr at DEBUG without mixing them into
+# ``subprocess.run`` capture (assertions depend on stdout/stderr staying clean of file-log content).
+_RALLY_LOG_STDERR = logging.getLogger(f"{__name__}.rally_log_mirror")
+RESOURCES: Final[Path] = Path(__file__).resolve().parent / "resources"
+# rally-prepare-only-it.ini sets reporting to a closed port (INACCESSIBLE_METRICS_PORT) for prepare-only subprocesses.
+# Full races use rally-es-it.ini (ES_IT_CONFIG) with the session metrics Elasticsearch; logs must never show contact to 65531.
+PREPARE_ONLY_IT_CONFIG: Final[str] = "prepare-only-it"
+# Second-phase full race: real reporting ES (session metrics store port), see rally-es-it.ini.
+ES_IT_CONFIG: Final[str] = "es-it"
+INACCESSIBLE_METRICS_PORT: Final[str] = "65531"
+# Unassigned port for --target-hosts (must differ from INACCESSIBLE_METRICS_PORT so logs stay distinguishable).
+INACCESSIBLE_TARGET_PORT: Final[str] = "65530"
+INACCESSIBLE_ES_HOST: Final[str] = f"127.0.0.1:{INACCESSIBLE_TARGET_PORT}"
+
+
+def _ensure_rally_log_stderr_mirror() -> None:
+    if _RALLY_LOG_STDERR.handlers:
+        return
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    _RALLY_LOG_STDERR.addHandler(handler)
+    _RALLY_LOG_STDERR.setLevel(logging.DEBUG)
+    _RALLY_LOG_STDERR.propagate = False
+
+
+def _debug_emit_new_rally_log_tail(rally_home: Path, prev_end: int) -> int:
+    log_path = rally_home / ".rally" / "logs" / "rally.log"
+    if not log_path.is_file():
+        return prev_end
+    data = log_path.read_bytes()
+    if len(data) < prev_end:
+        chunk = data
+    else:
+        chunk = data[prev_end:]
+    text = chunk.decode("utf-8", errors="replace")
+    for line in text.splitlines():
+        _RALLY_LOG_STDERR.debug("%s", line)
+    return len(data)
+
+
+def _wait_for_cluster_status_at_least_yellow(host: str, http_port: int, *, timeout_sec: float = 120.0, poll_interval_sec: float = 2.0) -> None:
+    """
+    Poll ``/_cluster/health`` until status is yellow or green (single-node clusters are often yellow).
+
+    Used before the second subprocess for ``benchmark-only`` when the race targets the session Elasticsearch.
+    """
+    es = EsClientFactory(hosts=[{"host": host, "port": http_port}], client_options={}).create()
+    deadline = time.perf_counter() + timeout_sec
+    last_exc: Exception | None = None
+    while time.perf_counter() < deadline:
+        try:
+            health = es.cluster.health()
+            status = health.get("status", "red")
+            if status in ("yellow", "green"):
+                LOG.info("Elasticsearch at %s:%s cluster health is %s", host, http_port, status)
+                return
+        except Exception as exc:
+            last_exc = exc
+            LOG.debug("cluster.health not ready yet: %s", exc)
+        time.sleep(poll_interval_sec)
+    msg = f"Elasticsearch at {host}:{http_port} did not reach yellow/green within {timeout_sec}s"
+    if last_exc is not None:
+        raise TimeoutError(msg) from last_exc
+    raise TimeoutError(msg)
+
+
+def _esrally_cmd_prefix() -> list[str]:
+    resolved = shutil.which("esrally")
+    if resolved:
+        return [resolved]
+    return [sys.executable, "-m", "esrally.rally"]
+
+
+@dataclass(frozen=True)
+class PrepareOnlyRaceCase:
+    """One table row: pipeline and optional ``--distribution-version`` string."""
+
+    # If set, passed to Rally as ``--pipeline``; if ``None``, that flag is omitted.
+    pipeline: str | None = None
+    
+    # If set, passed to Rally as ``--distribution-version``; if ``None``, that flag is omitted.
+    distribution_version: str | None = None
+
+    # It will assert that the target Elasticsearch cluster is prepared in the first subprocess and executed in the second one.
+    want_cluster_prepared: bool = False
+
+    def run_rally_subprocess(
+        self,
+        rally_home: Path,
+        prepare_only: bool,
+        *,
+        target_hosts: str | None = None,
+        enable_assertions: bool = False,
+        configuration_name: str | None = None,
+    ) -> tuple[int, str]:
+        """
+        Run ``esrally race`` for this case in a subprocess with ``RALLY_HOME`` set.
+
+        :param prepare_only: If True, pass ``--prepare-only`` and ``--target-hosts`` to a closed port (unless
+            ``target_hosts`` overrides). If False, omit ``--target-hosts`` when ``target_hosts`` is None so Rally
+            applies pipeline defaults (e.g. provisioned cluster); for ``benchmark-only``, pass the session cluster
+            via ``target_hosts``.
+        :param configuration_name: Rally config name under ``RALLY_HOME/.rally`` (default: ``prepare-only-it``).
+        """
+        cfg_name = configuration_name if configuration_name is not None else PREPARE_ONLY_IT_CONFIG
+        argv: list[str] = ["esrally", "race"]
+        if prepare_only:
+            argv.append("--prepare-only")
+        argv.extend(
+            [
+                "--test-mode",
+                "--track=geonames",
+                "--challenge=append-no-conflicts-index-only",
+            ]
+        )
+        if prepare_only:
+            hosts = target_hosts if target_hosts is not None else INACCESSIBLE_ES_HOST
+            argv.append(f"--target-hosts={hosts}")
+        elif target_hosts is not None:
+            argv.append(f"--target-hosts={target_hosts}")
+        argv.extend(
+            [
+                "--kill-running-processes",
+                "--on-error=abort",
+                f"--configuration-name={cfg_name}",
+            ]
+        )
+        if self.pipeline is not None:
+            argv.append(f"--pipeline={self.pipeline}")
+        if self.distribution_version is not None:
+            argv.append(f"--distribution-version={self.distribution_version}")
+        if enable_assertions:
+            argv.append("--enable-assertions")
+
+        if argv[:1] == ["esrally"]:
+            argv = _esrally_cmd_prefix() + argv[1:]
+        cmd: str = shlex.join(argv)
+        env: dict[str, str] = dict(os.environ)
+        env["RALLY_HOME"] = str(rally_home)
+        _ensure_rally_log_stderr_mirror()
+        log_path = rally_home / ".rally" / "logs" / "rally.log"
+        rally_log_end = log_path.stat().st_size if log_path.is_file() else 0
+        LOG.info("Running rally subprocess (shell): %s", cmd)
+        completed = subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=900,
+            check=False,
+        )
+        _debug_emit_new_rally_log_tail(rally_home, rally_log_end)
+        LOG.info(
+            "Rally subprocess finished: returncode=%s\nstdout:\n\t%s\n\nstderr:\n\t%s\n\n",
+            completed.returncode,
+            "\t\n".join((completed.stdout or "").splitlines()),
+            "\t\n".join((completed.stderr or "").splitlines()),
+        )
+        out: str = (completed.stdout or "") + (completed.stderr or "")
+        return completed.returncode, out
+
+
+def _install_prepare_only_test_config(rally_home: Path) -> None:
+    """
+    Install two Rally configs under ``RALLY_HOME``:
+
+    * ``prepare-only-it`` — fake reporting endpoint (unreachable port) for ``--prepare-only`` runs.
+    * ``es-it`` — real reporting Elasticsearch (session metrics store) for full races.
+    """
+    rally_confdir = rally_home / ".rally"
+    rally_confdir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(RESOURCES / f"rally-{PREPARE_ONLY_IT_CONFIG}.ini", rally_confdir / f"rally-{PREPARE_ONLY_IT_CONFIG}.ini")
+    shutil.copyfile(RESOURCES / f"rally-{ES_IT_CONFIG}.ini", rally_confdir / f"rally-{ES_IT_CONFIG}.ini")
+
+
+def _read_rally_log(rally_home: Path) -> str:
+    log_path = rally_home / ".rally" / "logs" / "rally.log"
+    if not log_path.is_file():
+        return ""
+    return log_path.read_text(encoding="utf-8", errors="replace")
+
+
+# Substrings that indicate track corpus transfer (download or progress); second race should not repeat them on stdout/stderr.
+_TRACK_CORPUS_TRANSFER_STDOUT_MARKERS: Final[tuple[str, ...]] = (
+    "Downloading data from",
+    "[INFO] Downloading track data",
+    "Downloaded data from",
+)
+
+
+def _corpus_transfer_events_in_log(log: str) -> int:
+    return sum(log.count(s) for s in _TRACK_CORPUS_TRANSFER_STDOUT_MARKERS)
+
+
+_PREPARE_ONLY_STDOUT_PHRASE: Final[str] = "prepare-only mode"
+
+
+def _subprocess_output_mentions_prepare_only(combined_stdout_stderr: str) -> bool:
+    """True if any line of captured subprocess output contains the prepare-only banner phrase (case-insensitive)."""
+    needle = _PREPARE_ONLY_STDOUT_PHRASE.casefold()
+    return any(needle in line.casefold() for line in combined_stdout_stderr.splitlines())
+
+
+@cases(
+    default=PrepareOnlyRaceCase(),
+    benchmark_only=PrepareOnlyRaceCase(pipeline="benchmark-only"),
+    from_distribution_=PrepareOnlyRaceCase(pipeline="from-distribution", distribution_version=it.DISTRIBUTIONS[-1], want_cluster_prepared=True),
+    with_distribution_version=PrepareOnlyRaceCase(distribution_version=it.DISTRIBUTIONS[-1], want_cluster_prepared=True),
+    from_distribution_with_distribution_version=PrepareOnlyRaceCase("from-distribution", it.DISTRIBUTIONS[-1], want_cluster_prepared=True),
+    from_sources=PrepareOnlyRaceCase(pipeline="from-sources", want_cluster_prepared=True),
+)
+def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
+    """
+    Every row runs two subprocesses in the same ``RALLY_HOME``:
+
+    1. ``--prepare-only`` with ``--configuration-name=prepare-only-it``: reporting points at an unreachable
+       Elasticsearch (``INACCESSIBLE_METRICS_PORT``). That port must never appear in ``rally.log`` after this step.
+       Rally also forces in-memory reporting in-process for prepare-only, but the on-disk config stays a decoy.
+       ``--target-hosts`` uses another closed port so an accidental probe would fail or stall.
+
+    2. Full ``race`` with ``--configuration-name=es-it``: reporting uses the live session metrics Elasticsearch
+       (``rally-es-it.ini``). Reuses the same track cache: no repeated corpus-transfer lines on stdout/stderr and the
+       same corpus-transfer event count in ``rally.log`` as after step 1. For ``benchmark-only``, the second run targets
+       the session cluster from ``it/conftest.py`` and waits for cluster health yellow/green before starting. Other
+       pipelines omit ``--target-hosts`` so Rally uses pipeline defaults. ``INACCESSIBLE_METRICS_PORT`` must never appear
+       in the log (no contact to the decoy endpoint); logging may reference the real metrics port (e.g. 10200).
+
+    New lines appended to ``rally.log`` after each subprocess are emitted as DEBUG on stderr (logger
+    ``it.prepare_only_test.rally_log_mirror``) so CI or local runs show file-equivalent tracing without polluting
+    captured subprocess output.
+    """
+    _install_prepare_only_test_config(tmp_path)
+
+    rc1, out1 = case.run_rally_subprocess(tmp_path, True)
+    log_after_prepare = _read_rally_log(tmp_path)
+
+    assert rc1 == 0, f"prepare-only failed ({rc1})\n{out1}\n--- log ---\n{log_after_prepare}"
+    assert _subprocess_output_mentions_prepare_only(out1), (
+        f"expected {_PREPARE_ONLY_STDOUT_PHRASE!r} on subprocess stdout/stderr:\n{out1}"
+    )
+    assert "Racing on track" not in out1
+    assert "Telling driver to start benchmark." not in log_after_prepare
+    assert "Asking mechanic to start the engine." not in log_after_prepare
+    assert "Checking if REST API is available." not in log_after_prepare
+    assert "Automatically derived distribution flavor" not in log_after_prepare
+    assert INACCESSIBLE_METRICS_PORT not in log_after_prepare, "prepare-only must not contact configured metrics Elasticsearch"
+    transfers_after_prepare = _corpus_transfer_events_in_log(log_after_prepare)
+    assert transfers_after_prepare > 0, (
+        "expected at least one corpus download/prepare log event after prepare-only; "
+        f"log excerpt:\n{log_after_prepare[-8000:]}"
+    )
+
+    if case.pipeline == "benchmark-only":
+        from it.conftest import ES_METRICS_STORE
+        # TODO: Start a new ES cluster for this test."
+        LOG.warning("Second subprocess targets the Elasticsearch metric store because it is missing one as target hosts.")
+        session_target = f"127.0.0.1:{ES_METRICS_STORE.cluster.http_port}"
+        _wait_for_cluster_status_at_least_yellow("127.0.0.1", ES_METRICS_STORE.cluster.http_port)
+        rc2, out2 = case.run_rally_subprocess(
+            tmp_path,
+            False,
+            target_hosts=session_target,
+            enable_assertions=True,
+            configuration_name=ES_IT_CONFIG,
+        )
+    else:
+        rc2, out2 = case.run_rally_subprocess(
+            tmp_path, False, enable_assertions=True, configuration_name=ES_IT_CONFIG
+        )
+
+    log_after_full = _read_rally_log(tmp_path)
+
+    assert rc2 == 0, f"full race failed ({rc2})\n{out2}\n--- log ---\n{log_after_full}"
+    assert INACCESSIBLE_METRICS_PORT not in log_after_full, (
+        "full race must not contact the decoy reporting endpoint (prepare-only-it.ini); es-it metrics traffic may log the real port"
+    )
+    assert "Racing on track" in out2, f"expected benchmark console banner\n{out2}"
+    for marker in _TRACK_CORPUS_TRANSFER_STDOUT_MARKERS:
+        assert marker not in out2, f"second run must not repeat track corpus transfer; found {marker!r} in:\n{out2}"
+
+    assert _corpus_transfer_events_in_log(log_after_full) == transfers_after_prepare, (
+        "second run must not add corpus download/prepare log lines; "
+        f"before={transfers_after_prepare} after={_corpus_transfer_events_in_log(log_after_full)}"
+    )

--- a/it/prepare_only_test.py
+++ b/it/prepare_only_test.py
@@ -29,6 +29,7 @@ from typing import Final
 import it
 from esrally.client import EsClientFactory
 from esrally.utils.cases import cases
+from it.conftest import ES_METRICS_STORE
 
 LOG = logging.getLogger(__name__)
 # Mirror ``rally.log`` lines from each esrally subprocess to stderr at DEBUG without mixing them into
@@ -72,7 +73,9 @@ def _debug_emit_new_rally_log_tail(rally_home: Path, prev_end: int) -> int:
     return len(data)
 
 
-def _wait_for_cluster_status_at_least_yellow(host: str, http_port: int, *, timeout_sec: float = 120.0, poll_interval_sec: float = 2.0) -> None:
+def _wait_for_cluster_status_at_least_yellow(
+    host: str, http_port: int, *, timeout_sec: float = 120.0, poll_interval_sec: float = 2.0
+) -> None:
     """
     Poll ``/_cluster/health`` until status is yellow or green (single-node clusters are often yellow).
 
@@ -111,7 +114,7 @@ class PrepareOnlyRaceCase:
 
     # If set, passed to Rally as ``--pipeline``; if ``None``, that flag is omitted.
     pipeline: str | None = None
-    
+
     # If set, passed to Rally as ``--distribution-version``; if ``None``, that flag is omitted.
     distribution_version: str | None = None
 
@@ -264,9 +267,7 @@ def _assert_track_materialized_under_rally_home(rally_home: Path) -> None:
         pipeline="from-distribution", distribution_version=it.DISTRIBUTIONS[-1], want_cluster_prepared=True
     ),
     with_distribution_version=PrepareOnlyRaceCase(distribution_version=it.DISTRIBUTIONS[-1], want_cluster_prepared=True),
-    from_distribution_with_distribution_version=PrepareOnlyRaceCase(
-        "from-distribution", it.DISTRIBUTIONS[-1], want_cluster_prepared=True
-    ),
+    from_distribution_with_distribution_version=PrepareOnlyRaceCase("from-distribution", it.DISTRIBUTIONS[-1], want_cluster_prepared=True),
     from_sources=PrepareOnlyRaceCase(pipeline="from-sources", want_cluster_prepared=True),
 )
 def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
@@ -299,9 +300,7 @@ def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
     log_after_prepare = _read_rally_log(tmp_path)
 
     assert rc1 == 0, f"prepare-only failed ({rc1})\n{out1}\n--- log ---\n{log_after_prepare}"
-    assert _subprocess_output_mentions_prepare_only(out1), (
-        f"expected {_PREPARE_ONLY_STDOUT_PHRASE!r} on subprocess stdout/stderr:\n{out1}"
-    )
+    assert _subprocess_output_mentions_prepare_only(out1), f"expected {_PREPARE_ONLY_STDOUT_PHRASE!r} on subprocess stdout/stderr:\n{out1}"
     assert "Racing on track" not in out1
     assert "Telling driver to start benchmark." not in log_after_prepare
     assert "Asking mechanic to start the engine." not in log_after_prepare
@@ -310,26 +309,26 @@ def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
     assert INACCESSIBLE_METRICS_PORT not in log_after_prepare, "prepare-only must not contact configured metrics Elasticsearch"
     transfers_after_prepare = _corpus_transfer_events_in_log(log_after_prepare)
     assert transfers_after_prepare > 0, (
-        "expected at least one corpus download/prepare log event after prepare-only; "
-        f"log excerpt:\n{log_after_prepare[-8000:]}"
+        "expected at least one corpus download/prepare log event after prepare-only; " f"log excerpt:\n{log_after_prepare[-8000:]}"
     )
     _assert_track_materialized_under_rally_home(tmp_path)
-    assert _PREPARE_ONLY_SKIPS_ENGINE_LOG in log_after_prepare, (
-        "prepare-only subprocess must skip the engine and only prepare track data (no Elasticsearch start/provision)"
-    )
-    assert _MECHANIC_PROVISIONS_CLUSTER not in log_after_prepare, (
-        "prepare-only must not provision Elasticsearch; first subprocess only prepares track on disk"
-    )
-    assert _MECHANIC_EXTERNAL_CLUSTER not in log_after_prepare, (
-        "prepare-only must not run benchmark-only external-cluster mechanic path in the first subprocess"
-    )
+    assert (
+        _PREPARE_ONLY_SKIPS_ENGINE_LOG in log_after_prepare
+    ), "prepare-only subprocess must skip the engine and only prepare track data (no Elasticsearch start/provision)"
+    assert (
+        _MECHANIC_PROVISIONS_CLUSTER not in log_after_prepare
+    ), "prepare-only must not provision Elasticsearch; first subprocess only prepares track on disk"
+    assert (
+        _MECHANIC_EXTERNAL_CLUSTER not in log_after_prepare
+    ), "prepare-only must not run benchmark-only external-cluster mechanic path in the first subprocess"
 
     if case.pipeline == "benchmark-only":
-        from it.conftest import ES_METRICS_STORE
         # TODO: Start a new ES cluster for this test."
         LOG.warning("Second subprocess targets the Elasticsearch metric store because it is missing one as target hosts.")
-        session_target = f"127.0.0.1:{ES_METRICS_STORE.cluster.http_port}"
-        _wait_for_cluster_status_at_least_yellow("127.0.0.1", ES_METRICS_STORE.cluster.http_port)
+        metrics_http_port = ES_METRICS_STORE.cluster.http_port
+        assert metrics_http_port is not None, "session metrics Elasticsearch must be started (shared_setup)"
+        session_target = f"127.0.0.1:{metrics_http_port}"
+        _wait_for_cluster_status_at_least_yellow("127.0.0.1", metrics_http_port)
         rc2, out2 = case.run_rally_subprocess(
             tmp_path,
             False,
@@ -338,18 +337,16 @@ def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
             configuration_name=ES_IT_CONFIG,
         )
     else:
-        rc2, out2 = case.run_rally_subprocess(
-            tmp_path, False, enable_assertions=True, configuration_name=ES_IT_CONFIG
-        )
+        rc2, out2 = case.run_rally_subprocess(tmp_path, False, enable_assertions=True, configuration_name=ES_IT_CONFIG)
 
     log_after_full = _read_rally_log(tmp_path)
     # Mechanic provisioning vs external-cluster lines come from subprocess 2 only; slice avoids coupling to prepare-only text.
     log_after_full_race_only = log_after_full[len(log_after_prepare) :]
 
     assert rc2 == 0, f"full race failed ({rc2})\n{out2}\n--- log ---\n{log_after_full}"
-    assert INACCESSIBLE_METRICS_PORT not in log_after_full, (
-        "full race must not contact the decoy reporting endpoint (prepare-only-it.ini); es-it metrics traffic may log the real port"
-    )
+    assert (
+        INACCESSIBLE_METRICS_PORT not in log_after_full
+    ), "full race must not contact the decoy reporting endpoint (prepare-only-it.ini); es-it metrics traffic may log the real port"
     assert "Racing on track" in out2, f"expected benchmark console banner\n{out2}"
     for marker in _TRACK_CORPUS_TRANSFER_STDOUT_MARKERS:
         assert marker not in out2, f"second run must not repeat track corpus transfer; found {marker!r} in:\n{out2}"
@@ -360,16 +357,16 @@ def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
     )
 
     if case.want_cluster_prepared:
-        assert _MECHANIC_PROVISIONS_CLUSTER in log_after_full_race_only, (
-            f"expected Rally to provision Elasticsearch ({_MECHANIC_PROVISIONS_CLUSTER!r}) in full-race rally.log tail"
-        )
-        assert _MECHANIC_EXTERNAL_CLUSTER not in log_after_full_race_only, (
-            f"did not expect external-only cluster log ({_MECHANIC_EXTERNAL_CLUSTER!r}) when want_cluster_prepared is True"
-        )
+        assert (
+            _MECHANIC_PROVISIONS_CLUSTER in log_after_full_race_only
+        ), f"expected Rally to provision Elasticsearch ({_MECHANIC_PROVISIONS_CLUSTER!r}) in full-race rally.log tail"
+        assert (
+            _MECHANIC_EXTERNAL_CLUSTER not in log_after_full_race_only
+        ), f"did not expect external-only cluster log ({_MECHANIC_EXTERNAL_CLUSTER!r}) when want_cluster_prepared is True"
     else:
-        assert _MECHANIC_EXTERNAL_CLUSTER in log_after_full_race_only, (
-            f"expected benchmark-only external cluster log ({_MECHANIC_EXTERNAL_CLUSTER!r}) in full-race rally.log tail"
-        )
-        assert _MECHANIC_PROVISIONS_CLUSTER not in log_after_full_race_only, (
-            f"did not expect Rally provisioning ({_MECHANIC_PROVISIONS_CLUSTER!r}) when want_cluster_prepared is False"
-        )
+        assert (
+            _MECHANIC_EXTERNAL_CLUSTER in log_after_full_race_only
+        ), f"expected benchmark-only external cluster log ({_MECHANIC_EXTERNAL_CLUSTER!r}) in full-race rally.log tail"
+        assert (
+            _MECHANIC_PROVISIONS_CLUSTER not in log_after_full_race_only
+        ), f"did not expect Rally provisioning ({_MECHANIC_PROVISIONS_CLUSTER!r}) when want_cluster_prepared is False"

--- a/it/prepare_only_test.py
+++ b/it/prepare_only_test.py
@@ -22,7 +22,6 @@ import shutil
 import subprocess
 import sys
 import time
-import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
@@ -116,8 +115,10 @@ class PrepareOnlyRaceCase:
     # If set, passed to Rally as ``--distribution-version``; if ``None``, that flag is omitted.
     distribution_version: str | None = None
 
-    # It will assert that the target Elasticsearch cluster is prepared in the first subprocess and executed in the second one.
-    want_cluster_prepared: bool = False
+    # If True, the second subprocess must have Rally provision/start Elasticsearch (after track prep in subprocess 1). If False, the
+    # second subprocess must use an externally provisioned cluster only (benchmark-only). Subprocess 1 is always ``--prepare-only``:
+    # it prepares track data on disk under RALLY_HOME and never starts or provisions Elasticsearch (see racecontrol BenchmarkActor).
+    want_cluster_prepared: bool = True
 
     def run_rally_subprocess(
         self,
@@ -222,6 +223,11 @@ _TRACK_CORPUS_TRANSFER_STDOUT_MARKERS: Final[tuple[str, ...]] = (
     "[INFO] Downloading track data",
     "Downloaded data from",
 )
+# MechanicActor.receiveMsg_StartEngine (esrally/mechanic/mechanic.py): provisioning vs benchmark-only external cluster.
+_MECHANIC_PROVISIONS_CLUSTER: Final[str] = "will be provisioned by Rally."
+_MECHANIC_EXTERNAL_CLUSTER: Final[str] = "Cluster will not be provisioned by Rally."
+# racecontrol.BenchmarkActor.receiveMsg_Setup when race.prepare.only is true
+_PREPARE_ONLY_SKIPS_ENGINE_LOG: Final[str] = "Prepare-only mode: skipping engine; preparing track data only."
 
 
 def _corpus_transfer_events_in_log(log: str) -> int:
@@ -237,12 +243,30 @@ def _subprocess_output_mentions_prepare_only(combined_stdout_stderr: str) -> boo
     return any(needle in line.casefold() for line in combined_stdout_stderr.splitlines())
 
 
+def _assert_track_materialized_under_rally_home(rally_home: Path) -> None:
+    """
+    After ``--prepare-only``, the geonames track repo and dataset cache must exist under ``RALLY_HOME`` (see
+    ``it/resources/rally-prepare-only-it.ini``: ``node.root.dir``, ``benchmarks.local.dataset.cache``).
+    """
+    root = rally_home / ".rally" / "benchmarks"
+    track_repo = root / "tracks" / "default"
+    data_cache = root / "data"
+    assert track_repo.is_dir(), f"expected track repository checkout at {track_repo}"
+    assert any(track_repo.iterdir()), f"expected non-empty track repo at {track_repo}"
+    assert data_cache.is_dir(), f"expected dataset cache directory at {data_cache}"
+    assert any(data_cache.iterdir()), f"expected non-empty dataset cache at {data_cache} after track prepare"
+
+
 @cases(
-    default=PrepareOnlyRaceCase(),
-    benchmark_only=PrepareOnlyRaceCase(pipeline="benchmark-only"),
-    from_distribution_=PrepareOnlyRaceCase(pipeline="from-distribution", distribution_version=it.DISTRIBUTIONS[-1], want_cluster_prepared=True),
+    default=PrepareOnlyRaceCase(want_cluster_prepared=True),
+    benchmark_only=PrepareOnlyRaceCase(pipeline="benchmark-only", want_cluster_prepared=False),
+    from_distribution_=PrepareOnlyRaceCase(
+        pipeline="from-distribution", distribution_version=it.DISTRIBUTIONS[-1], want_cluster_prepared=True
+    ),
     with_distribution_version=PrepareOnlyRaceCase(distribution_version=it.DISTRIBUTIONS[-1], want_cluster_prepared=True),
-    from_distribution_with_distribution_version=PrepareOnlyRaceCase("from-distribution", it.DISTRIBUTIONS[-1], want_cluster_prepared=True),
+    from_distribution_with_distribution_version=PrepareOnlyRaceCase(
+        "from-distribution", it.DISTRIBUTIONS[-1], want_cluster_prepared=True
+    ),
     from_sources=PrepareOnlyRaceCase(pipeline="from-sources", want_cluster_prepared=True),
 )
 def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
@@ -253,6 +277,8 @@ def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
        Elasticsearch (``INACCESSIBLE_METRICS_PORT``). That port must never appear in ``rally.log`` after this step.
        Rally also forces in-memory reporting in-process for prepare-only, but the on-disk config stays a decoy.
        ``--target-hosts`` uses another closed port so an accidental probe would fail or stall.
+       This step never starts or provisions Elasticsearch; it must leave the geonames track checkout and dataset cache
+       on disk under ``RALLY_HOME/.rally/benchmarks/`` (see ``_assert_track_materialized_under_rally_home``).
 
     2. Full ``race`` with ``--configuration-name=es-it``: reporting uses the live session metrics Elasticsearch
        (``rally-es-it.ini``). Reuses the same track cache: no repeated corpus-transfer lines on stdout/stderr and the
@@ -260,6 +286,8 @@ def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
        the session cluster from ``it/conftest.py`` and waits for cluster health yellow/green before starting. Other
        pipelines omit ``--target-hosts`` so Rally uses pipeline defaults. ``INACCESSIBLE_METRICS_PORT`` must never appear
        in the log (no contact to the decoy endpoint); logging may reference the real metrics port (e.g. 10200).
+       ``want_cluster_prepared``: when True, Rally must provision/start Elasticsearch in this step; when False
+       (``benchmark-only``), Rally must connect to an existing cluster only (mechanic log: not provisioned by Rally).
 
     New lines appended to ``rally.log`` after each subprocess are emitted as DEBUG on stderr (logger
     ``it.prepare_only_test.rally_log_mirror``) so CI or local runs show file-equivalent tracing without polluting
@@ -285,6 +313,16 @@ def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
         "expected at least one corpus download/prepare log event after prepare-only; "
         f"log excerpt:\n{log_after_prepare[-8000:]}"
     )
+    _assert_track_materialized_under_rally_home(tmp_path)
+    assert _PREPARE_ONLY_SKIPS_ENGINE_LOG in log_after_prepare, (
+        "prepare-only subprocess must skip the engine and only prepare track data (no Elasticsearch start/provision)"
+    )
+    assert _MECHANIC_PROVISIONS_CLUSTER not in log_after_prepare, (
+        "prepare-only must not provision Elasticsearch; first subprocess only prepares track on disk"
+    )
+    assert _MECHANIC_EXTERNAL_CLUSTER not in log_after_prepare, (
+        "prepare-only must not run benchmark-only external-cluster mechanic path in the first subprocess"
+    )
 
     if case.pipeline == "benchmark-only":
         from it.conftest import ES_METRICS_STORE
@@ -305,6 +343,8 @@ def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
         )
 
     log_after_full = _read_rally_log(tmp_path)
+    # Mechanic provisioning vs external-cluster lines come from subprocess 2 only; slice avoids coupling to prepare-only text.
+    log_after_full_race_only = log_after_full[len(log_after_prepare) :]
 
     assert rc2 == 0, f"full race failed ({rc2})\n{out2}\n--- log ---\n{log_after_full}"
     assert INACCESSIBLE_METRICS_PORT not in log_after_full, (
@@ -318,3 +358,18 @@ def test_prepare_only(case: PrepareOnlyRaceCase, tmp_path: Path) -> None:
         "second run must not add corpus download/prepare log lines; "
         f"before={transfers_after_prepare} after={_corpus_transfer_events_in_log(log_after_full)}"
     )
+
+    if case.want_cluster_prepared:
+        assert _MECHANIC_PROVISIONS_CLUSTER in log_after_full_race_only, (
+            f"expected Rally to provision Elasticsearch ({_MECHANIC_PROVISIONS_CLUSTER!r}) in full-race rally.log tail"
+        )
+        assert _MECHANIC_EXTERNAL_CLUSTER not in log_after_full_race_only, (
+            f"did not expect external-only cluster log ({_MECHANIC_EXTERNAL_CLUSTER!r}) when want_cluster_prepared is True"
+        )
+    else:
+        assert _MECHANIC_EXTERNAL_CLUSTER in log_after_full_race_only, (
+            f"expected benchmark-only external cluster log ({_MECHANIC_EXTERNAL_CLUSTER!r}) in full-race rally.log tail"
+        )
+        assert _MECHANIC_PROVISIONS_CLUSTER not in log_after_full_race_only, (
+            f"did not expect Rally provisioning ({_MECHANIC_PROVISIONS_CLUSTER!r}) when want_cluster_prepared is False"
+        )

--- a/it/resources/rally-prepare-only-it.ini
+++ b/it/resources/rally-prepare-only-it.ini
@@ -1,0 +1,39 @@
+[meta]
+config.version = 17
+
+[system]
+env.name = local
+
+[node]
+root.dir = ${CONFIG_DIR}/benchmarks
+src.root.dir = ${CONFIG_DIR}/benchmarks/src
+
+[source]
+remote.repo.url = https://github.com/elastic/elasticsearch.git
+elasticsearch.src.subdir = elasticsearch
+
+[benchmarks]
+local.dataset.cache = ${CONFIG_DIR}/benchmarks/data
+
+[reporting]
+# Intentionally unreachable: integration tests assert prepare-only never opens a client here.
+datastore.type = elasticsearch
+datastore.host = 127.0.0.1
+datastore.port = 65531
+datastore.secure = False
+datastore.user =
+datastore.password =
+
+
+[tracks]
+default.url = https://github.com/elastic/rally-tracks
+eventdata.url = https://github.com/elastic/rally-eventdata-track
+
+[teams]
+default.url = https://github.com/elastic/rally-teams
+
+[defaults]
+preserve_benchmark_candidate = False
+
+[distributions]
+release.cache = true

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -27,6 +27,7 @@ import elasticsearch
 import pytest
 
 from esrally import config, exceptions, metrics, track
+from esrally import version as rally_version
 from esrally.driver import driver, runner, scheduler
 from esrally.driver.driver import ApiKey, ClientContext
 from esrally.track import params
@@ -158,12 +159,26 @@ class TestDriver:
         self.track = track.Track(name="unittest", description="unittest track", challenges=[another_challenge, default_challenge])
 
     def teardown_method(self):
-        self.StaticClientFactory.close()
+        if TestDriver.StaticClientFactory.PATCHER is not None:
+            self.StaticClientFactory.close()
 
     def create_test_driver_actor(self):
         client = "client_marker"
         attrs = {"create_client.return_value": client}
         return mock.Mock(**attrs)
+
+    def test_prepare_benchmark_prepare_only_skips_es_client_factory(self) -> None:
+        self.cfg.add(config.Scope.applicationOverride, "race", "prepare.only", True)
+        factory = mock.Mock(side_effect=AssertionError("EsClientFactory must not be used in prepare-only mode"))
+        driver_actor = self.create_test_driver_actor()
+        d = driver.Driver(driver_actor, self.cfg, es_client_factory_class=factory)
+        d.prepare_benchmark(t=self.track)
+
+        factory.assert_not_called()
+        driver_actor.prepare_track.assert_called_once_with(["localhost"], self.cfg, self.track)
+        assert d.driver_actor.cluster_details["version"]["build_flavor"] == "default"
+        assert d.driver_actor.cluster_details["version"]["number"] == rally_version.minimum_es_version()
+        assert d.telemetry.devices == []
 
     @mock.patch("esrally.utils.net.resolve")
     def test_start_benchmark_and_prepare_track(self, resolve):

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -107,3 +107,49 @@ def test_runs_a_known_pipeline(unittest_pipeline):
     racecontrol.run(cfg)
 
     unittest_pipeline.target.assert_called_once_with(cfg)
+
+
+def test_on_preparation_complete_stores_race_by_default():
+    cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "race", "prepare.only", False)
+    coord = racecontrol.BenchmarkCoordinator(cfg)
+    coord.race = mock.Mock()
+    coord.race.challenge = mock.Mock(auto_generated=False)
+    coord.race.track_name = "t"
+    coord.race.challenge_name = "c"
+    coord.race.car = "defaults"
+    coord.race.distribution_version = "8.0.0"
+    coord.race_store = mock.Mock()
+
+    with mock.patch("esrally.racecontrol.console"):
+        coord.on_preparation_complete("oss", "8.0.0", "abc123")
+
+    coord.race_store.store_race.assert_called_once_with(coord.race)
+
+
+def test_on_preparation_complete_skips_race_store_when_prepare_only():
+    cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "race", "prepare.only", True)
+    coord = racecontrol.BenchmarkCoordinator(cfg)
+    coord.race = mock.Mock()
+    coord.race.challenge = mock.Mock(auto_generated=False)
+    coord.race.track_name = "t"
+    coord.race.challenge_name = "c"
+    coord.race.car = "defaults"
+    coord.race.distribution_version = "8.0.0"
+    coord.race_store = mock.Mock()
+
+    with mock.patch("esrally.racecontrol.console"):
+        coord.on_preparation_complete("oss", "8.0.0", "abc123")
+
+    coord.race_store.store_race.assert_not_called()
+
+
+def test_on_prepare_only_complete_closes_metrics_store():
+    cfg = config.Config()
+    coord = racecontrol.BenchmarkCoordinator(cfg)
+    coord.metrics_store = mock.Mock()
+
+    coord.on_prepare_only_complete()
+
+    coord.metrics_store.close.assert_called_once()

--- a/tests/racecontrol_test.py
+++ b/tests/racecontrol_test.py
@@ -17,11 +17,13 @@
 
 import os
 import re
+from datetime import datetime
 from unittest import mock
 
 import pytest
 
 from esrally import config, exceptions, racecontrol
+from esrally import version as rally_version
 
 
 @pytest.fixture
@@ -109,7 +111,7 @@ def test_runs_a_known_pipeline(unittest_pipeline):
     unittest_pipeline.target.assert_called_once_with(cfg)
 
 
-def test_on_preparation_complete_stores_race_by_default():
+def test_on_preparation_complete_stores_race_by_default() -> None:
     cfg = config.Config()
     cfg.add(config.Scope.benchmark, "race", "prepare.only", False)
     coord = racecontrol.BenchmarkCoordinator(cfg)
@@ -127,7 +129,7 @@ def test_on_preparation_complete_stores_race_by_default():
     coord.race_store.store_race.assert_called_once_with(coord.race)
 
 
-def test_on_preparation_complete_skips_race_store_when_prepare_only():
+def test_on_preparation_complete_skips_race_store_when_prepare_only() -> None:
     cfg = config.Config()
     cfg.add(config.Scope.benchmark, "race", "prepare.only", True)
     coord = racecontrol.BenchmarkCoordinator(cfg)
@@ -145,7 +147,7 @@ def test_on_preparation_complete_skips_race_store_when_prepare_only():
     coord.race_store.store_race.assert_not_called()
 
 
-def test_on_prepare_only_complete_closes_metrics_store():
+def test_on_prepare_only_complete_closes_metrics_store() -> None:
     cfg = config.Config()
     coord = racecontrol.BenchmarkCoordinator(cfg)
     coord.metrics_store = mock.Mock()
@@ -153,3 +155,54 @@ def test_on_prepare_only_complete_closes_metrics_store():
     coord.on_prepare_only_complete()
 
     coord.metrics_store.close.assert_called_once()
+
+
+@mock.patch("esrally.racecontrol.client.factory.cluster_distribution_version")
+@mock.patch("esrally.racecontrol.track.load_track")
+@mock.patch("esrally.racecontrol.metrics.create_race")
+@mock.patch("esrally.racecontrol.metrics.metrics_store")
+@mock.patch("esrally.racecontrol.metrics.race_store")
+def test_setup_prepare_only_skips_cluster_distribution_probe(
+    mock_race_store: mock.Mock,
+    mock_metrics_store: mock.Mock,
+    mock_create_race: mock.Mock,
+    mock_load_track: mock.Mock,
+    mock_cluster_version: mock.Mock,
+) -> None:
+    mock_cluster_version.side_effect = AssertionError("cluster probe should not run")
+    mock_challenge = mock.Mock()
+    mock_challenge.user_info = None
+    mock_challenge.serverless_info = []
+    mock_challenge.__str__ = mock.Mock(return_value="default")
+    mock_track = mock.Mock()
+    mock_track.find_challenge_or_default.return_value = mock_challenge
+    mock_track.__str__ = mock.Mock(return_value="unittest")
+    mock_load_track.return_value = mock_track
+    mock_race = mock.Mock()
+    mock_race.track = mock_track
+    mock_race.challenge = mock_challenge
+    mock_create_race.return_value = mock_race
+    mock_metrics_store.return_value = mock.Mock()
+    mock_race_store.return_value = mock.Mock()
+
+    cfg = config.Config()
+    cfg.add(config.Scope.benchmark, "race", "prepare.only", True)
+    cfg.add(config.Scope.benchmark, "system", "race.id", "28a032d1-0b03-4579-ad2a-c65316f126e9")
+    cfg.add(config.Scope.benchmark, "system", "time.start", datetime(2017, 8, 20, 1, 0, 0))
+    cfg.add(config.Scope.benchmark, "system", "env.name", "unittest")
+    cfg.add(config.Scope.benchmark, "race", "pipeline", "benchmark-only")
+    cfg.add(config.Scope.benchmark, "race", "user.tags", {})
+    cfg.add(config.Scope.benchmark, "track", "challenge.name", "default")
+    cfg.add(config.Scope.benchmark, "track", "params", {})
+    cfg.add(config.Scope.benchmark, "mechanic", "car.names", ["defaults"])
+    cfg.add(config.Scope.benchmark, "mechanic", "car.params", {})
+    cfg.add(config.Scope.benchmark, "mechanic", "plugin.params", {})
+    cfg.add(config.Scope.benchmark, "reporting", "datastore.type", "in-memory")
+
+    coord = racecontrol.BenchmarkCoordinator(cfg)
+    coord.setup(sources=False)
+
+    mock_cluster_version.assert_not_called()
+    assert cfg.opts("mechanic", "distribution.version") == rally_version.minimum_es_version()
+    assert cfg.opts("mechanic", "distribution.flavor") == "default"
+    assert cfg.opts("reporting", "datastore.type") == "in-memory"


### PR DESCRIPTION
## Summary

Adds `--prepare-only` to `esrally race` so Rally can provision Elasticsearch (when the pipeline does), download and prepare track data under the Rally root, then exit successfully **without** running the challenge schedule or printing benchmark results.

## Behavior

- After preparation completes, the driver and engine are shut down the same way as after a normal race (so `--preserve-install` and pipeline semantics still apply).
- In prepare-only mode, Rally does **not** persist a partial race record via `race_store.store_race` during preparation.
