### PR TITLE
Ensure the correct op_type is used when indexing telemetry

### DIFF
--- a/benchmarks/metrics/metrics_store_test.py
+++ b/benchmarks/metrics/metrics_store_test.py
@@ -21,18 +21,20 @@ concurrent access between flush() and background sampler threads (_add()).
 
 Three scenarios are measured:
 
-  uncontended  – single thread calling _add() in a tight loop.  Represents
+  uncontended   single thread calling _add() in a tight loop.  Represents
                  worker processes (InMemoryMetricsStore) and the coordinator
                  between flushes.
 
-  contended    – N sampler threads continuously calling _add() while the
+  contended     N sampler threads continuously calling _add() while the
                  main thread calls _add() too.  Represents the coordinator
                  with active telemetry devices.
 
-  no_lock      – same single-threaded loop but with the lock replaced by a
+  no_lock       same single-threaded loop but with the lock replaced by a
                  no-op context manager.  Provides the baseline cost without
                  locking so the overhead can be quantified.
 """
+
+# pylint: disable=protected-access
 
 import datetime
 import threading
@@ -40,7 +42,6 @@ import threading
 import pytest
 
 from esrally import config, metrics, time
-
 
 # ---------------------------------------------------------------------------
 # Shared fixtures

--- a/benchmarks/metrics/metrics_store_test.py
+++ b/benchmarks/metrics/metrics_store_test.py
@@ -144,7 +144,7 @@ def test_add_no_lock_with_sampler_threads(benchmark, in_memory_store):
     def sampler():
         while not stop.wait(timeout=0.1):
             for _ in range(SAMPLER_DOCS_PER_CALL):
-                in_memory_store._add(DOC)
+                in_memory_store._add_unlocked(DOC)
 
     threads = [threading.Thread(target=sampler, daemon=True) for _ in range(SAMPLER_THREADS)]
     for t in threads:

--- a/benchmarks/metrics/metrics_store_test.py
+++ b/benchmarks/metrics/metrics_store_test.py
@@ -21,17 +21,16 @@ concurrent access between flush() and background sampler threads (_add()).
 
 Three scenarios are measured:
 
-  uncontended   single thread calling _add() in a tight loop.  Represents
-                 worker processes (InMemoryMetricsStore) and the coordinator
-                 between flushes.
+  uncontended   single thread calling _add() in a tight loop. Represents
+                worker processes (InMemoryMetricsStore) and the coordinator
+                between flushes.
 
-  contended     N sampler threads continuously calling _add() while the
-                 main thread calls _add() too.  Represents the coordinator
-                 with active telemetry devices.
+  contended     N sampler threads periodically calling _add() while the
+                main thread calls _add() too. Represents the coordinator
+                with active telemetry devices.
 
-  no_lock       same single-threaded loop but with the lock replaced by a
-                 no-op context manager.  Provides the baseline cost without
-                 locking so the overhead can be quantified.
+  no_lock       uses _add_unlocked() without lock. Provides the baseline
+                cost without locking so the overhead can be quantified.
 """
 
 # pylint: disable=protected-access
@@ -50,16 +49,7 @@ from esrally import config, metrics, time
 DOC = {"name": "indexing_throughput", "value": 5000, "unit": "docs/s"}
 SAMPLER_THREADS = 4  # used by the single contended test; sweep uses its own range
 DOCS_PER_CALL = 1000
-
-
-class _NoOpLock:
-    """Drop-in replacement for threading.Lock that acquires/releases nothing."""
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        pass
+SAMPLER_DOCS_PER_CALL = 10
 
 
 @pytest.fixture
@@ -95,18 +85,17 @@ def test_add_uncontended(benchmark, in_memory_store):
 
 
 # ---------------------------------------------------------------------------
-# Uncontended baseline: single thread, no-op lock
+# No lock: single thread
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.benchmark(group="metrics_store_add", warmup="on", warmup_iterations=1000, disable_gc=True)
-def test_add_no_lock_baseline(benchmark, in_memory_store):
-    """Baseline: same loop with the lock replaced by a no-op to isolate lock cost."""
-    in_memory_store._docs_lock = _NoOpLock()
+def test_add_no_lock(benchmark, in_memory_store):
+    """Baseline: same loop without lock."""
 
     def run():
         for _ in range(DOCS_PER_CALL):
-            in_memory_store._add(DOC)
+            in_memory_store._add_unlocked(DOC)
 
     benchmark(run)
 
@@ -116,14 +105,15 @@ def test_add_no_lock_baseline(benchmark, in_memory_store):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.benchmark(group="metrics_store_add", warmup="on", warmup_iterations=100, disable_gc=True)
+@pytest.mark.benchmark(group="metrics_store_add", warmup="on", warmup_iterations=100, disable_gc=True, max_time=10)
 def test_add_contended(benchmark, in_memory_store):
     """Cost of _add() while SAMPLER_THREADS background threads also call _add()."""
     stop = threading.Event()
 
     def sampler():
-        while not stop.is_set():
-            in_memory_store._add(DOC)
+        while not stop.wait(timeout=0.1):
+            for _ in range(SAMPLER_DOCS_PER_CALL):
+                in_memory_store._add(DOC)
 
     threads = [threading.Thread(target=sampler, daemon=True) for _ in range(SAMPLER_THREADS)]
     for t in threads:
@@ -142,6 +132,37 @@ def test_add_contended(benchmark, in_memory_store):
 
 
 # ---------------------------------------------------------------------------
+# No lock: background sampler threads together with the benchmark thread
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="metrics_store_add", warmup="on", warmup_iterations=100, disable_gc=True, max_time=10)
+def test_add_no_lock_with_sampler_threads(benchmark, in_memory_store):
+    """Baseline: Cost of _add_unlocked() while SAMPLER_THREADS background threads also call _add_unlocked()."""
+    stop = threading.Event()
+
+    def sampler():
+        while not stop.wait(timeout=0.1):
+            for _ in range(SAMPLER_DOCS_PER_CALL):
+                in_memory_store._add(DOC)
+
+    threads = [threading.Thread(target=sampler, daemon=True) for _ in range(SAMPLER_THREADS)]
+    for t in threads:
+        t.start()
+
+    def run():
+        for _ in range(DOCS_PER_CALL):
+            in_memory_store._add_unlocked(DOC)
+
+    try:
+        benchmark(run)
+    finally:
+        stop.set()
+        for t in threads:
+            t.join()
+
+
+# ---------------------------------------------------------------------------
 # Thread-count sweep: 1 … 8 sampler threads (one per active telemetry device)
 # ---------------------------------------------------------------------------
 
@@ -150,8 +171,9 @@ def _contended_add(benchmark, store, n_samplers):
     stop = threading.Event()
 
     def sampler():
-        while not stop.is_set():
-            store._add(DOC)
+        while not stop.wait(timeout=0.1):
+            for _ in range(SAMPLER_DOCS_PER_CALL):
+                store._add(DOC)
 
     threads = [threading.Thread(target=sampler, daemon=True) for _ in range(n_samplers)]
     for t in threads:
@@ -169,21 +191,21 @@ def _contended_add(benchmark, store, n_samplers):
             t.join()
 
 
-@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True)
+@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True, max_time=10)
 def test_add_contended_1_sampler(benchmark, in_memory_store):
     _contended_add(benchmark, in_memory_store, 1)
 
 
-@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True)
+@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True, max_time=10)
 def test_add_contended_2_samplers(benchmark, in_memory_store):
     _contended_add(benchmark, in_memory_store, 2)
 
 
-@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True)
+@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True, max_time=10)
 def test_add_contended_4_samplers(benchmark, in_memory_store):
     _contended_add(benchmark, in_memory_store, 4)
 
 
-@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True)
+@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True, max_time=10)
 def test_add_contended_8_samplers(benchmark, in_memory_store):
     _contended_add(benchmark, in_memory_store, 8)

--- a/benchmarks/metrics/metrics_store_test.py
+++ b/benchmarks/metrics/metrics_store_test.py
@@ -1,0 +1,188 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Benchmarks for the metrics store locking overhead introduced to guard
+concurrent access between flush() and background sampler threads (_add()).
+
+Three scenarios are measured:
+
+  uncontended  – single thread calling _add() in a tight loop.  Represents
+                 worker processes (InMemoryMetricsStore) and the coordinator
+                 between flushes.
+
+  contended    – N sampler threads continuously calling _add() while the
+                 main thread calls _add() too.  Represents the coordinator
+                 with active telemetry devices.
+
+  no_lock      – same single-threaded loop but with the lock replaced by a
+                 no-op context manager.  Provides the baseline cost without
+                 locking so the overhead can be quantified.
+"""
+
+import datetime
+import threading
+
+import pytest
+
+from esrally import config, metrics, time
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+DOC = {"name": "indexing_throughput", "value": 5000, "unit": "docs/s"}
+SAMPLER_THREADS = 4  # used by the single contended test; sweep uses its own range
+DOCS_PER_CALL = 1000
+
+
+class _NoOpLock:
+    """Drop-in replacement for threading.Lock that acquires/releases nothing."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+@pytest.fixture
+def in_memory_store():
+    cfg = config.Config()
+    cfg.add(config.Scope.application, "system", "env.name", "benchmark")
+    cfg.add(config.Scope.application, "track", "params", {})
+    store = metrics.InMemoryMetricsStore(cfg, clock=time.Clock)
+    store.open(
+        race_id="benchmark-race",
+        race_timestamp=datetime.datetime(2016, 1, 31),
+        track_name="benchmark",
+        challenge_name="benchmark",
+        car_name="benchmark",
+    )
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Uncontended: single thread, real lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="metrics_store_add", warmup="on", warmup_iterations=1000, disable_gc=True)
+def test_add_uncontended(benchmark, in_memory_store):
+    """Cost of _add() under no contention (lock always acquired immediately)."""
+
+    def run():
+        for _ in range(DOCS_PER_CALL):
+            in_memory_store._add(DOC)
+
+    benchmark(run)
+
+
+# ---------------------------------------------------------------------------
+# Uncontended baseline: single thread, no-op lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="metrics_store_add", warmup="on", warmup_iterations=1000, disable_gc=True)
+def test_add_no_lock_baseline(benchmark, in_memory_store):
+    """Baseline: same loop with the lock replaced by a no-op to isolate lock cost."""
+    in_memory_store._docs_lock = _NoOpLock()
+
+    def run():
+        for _ in range(DOCS_PER_CALL):
+            in_memory_store._add(DOC)
+
+    benchmark(run)
+
+
+# ---------------------------------------------------------------------------
+# Contended: background sampler threads competing with the benchmark thread
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="metrics_store_add", warmup="on", warmup_iterations=100, disable_gc=True)
+def test_add_contended(benchmark, in_memory_store):
+    """Cost of _add() while SAMPLER_THREADS background threads also call _add()."""
+    stop = threading.Event()
+
+    def sampler():
+        while not stop.is_set():
+            in_memory_store._add(DOC)
+
+    threads = [threading.Thread(target=sampler, daemon=True) for _ in range(SAMPLER_THREADS)]
+    for t in threads:
+        t.start()
+
+    def run():
+        for _ in range(DOCS_PER_CALL):
+            in_memory_store._add(DOC)
+
+    try:
+        benchmark(run)
+    finally:
+        stop.set()
+        for t in threads:
+            t.join()
+
+
+# ---------------------------------------------------------------------------
+# Thread-count sweep: 1 … 8 sampler threads (one per active telemetry device)
+# ---------------------------------------------------------------------------
+
+
+def _contended_add(benchmark, store, n_samplers):
+    stop = threading.Event()
+
+    def sampler():
+        while not stop.is_set():
+            store._add(DOC)
+
+    threads = [threading.Thread(target=sampler, daemon=True) for _ in range(n_samplers)]
+    for t in threads:
+        t.start()
+
+    def run():
+        for _ in range(DOCS_PER_CALL):
+            store._add(DOC)
+
+    try:
+        benchmark(run)
+    finally:
+        stop.set()
+        for t in threads:
+            t.join()
+
+
+@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True)
+def test_add_contended_1_sampler(benchmark, in_memory_store):
+    _contended_add(benchmark, in_memory_store, 1)
+
+
+@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True)
+def test_add_contended_2_samplers(benchmark, in_memory_store):
+    _contended_add(benchmark, in_memory_store, 2)
+
+
+@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True)
+def test_add_contended_4_samplers(benchmark, in_memory_store):
+    _contended_add(benchmark, in_memory_store, 4)
+
+
+@pytest.mark.benchmark(group="metrics_store_add_sweep", warmup="on", warmup_iterations=100, disable_gc=True)
+def test_add_contended_8_samplers(benchmark, in_memory_store):
+    _contended_add(benchmark, in_memory_store, 8)

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -189,8 +189,9 @@ class EsClient:
                 raise exceptions.SystemSetupError(msg)
             except elasticsearch.helpers.BulkIndexError as e:
                 for err in e.errors:
-                    err_type = err.get("index", {}).get("error", {}).get("type", None)
-                    if err.get("index", {}).get("status", None) not in self.retryable_status_codes:
+                    op = err.get("create") or err.get("index") or {}
+                    err_type = op.get("error", {}).get("type", None)
+                    if op.get("status", None) not in self.retryable_status_codes:
                         msg = f"Unretryable error encountered when sending metrics to remote metrics store: [{err_type}]"
                         self.logger.exception("%s - Full error(s) [%s]", msg, str(e.errors))
                         raise exceptions.RallyError(msg)

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1444,6 +1444,10 @@ class InMemoryMetricsStore(MetricsStore):
         with self._docs_lock:
             self.docs.append(doc)
 
+    # for testing purposes only
+    def _add_unlocked(self, doc):
+        self.docs.append(doc)
+
     def flush(self, refresh=True):
         pass
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -702,6 +702,7 @@ class MetricsStore:
         self._clock = clock
         self._stop_watch = self._clock.stop_watch()
         self.logger = logging.getLogger(__name__)
+        self._docs_lock = threading.Lock()
 
     def open(self, race_id=None, race_timestamp=None, track_name=None, challenge_name=None, car_name=None, ctx=None, create=False):
         """
@@ -1181,7 +1182,6 @@ class EsMetricsStore(MetricsStore):
         self._client = client_factory_class(cfg).create()
         self._index_handler = IndexHandler(self._config, self._client, EsStoreType.metrics)
         self._docs = None
-        self._docs_lock = threading.Lock()
 
     def open(self, race_id=None, race_timestamp=None, track_name=None, challenge_name=None, car_name=None, ctx=None, create=False):
         self._docs = []
@@ -1433,7 +1433,6 @@ class InMemoryMetricsStore(MetricsStore):
         """
         super().__init__(cfg=cfg, clock=clock, meta_info=meta_info)
         self.docs = []
-        self._docs_lock = threading.Lock()
 
     def __del__(self):
         """

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1204,25 +1204,26 @@ class EsMetricsStore(MetricsStore):
             self._client.refresh(index=index_name)
 
     def flush(self, refresh=True):
-        if self._docs:
+        docs_to_flush = self._docs
+        self._docs = []
+        if docs_to_flush:
             sw = time.StopWatch()
             sw.start()
             self._client.bulk_index(
                 index=self._index_handler.index_name(self._race_timestamp),
-                items=self._docs,
+                items=docs_to_flush,
                 use_data_streams=self._index_handler.use_data_streams,
             )
             sw.stop()
             self.logger.info(
                 "Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",
-                len(self._docs),
+                len(docs_to_flush),
                 self._race_timestamp,
                 self._track,
                 self._challenge,
                 self._car,
                 sw.total_time(),
             )
-        self._docs = []
         # ensure we can search immediately after flushing
         if refresh:
             self._client.refresh(index=self._index_handler.index_name(self._race_timestamp))

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1213,18 +1213,11 @@ class EsMetricsStore(MetricsStore):
         if docs_to_flush:
             sw = time.StopWatch()
             sw.start()
-            try:
-                self._client.bulk_index(
-                    index=self._index_handler.index_name(self._race_timestamp),
-                    items=docs_to_flush,
-                    use_data_streams=self._index_handler.use_data_streams,
-                )
-            except Exception:
-                # Re-queue at the front so the next flush retries these docs in order,
-                # ahead of any docs added to self._docs during the failed attempt.
-                with self._docs_lock:
-                    self._docs = docs_to_flush + self._docs
-                raise
+            self._client.bulk_index(
+                index=self._index_handler.index_name(self._race_timestamp),
+                items=docs_to_flush,
+                use_data_streams=self._index_handler.use_data_streams,
+            )
             sw.stop()
             self.logger.info(
                 "Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -25,6 +25,7 @@ import pickle
 import random
 import statistics
 import sys
+import threading
 import uuid
 import zlib
 from enum import Enum, IntEnum
@@ -1179,6 +1180,7 @@ class EsMetricsStore(MetricsStore):
         self._client = client_factory_class(cfg).create()
         self._index_handler = IndexHandler(self._config, self._client, EsStoreType.metrics)
         self._docs = None
+        self._docs_lock = threading.Lock()
 
     def open(self, race_id=None, race_timestamp=None, track_name=None, challenge_name=None, car_name=None, ctx=None, create=False):
         self._docs = []
@@ -1204,8 +1206,9 @@ class EsMetricsStore(MetricsStore):
             self._client.refresh(index=index_name)
 
     def flush(self, refresh=True):
-        docs_to_flush = self._docs
-        self._docs = []
+        with self._docs_lock:
+            docs_to_flush = self._docs
+            self._docs = []
         if docs_to_flush:
             sw = time.StopWatch()
             sw.start()
@@ -1218,7 +1221,8 @@ class EsMetricsStore(MetricsStore):
             except Exception:
                 # Re-queue at the front so the next flush retries these docs in order,
                 # ahead of any docs added to self._docs during the failed attempt.
-                self._docs = docs_to_flush + self._docs
+                with self._docs_lock:
+                    self._docs = docs_to_flush + self._docs
                 raise
             sw.stop()
             self.logger.info(
@@ -1235,7 +1239,8 @@ class EsMetricsStore(MetricsStore):
             self._client.refresh(index=self._index_handler.index_name(self._race_timestamp))
 
     def _add(self, doc):
-        self._docs.append(doc)
+        with self._docs_lock:
+            self._docs.append(doc)
 
     def _get(self, name, task, operation_type, sample_type, node_name, mapper):
         query = {
@@ -1434,6 +1439,7 @@ class InMemoryMetricsStore(MetricsStore):
         """
         super().__init__(cfg=cfg, clock=clock, meta_info=meta_info)
         self.docs = []
+        self._docs_lock = threading.Lock()
 
     def __del__(self):
         """
@@ -1442,15 +1448,18 @@ class InMemoryMetricsStore(MetricsStore):
         del self.docs
 
     def _add(self, doc):
-        self.docs.append(doc)
+        with self._docs_lock:
+            self.docs.append(doc)
 
     def flush(self, refresh=True):
         pass
 
     def to_externalizable(self, clear=False):
-        docs = self.docs
-        if clear:
-            self.docs = []
+        with self._docs_lock:
+            if clear:
+                docs, self.docs = self.docs, []
+            else:
+                docs = list(self.docs)
         compressed = zlib.compress(pickle.dumps(docs))
         self.logger.debug(
             "Compression changed size of metric store from [%d] bytes to [%d] bytes", sys.getsizeof(docs, -1), sys.getsizeof(compressed, -1)

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1209,11 +1209,17 @@ class EsMetricsStore(MetricsStore):
         if docs_to_flush:
             sw = time.StopWatch()
             sw.start()
-            self._client.bulk_index(
-                index=self._index_handler.index_name(self._race_timestamp),
-                items=docs_to_flush,
-                use_data_streams=self._index_handler.use_data_streams,
-            )
+            try:
+                self._client.bulk_index(
+                    index=self._index_handler.index_name(self._race_timestamp),
+                    items=docs_to_flush,
+                    use_data_streams=self._index_handler.use_data_streams,
+                )
+            except Exception:
+                # Re-queue at the front so the next flush retries these docs in order,
+                # ahead of any docs added to self._docs during the failed attempt.
+                self._docs = docs_to_flush + self._docs
+                raise
             sw.stop()
             self.logger.info(
                 "Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1790,6 +1790,27 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
             use_data_streams=True,
         )
 
+    def test_flush_requeues_docs_on_bulk_index_failure(self):
+        # If bulk_index raises, docs_to_flush must be prepended back to self._docs so
+        # the next flush can retry them. Docs added during the failed attempt come after.
+        ms, es_mock = self._make_metrics_store(use_data_streams=True)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        doc_before = {"name": "before"}
+        doc_during = {"name": "during"}
+        ms._add(doc_before)
+
+        def failing_bulk_index(*, index, items, use_data_streams):
+            ms._add(doc_during)
+            raise exceptions.RallyError("bulk failed")
+
+        es_mock.bulk_index.side_effect = failing_bulk_index
+        with pytest.raises(exceptions.RallyError):
+            ms.flush(refresh=False)
+
+        # doc_before must be re-queued ahead of doc_during.
+        assert ms._docs == [doc_before, doc_during]
+
 
 class TestEsRaceStore:
     RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -566,6 +566,55 @@ class TestEsClient:
         ):
             client.guarded(raise_bulk_index_error)
 
+    def test_bulk_index_error_retryable_via_create_key(self):
+        # When data streams are in use, Elasticsearch structures bulk errors under "create",
+        # not "index". A retryable status (429) must still be retried, not treated as fatal.
+        bulk_index_errors = [
+            {
+                "create": {
+                    "_index": "rally-metrics-v1",
+                    "_id": None,
+                    "status": 429,
+                    "error": {"type": "circuit_breaking_exception", "reason": "Data too large"},
+                }
+            }
+        ]
+
+        call_count = 0
+
+        def raise_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise elasticsearch.helpers.BulkIndexError("1 document(s) failed to index", bulk_index_errors)
+
+        client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
+        client.guarded(raise_then_succeed)
+        assert call_count == 2
+
+    def test_bulk_index_error_unretryable_via_create_key(self):
+        # An unretryable error under "create" must raise RallyError immediately.
+        bulk_index_errors = [
+            {
+                "create": {
+                    "_index": "rally-metrics-v1",
+                    "_id": None,
+                    "status": 409,
+                    "error": {"type": "version_conflict_engine_exception"},
+                }
+            }
+        ]
+
+        def raise_bulk_index_error():
+            raise elasticsearch.helpers.BulkIndexError("1 document(s) failed to index", bulk_index_errors)
+
+        client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
+        with pytest.raises(
+            exceptions.RallyError,
+            match=r"Unretryable error encountered when sending metrics to remote metrics store: \[version_conflict_engine_exception\]",
+        ):
+            client.guarded(raise_bulk_index_error)
+
 
 class TestIndexTemplateProvider:
     def setup_method(self, method):

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1839,27 +1839,6 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
             use_data_streams=True,
         )
 
-    def test_flush_requeues_docs_on_bulk_index_failure(self):
-        # If bulk_index raises, docs_to_flush must be prepended back to self._docs so
-        # the next flush can retry them. Docs added during the failed attempt come after.
-        ms, es_mock = self._make_metrics_store(use_data_streams=True)
-        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
-
-        doc_before = {"name": "before"}
-        doc_during = {"name": "during"}
-        ms._add(doc_before)
-
-        def failing_bulk_index(*, index, items, use_data_streams):
-            ms._add(doc_during)
-            raise exceptions.RallyError("bulk failed")
-
-        es_mock.bulk_index.side_effect = failing_bulk_index
-        with pytest.raises(exceptions.RallyError):
-            ms.flush(refresh=False)
-
-        # doc_before must be re-queued ahead of doc_during.
-        assert ms._docs == [doc_before, doc_during]
-
 
 class TestEsRaceStore:
     RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1754,6 +1754,42 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         )
         return actual_error_rate
 
+    def test_flush_snapshots_docs_before_bulk_index(self):
+        # Docs appended to _docs between the for-loop in bulk_index (which sets _op_type)
+        # and helpers.bulk's iteration must not slip through without _op_type="create".
+        # The fix captures self._docs and resets it before calling bulk_index so that
+        # concurrent _add calls land in the new buffer and never reach this flush.
+        ms, es_mock = self._make_metrics_store(use_data_streams=True)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        doc_before = {"name": "before"}
+        doc_during = {"name": "during"}
+        ms._add(doc_before)
+
+        captured_items = []
+
+        def bulk_index_side_effect(*, index, items, use_data_streams):
+            # Simulate a background thread appending during bulk_index.
+            ms._add(doc_during)
+            captured_items.extend(items)
+
+        es_mock.bulk_index.side_effect = bulk_index_side_effect
+        ms.flush(refresh=False)
+
+        # Only doc_before should have been sent in this flush.
+        assert captured_items == [doc_before]
+        # doc_during must be buffered for the next flush, not lost.
+        assert ms._docs == [doc_during]
+
+        # A second flush sends doc_during.
+        es_mock.bulk_index.side_effect = None
+        ms.flush(refresh=False)
+        es_mock.bulk_index.assert_called_with(
+            index=ms._index_handler.index_name(self.RACE_TIMESTAMP),
+            items=[doc_during],
+            use_data_streams=True,
+        )
+
 
 class TestEsRaceStore:
     RACE_TIMESTAMP = datetime.datetime(2016, 1, 31)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1804,10 +1804,9 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         return actual_error_rate
 
     def test_flush_snapshots_docs_before_bulk_index(self):
-        # Docs appended to _docs between the for-loop in bulk_index (which sets _op_type)
-        # and helpers.bulk's iteration must not slip through without _op_type="create".
-        # The fix captures self._docs and resets it before calling bulk_index so that
-        # concurrent _add calls land in the new buffer and never reach this flush.
+        # flush() must snapshot and reset self._docs before calling bulk_index so that
+        # docs added concurrently by background sampler threads land in the next flush,
+        # not in the current one where they would be sent without _op_type="create".
         ms, es_mock = self._make_metrics_store(use_data_streams=True)
         ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -566,9 +566,13 @@ class TestEsClient:
         ):
             client.guarded(raise_bulk_index_error)
 
-    def test_bulk_index_error_retryable_via_create_key(self):
+    @mock.patch("random.random")
+    @mock.patch("esrally.time.sleep")
+    def test_bulk_index_error_retryable_via_create_key(self, mocked_sleep, mocked_random):
         # When data streams are in use, Elasticsearch structures bulk errors under "create",
         # not "index". A retryable status (429) must still be retried, not treated as fatal.
+        mocked_random.return_value = 0
+
         bulk_index_errors = [
             {
                 "create": {
@@ -591,6 +595,7 @@ class TestEsClient:
         client = metrics.EsClient(self.ClientMock([{"host": "127.0.0.1", "port": "9243"}]))
         client.guarded(raise_then_succeed)
         assert call_count == 2
+        mocked_sleep.assert_called_once_with(1)
 
     def test_bulk_index_error_unretryable_via_create_key(self):
         # An unretryable error under "create" must raise RallyError immediately.


### PR DESCRIPTION
From Claude:

Fixes a thread-safety race in `EsMetricsStore.flush()` that occurs when `bulk_index` first loops over `items` setting `_op_type = "create"` on each item, then calls `helpers.bulk` on the same list. Background sampler threads (`RecoveryStatsRecorder`, `BlobStoreStatsRecorder`) can append new docs to that same list between those two steps. Those late-arriving docs never get `_op_type = "create"` set and `expand_action` defaults them to `"index"`.

The fix is to snapshot and reset `self._docs` before calling `bulk_index`, so background threads' new docs land in a fresh list that `bulk_index` never sees.