### PR TITLE
Implement track parameter filtering for metrics reporting

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -280,7 +280,7 @@ Example JSON file::
       "clients": 16
    }
 
-Track parameters whose names start with ``secret_`` (for example ``secret_api_key``) are **not** written to the metrics store, race records, or results documents; they are still available to the track (Jinja templates, parameter sources, and so on). All other track parameters are recorded for each metrics record in the metrics store. Also, when you run ``esrally list races`` with JSON output, persisted ``track-params`` follow the same rule::
+Track parameters whose names start with ``secret_`` (for example ``secret_api_key``) are written to the metrics store, race records, and results documents with their value replaced by ``<hidden>``; the real value is still available to the track (Jinja templates, parameter sources, and so on) and is not persisted. All track parameter keys are recorded for each metrics record in the metrics store. Also, when you run ``esrally list races`` with JSON output, persisted ``track-params`` follow the same rule::
 
 
     Race Timestamp    Track    Track Parameters          Challenge            Car       User Tags

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -280,7 +280,8 @@ Example JSON file::
       "clients": 16
    }
 
-All track parameters are recorded for each metrics record in the metrics store. Also, when you run ``esrally list races``, it will show all track parameters::
+Track parameters whose names start with ``secret_`` (for example ``secret_api_key``) are **not** written to the metrics store, race records, or results documents; they are still available to the track (Jinja templates, parameter sources, and so on). All other track parameters are recorded for each metrics record in the metrics store. Also, when you run ``esrally list races`` with JSON output, persisted ``track-params`` follow the same rule::
+
 
     Race Timestamp    Track    Track Parameters          Challenge            Car       User Tags
     ----------------  -------  ------------------------- -------------------  --------  ---------

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -389,6 +389,16 @@ class SampleType(IntEnum):
     Normal = 1
 
 
+def track_params_for_reporting(track_params):
+    """
+    Track parameters whose names start with ``secret_`` are omitted from metrics documents,
+    race records, and other persisted reporting. They remain in configuration for track loading.
+    """
+    if not track_params:
+        return {}
+    return {k: v for k, v in track_params.items() if not str(k).startswith("secret_")}
+
+
 class MetricsStore:
     """
     Abstract metrics store
@@ -406,7 +416,7 @@ class MetricsStore:
         self._race_id = None
         self._race_timestamp = None
         self._track = None
-        self._track_params = cfg.opts("track", "params", default_value={}, mandatory=False)
+        self._track_params = track_params_for_reporting(cfg.opts("track", "params", default_value={}, mandatory=False))
         self._challenge = None
         self._car = None
         self._car_name = None
@@ -1539,8 +1549,9 @@ class Race:
         if self.challenge:
             if not hasattr(self.challenge, "auto_generated") or not self.challenge.auto_generated:
                 d["challenge"] = self.challenge_name
-        if self.track_params:
-            d["track-params"] = self.track_params
+        reporting_params = track_params_for_reporting(self.track_params)
+        if reporting_params:
+            d["track-params"] = reporting_params
         if self.car_params:
             d["car-params"] = self.car_params
         if self.plugin_params:
@@ -1572,8 +1583,9 @@ class Race:
             result_template["team-revision"] = self.team_revision
         if self.track_revision:
             result_template["track-revision"] = self.track_revision
-        if self.track_params:
-            result_template["track-params"] = self.track_params
+        reporting_params = track_params_for_reporting(self.track_params)
+        if reporting_params:
+            result_template["track-params"] = reporting_params
         if self.car_params:
             result_template["car-params"] = self.car_params
         if self.plugin_params:

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -400,9 +400,7 @@ def track_params_for_reporting(track_params):
     """
     if not track_params:
         return {}
-    return {
-        k: (SECRET_TRACK_PARAM_PLACEHOLDER if str(k).startswith("secret_") else v) for k, v in track_params.items()
-    }
+    return {k: (SECRET_TRACK_PARAM_PLACEHOLDER if str(k).startswith("secret_") else v) for k, v in track_params.items()}
 
 
 class MetricsStore:

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -389,14 +389,20 @@ class SampleType(IntEnum):
     Normal = 1
 
 
+SECRET_TRACK_PARAM_PLACEHOLDER = "<hidden>"
+
+
 def track_params_for_reporting(track_params):
     """
-    Track parameters whose names start with ``secret_`` are omitted from metrics documents,
-    race records, and other persisted reporting. They remain in configuration for track loading.
+    Track parameters whose names start with ``secret_`` are included in metrics documents,
+    race records, and other persisted reporting, but their values are replaced with
+    ``SECRET_TRACK_PARAM_PLACEHOLDER`` (``"<hidden>"``). Actual values remain only in configuration for track loading.
     """
     if not track_params:
         return {}
-    return {k: v for k, v in track_params.items() if not str(k).startswith("secret_")}
+    return {
+        k: (SECRET_TRACK_PARAM_PLACEHOLDER if str(k).startswith("secret_") else v) for k, v in track_params.items()
+    }
 
 
 class MetricsStore:

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -134,9 +134,14 @@ class TestTrackParamsForReporting:
         assert metrics.track_params_for_reporting({}) == {}
         assert metrics.track_params_for_reporting(None) == {}
 
-    def test_omits_secret_prefix(self):
+    def test_redacts_secret_prefix_values(self):
         params = {"clients": 8, "secret_api_key": "x", "secret_": "edge", "SECRET_not_filtered": 1}
-        assert metrics.track_params_for_reporting(params) == {"clients": 8, "SECRET_not_filtered": 1}
+        assert metrics.track_params_for_reporting(params) == {
+            "clients": 8,
+            "secret_api_key": metrics.SECRET_TRACK_PARAM_PLACEHOLDER,
+            "secret_": metrics.SECRET_TRACK_PARAM_PLACEHOLDER,
+            "SECRET_not_filtered": 1,
+        }
 
 
 class TestEsClient:
@@ -679,7 +684,7 @@ class TestEsMetrics:
         self.es_mock.create_index.assert_called_with(index="rally-metrics-2016-01")
         self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc])
 
-    def test_put_value_omits_secret_prefixed_track_params(self):
+    def test_put_value_redacts_secret_prefixed_track_param_values(self):
         self.cfg.add(config.Scope.application, "track", "params", {"shard-count": 3, "secret_token": "nope"})
         self.metrics_store = metrics.EsMetricsStore(
             self.cfg, client_factory_class=MockClientFactory, index_template_provider_class=DummyIndexTemplateProvider, clock=StaticClock
@@ -701,7 +706,7 @@ class TestEsMetrics:
             "environment": "unittest",
             "sample-type": "normal",
             "track": "test",
-            "track-params": {"shard-count": 3},
+            "track-params": {"shard-count": 3, "secret_token": metrics.SECRET_TRACK_PARAM_PLACEHOLDER},
             "challenge": "append",
             "car": "defaults",
             "name": "indexing_throughput",
@@ -1404,7 +1409,7 @@ class TestEsRaceStore:
         }
         self.es_mock.index.assert_called_with(index="rally-races-2016-01", id=self.RACE_ID, item=expected_doc)
 
-    def test_store_race_omits_secret_prefixed_track_params(self):
+    def test_store_race_redacts_secret_prefixed_track_param_values(self):
         schedule = [track.Task("index #1", track.Operation("index", track.OperationType.Bulk))]
 
         t = track.Track(
@@ -1438,7 +1443,10 @@ class TestEsRaceStore:
         self.race_store.store_race(race)
 
         indexed = self.es_mock.index.call_args.kwargs["item"]
-        assert indexed["track-params"] == {"shard-count": 3}
+        assert indexed["track-params"] == {
+            "shard-count": 3,
+            "secret_token": metrics.SECRET_TRACK_PARAM_PLACEHOLDER,
+        }
 
     @mock.patch("esrally.utils.console.println")
     def test_delete_race(self, console):

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -129,6 +129,16 @@ class StaticStopWatch:
         return 0
 
 
+class TestTrackParamsForReporting:
+    def test_empty(self):
+        assert metrics.track_params_for_reporting({}) == {}
+        assert metrics.track_params_for_reporting(None) == {}
+
+    def test_omits_secret_prefix(self):
+        params = {"clients": 8, "secret_api_key": "x", "secret_": "edge", "SECRET_not_filtered": 1}
+        assert metrics.track_params_for_reporting(params) == {"clients": 8, "SECRET_not_filtered": 1}
+
+
 class TestEsClient:
     class NodeMock:
         def __init__(self, host, port):
@@ -667,6 +677,39 @@ class TestEsMetrics:
         self.metrics_store.close()
         self.es_mock.exists.assert_called_with(index="rally-metrics-2016-01")
         self.es_mock.create_index.assert_called_with(index="rally-metrics-2016-01")
+        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc])
+
+    def test_put_value_omits_secret_prefixed_track_params(self):
+        self.cfg.add(config.Scope.application, "track", "params", {"shard-count": 3, "secret_token": "nope"})
+        self.metrics_store = metrics.EsMetricsStore(
+            self.cfg, client_factory_class=MockClientFactory, index_template_provider_class=DummyIndexTemplateProvider, clock=StaticClock
+        )
+        self.es_mock = self.metrics_store._client
+        self.es_mock.exists.return_value = False
+        self.es_mock.template_exists.return_value = False
+        self.es_mock.get_template.return_value = mock.create_autospec(elastic_transport.ObjectApiResponse, body={"index_templates": []})
+        self.metrics_store.logger = mock.create_autospec(logging.Logger)
+
+        throughput = 5000
+        self.metrics_store.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+        self.metrics_store.put_value_cluster_level("indexing_throughput", throughput, "docs/s")
+        expected_doc = {
+            "@timestamp": StaticClock.NOW * 1000,
+            "race-id": self.RACE_ID,
+            "race-timestamp": "20160131T000000Z",
+            "relative-time": 0,
+            "environment": "unittest",
+            "sample-type": "normal",
+            "track": "test",
+            "track-params": {"shard-count": 3},
+            "challenge": "append",
+            "car": "defaults",
+            "name": "indexing_throughput",
+            "value": throughput,
+            "unit": "docs/s",
+            "meta": {},
+        }
+        self.metrics_store.close()
         self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc])
 
     def test_put_value_with_explicit_timestamps(self):
@@ -1360,6 +1403,42 @@ class TestEsRaceStore:
             },
         }
         self.es_mock.index.assert_called_with(index="rally-races-2016-01", id=self.RACE_ID, item=expected_doc)
+
+    def test_store_race_omits_secret_prefixed_track_params(self):
+        schedule = [track.Task("index #1", track.Operation("index", track.OperationType.Bulk))]
+
+        t = track.Track(
+            name="unittest",
+            indices=[track.Index(name="tests", types=["_doc"])],
+            challenges=[track.Challenge(name="index", default=True, schedule=schedule)],
+        )
+
+        race = metrics.Race(
+            rally_version="0.4.4",
+            rally_revision="123abc",
+            environment_name="unittest",
+            race_id=self.RACE_ID,
+            race_timestamp=self.RACE_TIMESTAMP,
+            pipeline="from-sources",
+            user_tags={},
+            track=t,
+            track_params={"shard-count": 3, "secret_token": "hidden"},
+            challenge=t.default_challenge,
+            car="defaults",
+            car_params=None,
+            plugin_params=None,
+            track_revision=None,
+            team_revision=None,
+            distribution_version=None,
+            distribution_flavor=None,
+            revision=None,
+            results={},
+        )
+
+        self.race_store.store_race(race)
+
+        indexed = self.es_mock.index.call_args.kwargs["item"]
+        assert indexed["track-params"] == {"shard-count": 3}
 
     @mock.patch("esrally.utils.console.println")
     def test_delete_race(self, console):


### PR DESCRIPTION
- Introduced a new function `track_params_for_reporting` to omit track parameters starting with `secret_` from metrics documents and race records while retaining them in configuration.
- Updated the `MetricsStore` and `Race` classes to utilize this new filtering function.
- Added unit tests to ensure that secret-prefixed parameters are correctly omitted during reporting.
