### PR TITLE
Avoid warnings in common test

### DIFF
--- a/tests/client/common_test.py
+++ b/tests/client/common_test.py
@@ -153,6 +153,7 @@ class EnsureMimetypeHeadersCase:
         version=7,
         want_content_type="application/vnd.elasticsearch+json; compatible-with=8",
         want_accept="application/vnd.elasticsearch+json; compatible-with=8",
+        want_warning_message=r"Invalid compatibility mode 7,.*",
     ),
     unsupported_version_str=EnsureMimetypeHeadersCase(
         headers={"accept": "application/json"},
@@ -160,6 +161,7 @@ class EnsureMimetypeHeadersCase:
         body=None,
         version="7.0.0",
         want_accept="application/vnd.elasticsearch+json; compatible-with=8",
+        want_warning_message=r"Invalid compatibility mode '7.0.0',.*",
     ),
     valid_version_no_warning=EnsureMimetypeHeadersCase(
         headers={"content-type": "application/json"},
@@ -180,7 +182,7 @@ class EnsureMimetypeHeadersCase:
 )
 def test_ensure_mimetype_headers(case: EnsureMimetypeHeadersCase) -> None:
     if case.want_warning_message is not None:
-        catch_warnings = pytest.warns(Warning, match=case.want_warning_message)
+        catch_warnings = pytest.warns(UserWarning, match=case.want_warning_message)
     else:
         catch_warnings = contextlib.nullcontext()
 
@@ -196,6 +198,5 @@ def test_ensure_mimetype_headers(case: EnsureMimetypeHeadersCase) -> None:
     assert got.get("accept") == case.want_accept
     if case.want_warning_message is not None:
         assert len(warnings) == 1
-        assert str(warnings[0].message) == case.want_warning_message
     else:
         assert warnings is None

--- a/tests/client/common_test.py
+++ b/tests/client/common_test.py
@@ -161,7 +161,7 @@ class EnsureMimetypeHeadersCase:
         body=None,
         version="7.0.0",
         want_accept="application/vnd.elasticsearch+json; compatible-with=8",
-        want_warning_message=r"Invalid compatibility mode '7.0.0',.*",
+        want_warning_message=r"Invalid compatibility mode '7\.0\.0',.*",
     ),
     valid_version_no_warning=EnsureMimetypeHeadersCase(
         headers={"content-type": "application/json"},

--- a/tests/client/common_test.py
+++ b/tests/client/common_test.py
@@ -182,7 +182,7 @@ class EnsureMimetypeHeadersCase:
 )
 def test_ensure_mimetype_headers(case: EnsureMimetypeHeadersCase) -> None:
     if case.want_warning_message is not None:
-        catch_warnings = pytest.warns(UserWarning, match=case.want_warning_message)
+        catch_warnings = pytest.warns(Warning, match=case.want_warning_message)
     else:
         catch_warnings = contextlib.nullcontext()
 


### PR DESCRIPTION
Removes the following pytest warnings:
```
tests/client/common_test.py::test_ensure_mimetype_headers[unsupported_version_int]
  /Users/grzegorz/src/rally/esrally/client/common.py:49: UserWarning: Invalid compatibility mode 7, defaulting to 8: Elasticsearch version 7 is not supported, supported versions are: 8, 9.
    warnings.warn(f"Invalid compatibility mode {version!r}, defaulting to {_MIN_COMPATIBILITY_MODE!r}: {ex}")

tests/client/common_test.py::test_ensure_mimetype_headers[unsupported_version_str]
  /Users/grzegorz/src/rally/esrally/client/common.py:49: UserWarning: Invalid compatibility mode '7.0.0', defaulting to 8: Elasticsearch version 7 is not supported, supported versions are: 8, 9.
    warnings.warn(f"Invalid compatibility mode {version!r}, defaulting to {_MIN_COMPATIBILITY_MODE!r}: {ex}")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```