### PR TITLE
Fix null client timeout handling

### DIFF
--- a/esrally/client/factory.py
+++ b/esrally/client/factory.py
@@ -163,7 +163,7 @@ class EsClientFactory:
         self.max_connections = max(256, self.client_options.pop("max_connections", 0))
         self.static_responses = self.client_options.pop("static_responses", None)
 
-        if self._is_set(self.client_options, "timeout"):
+        if "timeout" in self.client_options:
             self.client_options["request_timeout"] = self.client_options.pop("timeout")
 
     @staticmethod

--- a/tests/client/factory_test.py
+++ b/tests/client/factory_test.py
@@ -345,6 +345,36 @@ class TestEsClientFactory:
 
         assert client_options == original_client_options
 
+    def test_timeout_is_translated_to_request_timeout(self):
+        hosts = [{"host": "localhost", "port": 9200}]
+        client_options = {"timeout": 60}
+        # make a copy so we can verify later that the factory did not modify it
+        original_client_options = dict(client_options)
+
+        f = client.EsClientFactory(hosts, client_options)
+
+        assert f.client_options["request_timeout"] == 60
+        assert "timeout" not in f.client_options
+        assert client_options == original_client_options
+
+    def test_no_request_timeout_set_when_timeout_absent(self):
+        hosts = [{"host": "localhost", "port": 9200}]
+        client_options = {}
+
+        f = client.EsClientFactory(hosts, client_options)
+
+        assert "request_timeout" not in f.client_options
+        assert "timeout" not in f.client_options
+
+    def test_timeout_none_is_translated_to_request_timeout(self):
+        hosts = [{"host": "localhost", "port": 9200}]
+        client_options = {"timeout": None}
+
+        f = client.EsClientFactory(hosts, client_options)
+
+        assert f.client_options["request_timeout"] is None
+        assert "timeout" not in f.client_options
+
     @mock.patch("esrally.client.asynchronous.RallyAsyncElasticsearch")
     def test_create_async_client_with_api_key_auth_override(self, es):
         hosts = [{"host": "localhost", "port": 9200}]

--- a/tests/client/factory_test.py
+++ b/tests/client/factory_test.py
@@ -348,8 +348,8 @@ class TestEsClientFactory:
     def test_timeout_is_translated_to_request_timeout(self):
         hosts = [{"host": "localhost", "port": 9200}]
         client_options = {"timeout": 60}
-        # make a copy so we can verify later that the factory did not modify it
-        original_client_options = dict(client_options)
+        # used to verify later that the factory did not modify it
+        original_client_options = client_options.copy()
 
         f = client.EsClientFactory(hosts, client_options)
 


### PR DESCRIPTION
With `--client-options='{"default": {"timeout": null}}'` we're getting the following exception:

```
esrally.exceptions.RallyError: Traceback (most recent call last):
  File "/Users/grzegorz/src/rally/esrally/actor.py", line 96, in guard
    return f(self, msg, sender)
  File "/Users/grzegorz/src/rally/esrally/driver/driver.py", line 282, in receiveMsg_PrepareBenchmark
    self.driver.prepare_benchmark(msg.track)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/Users/grzegorz/src/rally/esrally/driver/driver.py", line 728, in prepare_benchmark
    es_clients = self.create_es_clients()
  File "/Users/grzegorz/src/rally/esrally/driver/driver.py", line 636, in create_es_clients
    ).create()
      ~~~~~~^^
  File "/Users/grzegorz/src/rally/esrally/client/factory.py", line 195, in create
    return RallySyncElasticsearch(
        distribution_version=self.distribution_version,
    ...<3 lines>...
        **self.client_options,
    )
  File "/Users/grzegorz/src/rally/esrally/client/synchronous.py", line 30, in __init__
    super().__init__(hosts, **kwargs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
TypeError: Elasticsearch.__init__() got an unexpected keyword argument 'timeout'
```