### PR TITLE
feat: Optionally ignore unused track parameters

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -289,6 +289,11 @@ All track parameters are recorded for each metrics record in the metrics store. 
 
 Note that the default values are not recorded or shown (Rally does not know about them).
 
+``ignore-unused-track-params``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, Rally mandates that all provided track-parameters be used by the target track. Adding this flag suppresses that behavior; instead, Rally will write a warning to the log-file, then proceed as normal.
+
 ``challenge``
 ~~~~~~~~~~~~~
 

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -230,6 +230,12 @@ def create_arg_parser():
         default="",
     )
     info_parser.add_argument(
+        "--ignore-unused-track-params",
+        help="Only warn (instead of failing) when track parameters are given that are not used by the track.",
+        action="store_true",
+        default=False,
+    )
+    info_parser.add_argument(
         "--challenge",
         help=f"Define the challenge to use. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`.",
     )
@@ -253,6 +259,12 @@ def create_arg_parser():
         "--track-params",
         help="Define a comma-separated list of key:value pairs that are injected verbatim to the track as variables.",
         default="",
+    )
+    render_track_parser.add_argument(
+        "--ignore-unused-track-params",
+        help="Only warn (instead of failing) when track parameters are given that are not used by the track.",
+        action="store_true",
+        default=False,
     )
     render_track_parser.add_argument(
         "--build-flavor",
@@ -686,6 +698,12 @@ def create_arg_parser():
         default="",
     )
     race_parser.add_argument(
+        "--ignore-unused-track-params",
+        help="Only warn (instead of failing) when track parameters are given that are not used by the track.",
+        action="store_true",
+        default=False,
+    )
+    race_parser.add_argument(
         "--challenge",
         help=f"Define the challenge to use. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`.",
     )
@@ -1115,6 +1133,7 @@ def configure_track_params(arg_parser, args, cfg: types.Config, command_requires
 
     if command_requires_track_details:
         cfg.add(config.Scope.applicationOverride, "track", "params", opts.to_dict(args.track_params))
+        cfg.add(config.Scope.applicationOverride, "track", "params.ignore_unused", args.ignore_unused_track_params)
         cfg.add(config.Scope.applicationOverride, "track", "challenge.name", args.challenge)
         cfg.add(config.Scope.applicationOverride, "track", "include.tasks", opts.csv_to_list(args.include_tasks))
         cfg.add(config.Scope.applicationOverride, "track", "exclude.tasks", opts.csv_to_list(args.exclude_tasks))

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -1132,6 +1132,7 @@ class TrackFileReader:
         self.build_flavor = cfg.opts("mechanic", "distribution.flavor", default_value="default", mandatory=False)
         self.serverless_operator = cfg.opts("driver", "serverless.operator", default_value=False, mandatory=False)
         self.track_params = cfg.opts("track", "params", mandatory=False)
+        self.ignore_unused_params = cfg.opts("track", "params.ignore_unused", mandatory=False)
         self.complete_track_params = CompleteTrackParams(user_specified_track_params=self.track_params)
         self.read_track = TrackSpecificationReader(
             track_params=self.track_params,
@@ -1256,10 +1257,13 @@ class TrackFileReader:
                 )
             )
 
-            LOG.critical(err_msg)
-            # also dump the message on the console
-            console.println(err_msg)
-            raise exceptions.TrackConfigError(f"Unused track parameters {sorted(unused_user_defined_track_params)}.")
+            if self.ignore_unused_params:
+                LOG.warning(err_msg)
+                console.warn(err_msg)
+            else:
+                LOG.critical(err_msg)
+                console.error(err_msg)
+                raise exceptions.TrackConfigError(f"Unused track parameters {sorted(unused_user_defined_track_params)}.")
         return current_track
 
 

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -122,6 +122,7 @@ Key = Literal[
     "output.path",
     "output.processingtime",
     "params",
+    "params.ignore_unused",
     "passenv",
     "pipeline",
     "plugin.community-plugin.src.dir",


### PR DESCRIPTION
This makes it possible to ignore totally-unused track parameters, rather than always failing with an error when a track parameter is given but not used. This is, at minimum, a developer-experience improvement while building new tracks.

## Sample Output

```console
> esrally race --track=geonames --track-params="nonexistent_param:foo"

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/

[INFO] Race id is [66377ae1-42ab-4bf8-8c33-a3b8f215f3c0]
[ERROR] Some of your track parameter(s) "nonexistent_param" are not used by this track; perhaps you intend to use  instead.

All track parameters you provided are:
- nonexistent_param

All parameters exposed by this track:
- bulk_indexing_clients
- bulk_size
- cluster_health
- conflict_probability
- conflicts
- error_level
- include_force_merge
- include_non_serverless_index_settings
- include_target_throughput
- index_settings
- ingest_percentage
- max_num_segments
- number_of_replicas
- number_of_shards
- on_conflict
- post_ingest_sleep
- post_ingest_sleep_duration
- recency
- source_enabled
- store_type
[ERROR] Cannot race. Traceback (most recent call last):
  =~ snipped for brevity ~=

> esrally race --track=geonames --track-params="nonexistent_param:foo" --ignore-unused-track-params

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/

[INFO] Race id is [aef4d33b-b525-4e9a-886d-e9e16e443214]
[WARNING] Some of your track parameter(s) "nonexistent_param" are not used by this track; perhaps you intend to use  instead.

All track parameters you provided are:
- nonexistent_param

All parameters exposed by this track:
- bulk_indexing_clients
- bulk_size
- cluster_health
- conflict_probability
- conflicts
- error_level
- include_force_merge
- include_non_serverless_index_settings
- include_target_throughput
- index_settings
- ingest_percentage
- max_num_segments
- number_of_replicas
- number_of_shards
- on_conflict
- post_ingest_sleep
- post_ingest_sleep_duration
- recency
- source_enabled
- store_type
[INFO] Preparing for race ..
  =~ snipped for brevity ~=
```

## Testing

I get the following error when I run `make check-all` locally:

```
self = <it.TestCluster object at 0x107ad5160>, distribution_version = '8.5.1'
node_name = 'metrics-store', car = 'defaults,basic-license', http_port = 10200

    def install(self, distribution_version, node_name, car, http_port):
        self.http_port = http_port
        transport_port = http_port + 100
        try:
            output = process.run_subprocess_with_output(
                "esrally install --configuration-name={cfg} --quiet --distribution-version={dist}--build-type=tar "
                "--http-port={http_port} --node={node_name} --master-nodes={node_name} --car={car} "
                '--seed-hosts="127.0.0.1:{transport_port}" --cluster-name={cfg}'.format(
                    cfg=self.cfg,
                    dist=distribution_version,
                    http_port=http_port,
                    node_name=node_name,
                    car=car,
                    transport_port=transport_port,
                )
            )
            self.installation_id = json.loads("".join(output))["installation-id"]
        except BaseException as e:
>           raise AssertionError(f"Failed to install Elasticsearch {distribution_version}.", e)
E           AssertionError: ('Failed to install Elasticsearch 8.5.1.', JSONDecodeError('Expectingvalue: line 1 column 2 (char 1)'))

it/__init__.py:161: AssertionError
```