### PR TITLE
Avoid failing the benchmark when ML telemetry encounters elasticsearch.AuthorizationException

### DIFF
--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -2172,6 +2172,9 @@ class MlBucketProcessingTime(InternalTelemetryDevice):
                     },
                 },
             )
+        except elasticsearch.AuthorizationException:
+            self.logger.warning("Not authorized to retrieve ML bucket processing time (insufficient index privileges).")
+            return
         except elasticsearch.TransportError:
             self.logger.exception("Could not retrieve ML bucket processing time.")
             return

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -4269,6 +4269,19 @@ class TestMlBucketProcessingTime:
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
     @mock.patch("elasticsearch.Elasticsearch.search")
+    def test_authorization_error_does_not_store_metrics(self, search, metrics_store_put_doc):
+        search.side_effect = elasticsearch.AuthorizationException(meta=None, body=None, message="unit test error")  # type: ignore[arg-type]
+
+        cfg = create_config()
+        metrics_store = metrics.EsMetricsStore(cfg)
+        device = telemetry.MlBucketProcessingTime(elasticsearch.Elasticsearch, metrics_store)
+        t = telemetry.Telemetry(cfg, devices=[device])
+        t.on_benchmark_stop()
+
+        assert metrics_store_put_doc.call_count == 0
+
+    @mock.patch("esrally.metrics.EsMetricsStore.put_doc")
+    @mock.patch("elasticsearch.Elasticsearch.search")
     def test_empty_result_does_not_store_metrics(self, search, metrics_store_put_doc):
         search.return_value = {
             "aggregations": {


### PR DESCRIPTION
In some Serverless setups, the internal operator user may not always have the required index privileges for all telemetry devices. Here, we log a warning when `.ml-anomalies-*` is unreachable because of `elasticsearch.AuthorizationException` and allow the benchmark to finish.

```
2026-04-13 17:06:26,960 ActorAddr-(T|:34119)/PID:9506 elastic_transport.node DEBUG > POST /.ml-anomalies-*/_search HTTP/1.1
> Accept: application/json
> Authorization: Basic <hidden>
> Connection: keep-alive
> Content-Type: application/json
> User-Agent: elasticsearch-py/8.6.1 (Python/3.11.13; elastic-transport/8.4.1)
> X-Elastic-Client-Meta: es=8.6.1,py=3.11.13,t=8.4.1,ur=1.26.19
> {"aggs":{"jobs":{"terms":{"field":"job_id"},"aggs":{"min_pt":{"min":{"field":"processing_time_ms"}},"max_pt":{"max":{"field":"processing_time_ms"}},"mean_pt":{"avg":{"field":"processing_time_ms"}},"median_pt":{"percentiles":{"field":"processing_time_ms","percents":[50]}}}}},"query":{"bool":{"must":[{"term":{"result_type":"bucket"}}]}},"size":0}
< HTTP/1.1 403 Forbidden
< Content-Length: 577
< Content-Type: application/json
< Date: Mon, 13 Apr 2026 17:06:26 GMT
< Elastic-Api-Version: 2023-10-31
< X-Cloud-Request-Id: kmOdrFhcQVuULuNBbZT_Kw
< X-Found-Handling-Cluster: cd045e5ac2d646e9bb036f5f50cad20c.es
< X-Found-Handling-Instance: es-cluster-es-search-ccdcd7644-pv8gv
< {"error":{"root_cause":[{"type":"security_exception","reason":"action [indices:data/read/search] is unauthorized for user [testing-internal] with effective roles [admin], this action is granted by the index privileges [read,all]"}],"type":"security_exception","reason":"action [indices:data/read/search]
 is unauthorized for user [testing-internal] with effective roles [admin], this action is granted by the index privileges [read,all]","caused_by":{"type":"illegal_argument_exception","reason":"cannot resolve indices cross project if target set is local only"}},"status":403}
2026-04-13 17:06:26,960 ActorAddr-(T|:34119)/PID:9506 elastic_transport.transport INFO POST https://serverless.project.host:443/.ml-anomalies-*/_search [status:403 duration:0.003s]
```