### PR TITLE
feat(telemetry): add `disk-usage-stats-flush` param

### DIFF
--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -302,6 +302,7 @@ Supported telemetry parameters:
 
 * ``disk-usage-stats-indices`` (default all indices in the track): Comma separated string or a list of indices who's disk usage to fetch.
 * ``disk-usage-stats-timeout`` (default 600s): A time value specifying the timeout for the disk usage API call.
+* ``disk-usage-stats-flush`` (default true): Whether to pass ``flush=true`` to the disk usage API. When false, the response may not include uncommitted data.
 
 Example::
 

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -2359,12 +2359,8 @@ class DiskUsageStats(TelemetryDevice):
                 usage to fetch. Default is all indices in the track.
             ``disk-usage-stats-timeout``: Timeout in seconds for the disk usage API call. Default is 600s.
             ``disk-usage-stats-flush``: Whether to pass ``flush=true`` to the disk
-                usage API. Default is ``True`` (matches the API default). Set to
-                ``False`` on serverless, where the search-tier engine rejects
-                ``flush=true`` because the data lives on the index tier; with
-                ``flush=false`` the response may not include uncommitted data,
-                which is acceptable when telemetry runs after writes have
-                settled (e.g. post ``force-merge`` + ``wait-until-merges-finish``).
+                usage API. Default is ``True`` (matches the API default). When
+                ``False``, the response may not include uncommitted data.
         :param client: The Elasticsearch client for this cluster.
         :param metrics_store: The configured metrics store we write to.
         :param index_names: Names of indices defined by this track

--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -2358,6 +2358,13 @@ class DiskUsageStats(TelemetryDevice):
             ``disk-usage-stats-indices``: Comma separated list of indices who's disk
                 usage to fetch. Default is all indices in the track.
             ``disk-usage-stats-timeout``: Timeout in seconds for the disk usage API call. Default is 600s.
+            ``disk-usage-stats-flush``: Whether to pass ``flush=true`` to the disk
+                usage API. Default is ``True`` (matches the API default). Set to
+                ``False`` on serverless, where the search-tier engine rejects
+                ``flush=true`` because the data lives on the index tier; with
+                ``flush=false`` the response may not include uncommitted data,
+                which is acceptable when telemetry runs after writes have
+                settled (e.g. post ``force-merge`` + ``wait-until-merges-finish``).
         :param client: The Elasticsearch client for this cluster.
         :param metrics_store: The configured metrics store we write to.
         :param index_names: Names of indices defined by this track
@@ -2373,6 +2380,7 @@ class DiskUsageStats(TelemetryDevice):
     def on_benchmark_start(self):
         self.indices = self.telemetry_params.get("disk-usage-stats-indices", ",".join(self.index_names + self.data_stream_names))
         self.timeout = self.telemetry_params.get("disk-usage-stats-timeout", 600)
+        self.flush = self.telemetry_params.get("disk-usage-stats-flush", True)
         if not self.indices:
             msg = (
                 "No indices defined for disk-usage-stats. Set disk-usage-stats-indices "
@@ -2391,7 +2399,9 @@ class DiskUsageStats(TelemetryDevice):
         for index in self.indices.split(","):
             self.logger.debug("Gathering disk usage for [%s]", index)
             try:
-                response = self.client.options(request_timeout=self.timeout).indices.disk_usage(index=index, run_expensive_tasks=True)
+                response = self.client.options(request_timeout=self.timeout).indices.disk_usage(
+                    index=index, run_expensive_tasks=True, flush=self.flush
+                )
             except elasticsearch.RequestError:
                 msg = f"A transport error occurred while collecting disk usage for {index}"
                 self.logger.exception(msg)

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -5019,8 +5019,8 @@ class TestDiskUsageStats:
         t.on_benchmark_stop()
         es.options.return_value.indices.disk_usage.assert_has_calls(
             [
-                call(index="foo", run_expensive_tasks=True),
-                call(index="bar", run_expensive_tasks=True),
+                call(index="foo", run_expensive_tasks=True, flush=True),
+                call(index="bar", run_expensive_tasks=True, flush=True),
             ]
         )
 
@@ -5035,8 +5035,8 @@ class TestDiskUsageStats:
         t.on_benchmark_stop()
         es.options.return_value.indices.disk_usage.assert_has_calls(
             [
-                call(index="foo", run_expensive_tasks=True),
-                call(index="bar", run_expensive_tasks=True),
+                call(index="foo", run_expensive_tasks=True, flush=True),
+                call(index="bar", run_expensive_tasks=True, flush=True),
             ]
         )
 
@@ -5053,8 +5053,8 @@ class TestDiskUsageStats:
         t.on_benchmark_stop()
         es.options.return_value.indices.disk_usage.assert_has_calls(
             [
-                call(index="foo", run_expensive_tasks=True),
-                call(index="bar", run_expensive_tasks=True),
+                call(index="foo", run_expensive_tasks=True, flush=True),
+                call(index="bar", run_expensive_tasks=True, flush=True),
             ]
         )
 
@@ -5071,8 +5071,8 @@ class TestDiskUsageStats:
         t.on_benchmark_stop()
         es.options.return_value.indices.disk_usage.assert_has_calls(
             [
-                call(index="foo", run_expensive_tasks=True),
-                call(index="bar", run_expensive_tasks=True),
+                call(index="foo", run_expensive_tasks=True, flush=True),
+                call(index="bar", run_expensive_tasks=True, flush=True),
             ]
         )
 
@@ -5089,10 +5089,23 @@ class TestDiskUsageStats:
         t.on_benchmark_stop()
         es.options.return_value.indices.disk_usage.assert_has_calls(
             [
-                call(index="foo", run_expensive_tasks=True),
-                call(index="bar", run_expensive_tasks=True),
+                call(index="foo", run_expensive_tasks=True, flush=True),
+                call(index="bar", run_expensive_tasks=True, flush=True),
             ]
         )
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    def test_passes_flush_false_when_param_set(self, es):
+        cfg = create_config()
+        es.options.return_value.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
+        metrics_store = metrics.EsMetricsStore(cfg)
+        device = telemetry.DiskUsageStats(
+            {"disk-usage-stats-flush": False}, es, metrics_store, index_names=["foo"], data_stream_names=[]
+        )
+        t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
+        t.on_benchmark_start()
+        t.on_benchmark_stop()
+        es.options.return_value.indices.disk_usage.assert_called_once_with(index="foo", run_expensive_tasks=True, flush=False)
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     @mock.patch("elasticsearch.Elasticsearch")

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -5099,9 +5099,7 @@ class TestDiskUsageStats:
         cfg = create_config()
         es.options.return_value.indices.disk_usage.return_value = {"_shards": {"failed": 0}}
         metrics_store = metrics.EsMetricsStore(cfg)
-        device = telemetry.DiskUsageStats(
-            {"disk-usage-stats-flush": False}, es, metrics_store, index_names=["foo"], data_stream_names=[]
-        )
+        device = telemetry.DiskUsageStats({"disk-usage-stats-flush": False}, es, metrics_store, index_names=["foo"], data_stream_names=[])
         t = telemetry.Telemetry(enabled_devices=[device.command], devices=[device])
         t.on_benchmark_start()
         t.on_benchmark_stop()


### PR DESCRIPTION
## Summary

Add a `disk-usage-stats-flush` telemetry parameter (default `true`, no behavior change) that controls the `flush` argument the `disk-usage-stats` device passes to `_disk_usage`. Setting it to `false` lets the telemetry work on serverless, which today rejects the default call.

## Why

`_disk_usage` defaults to `flush=true`. On serverless the search-tier engine refuses that with `illegal_argument_exception: "Search engine does not support acquiring last index commit with flush_first"`: the data being asked to flush lives on the index tier, not the search tier the call hits. The search tier reads committed segments from object storage and has no in-memory write buffer to flush, so `flush=false` is the architecturally correct call shape there, not a degraded mode.

For Rally benchmarks `flush=false` is also safe in practice. `disk-usage-stats` runs after the steady-state phase. The canonical schedule fires `disk-usage-stats` last, after `index`, `refresh`, `force-merge`, `wait-until-merges-finish`, and a final `refresh`. By telemetry time no writes are in flight, so `flush=false` returns the same bytes `flush=true` would. The two diverge only for live-indexing workloads that fire `disk-usage-stats` while writes are still settling, where bytes would be slightly under-reported.

Today the only workaround on serverless is to drop `disk-usage-stats` entirely, which loses per-field byte attribution. This param adds a knob so callers can opt into `flush=false` instead.

## Change

`DiskUsageStats` reads a new `disk-usage-stats-flush` telemetry param (default `True`) and passes it through to `client.indices.disk_usage(..., flush=...)`. A new unit test asserts `flush=False` is plumbed through when set; existing `TestDiskUsageStats` assertions are updated to include the now-explicit `flush=True` kwarg.

Usage in a benchmark entry's `stats.telemetry.params`:

```yaml
stats.telemetry: ["disk-usage-stats", "shard-stats"]
stats.telemetry.params:
  disk-usage-stats-flush: false
```

Unset means current behavior (`flush=true`). The follow-up consumer is the serverless `tsdb-metricsgen-270m-es95-vs-es819` entry in `elastic/elasticsearch-benchmarks`, filed separately because Rally has its own release cadence. Part of elastic/elasticsearch#148193.
