### PR TITLE
Use esrally/race check= consistently in integration tests

### DIFF
--- a/it/__init__.py
+++ b/it/__init__.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import random
+import shlex
 import socket
 import subprocess
 import time
@@ -76,11 +77,7 @@ def rally_es(t):
     return wrapper
 
 
-def esrally_command_line_for(cfg: str, command_line: str) -> str:
-    return f"esrally {command_line} --configuration-name='{cfg}'"
-
-
-def esrally(cfg: str, command_line: str, check: bool = True) -> CompletedProcess:
+def esrally(cfg: str, command_line: str, check: bool = True, env: dict[str, str] | None = None, **kwargs) -> CompletedProcess:
     """
     Run ``esrally`` for subcommands other than ``race`` (see ``race``).
 
@@ -88,14 +85,20 @@ def esrally(cfg: str, command_line: str, check: bool = True) -> CompletedProcess
     ``pytest.fail`` and the captured stdout is included in the message.
     With ``check=False``, returns ``subprocess.CompletedProcess`` so callers
     can inspect ``returncode`` and ``stdout``.
+
+    If ``env`` is given, it is passed to ``subprocess.run`` (full environment
+    for the child process); otherwise the current process environment is used.
     """
-    command_line = esrally_command_line_for(cfg, command_line)
-    LOG.info("Running rally: %r", command_line)
+    cmd = f"esrally {command_line} --configuration-name='{cfg}'"
+    LOG.info("Running rally: %r", cmd)
+    kwargs.setdefault("stderr", subprocess.STDOUT)
     try:
-        return subprocess.run(command_line, shell=True, check=check, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        return subprocess.run(cmd, shell=True, check=check, env=env, stdout=subprocess.PIPE, text=True, **kwargs)
     except subprocess.CalledProcessError as err:
-        output = "    ".join([""] + (err.stdout or "").splitlines(keepends=True))
-        pytest.fail(f"Failed running esrally:\n - command line: {command_line}\n - output: {output}\n")
+        stdout = "    ".join([""] + (err.stdout or "").splitlines(keepends=True))
+        stderr = "    ".join([""] + (err.stderr or "").splitlines(keepends=True))
+        command = shlex.join(err.args)
+        pytest.fail(f"Failed running esrally:\n - command: {command}\n - stdout: {stdout}\n - stderr: {stderr}\n")
 
 
 def race(cfg: str, command_line: str, enable_assertions: bool = True, check: bool = True) -> CompletedProcess:

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -24,6 +24,7 @@ import random
 import socket
 import subprocess
 import time
+from subprocess import CompletedProcess
 
 import pytest
 
@@ -79,30 +80,37 @@ def esrally_command_line_for(cfg: str, command_line: str) -> str:
     return f"esrally {command_line} --configuration-name='{cfg}'"
 
 
-def esrally(cfg: str, command_line: str, check: bool = False) -> int:
+def esrally(cfg: str, command_line: str, check: bool = True) -> CompletedProcess:
     """
-    This method should be used for rally invocations of the all commands besides race.
-    These commands may have different CLI options than race.
+    Run ``esrally`` for subcommands other than ``race`` (see ``race``).
+
+    With ``check=True`` (default), a non-zero exit code fails the test via
+    ``pytest.fail`` and the captured stdout is included in the message.
+    With ``check=False``, returns ``subprocess.CompletedProcess`` so callers
+    can inspect ``returncode`` and ``stdout``.
     """
     command_line = esrally_command_line_for(cfg, command_line)
     LOG.info("Running rally: %r", command_line)
     try:
-        return subprocess.run(command_line, shell=True, check=check, capture_output=True, text=True).returncode
+        return subprocess.run(command_line, shell=True, check=check, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
     except subprocess.CalledProcessError as err:
-        stdout = "    ".join([""] + (err.stdout or "").splitlines(keepends=True))
-        stderr = "    ".join([""] + (err.stderr or "").splitlines(keepends=True))
-        pytest.fail("Failed running esrally:\n" f" - command line: {command_line}\n" f" - stdout: {stdout}\n" f" - stderr: {stderr}\n")
+        output = "    ".join([""] + (err.stdout or "").splitlines(keepends=True))
+        pytest.fail(f"Failed running esrally:\n - command line: {command_line}\n - output: {output}\n")
 
 
-def race(cfg: str, command_line: str, enable_assertions: bool = True, check: bool = False) -> int:
+def race(cfg: str, command_line: str, enable_assertions: bool = True, check: bool = True) -> CompletedProcess:
     """
-    This method should be used for rally invocations of the race command.
-    It sets up some defaults for how the integration tests expect to run races.
+    Run ``esrally race`` with integration-test defaults (kill running processes,
+    abort on error, optional ``--enable-assertions``).
+
+    The ``check`` argument is forwarded to ``esrally``: ``True`` fails the test
+    on non-zero exit; ``False`` returns ``subprocess.CompletedProcess`` for
+    ``returncode`` / ``stdout`` inspection.
     """
-    race_command = f"race {command_line} --kill-running-processes --on-error='abort'"
+    cmd = f"race {command_line} --kill-running-processes --on-error='abort'"
     if enable_assertions:
-        race_command += " --enable-assertions"
-    return esrally(cfg, race_command, check=check)
+        cmd += " --enable-assertions"
+    return esrally(cfg, cmd, check=check)
 
 
 def shell_cmd(command_line):
@@ -169,14 +177,15 @@ class TestCluster:
 
     def start(self, race_id):
         cmd = f'start --runtime-jdk="bundled" --installation-id={self.installation_id} --race-id={race_id}'
-        esrally(self.cfg, cmd, check=True)
+        esrally(self.cfg, cmd)
         es = client.EsClientFactory(hosts=[{"host": "127.0.0.1", "port": self.http_port}], client_options={}).create()
         client.wait_for_rest_layer(es)
         assert es.info()["cluster_name"] == self.cfg
 
     def stop(self):
         if self.installation_id:
-            if esrally(self.cfg, f"stop --installation-id={self.installation_id}") != 0:
+            r = esrally(self.cfg, f"stop --installation-id={self.installation_id}", check=False)
+            if r.returncode != 0:
                 raise AssertionError("Failed to stop Elasticsearch test cluster.")
 
     def __str__(self):

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -21,7 +21,6 @@ import json
 import logging
 import os
 import random
-import shlex
 import socket
 import subprocess
 import time
@@ -103,8 +102,7 @@ def esrally(cfg: str, command_line: str, check: bool = True, env: dict[str, str]
     except subprocess.CalledProcessError as err:
         stdout = "    ".join([""] + (err.stdout or "").splitlines(keepends=True))
         stderr = "    ".join([""] + (err.stderr or "").splitlines(keepends=True))
-        command = shlex.join(err.args)
-        pytest.fail(f"Failed running esrally:\n - command: {command}\n - stdout: {stdout}\n - stderr: {stderr}\n")
+        pytest.fail(f"Failed running esrally:\n - command: {err.cmd}\n - stdout: {stdout}\n - stderr: {stderr}\n")
 
 
 def race(cfg: str, command_line: str, enable_assertions: bool = True, check: bool = True) -> CompletedProcess:

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -183,7 +183,7 @@ class TestCluster:
                 f'--seed-hosts="127.0.0.1:{http_port + 100}" --cluster-name={self.cfg}'
             ),
         )
-        self.installation_id = json.loads("".join(result.stdout))["installation-id"]
+        self.installation_id = json.loads(result.stdout)["installation-id"]
 
     def start(self, race_id):
         esrally(self.cfg, f'start --runtime-jdk="bundled" --installation-id={self.installation_id} --race-id={race_id}')

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -29,8 +29,7 @@ from subprocess import CompletedProcess
 
 import pytest
 
-from esrally import client, version
-from esrally.utils import process
+from esrally import client
 
 CONFIG_NAMES = ["in-memory-it", "es-it"]
 DISTRIBUTIONS = ["8.19.13", "9.2.7"]
@@ -79,19 +78,26 @@ def rally_es(t):
 
 def esrally(cfg: str, command_line: str, check: bool = True, env: dict[str, str] | None = None, **kwargs) -> CompletedProcess:
     """
-    Run ``esrally`` for subcommands other than ``race`` (see ``race``).
+    Run ``esrally`` in a shell for integration tests.
 
-    With ``check=True`` (default), a non-zero exit code fails the test via
-    ``pytest.fail`` and the captured stdout is included in the message.
-    With ``check=False``, returns ``subprocess.CompletedProcess`` so callers
-    can inspect ``returncode`` and ``stdout``.
+    ``command_line`` is everything after the ``esrally`` executable: the
+    subcommand and its flags. ``cfg`` is passed as ``--configuration-name``.
 
-    If ``env`` is given, it is passed to ``subprocess.run`` (full environment
-    for the child process); otherwise the current process environment is used.
+    Returns a ``subprocess.CompletedProcess``. If ``check`` is ``True`` (the
+    default), a non-zero exit code triggers ``pytest.fail`` with command and
+    captured output in the failure message. If ``check`` is ``False``, callers
+    inspect ``returncode`` and ``stdout`` themselves.
+
+    ``env`` is the complete environment for the child process when set; when
+    ``None``, the child inherits the current process environment.
+
+    Extra keyword arguments are forwarded to ``subprocess.run`` (alongside
+    ``shell=True``, ``stdout=subprocess.PIPE``, and ``text=True``). Unless
+    overridden, ``stderr`` defaults to ``subprocess.PIPE``.
     """
     cmd = f"esrally {command_line} --configuration-name='{cfg}'"
     LOG.info("Running rally: %r", cmd)
-    kwargs.setdefault("stderr", subprocess.STDOUT)
+    kwargs.setdefault("stderr", subprocess.PIPE)
     try:
         return subprocess.run(cmd, shell=True, check=check, env=env, stdout=subprocess.PIPE, text=True, **kwargs)
     except subprocess.CalledProcessError as err:
@@ -103,12 +109,23 @@ def esrally(cfg: str, command_line: str, check: bool = True, env: dict[str, str]
 
 def race(cfg: str, command_line: str, enable_assertions: bool = True, check: bool = True) -> CompletedProcess:
     """
-    Run ``esrally race`` with integration-test defaults (kill running processes,
-    abort on error, optional ``--enable-assertions``).
+    Run ``esrally race`` with defaults used across the ``it`` suite.
 
-    The ``check`` argument is forwarded to ``esrally``: ``True`` fails the test
-    on non-zero exit; ``False`` returns ``subprocess.CompletedProcess`` for
-    ``returncode`` / ``stdout`` inspection.
+    ``command_line`` is everything after the ``race`` subcommand (track,
+    pipeline, hosts, and similar flags). The wrapper always appends
+    ``--kill-running-processes`` and ``--on-error='abort'``. When
+    ``enable_assertions`` is ``True`` (the default), it also adds
+    ``--enable-assertions``.
+
+    The return value and ``check`` semantics match ``esrally``: with
+    ``check=True``, failure is reported via ``pytest.fail``; with
+    ``check=False``, you read ``returncode`` and ``stdout`` from the
+    ``CompletedProcess``.
+
+    This helper only forwards ``check`` to ``esrally``. For a custom
+    ``env`` or other ``subprocess.run`` options, call ``esrally`` and pass a
+    ``race ...`` fragment in ``command_line`` yourself (including the same
+    trailing flags if you want parity with this function).
     """
     cmd = f"race {command_line} --kill-running-processes --on-error='abort'"
     if enable_assertions:
@@ -160,36 +177,25 @@ class TestCluster:
 
     def install(self, distribution_version, node_name, car, http_port):
         self.http_port = http_port
-        transport_port = http_port + 100
-        try:
-            output = process.run_subprocess_with_output(
-                "esrally install --configuration-name={cfg} --quiet --distribution-version={dist} --build-type=tar "
-                "--http-port={http_port} --node={node_name} --master-nodes={node_name} --car={car} "
-                '--seed-hosts="127.0.0.1:{transport_port}" --cluster-name={cfg}'.format(
-                    cfg=self.cfg,
-                    dist=distribution_version,
-                    http_port=http_port,
-                    node_name=node_name,
-                    car=car,
-                    transport_port=transport_port,
-                )
-            )
-            self.installation_id = json.loads("".join(output))["installation-id"]
-        except BaseException as e:
-            raise AssertionError(f"Failed to install Elasticsearch {distribution_version}.", e)
+        result = esrally(
+            self.cfg,
+            (
+                f"install --quiet --distribution-version={distribution_version} --build-type=tar "
+                f"--http-port={http_port} --node={node_name} --master-nodes={node_name} --car={car} "
+                f'--seed-hosts="127.0.0.1:{http_port + 100}" --cluster-name={self.cfg}'
+            ),
+        )
+        self.installation_id = json.loads("".join(result.stdout))["installation-id"]
 
     def start(self, race_id):
-        cmd = f'start --runtime-jdk="bundled" --installation-id={self.installation_id} --race-id={race_id}'
-        esrally(self.cfg, cmd)
+        esrally(self.cfg, f'start --runtime-jdk="bundled" --installation-id={self.installation_id} --race-id={race_id}')
         es = client.EsClientFactory(hosts=[{"host": "127.0.0.1", "port": self.http_port}], client_options={}).create()
         client.wait_for_rest_layer(es)
         assert es.info()["cluster_name"] == self.cfg
 
     def stop(self):
         if self.installation_id:
-            r = esrally(self.cfg, f"stop --installation-id={self.installation_id}", check=False)
-            if r.returncode != 0:
-                raise AssertionError("Failed to stop Elasticsearch test cluster.")
+            esrally(self.cfg, f"stop --installation-id={self.installation_id}")
 
     def __str__(self):
         return f"TestCluster[installation-id={self.installation_id}]"

--- a/it/basic_test.py
+++ b/it/basic_test.py
@@ -15,37 +15,26 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
-import tempfile
 
 import it
-from esrally.utils import process
 
 
 @it.rally_in_mem
 def test_run_without_arguments(cfg):
-    cmd = it.esrally_command_line_for(cfg, "")
-    output = process.run_subprocess_with_output(cmd)
-    expected = "usage: esrally [-h] [--version]"
-    assert expected in "\n".join(output)
+    assert "usage: esrally [-h] [--version]" in it.esrally(cfg, "", check=False).stderr
 
 
 @it.rally_in_mem
 def test_run_with_help(cfg):
-    cmd = it.esrally_command_line_for(cfg, "--help")
-    output = process.run_subprocess_with_output(cmd)
-    expected = "usage: esrally [-h] [--version]"
-    assert expected in "\n".join(output)
+    assert "usage: esrally [-h] [--version]" in it.esrally(cfg, "--help").stdout
 
 
 @it.rally_in_mem
-def test_run_without_http_connection(cfg):
-    cmd = it.esrally_command_line_for(cfg, "list tracks")
-    with tempfile.TemporaryDirectory() as tmpdir:
-        env = os.environ.copy()
-        env["http_proxy"] = "http://invalid"
-        env["https_proxy"] = "http://invalid"
-        # make sure we don't have any saved state
-        env["RALLY_HOME"] = tmpdir
-        output = process.run_subprocess_with_output(cmd, env=env)
-        expected = "[ERROR] Cannot list"
-        assert expected in "\n".join(output)
+def test_run_without_http_connection(cfg, tmpdir):
+    env = os.environ.copy()
+    env["http_proxy"] = "http://invalid"
+    env["https_proxy"] = "http://invalid"
+    # make sure we don't have any saved state
+    env["RALLY_HOME"] = str(tmpdir)
+    result = it.esrally(cfg, "list tracks", env=env, check=False)
+    assert "[ERROR] Cannot list" in result.stdout

--- a/it/dependencies_test.py
+++ b/it/dependencies_test.py
@@ -28,4 +28,4 @@ def test_track_dependencies(cfg):
     track_path = os.path.join(cwd, "resources", "track_with_dependency")
     # workaround for MacOS and Python deficiency. http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html
     os.environ["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
-    assert it.race(cfg, f"--distribution-version={dist_version} --track-path={track_path} --car=4gheap,basic-license") == 0
+    it.race(cfg, f"--distribution-version={dist_version} --track-path={track_path} --car=4gheap,basic-license")

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -74,13 +74,12 @@ def test_does_not_benchmark_unsupported_distribution(cfg):
 @it.random_rally_config
 def test_interrupt(cfg):
     port = 19200
-    dist = it.DISTRIBUTIONS[-1]
     # simulate a user cancelling a benchmark
-    cmd = it.esrally_command_line_for(
-        cfg,
-        f'race --distribution-version="{dist}" --track="geonames" '
+    cmd = (
+        f'esrally race --distribution-version="{it.DISTRIBUTIONS[-1]}" --track="geonames" '
         f"--kill-running-processes --target-hosts=127.0.0.1:{port} --test-mode "
-        f"--car=4gheap,basic-license",
+        f"--car=4gheap,basic-license "
+        f"--configuration-name='{cfg}'"
     )
     assert run_subprocess_and_interrupt(cmd, 2, 15) == 130
 
@@ -187,7 +186,7 @@ def execute_eventdata(cfg, test_cluster, challenges, track_params):
         it.race(cfg, cmd)
 
 
-def run_subprocess_and_interrupt(command_line, min_sleep=2, max_sleep=15):
+def run_subprocess_and_interrupt(command_line, min_sleep=2, max_sleep=15) -> int:
     logger = logging.getLogger(__name__)
     logger.debug("Running subprocess [%s] to interrupt.", command_line)
     command_line_args = shlex.split(command_line)

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -36,13 +36,10 @@ def test_tar_distributions(cfg, dist, track):
     it.wait_until_port_is_free(port_number=port)
 
     enable_assertions = track != "http_logs"  # http_logs assertions fail in test mode
-    assert (
-        it.race(
-            cfg,
-            f'--distribution-version="{dist}" --track="{track}" --test-mode --car=4gheap,basic-license --target-hosts=127.0.0.1:{port}',
-            enable_assertions=enable_assertions,
-        )
-        == 0
+    it.race(
+        cfg,
+        f'--distribution-version="{dist}" --track="{track}" --test-mode --car=4gheap,basic-license --target-hosts=127.0.0.1:{port}',
+        enable_assertions=enable_assertions,
     )
 
 
@@ -52,14 +49,11 @@ def test_docker_distribution(cfg):
     # only test the most recent Docker distribution
     dist = it.DISTRIBUTIONS[-1]
     it.wait_until_port_is_free(port_number=port)
-    assert (
-        it.race(
-            cfg,
-            f'--pipeline="docker" --distribution-version="{dist}" '
-            f'--track="geonames" --challenge="append-no-conflicts-index-only" --test-mode '
-            f"--car=4gheap,basic-license --target-hosts=127.0.0.1:{port}",
-        )
-        == 0
+    it.race(
+        cfg,
+        f'--pipeline="docker" --distribution-version="{dist}" '
+        f'--track="geonames" --challenge="append-no-conflicts-index-only" --test-mode '
+        f"--car=4gheap,basic-license --target-hosts=127.0.0.1:{port}",
     )
 
 
@@ -69,8 +63,10 @@ def test_does_not_benchmark_unsupported_distribution(cfg):
     it.wait_until_port_is_free(port_number=port)
     assert (
         it.race(
-            cfg, f'--distribution-version="1.7.6" --track="{it.TRACKS[0]}" ' f"--target-hosts=127.0.0.1:{port} --test-mode --car=4gheap"
-        )
+            cfg,
+            f'--distribution-version="1.7.6" --track="{it.TRACKS[0]}" ' f"--target-hosts=127.0.0.1:{port} --test-mode --car=4gheap",
+            check=False,
+        ).returncode
         != 0
     )
 
@@ -95,14 +91,11 @@ def test_create_api_key_per_client(cfg):
     it.wait_until_port_is_free(port_number=port)
     dist = it.DISTRIBUTIONS[-1]
     opts = "use_ssl:true,verify_certs:false,basic_auth_user:'rally',basic_auth_password:'rally-password',create_api_key_per_client:true"
-    assert (
-        it.race(
-            cfg,
-            f'--distribution-version={dist} --track="geonames" '
-            f"--test-mode --car=4gheap,trial-license,x-pack-security --target-hosts=127.0.0.1:{port} "
-            f"--client-options={opts}",
-        )
-        == 0
+    it.race(
+        cfg,
+        f'--distribution-version={dist} --track="geonames" '
+        f"--test-mode --car=4gheap,trial-license,x-pack-security --target-hosts=127.0.0.1:{port} "
+        f"--client-options={opts}",
     )
 
 
@@ -142,10 +135,10 @@ def test_multi_target_hosts(cfg, test_cluster):
             f"--client-options={client_options_str} "
         )
 
-    assert it.race(cfg, race_params()) == 0
+    it.race(cfg, race_params())
 
     target_hosts["extra_cluster"] = [hosts]
-    assert it.race(cfg, race_params()) != 0
+    assert it.race(cfg, race_params(), check=False).returncode != 0
 
 
 @it.random_rally_config
@@ -191,7 +184,7 @@ def execute_eventdata(cfg, test_cluster, challenges, track_params):
             f'--track-repository=eventdata --track=eventdata --track-params="{track_params}" '
             f"--challenge={challenge}"
         )
-        assert it.race(cfg, cmd) == 0
+        it.race(cfg, cmd)
 
 
 def run_subprocess_and_interrupt(command_line, min_sleep=2, max_sleep=15):

--- a/it/download_test.py
+++ b/it/download_test.py
@@ -21,9 +21,9 @@ import it
 @it.random_rally_config
 def test_download_distribution(cfg):
     for d in it.DISTRIBUTIONS:
-        assert it.esrally(cfg, f'download --distribution-version="{d}" --quiet') == 0
+        it.esrally(cfg, f'download --distribution-version="{d}" --quiet')
 
 
 @it.random_rally_config
 def test_does_not_download_unsupported_distribution(cfg):
-    assert it.esrally(cfg, 'download --distribution-version="1.7.6" --quiet') != 0
+    assert it.esrally(cfg, 'download --distribution-version="1.7.6" --quiet', check=False).returncode != 0

--- a/it/error_test.py
+++ b/it/error_test.py
@@ -15,12 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 import it
-from esrally.utils import process
 
 
 @it.rally_in_mem
 def test_error_prints_when_quiet(cfg):
-    cmd = it.esrally_command_line_for(cfg, "build --revision=nonsense --quiet")
-    output = process.run_subprocess_with_output(cmd)
-    expected = "[ERROR] Cannot build."
-    assert expected in "\n".join(output)
+    result = it.esrally(cfg, "build --revision=nonsense --quiet", check=False)
+    assert result.returncode != 0
+    assert "[ERROR] Cannot build." in result.stdout

--- a/it/esrallyd_test.py
+++ b/it/esrallyd_test.py
@@ -45,9 +45,13 @@ def test_elastic_transport_module_does_not_log_at_info_level(cfg, fresh_log_file
     port = 19200
     it.wait_until_port_is_free(port_number=port)
     dist = it.DISTRIBUTIONS[-1]
-    it.race(
-        cfg,
-        f'--distribution-version={dist} --track="geonames" --include-tasks=delete-index '
-        f"--test-mode --car=4gheap,trial-license --target-hosts=127.0.0.1:{port} ",
+    assert (
+        it.race(
+            cfg,
+            f'--distribution-version={dist} --track="geonames" --include-tasks=delete-index '
+            f"--test-mode --car=4gheap,trial-license --target-hosts=127.0.0.1:{port} ",
+            check=False,
+        ).returncode
+        == 0
     )
     assert it.find_log_line(fresh_log_file, "elastic_transport.transport INFO") is None

--- a/it/esrallyd_test.py
+++ b/it/esrallyd_test.py
@@ -45,13 +45,9 @@ def test_elastic_transport_module_does_not_log_at_info_level(cfg, fresh_log_file
     port = 19200
     it.wait_until_port_is_free(port_number=port)
     dist = it.DISTRIBUTIONS[-1]
-    assert (
-        it.race(
-            cfg,
-            f'--distribution-version={dist} --track="geonames" --include-tasks=delete-index '
-            f"--test-mode --car=4gheap,trial-license --target-hosts=127.0.0.1:{port} ",
-            check=False,
-        ).returncode
-        == 0
+    it.race(
+        cfg,
+        f'--distribution-version={dist} --track="geonames" --include-tasks=delete-index '
+        f"--test-mode --car=4gheap,trial-license --target-hosts=127.0.0.1:{port} ",
     )
     assert it.find_log_line(fresh_log_file, "elastic_transport.transport INFO") is None

--- a/it/info_test.py
+++ b/it/info_test.py
@@ -21,17 +21,17 @@ from esrally.utils import process
 
 @it.rally_in_mem
 def test_track_info_with_challenge(cfg):
-    assert it.esrally(cfg, "info --track=geonames --challenge=append-no-conflicts") == 0
+    it.esrally(cfg, "info --track=geonames --challenge=append-no-conflicts")
 
 
 @it.rally_in_mem
 def test_track_info_with_track_repo(cfg):
-    assert it.esrally(cfg, "info --track-repository=default --track=geonames") == 0
+    it.esrally(cfg, "info --track-repository=default --track=geonames")
 
 
 @it.rally_in_mem
 def test_track_info_with_task_filter(cfg):
-    assert it.esrally(cfg, 'info --track=geonames --challenge=append-no-conflicts --include-tasks="type:search"') == 0
+    it.esrally(cfg, 'info --track=geonames --challenge=append-no-conflicts --include-tasks="type:search"')
 
 
 @it.rally_in_mem

--- a/it/info_test.py
+++ b/it/info_test.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import it
-from esrally.utils import process
 
 
 @it.rally_in_mem
@@ -37,12 +36,17 @@ def test_track_info_with_task_filter(cfg):
 @it.rally_in_mem
 def test_track_info_fails_with_wrong_track_params(cfg):
     # simulate a typo in track parameter
-    cmd = it.esrally_command_line_for(cfg, "info --track=geonames --track-params='conflict_probability:5,number-of-replicas:1'")
-    output = process.run_subprocess_with_output(cmd)
+    result = it.esrally(
+        cfg,
+        "info --track=geonames --track-params='conflict_probability:5,number-of-replicas:1'",
+        check=False,
+    )
+    assert result.returncode != 0
+    output = (result.stdout or "") + (result.stderr or "")
     expected = (
         'Some of your track parameter(s) "number-of-replicas" are not used by this track; '
         'perhaps you intend to use "number_of_replicas" instead.\n\nAll track parameters you '
         "provided are:\n- conflict_probability\n- number-of-replicas\n\nAll parameters exposed by this track"
     )
 
-    assert expected in "\n".join(output)
+    assert expected in output

--- a/it/list_test.py
+++ b/it/list_test.py
@@ -20,26 +20,26 @@ import it
 
 @it.all_rally_configs
 def test_list_races(cfg):
-    assert it.esrally(cfg, "list races") == 0
+    it.esrally(cfg, "list races")
 
 
 @it.rally_in_mem
 def test_list_cars(cfg):
-    assert it.esrally(cfg, "list cars") == 0
+    it.esrally(cfg, "list cars")
 
 
 @it.rally_in_mem
 def test_list_elasticsearch_plugins(cfg):
-    assert it.esrally(cfg, "list elasticsearch-plugins") == 0
+    it.esrally(cfg, "list elasticsearch-plugins")
 
 
 @it.rally_in_mem
 def test_list_tracks(cfg):
-    assert it.esrally(cfg, "list tracks") == 0
-    assert it.esrally(cfg, "list tracks --track-repository=eventdata") == 0
-    assert it.esrally(cfg, "list tracks --track-repository=default --track-revision=4080dc9850d07e23b6fc7cfcdc7cf57b14e5168d") == 0
+    it.esrally(cfg, "list tracks")
+    it.esrally(cfg, "list tracks --track-repository=eventdata")
+    it.esrally(cfg, "list tracks --track-repository=default --track-revision=4080dc9850d07e23b6fc7cfcdc7cf57b14e5168d")
 
 
 @it.rally_in_mem
 def test_list_telemetry(cfg):
-    assert it.esrally(cfg, "list telemetry") == 0
+    it.esrally(cfg, "list telemetry")

--- a/it/proxy_test.py
+++ b/it/proxy_test.py
@@ -50,15 +50,14 @@ def test_run_with_direct_internet_connection(cfg, http_proxy, fresh_log_file):
 
 @it.rally_in_mem
 def test_anonymous_proxy_no_connection(cfg, http_proxy):
-    env = dict(os.environ)
+    env = os.environ.copy()
     env["http_proxy"] = http_proxy.anonymous_url
     env["https_proxy"] = http_proxy.anonymous_url
-    lines = process.run_subprocess_with_output(it.esrally_command_line_for(cfg, "list tracks"), env=env)
-    output = "\n".join(lines)
+    result = it.esrally(cfg, "list tracks", env=env)
     # there should be a warning because we can't connect
-    assert "[WARNING] Could not update tracks." in output
+    assert "[WARNING] Could not update tracks." in result.stdout
     # still, the command succeeds because of local state
-    assert "[INFO] SUCCESS" in output
+    assert "[INFO] SUCCESS" in result.stdout
 
 
 @it.rally_in_mem
@@ -66,8 +65,7 @@ def test_authenticated_proxy_user_can_connect(cfg, http_proxy):
     env = dict(os.environ)
     env["http_proxy"] = http_proxy.authenticated_url
     env["https_proxy"] = http_proxy.authenticated_url
-    lines = process.run_subprocess_with_output(it.esrally_command_line_for(cfg, "list tracks"), env=env)
-    output = "\n".join(lines)
+    output = it.esrally(cfg, "list tracks", env=env).stdout or ""
     # rally should be able to connect, no warning
     assert "[WARNING] Could not update tracks." not in output
     # the command should succeed

--- a/it/proxy_test.py
+++ b/it/proxy_test.py
@@ -44,7 +44,7 @@ def http_proxy():
 
 @it.rally_in_mem
 def test_run_with_direct_internet_connection(cfg, http_proxy, fresh_log_file):
-    assert it.esrally(cfg, "list tracks") == 0
+    it.esrally(cfg, "list tracks")
     assert it.find_log_line(fresh_log_file, "Connecting directly to the Internet")
 
 

--- a/it/sources_test.py
+++ b/it/sources_test.py
@@ -26,69 +26,51 @@ def test_sources(cfg):
     it.wait_until_port_is_free(port_number=port)
 
     # Default sources build method
-    assert (
-        it.race(
-            cfg,
-            f"--revision=latest --track=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
-            f"--challenge=append-no-conflicts --car=4gheap,basic-license --elasticsearch-plugins=analysis-icu",
-        )
-        == 0
+    it.race(
+        cfg,
+        f"--revision=latest --track=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
+        f"--challenge=append-no-conflicts --car=4gheap,basic-license --elasticsearch-plugins=analysis-icu",
     )
 
     # Default sources build method
     it.wait_until_port_is_free(port_number=port)
-    assert (
-        it.race(
-            cfg,
-            f"--pipeline=from-sources --track=geonames --test-mode --target-hosts=127.0.0.1:{port} "
-            f'--challenge=append-no-conflicts-index-only --car="4gheap,basic-license,ea"',
-        )
-        == 0
+    it.race(
+        cfg,
+        f"--pipeline=from-sources --track=geonames --test-mode --target-hosts=127.0.0.1:{port} "
+        f'--challenge=append-no-conflicts-index-only --car="4gheap,basic-license,ea"',
     )
 
     # Docker sources build method
-    assert (
-        it.race(
-            cfg,
-            f"--revision=@2022-07-07 --track=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
-            f"--challenge=append-no-conflicts --car=4gheap,basic-license --elasticsearch-plugins=analysis-icu "
-            f"--source-build-method=docker",
-        )
-        == 0
+    it.race(
+        cfg,
+        f"--revision=@2022-07-07 --track=geonames --test-mode  --target-hosts=127.0.0.1:{port} "
+        f"--challenge=append-no-conflicts --car=4gheap,basic-license --elasticsearch-plugins=analysis-icu "
+        f"--source-build-method=docker",
     )
 
     # Docker sources build method
     it.wait_until_port_is_free(port_number=port)
-    assert (
-        it.race(
-            cfg,
-            f"--pipeline=from-sources --track=geonames --test-mode --target-hosts=127.0.0.1:{port} "
-            f'--source-build-method=docker --challenge=append-no-conflicts-index-only --car="4gheap,basic-license,ea"',
-        )
-        == 0
+    it.race(
+        cfg,
+        f"--pipeline=from-sources --track=geonames --test-mode --target-hosts=127.0.0.1:{port} "
+        f'--source-build-method=docker --challenge=append-no-conflicts-index-only --car="4gheap,basic-license,ea"',
     )
 
 
 @it.random_rally_config
 def test_build_es_and_plugin_with_docker(cfg):
-    assert (
-        it.esrally(
-            cfg,
-            "build --source-build-method=docker --revision=latest --target-arch aarch64 --target-os linux "
-            "--elasticsearch-plugins=analysis-icu --quiet",
-        )
-        == 0
+    it.esrally(
+        cfg,
+        "build --source-build-method=docker --revision=latest --target-arch aarch64 --target-os linux "
+        "--elasticsearch-plugins=analysis-icu --quiet",
     )
 
 
 @it.random_rally_config
 def test_build_es(cfg):
-    assert (
-        it.esrally(
-            cfg,
-            "build --revision=latest --target-arch aarch64 --target-os linux --quiet",
-        )
-        == 0
+    it.esrally(
+        cfg,
+        "build --revision=latest --target-arch aarch64 --target-os linux --quiet",
     )
 
 

--- a/it/static_responses_test.py
+++ b/it/static_responses_test.py
@@ -27,12 +27,9 @@ def test_static_responses(cfg):
     cwd = os.path.dirname(__file__)
     responses = os.path.join(cwd, "resources", "static-responses.json")
 
-    assert (
-        it.race(
-            cfg,
-            f'--pipeline=benchmark-only --distribution-version="{dist_version}" '
-            f"--client-options=\"static_responses:'{responses}'\" "
-            "--track=geonames --challenge=append-no-conflicts-index-only",
-        )
-        == 0
+    it.race(
+        cfg,
+        f'--pipeline=benchmark-only --distribution-version="{dist_version}" '
+        f"--client-options=\"static_responses:'{responses}'\" "
+        "--track=geonames --challenge=append-no-conflicts-index-only",
     )

--- a/it/tracker_test.py
+++ b/it/tracker_test.py
@@ -47,19 +47,16 @@ def test_create_track(cfg, tmp_path, test_cluster):
         f'--include-tasks="delete-index,create-index,check-cluster-health,index-append" --quiet'
     )
 
-    it.race(cfg, cmd, check=True)
+    assert it.race(cfg, cmd, check=False).returncode == 0
 
     # create the track
     track_name = f"test-track-{uuid.uuid4()}"
     track_path = tmp_path / track_name
 
-    assert (
-        it.esrally(
-            cfg,
-            f"create-track --target-hosts=127.0.0.1:{test_cluster.http_port} --indices=geonames "
-            f"--track={track_name} --output-path={tmp_path}",
-        )
-        == 0
+    it.esrally(
+        cfg,
+        f"create-track --target-hosts=127.0.0.1:{test_cluster.http_port} --indices=geonames "
+        f"--track={track_name} --output-path={tmp_path}",
     )
 
     base_generated_corpora = "geonames-documents"
@@ -84,8 +81,8 @@ def test_create_track(cfg, tmp_path, test_cluster):
 
     # run a benchmark in test mode with the created track
     cmd = f"--test-mode --pipeline=benchmark-only --target-hosts=127.0.0.1:{test_cluster.http_port} --track-path={track_path}"
-    assert it.race(cfg, cmd) == 0
+    it.race(cfg, cmd)
 
     # and also run a normal (short) benchmark using the created track
     cmd = f"--pipeline=benchmark-only --target-hosts=127.0.0.1:{test_cluster.http_port} --track-path={track_path}"
-    assert it.race(cfg, cmd) == 0
+    it.race(cfg, cmd)

--- a/it/tracker_test.py
+++ b/it/tracker_test.py
@@ -47,7 +47,7 @@ def test_create_track(cfg, tmp_path, test_cluster):
         f'--include-tasks="delete-index,create-index,check-cluster-health,index-append" --quiet'
     )
 
-    assert it.race(cfg, cmd, check=False).returncode == 0
+    it.race(cfg, cmd)
 
     # create the track
     track_name = f"test-track-{uuid.uuid4()}"


### PR DESCRIPTION
This updates integration tests to rely on `esrally` / `race` with `check=True` by default instead of `assert ... == 0`, and uses `check=False` with `CompletedProcess.returncode` where the test needs a non-zero exit or an explicit success check.

Also fixes the `pytest.fail` message in `it.esrally` (f-string), handles `TestCluster.stop` via `returncode`, imports `CompletedProcess`, and expands docstrings for `esrally` and `race` without Sphinx roles in Python strings.

Made with [Cursor](https://cursor.com)