### PR TITLE
Ignore ILM settings for Serverless metrics stores

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -67,6 +67,10 @@ class EsClient:
     def component_template_exists(self, name):
         return self.guarded(self._client.cluster.exists_component_template, name=name)
 
+    @property
+    def is_serverless(self):
+        return getattr(self._client, "is_serverless", False)
+
     def get_lifecycle(self, name):
         return self.guarded(self._client.ilm.get_lifecycle, name=name)
 
@@ -393,32 +397,31 @@ class ComponentTemplateProvider(IndexTemplateProvider):
         with open("%s/resources/%s.json" % (self.script_dir, template_name), encoding="utf-8") as f:
             return json.load(f)
 
-    def _get_component_templates(self, name, template_name, lifecycle_policy_name):
+    def _get_component_templates(self, name, template_name, lifecycle_policy_name, include_ilm=True):
         template = self._read(template_name)["template"]
+        index_settings = {**template.get("settings", {}).get("index", {})}
+        if include_ilm:
+            index_settings["lifecycle"] = {"name": lifecycle_policy_name}
 
         return {
             name: json.dumps(
                 {
                     "template": {
                         "mappings": template["mappings"],
-                        "settings": {
-                            "index": {
-                                **template.get("settings", {}).get("index", {}),
-                                "lifecycle": {"name": lifecycle_policy_name},
-                            }
-                        },
+                        "settings": {"index": index_settings},
                     }
                 }
             ),
             f"{name}{self.COMPONENT_TEMPLATE_CUSTOM_SUFFIX}": json.dumps({"template": {}}),
         }
 
-    def get_template(self, es_store_type: EsStoreType):
+    def get_template(self, es_store_type: EsStoreType, include_ilm=True):
         return json.dumps(
             self._get_component_templates(
                 f"{es_store_type.index_prefix}{es_store_type.data_stream_version}",
                 es_store_type.index_template_resource,
                 es_store_type.ilm_default_name,
+                include_ilm=include_ilm,
             )
         )
 
@@ -461,6 +464,10 @@ class IndexHandler:
         return convert.to_bool(self._config.opts("reporting", "datastore.use_data_streams", default_value=True, mandatory=False))
 
     @property
+    def is_serverless(self):
+        return getattr(self._client, "is_serverless", False)
+
+    @property
     def overwrite_templates(self):
         return convert.to_bool(
             self._config.opts(section="reporting", key="datastore.overwrite_existing_templates", default_value=False, mandatory=False)
@@ -475,9 +482,10 @@ class IndexHandler:
 
     def ensure_index_template(self, create=False):
         if self.use_data_streams:
-            self._ensure_lifecycle_policy(
-                self._es_store_type.ilm_default_name, self._ilm_default_template(self._es_store_type.ilm_default_resource)
-            )
+            if not self.is_serverless:
+                self._ensure_lifecycle_policy(
+                    self._es_store_type.ilm_default_name, self._ilm_default_template(self._es_store_type.ilm_default_resource)
+                )
             self._ensure_data_stream_template()
         else:
             self._ensure_date_based_template(create)
@@ -547,7 +555,7 @@ class IndexHandler:
             self._index_template_provider, ComponentTemplateProvider
         ), "Expected ComponentTemplateProvider for data streams but got [%s]" % type(self._index_template_provider)
 
-        _index_template = json.loads(self._index_template_provider.get_template(self._es_store_type))
+        _index_template = json.loads(self._index_template_provider.get_template(self._es_store_type, include_ilm=not self.is_serverless))
 
         # The index template is composed of multiple component templates.
         # We need to ensure that all component templates exist and are up to date

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -766,6 +766,15 @@ class TestComponentTemplateProvider:
         custom_tmpl = json.loads(components[custom_key])
         assert custom_tmpl["template"] == {}
 
+    def test_component_template_structure_serverless(self):
+        provider = self._make_provider()
+        for store_name in ["metrics", "races", "results"]:
+            es_store_type = metrics.EsStoreType[store_name]
+            components = json.loads(provider.get_template(es_store_type, include_ilm=False))
+            versioned_name = f"{es_store_type.index_prefix}{es_store_type.data_stream_version}"
+            main_tmpl = json.loads(components[versioned_name])
+            assert "lifecycle" not in main_tmpl["template"]["settings"]["index"]
+
     def test_shard_settings_ignored_for_component_templates(self):
         provider = self._make_provider(number_of_shards=3, number_of_replicas=2)
 
@@ -804,6 +813,7 @@ class TestIndexHandler:
         self.cfg = config.Config()
         self.cfg.add(config.Scope.application, "node", "rally.root", paths.rally_root())
         self.client = mock.create_autospec(metrics.EsClient)
+        self.client.is_serverless = False
 
     def test_data_stream_template(self):
         self.cfg.add(config.Scope.application, "reporting", "datastore.use_data_streams", True)
@@ -1025,6 +1035,30 @@ class TestIndexHandler:
             expect_get_template=case.expect_get_template,
             expect_put_template=case.expect_put_template,
         )
+
+    def test_ensure_index_template_data_stream_serverless(self):
+        self.cfg.add(config.Scope.application, "reporting", "datastore.use_data_streams", True)
+        self.cfg.add(config.Scope.applicationOverride, "reporting", "datastore.overwrite_existing_templates", False)
+        self.client.is_serverless = True
+
+        handler = metrics.IndexHandler(self.cfg, self.client, metrics.EsStoreType.metrics)
+        self.client.component_template_exists.return_value = False
+        self.client.index_template_exists.return_value = False
+
+        handler.ensure_index_template(create=True)
+
+        self.client.get_lifecycle.assert_not_called()
+        self.client.put_lifecycle.assert_not_called()
+
+        # component template should be created without lifecycle settings
+        assert self.client.put_component_template.call_count == 2
+        for call_args in self.client.put_component_template.call_args_list:
+            name, tmpl = call_args.args
+            if metrics.ComponentTemplateProvider.COMPONENT_TEMPLATE_CUSTOM_SUFFIX not in name:
+                tmpl_body = json.loads(tmpl)
+                assert "lifecycle" not in tmpl_body["template"]["settings"]["index"]
+
+        self._assert_index_template_calls(True, metrics.EsStoreType.metrics, expect_get_template=False, expect_put_template=True)
 
     @cases.cases(
         fresh_create=DateBasedEnsureTemplateCase(),


### PR DESCRIPTION
This should be the final PR needed to make Rally compatible with a Serverless metrics store for reporting.

- Check if the target metrics store is serverless
- Do not include ILM in the configuration if it is serverless