### PR TITLE
Publish to TestPyPI on every commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release to PyPI
 
 on:
   push:
+    branches:
+      - "main"
     tags:
       - "*"
 
@@ -37,7 +39,7 @@ jobs:
 
   pypi-publish:
     name: Upload release to PyPI
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: [build]
     runs-on: ubuntu-latest
     environment: release
@@ -52,3 +54,23 @@ jobs:
           path: "dist/"
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+
+  test-pypi-publish:
+    name: "Upload release to Test PyPI"
+    needs: ["build"]
+    permissions:
+      id-token: write # Needed for trusted publishing to Test PyPI.
+    runs-on: "ubuntu-latest"
+    environment:
+      name: "testpypi"
+
+    steps:
+      - name: "Download dists"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          artifact-ids: ${{ needs.build.outputs.artifact-id }}
+          path: "dist/"
+      - name: "Publish dists to Test PyPI"
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release to PyPI
 on:
   push:
     branches:
-      - "main"
+      - "master"
     tags:
       - "*"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: Setup python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.x
       - name: Install dependencies
@@ -28,7 +28,7 @@ jobs:
       - name: Build dists
         run: python -m build
       - name: Upload dists
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: "dist"
           path: "dist/"
@@ -46,9 +46,9 @@ jobs:
 
     steps:
       - name: Download dists
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: "dist"
           path: "dist/"
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0


### PR DESCRIPTION
And also upgrade the GitHub Actions versions.

This should allow us to see issues sooner, not at every release.