### PR TITLE
Add pre-commit hook to catch Sphinx role markup in Python files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,12 @@ repos:
         types: [python]
         args: []
 
+      - id: no-sphinx-role-xrefs-in-python
+        name: no Sphinx :role:`...` in Python
+        entry: ':[a-z]+:`[^`]*`'
+        language: pygrep
+        types: [python]
+
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:


### PR DESCRIPTION
## Summary

- Add a local `pygrep` pre-commit hook that flags Sphinx cross-reference roles (`:func:`...``, `:class:`...``, `:meth:`...``, etc.) in Python files.
- Rally does not use `sphinx.ext.autodoc` — docstrings are never pulled into the rendered Sphinx docs — so these markers are just noise when reading code in an editor or IDE.

## Test plan

- [x] `pre-commit run no-sphinx-role-xrefs-in-python --all-files` passes on the current codebase
- [x] Deliberately adding a marker like `:func:`foo`` to a `.py` file causes the hook to fail