### PR TITLE
Replace port probing with ES process termination in ITs

### DIFF
--- a/.buildkite/it/run.sh
+++ b/.buildkite/it/run.sh
@@ -7,8 +7,8 @@ source .buildkite/retry.sh
 function upload_logs {
     echo "--- Upload artifacts"
     buildkite-agent artifact upload "${RALLY_HOME}/.rally/logs/*.log"
-    tar zcf "${HOME}/race-files.tar.gz" "${RALLY_HOME}/.rally/benchmarks/races"
-    buildkite-agent artifact upload "${HOME}/race-files.tar.gz"
+    tar zcf "${HOME}/rally-es-logs.tar.gz" "${RALLY_HOME}/.rally/benchmarks/races"/*/*/logs
+    buildkite-agent artifact upload "${HOME}/rally-es-logs.tar.gz"
 }
 
 export TERM=dumb

--- a/.buildkite/it/run.sh
+++ b/.buildkite/it/run.sh
@@ -6,9 +6,10 @@ source .buildkite/retry.sh
 
 function upload_logs {
     echo "--- Upload artifacts"
-    buildkite-agent artifact upload "${RALLY_HOME}/.rally/logs/*.log"
-    tar zcf "${HOME}/rally-es-logs.tar.gz" "${RALLY_HOME}/.rally/benchmarks/races"/*/*/logs
-    buildkite-agent artifact upload "${HOME}/rally-es-logs.tar.gz"
+    tar zcf "${RALLY_HOME}/rally-logs.tar.gz" "${RALLY_HOME}/.rally/logs"
+    buildkite-agent artifact upload "${RALLY_HOME}/rally-logs.tar.gz"
+    tar zcf "${RALLY_HOME}/rally-es-logs.tar.gz" "${RALLY_HOME}/.rally/benchmarks/races"/*/*/logs
+    buildkite-agent artifact upload "${RALLY_HOME}/rally-es-logs.tar.gz"
 }
 
 export TERM=dumb

--- a/.buildkite/it/run.sh
+++ b/.buildkite/it/run.sh
@@ -7,6 +7,8 @@ source .buildkite/retry.sh
 function upload_logs {
     echo "--- Upload artifacts"
     buildkite-agent artifact upload "${RALLY_HOME}/.rally/logs/*.log"
+    tar zcf "${HOME}/race-files.tar.gz" "${RALLY_HOME}/.rally/benchmarks/races"
+    buildkite-agent artifact upload "${HOME}/race-files.tar.gz"
 }
 
 export TERM=dumb

--- a/.buildkite/it/run.sh
+++ b/.buildkite/it/run.sh
@@ -49,8 +49,8 @@ echo "--- Run IT test :pytest:"
 
 export RALLY_HOME=$HOME
 export THESPLOG_FILE="${THESPLOG_FILE:-${RALLY_HOME}/.rally/logs/actor-system-internal.log}"
-# this value is in bytes, the default is 50kB. We increase it to 200kiB.
-export THESPLOG_FILE_MAXSIZE=${THESPLOG_FILE_MAXSIZE:-204800}
+# this value is in bytes, the default is 50kB. We increase it to 10MiB.
+export THESPLOG_FILE_MAXSIZE=${THESPLOG_FILE_MAXSIZE:-10485760}
 # adjust the default log level from WARNING
 export THESPLOG_THRESHOLD="INFO"
 export TERM=dumb

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ clean-docs: venv
 
 # It runs unit tests using the default python interpreter version.
 test: venv
-	uv run -- pytest -s --log-file="$HOME/.rally/logs/pytest.log" $(or $(ARGS), tests/)
+	uv run -- pytest -s --log-file="$$HOME/.rally/logs/pytest.log" $(or $(ARGS), tests/)
 
 # It runs unit tests using all supported python versions.
 test-all: test-3.10 test-3.11 test-3.12 test-3.13

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ clean-docs: venv
 
 # It runs unit tests using the default python interpreter version.
 test: venv
-	uv run -- pytest -s $(or $(ARGS), tests/)
+	uv run -- pytest -s --log-file="$HOME/.rally/logs/pytest.log" $(or $(ARGS), tests/)
 
 # It runs unit tests using all supported python versions.
 test-all: test-3.10 test-3.11 test-3.12 test-3.13

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,8 @@ clean-docs: venv
 
 # It runs unit tests using the default python interpreter version.
 test: venv
-	uv run -- pytest -s --log-file="$$HOME/.rally/logs/pytest.log" $(or $(ARGS), tests/)
+	mkdir -p "$${RALLY_HOME:-$$HOME/.rally}/logs"
+	uv run -- pytest -s --log-file="$${RALLY_HOME:-$$HOME/.rally}/logs/pytest.log" $(or $(ARGS), tests/)
 
 # It runs unit tests using all supported python versions.
 test-all: test-3.10 test-3.11 test-3.12 test-3.13

--- a/Makefile
+++ b/Makefile
@@ -174,8 +174,8 @@ clean-docs: venv
 
 # It runs unit tests using the default python interpreter version.
 test: venv
-	mkdir -p "$${RALLY_HOME:-$$HOME/.rally}/logs"
-	uv run -- pytest -s --log-file="$${RALLY_HOME:-$$HOME/.rally}/logs/pytest.log" $(or $(ARGS), tests/)
+	mkdir -p "$${RALLY_HOME:-$$HOME}/.rally/logs"
+	uv run -- pytest -s --log-file="$${RALLY_HOME:-$$HOME}/.rally/logs/pytest.log" $(or $(ARGS), tests/)
 
 # It runs unit tests using all supported python versions.
 test-all: test-3.10 test-3.11 test-3.12 test-3.13

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -334,7 +334,7 @@ def stop_process_on_port(port: int) -> None:
 
 def ensure_benchmark_transport_port_free(transport_port: int = BENCHMARK_IT_TRANSPORT_PORT, wait_timeout: int = 120) -> int:
     """
-    Stop any process on ``transport_port` and wait until the port is free.
+    Stop any process on ``transport_port`` and wait until the port is free.
     """
     stop_process_on_port(transport_port)
     wait_until_port_is_free(port_number=transport_port, timeout=wait_timeout)

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -37,7 +37,6 @@ DISTRIBUTIONS = ["8.19.13", "9.2.7"]
 TRACKS = ["geonames", "nyc_taxis", "http_logs", "nested"]
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
-_LOG = logging.getLogger(__name__)
 _CLUSTER_PROBE_ATTEMPTS = 5
 _CLUSTER_PROBE_DELAY_SEC = 0.5
 _CLUSTER_PROBE_REQUEST_TIMEOUT_SEC = 5.0
@@ -176,7 +175,7 @@ def cluster_name_on_port(http_port: int) -> str | None:
             last_error = e
             if attempt < _CLUSTER_PROBE_ATTEMPTS - 1:
                 time.sleep(_CLUSTER_PROBE_DELAY_SEC)
-    _LOG.debug(
+    LOG.debug(
         "cluster_name_on_port: 127.0.0.1:%s did not return cluster info: %s",
         http_port,
         last_error,
@@ -196,7 +195,7 @@ def _stop_docker_publishers(http_port: int) -> None:
     try:
         lines = process.run_subprocess_with_output(f"docker ps -q -f publish={http_port}")
     except BaseException as e:
-        _LOG.debug("docker ps for publish=%s failed: %s", http_port, e)
+        LOG.debug("docker ps for publish=%s failed: %s", http_port, e)
         return
     seen: set[str] = set()
     for line in lines:
@@ -205,7 +204,7 @@ def _stop_docker_publishers(http_port: int) -> None:
             continue
         seen.add(cid)
         if process.run_subprocess_with_logging(f"docker stop -t 30 {cid}") != 0:
-            _LOG.warning("docker stop failed for container %s", cid)
+            LOG.warning("docker stop failed for container %s", cid)
 
 
 def _listener_pids_on_port(http_port: int) -> set[int]:
@@ -229,7 +228,7 @@ def _listener_pids_on_port(http_port: int) -> set[int]:
     try:
         lines = process.run_subprocess_with_output(f"lsof -nP -iTCP:{http_port} -sTCP:LISTEN -t")
     except BaseException as e:
-        _LOG.debug("lsof for port %s failed: %s", http_port, e)
+        LOG.debug("lsof for port %s failed: %s", http_port, e)
         return pids
     for line in lines:
         s = line.strip()
@@ -285,7 +284,7 @@ def stop_rally_provisioned_es_on_port(http_port: int = BENCHMARK_IT_HTTP_PORT) -
         return
     name = cluster_name_on_port(http_port)
     if name is None:
-        _LOG.debug(
+        LOG.info(
             "Port 127.0.0.1:%s has a listener but no Elasticsearch cluster name; skip teardown.",
             http_port,
         )
@@ -316,6 +315,7 @@ def ensure_benchmark_http_port_free(http_port: int = BENCHMARK_IT_HTTP_PORT, wai
     assert http_port is not None
     stop_rally_provisioned_es_on_port(http_port)
     wait_until_port_is_free(port_number=http_port, timeout=wait_timeout)
+    LOG.info("Port %d seems to be free", http_port)
     return http_port
 
 

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -191,10 +191,12 @@ def _stop_docker_publishers(http_port: int) -> None:
             LOG.warning("docker stop failed for container %s", cid)
 
 
-def _is_rally_es_process(p: psutil.Process, metrics_store_install_id: str) -> bool:
+def _is_rally_es_process(p: psutil.Process, metrics_store_install_id: str | None = None) -> bool:
     """
     True if ``p`` is a host-JVM Elasticsearch provisioned by Rally, identified by the bootstrap main class in its
-    cmdline and the rally install path in its working directory. The session-scoped metrics store is excluded by
+    cmdline and the rally install path in its working directory.
+
+    If ``metrics_store_install_id`` is provided, the session-scoped metrics store is excluded by
     matching its installation id segment in the working directory: Rally lays out node working dirs as
     ``…/benchmarks/races/<install-id>/<node-name>/install/elasticsearch-X.Y.Z``.
     """
@@ -206,11 +208,23 @@ def _is_rally_es_process(p: psutil.Process, metrics_store_install_id: str) -> bo
         cwd = p.cwd()
         if "/benchmarks/races/" not in cwd:
             return False
-        if f"/benchmarks/races/{metrics_store_install_id}/" in cwd:
+        if metrics_store_install_id and f"/benchmarks/races/{metrics_store_install_id}/" in cwd:
             return False
         return True
     except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
         return False
+
+
+def find_rally_es_pids(metrics_store_install_id: str | None = None) -> set[int]:
+    mypid = os.getpid()
+    pids: set[int] = set()
+    for p in psutil.process_iter():
+        try:
+            if p.pid != mypid and _is_rally_es_process(p, metrics_store_install_id):
+                pids.add(p.pid)
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
+            pass
+    return pids
 
 
 def _kill_rally_es_processes(metrics_store_install_id: str, wait_timeout: float = _ES_SIGTERM_WAIT_SEC) -> None:
@@ -220,14 +234,7 @@ def _kill_rally_es_processes(metrics_store_install_id: str, wait_timeout: float 
 
     Requires ``metrics_store_install_id`` to identify the session-scoped metrics store JVM so it is not killed.
     """
-    mypid = os.getpid()
-    pids: set[int] = set()
-    for p in psutil.process_iter():
-        try:
-            if p.pid != mypid and _is_rally_es_process(p, metrics_store_install_id):
-                pids.add(p.pid)
-        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
-            pass
+    pids = find_rally_es_pids(metrics_store_install_id)
     if not pids:
         return
     for pid in pids:
@@ -264,7 +271,6 @@ def ensure_benchmark_http_port_free(
 
     ``metrics_store_install_id`` is the session metrics store's installation id, threaded through to
     ``_kill_rally_es_processes`` so the metrics store JVM is excluded from the orphan-JVM scan.
-    See ``_kill_rally_es_processes`` for behaviour when it is None.
     """
     assert http_port is not None
     _kill_rally_es_processes(metrics_store_install_id)
@@ -323,7 +329,7 @@ class TestCluster:
                 )
             )
             self.installation_id = json.loads("".join(output))["installation-id"]
-            LOG.info("Cluster %s installed with %s ID", self.cfg, self.installation_id)
+            LOG.info("Elasticsearch cluster listening at port %d installed with %s ID", self.http_port, self.installation_id)
         except BaseException as e:
             raise AssertionError(f"Failed to install Elasticsearch {distribution_version}.", e)
 

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -45,6 +45,7 @@ _CLUSTER_PROBE_REQUEST_TIMEOUT_SEC = 5.0
 # files assume this value. Switching to a free port would require threading it through every caller and external
 # reference, so we instead clear leftovers on this port before/after tests when teardown is incomplete.
 BENCHMARK_IT_HTTP_PORT = 19200
+BENCHMARK_IT_TRANSPORT_PORT = 19300
 # Default ``--cluster-name`` for ``esrally race`` / install; keep aligned with ``esrally/rally.py``.
 RALLY_DEFAULT_BENCHMARK_CLUSTER_NAME = "rally-benchmark"
 # Only these cluster names may be torn down on `BENCHMARK_IT_HTTP_PORT` (metrics store uses 10200).
@@ -248,6 +249,7 @@ def _terminate_listeners_on_port(http_port: int) -> None:
         if pid == mypid:
             continue
         try:
+            LOG.info("Sending SIGTERM to process %d listening on %d port", pid, http_port)
             os.kill(pid, signal.SIGTERM)
         except (ProcessLookupError, PermissionError):
             pass
@@ -261,6 +263,7 @@ def _terminate_listeners_on_port(http_port: int) -> None:
         if pid == mypid:
             continue
         try:
+            LOG.info("Sending SIGKILL to process %d listening on %d port", pid, http_port)
             os.kill(pid, signal.SIGKILL)
         except (ProcessLookupError, PermissionError):
             pass
@@ -273,7 +276,7 @@ def stop_rally_provisioned_es_on_port(http_port: int = BENCHMARK_IT_HTTP_PORT) -
     Rally subprocess trees do not always exit cleanly when the test runner gets a signal (e.g. ES JVM can
     outlive the parent), and Docker can keep a published port busy briefly after ``docker stop``. That leaves
     ``BENCHMARK_IT_HTTP_PORT`` occupied and the next test fails with low-signal bind errors. This helper is a
-    best-effort cleanup for those cases without changing Rally's global process model in this PR.
+    best-effort cleanup for those cases without changing Rally's global process model.
 
     Docker-provisioned nodes are stopped via ``docker stop``; tar / host-JVM nodes via terminating the
     listener PIDs (after ``SIGTERM``, ``SIGKILL`` as last resort). Only clusters named
@@ -315,8 +318,28 @@ def ensure_benchmark_http_port_free(http_port: int = BENCHMARK_IT_HTTP_PORT, wai
     assert http_port is not None
     stop_rally_provisioned_es_on_port(http_port)
     wait_until_port_is_free(port_number=http_port, timeout=wait_timeout)
-    LOG.info("Port %d seems to be free", http_port)
+    LOG.info("HTTP port %d seems to be free", http_port)
     return http_port
+
+
+def stop_process_on_port(port: int) -> None:
+    """
+    Stops process listening on a port.
+    """
+    if not _tcp_port_has_listener(port):
+        return
+    _terminate_listeners_on_port(port)
+    return
+
+
+def ensure_benchmark_transport_port_free(transport_port: int = BENCHMARK_IT_TRANSPORT_PORT, wait_timeout: int = 120) -> int:
+    """
+    Stop any process on ``transport_port` and wait until the port is free.
+    """
+    stop_process_on_port(transport_port)
+    wait_until_port_is_free(port_number=transport_port, timeout=wait_timeout)
+    LOG.info("Transport port %d seems to be free", transport_port)
+    return transport_port
 
 
 class TestCluster:

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -213,17 +213,13 @@ def _is_rally_es_process(p: psutil.Process, metrics_store_install_id: str) -> bo
         return False
 
 
-def _kill_rally_es_processes(metrics_store_install_id: str | None, wait_timeout: float = _ES_SIGTERM_WAIT_SEC) -> None:
+def _kill_rally_es_processes(metrics_store_install_id: str, wait_timeout: float = _ES_SIGTERM_WAIT_SEC) -> None:
     """
     Kill any host-JVM Elasticsearch provisioned by Rally that survived a previous test. Docker-provisioned ES is
     unaffected (handled by ``_stop_docker_publishers``).
 
-    Requires ``metrics_store_install_id`` to identify the session-scoped metrics store JVM so it is not killed. If it is
-    ``None`` (e.g. the metrics store was reused from a previous run and its install id was not recorded), this function
-    returns without scanning, since we cannot safely distinguish orphan benchmark JVMs from the reused metrics store.
+    Requires ``metrics_store_install_id`` to identify the session-scoped metrics store JVM so it is not killed.
     """
-    if metrics_store_install_id is None:
-        return
     mypid = os.getpid()
     pids: set[int] = set()
     for p in psutil.process_iter():
@@ -255,13 +251,12 @@ def _kill_rally_es_processes(metrics_store_install_id: str | None, wait_timeout:
 
 
 def ensure_benchmark_http_port_free(
+    metrics_store_install_id: str,
     http_port: int = BENCHMARK_IT_HTTP_PORT,
-    wait_timeout: int = 120,
-    *,
-    metrics_store_install_id: str | None = None,
+    wait_timeout: int = 10,
 ) -> int:
     """
-    Stops ES processes other than metric store, and Docker containers cluster on ``http_port``. Then waits until
+    Stops ES processes other than metrics store, and Docker containers listening at ``http_port``. Then waits until
     ``http_port`` is free.
 
     Used by pytest fixtures around benchmark tests so each run starts from a known state on the fixed IT port;

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -45,7 +45,6 @@ _CLUSTER_PROBE_REQUEST_TIMEOUT_SEC = 5.0
 # files assume this value. Switching to a free port would require threading it through every caller and external
 # reference, so we instead clear leftovers on this port before/after tests when teardown is incomplete.
 BENCHMARK_IT_HTTP_PORT = 19200
-BENCHMARK_IT_TRANSPORT_PORT = BENCHMARK_IT_HTTP_PORT + 100
 # Default ``--cluster-name`` for ``esrally race`` / install; keep aligned with ``esrally/rally.py``.
 RALLY_DEFAULT_BENCHMARK_CLUSTER_NAME = "rally-benchmark"
 # Only these cluster names may be torn down on `BENCHMARK_IT_HTTP_PORT` (metrics store uses 10200).
@@ -143,19 +142,15 @@ def wait_until_port_is_free(port_number=39200, timeout=120):
     start = time.perf_counter()
     end = start + timeout
     while time.perf_counter() < end:
-        c = socket.socket()
-        connect_result = c.connect_ex(("127.0.0.1", port_number))
-        # noinspection PyBroadException
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
-            if connect_result == errno.ECONNREFUSED:
-                c.close()
-                return
-            else:
-                c.close()
-                time.sleep(0.5)
-        except Exception:
-            pass
-
+            s.bind(("127.0.0.1", port_number))
+            return
+        except OSError:
+            time.sleep(0.5)
+        finally:
+            s.close()
     raise TimeoutError(f"Port [{port_number}] is occupied after [{timeout}] seconds")
 
 
@@ -184,14 +179,6 @@ def cluster_name_on_port(http_port: int) -> str | None:
     return None
 
 
-def _tcp_port_has_listener(port: int, host: str = "127.0.0.1") -> bool:
-    sock = socket.socket()
-    try:
-        return sock.connect_ex((host, port)) != errno.ECONNREFUSED
-    finally:
-        sock.close()
-
-
 def _stop_docker_publishers(http_port: int) -> None:
     try:
         lines = process.run_subprocess_with_output(f"docker ps -q -f publish={http_port}")
@@ -208,138 +195,94 @@ def _stop_docker_publishers(http_port: int) -> None:
             LOG.warning("docker stop failed for container %s", cid)
 
 
-def _listener_pids_on_port(http_port: int) -> set[int]:
-    pids: set[int] = set()
-    mypid = os.getpid()
+def _is_rally_es_process(p: psutil.Process, metrics_store_install_id: str) -> bool:
+    """
+    True if ``p`` is a host-JVM Elasticsearch provisioned by Rally, identified by the bootstrap main class in its
+    cmdline and the rally install path in its working directory. The session-scoped metrics store is excluded by
+    matching its installation id segment in the working directory: Rally lays out node working dirs as
+    ``…/benchmarks/races/<install-id>/<node-name>/install/elasticsearch-X.Y.Z``.
+    """
     try:
-        for conn in psutil.net_connections(kind="inet"):
-            if conn.status != psutil.CONN_LISTEN:
-                continue
-            if conn.laddr is None or conn.laddr.port != http_port:
-                continue
-            lip = conn.laddr.ip
-            if lip not in ("127.0.0.1", "0.0.0.0", "::", "::1", ""):
-                continue
-            if conn.pid is not None and conn.pid != mypid:
-                pids.add(conn.pid)
-    except (psutil.AccessDenied, PermissionError):
-        pass
-    if pids:
-        return pids
-    try:
-        lines = process.run_subprocess_with_output(f"lsof -nP -iTCP:{http_port} -sTCP:LISTEN -t")
-    except BaseException as e:
-        LOG.debug("lsof for port %s failed: %s", http_port, e)
-        return pids
-    for line in lines:
-        s = line.strip()
-        if s.isdigit():
-            pid = int(s)
-            if pid != mypid:
-                pids.add(pid)
-    return pids
+        if p.name().lower() != "java":
+            return False
+        if not any("org.elasticsearch.bootstrap.Elasticsearch" in arg for arg in p.cmdline()):
+            return False
+        cwd = p.cwd()
+        if "/benchmarks/races/" not in cwd:
+            return False
+        if f"/benchmarks/races/{metrics_store_install_id}/" in cwd:
+            return False
+        return True
+    except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
+        return False
 
 
-def _terminate_listeners_on_port(http_port: int) -> None:
-    pids = _listener_pids_on_port(http_port)
-    if not pids:
+def _kill_rally_es_processes(metrics_store_install_id: str | None, wait_timeout: float = _LISTENER_SIGTERM_WAIT_SEC) -> None:
+    """
+    Kill any host-JVM Elasticsearch provisioned by Rally that survived a previous test. Docker-provisioned ES is
+    unaffected (handled by ``_stop_docker_publishers``).
+
+    Requires ``metrics_store_install_id`` to identify the session-scoped metrics store JVM so it is not killed. If it is
+    ``None`` (e.g. the metrics store was reused from a previous run and its install id was not recorded), this function
+    returns without scanning, since we cannot safely distinguish orphan benchmark JVMs from the reused metrics store.
+    """
+    if metrics_store_install_id is None:
         return
     mypid = os.getpid()
-    for pid in pids:
-        if pid == mypid:
-            continue
+    pids: set[int] = set()
+    for p in psutil.process_iter():
         try:
-            LOG.info("Sending SIGTERM to process %d listening on %d port", pid, http_port)
+            if p.pid != mypid and _is_rally_es_process(p, metrics_store_install_id):
+                pids.add(p.pid)
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
+            pass
+    if not pids:
+        return
+    for pid in pids:
+        try:
+            LOG.info("Sending SIGTERM to orphaned rally IT ES JVM PID %d", pid)
             os.kill(pid, signal.SIGTERM)
         except (ProcessLookupError, PermissionError):
             pass
-    deadline = time.perf_counter() + _LISTENER_SIGTERM_WAIT_SEC
+    deadline = time.perf_counter() + wait_timeout
     while time.perf_counter() < deadline:
-        remaining = _listener_pids_on_port(http_port) - {mypid}
-        if not remaining:
+        if not any(psutil.pid_exists(pid) for pid in pids):
             return
         time.sleep(0.3)
-    for pid in _listener_pids_on_port(http_port):
-        if pid == mypid:
-            continue
+    for pid in pids:
         try:
-            LOG.info("Sending SIGKILL to process %d listening on %d port", pid, http_port)
-            os.kill(pid, signal.SIGKILL)
+            if psutil.pid_exists(pid):
+                LOG.info("Sending SIGKILL to orphaned rally IT ES JVM PID %d", pid)
+                os.kill(pid, signal.SIGKILL)
         except (ProcessLookupError, PermissionError):
             pass
 
 
-def stop_rally_provisioned_es_on_port(http_port: int = BENCHMARK_IT_HTTP_PORT) -> None:
+def ensure_benchmark_http_port_free(
+    http_port: int = BENCHMARK_IT_HTTP_PORT,
+    wait_timeout: int = 120,
+    *,
+    metrics_store_install_id: str | None = None,
+) -> int:
     """
-    If a Rally benchmark or IT ``TestCluster`` Elasticsearch is listening on ``http_port``, stop it.
-
-    Rally subprocess trees do not always exit cleanly when the test runner gets a signal (e.g. ES JVM can
-    outlive the parent), and Docker can keep a published port busy briefly after ``docker stop``. That leaves
-    ``BENCHMARK_IT_HTTP_PORT`` occupied and the next test fails with low-signal bind errors. This helper is a
-    best-effort cleanup for those cases without changing Rally's global process model.
-
-    Docker-provisioned nodes are stopped via ``docker stop``; tar / host-JVM nodes via terminating the
-    listener PIDs (after ``SIGTERM``, ``SIGKILL`` as last resort). Only clusters named
-    ``rally-benchmark`` or ``in-memory-it`` are touched; anything else raises ``AssertionError``.
-    """
-    assert http_port is not None
-    if not _tcp_port_has_listener(http_port):
-        return
-    name = cluster_name_on_port(http_port)
-    if name is None:
-        LOG.info(
-            "Port 127.0.0.1:%s has a listener but no Elasticsearch cluster name; skip teardown.",
-            http_port,
-        )
-        return
-    if name not in _BENCHMARK_CLUSTER_NAMES_ON_IT_PORT:
-        raise AssertionError(
-            f"127.0.0.1:{http_port} serves Elasticsearch cluster {name!r}; "
-            f"integration tests only auto-clear {_BENCHMARK_CLUSTER_NAMES_ON_IT_PORT!r}. "
-            "Free the port manually or change BENCHMARK_IT_HTTP_PORT."
-        )
-    for _ in range(_DOCKER_PUBLISH_STOP_ROUNDS):
-        _stop_docker_publishers(http_port)
-        time.sleep(0.5)
-    if _tcp_port_has_listener(http_port):
-        name2 = cluster_name_on_port(http_port)
-        if name2 in _BENCHMARK_CLUSTER_NAMES_ON_IT_PORT:
-            _terminate_listeners_on_port(http_port)
-    return
-
-
-def ensure_benchmark_http_port_free(http_port: int = BENCHMARK_IT_HTTP_PORT, wait_timeout: int = 120) -> int:
-    """
-    Stop any Rally IT benchmark cluster on ``http_port`` and wait until the port is free.
+    Stops ES processes other than metric store, and Docker containers cluster on ``http_port``. Then waits until
+    ``http_port`` is free.
 
     Used by pytest fixtures around benchmark tests so each run starts from a known state on the fixed IT port;
     see `BENCHMARK_IT_HTTP_PORT` for why the port is not chosen dynamically.
+
+    ``metrics_store_install_id`` is the session metrics store's installation id, threaded through to
+    ``_kill_rally_it_es_processes`` so the metrics store JVM is excluded from the orphan-JVM scan.
+    See ``_kill_rally_it_es_processes`` for behaviour when it is None.
     """
     assert http_port is not None
-    stop_rally_provisioned_es_on_port(http_port)
+    _kill_rally_es_processes(metrics_store_install_id)
+    for _ in range(_DOCKER_PUBLISH_STOP_ROUNDS):
+        _stop_docker_publishers(http_port)
+        time.sleep(0.5)
     wait_until_port_is_free(port_number=http_port, timeout=wait_timeout)
     LOG.info("HTTP port %d seems to be free", http_port)
     return http_port
-
-
-def stop_process_on_port(port: int) -> None:
-    """
-    Stops process listening on a port.
-    """
-    if not _tcp_port_has_listener(port):
-        return
-    _terminate_listeners_on_port(port)
-    return
-
-
-def ensure_benchmark_transport_port_free(transport_port: int = BENCHMARK_IT_TRANSPORT_PORT, wait_timeout: int = 120) -> int:
-    """
-    Stop any process on ``transport_port`` and wait until the port is free.
-    """
-    stop_process_on_port(transport_port)
-    wait_until_port_is_free(port_number=transport_port, timeout=wait_timeout)
-    LOG.info("Transport port %d seems to be free", transport_port)
-    return transport_port
 
 
 class TestCluster:
@@ -389,6 +332,7 @@ class TestCluster:
                 )
             )
             self.installation_id = json.loads("".join(output))["installation-id"]
+            LOG.info("Cluster %s installed with %s ID", self.cfg, self.installation_id)
         except BaseException as e:
             raise AssertionError(f"Failed to install Elasticsearch {distribution_version}.", e)
 

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -45,7 +45,7 @@ _CLUSTER_PROBE_REQUEST_TIMEOUT_SEC = 5.0
 # files assume this value. Switching to a free port would require threading it through every caller and external
 # reference, so we instead clear leftovers on this port before/after tests when teardown is incomplete.
 BENCHMARK_IT_HTTP_PORT = 19200
-BENCHMARK_IT_TRANSPORT_PORT = 19300
+BENCHMARK_IT_TRANSPORT_PORT = BENCHMARK_IT_HTTP_PORT + 100
 # Default ``--cluster-name`` for ``esrally race`` / install; keep aligned with ``esrally/rally.py``.
 RALLY_DEFAULT_BENCHMARK_CLUSTER_NAME = "rally-benchmark"
 # Only these cluster names may be torn down on `BENCHMARK_IT_HTTP_PORT` (metrics store uses 10200).

--- a/it/__init__.py
+++ b/it/__init__.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import errno
 import functools
 import json
 import logging
@@ -29,10 +28,10 @@ import time
 import psutil
 import pytest
 
-from esrally import client, version
+from esrally import client
 from esrally.utils import process
 
-CONFIG_NAMES = ["in-memory-it", "es-it"]
+IT_CONFIG_NAMES = ["in-memory-it", "es-it"]
 DISTRIBUTIONS = ["8.19.13", "9.2.7"]
 TRACKS = ["geonames", "nyc_taxis", "http_logs", "nested"]
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -45,12 +44,9 @@ _CLUSTER_PROBE_REQUEST_TIMEOUT_SEC = 5.0
 # files assume this value. Switching to a free port would require threading it through every caller and external
 # reference, so we instead clear leftovers on this port before/after tests when teardown is incomplete.
 BENCHMARK_IT_HTTP_PORT = 19200
-# Default ``--cluster-name`` for ``esrally race`` / install; keep aligned with ``esrally/rally.py``.
-RALLY_DEFAULT_BENCHMARK_CLUSTER_NAME = "rally-benchmark"
-# Only these cluster names may be torn down on `BENCHMARK_IT_HTTP_PORT` (metrics store uses 10200).
-_BENCHMARK_CLUSTER_NAMES_ON_IT_PORT = frozenset({RALLY_DEFAULT_BENCHMARK_CLUSTER_NAME, "in-memory-it"})
+
 _DOCKER_PUBLISH_STOP_ROUNDS = 3
-_LISTENER_SIGTERM_WAIT_SEC = 8.0
+_ES_SIGTERM_WAIT_SEC = 8.0
 
 
 LOG = logging.getLogger(__name__)
@@ -58,7 +54,7 @@ LOG = logging.getLogger(__name__)
 
 def all_rally_configs(t):
     @functools.wraps(t)
-    @pytest.mark.parametrize("cfg", CONFIG_NAMES)
+    @pytest.mark.parametrize("cfg", IT_CONFIG_NAMES)
     def wrapper(cfg, *args, **kwargs):
         t(cfg, *args, **kwargs)
 
@@ -67,7 +63,7 @@ def all_rally_configs(t):
 
 def random_rally_config(t):
     @functools.wraps(t)
-    @pytest.mark.parametrize("cfg", [random.choice(CONFIG_NAMES)])
+    @pytest.mark.parametrize("cfg", [random.choice(IT_CONFIG_NAMES)])
     def wrapper(cfg, *args, **kwargs):
         t(cfg, *args, **kwargs)
 
@@ -138,7 +134,7 @@ def command_in_docker(command_line, python_version):
     return subprocess.run(docker_command, shell=True, check=True).returncode
 
 
-def wait_until_port_is_free(port_number=39200, timeout=120):
+def wait_until_port_is_free(port_number=39200, timeout=10):
     start = time.perf_counter()
     end = start + timeout
     while time.perf_counter() < end:
@@ -217,7 +213,7 @@ def _is_rally_es_process(p: psutil.Process, metrics_store_install_id: str) -> bo
         return False
 
 
-def _kill_rally_es_processes(metrics_store_install_id: str | None, wait_timeout: float = _LISTENER_SIGTERM_WAIT_SEC) -> None:
+def _kill_rally_es_processes(metrics_store_install_id: str | None, wait_timeout: float = _ES_SIGTERM_WAIT_SEC) -> None:
     """
     Kill any host-JVM Elasticsearch provisioned by Rally that survived a previous test. Docker-provisioned ES is
     unaffected (handled by ``_stop_docker_publishers``).
@@ -272,8 +268,8 @@ def ensure_benchmark_http_port_free(
     see `BENCHMARK_IT_HTTP_PORT` for why the port is not chosen dynamically.
 
     ``metrics_store_install_id`` is the session metrics store's installation id, threaded through to
-    ``_kill_rally_it_es_processes`` so the metrics store JVM is excluded from the orphan-JVM scan.
-    See ``_kill_rally_it_es_processes`` for behaviour when it is None.
+    ``_kill_rally_es_processes`` so the metrics store JVM is excluded from the orphan-JVM scan.
+    See ``_kill_rally_es_processes`` for behaviour when it is None.
     """
     assert http_port is not None
     _kill_rally_es_processes(metrics_store_install_id)

--- a/it/conftest.py
+++ b/it/conftest.py
@@ -17,7 +17,6 @@
 
 import os
 import shutil
-import socket
 import tempfile
 from collections.abc import Generator
 
@@ -25,7 +24,15 @@ import pytest
 
 from esrally import config, version
 from esrally.utils import process
-from it import CONFIG_NAMES, ROOT_DIR, TestCluster, ensure_benchmark_http_port_free
+from it import (
+    IT_CONFIG_NAMES,
+    ROOT_DIR,
+    TestCluster,
+    ensure_benchmark_http_port_free,
+    wait_until_port_is_free,
+)
+
+METRICS_STORE_CONFIG_NAME = "metrics-store-it"
 
 
 def check_prerequisites():
@@ -43,7 +50,7 @@ def install_integration_test_config():
         f.store_default_config(template_path=source_path)
 
     print("Installing integration test configs...")
-    for n in CONFIG_NAMES:
+    for n in IT_CONFIG_NAMES:
         copy_config(n)
 
 
@@ -70,7 +77,7 @@ def build_docker_image():
 
 
 def remove_integration_test_config():
-    for config_name in CONFIG_NAMES:
+    for config_name in [*IT_CONFIG_NAMES, METRICS_STORE_CONFIG_NAME]:
         os.remove(config.ConfigFile(config_name).location)
 
 
@@ -81,35 +88,13 @@ class EsMetricsStore:
     HTTP_PORT = 10200
 
     def __init__(self) -> None:
-        self.cluster = TestCluster("metrics-store")
+        self.cluster = TestCluster(METRICS_STORE_CONFIG_NAME)
 
     def start(self) -> None:
-        """Ensure metrics Elasticsearch is up on ``HTTP_PORT``, installing it if needed."""
-        port = self.HTTP_PORT
-        cluster = self.cluster
-        name = cluster.probe_cluster_on_port(port)
-        if name == cluster.cfg:
-            print("Elasticsearch metrics store already running; waiting for cluster health (yellow)...")
-            cluster.http_port = port
-            cluster.wait_for_cluster_health()
-            return
-        if name is not None:
-            raise AssertionError(
-                f"Port {port} answers Elasticsearch but reports cluster name {name!r}; "
-                f"integration tests expect {cluster.cfg!r} for the metrics store. "
-                f"Stop the other cluster or change EsMetricsStore.HTTP_PORT."
-            )
-        probe_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            if probe_sock.connect_ex(("127.0.0.1", port)) == 0:
-                raise AssertionError(
-                    f"Something is listening on 127.0.0.1:{port} but the Elasticsearch REST probe did not succeed "
-                    f"(expected cluster name {cluster.cfg!r} when reusing the metrics store). "
-                    f"Free the port or check firewall/proxy. If Elasticsearch is still starting, wait and retry."
-                )
-        finally:
-            probe_sock.close()
-        print("Starting Elasticsearch metrics store...")
+        """Installs metrics Elasticsearch cluster listening at ``HTTP_PORT``, and verifies if healthy."""
+        print(f"Verifying if Elasticsearch metrics store port {self.HTTP_PORT} is free...")
+        wait_until_port_is_free(port_number=self.HTTP_PORT)
+        print(f"Starting Elasticsearch metrics store at port {self.HTTP_PORT}...")
         self.cluster.install(
             distribution_version=EsMetricsStore.VERSION,
             node_name="metrics-store",

--- a/it/conftest.py
+++ b/it/conftest.py
@@ -167,9 +167,10 @@ def free_benchmark_http_port() -> Generator[int]:
     See ``it.ensure_benchmark_http_port_free`` for rationale on the fixed port and teardown behavior.
     """
     install_id = ES_METRICS_STORE.cluster.installation_id
-    port = ensure_benchmark_http_port_free(metrics_store_install_id=install_id)
+    assert install_id is not None, "Elasticsearch metrics store should have been installed earlier"
+    port = ensure_benchmark_http_port_free(install_id)
     yield port
-    ensure_benchmark_http_port_free(port, metrics_store_install_id=install_id)
+    ensure_benchmark_http_port_free(install_id, port)
 
 
 @pytest.fixture(scope="module")
@@ -180,9 +181,10 @@ def free_benchmark_http_port_module() -> Generator[int]:
     See ``it.ensure_benchmark_http_port_free`` for rationale on the fixed port and teardown behavior.
     """
     install_id = ES_METRICS_STORE.cluster.installation_id
-    port = ensure_benchmark_http_port_free(metrics_store_install_id=install_id)
+    assert install_id is not None, "Elasticsearch metrics store should have been installed earlier"
+    port = ensure_benchmark_http_port_free(install_id)
     yield port
-    ensure_benchmark_http_port_free(port, metrics_store_install_id=install_id)
+    ensure_benchmark_http_port_free(install_id, port)
 
 
 # ensures that a fresh log file is available

--- a/it/conftest.py
+++ b/it/conftest.py
@@ -25,13 +25,7 @@ import pytest
 
 from esrally import config, version
 from esrally.utils import process
-from it import (
-    CONFIG_NAMES,
-    ROOT_DIR,
-    TestCluster,
-    ensure_benchmark_http_port_free,
-    ensure_benchmark_transport_port_free,
-)
+from it import CONFIG_NAMES, ROOT_DIR, TestCluster, ensure_benchmark_http_port_free
 
 
 def check_prerequisites():
@@ -87,7 +81,7 @@ class EsMetricsStore:
     HTTP_PORT = 10200
 
     def __init__(self) -> None:
-        self.cluster = TestCluster("in-memory-it")
+        self.cluster = TestCluster("metrics-store")
 
     def start(self) -> None:
         """Ensure metrics Elasticsearch is up on ``HTTP_PORT``, installing it if needed."""
@@ -187,12 +181,10 @@ def free_benchmark_http_port() -> Generator[int]:
 
     See ``it.ensure_benchmark_http_port_free`` for rationale on the fixed port and teardown behavior.
     """
-    port = ensure_benchmark_http_port_free()
-    # ES also listens on transport port
-    ensure_benchmark_transport_port_free()
+    install_id = ES_METRICS_STORE.cluster.installation_id
+    port = ensure_benchmark_http_port_free(metrics_store_install_id=install_id)
     yield port
-    ensure_benchmark_http_port_free(port)
-    ensure_benchmark_transport_port_free()
+    ensure_benchmark_http_port_free(port, metrics_store_install_id=install_id)
 
 
 @pytest.fixture(scope="module")
@@ -202,12 +194,10 @@ def free_benchmark_http_port_module() -> Generator[int]:
 
     See ``it.ensure_benchmark_http_port_free`` for rationale on the fixed port and teardown behavior.
     """
-    port = ensure_benchmark_http_port_free()
-    # ES also listens on transport port
-    ensure_benchmark_transport_port_free()
+    install_id = ES_METRICS_STORE.cluster.installation_id
+    port = ensure_benchmark_http_port_free(metrics_store_install_id=install_id)
     yield port
-    ensure_benchmark_http_port_free(port)
-    ensure_benchmark_transport_port_free()
+    ensure_benchmark_http_port_free(port, metrics_store_install_id=install_id)
 
 
 # ensures that a fresh log file is available

--- a/it/conftest.py
+++ b/it/conftest.py
@@ -25,14 +25,14 @@ import pytest
 from esrally import config, version
 from esrally.utils import process
 from it import (
+    BENCHMARK_IT_HTTP_PORT,
     IT_CONFIG_NAMES,
     ROOT_DIR,
     TestCluster,
     ensure_benchmark_http_port_free,
+    find_rally_es_pids,
     wait_until_port_is_free,
 )
-
-METRICS_STORE_CONFIG_NAME = "metrics-store-it"
 
 
 def check_prerequisites():
@@ -41,6 +41,23 @@ def check_prerequisites():
         raise AssertionError("Docker must be installed and the daemon must be up and running to run integration tests.")
     if process.run_subprocess_with_logging("docker compose version") != 0:
         raise AssertionError("Docker Compose is required to run integration tests.")
+    try:
+        wait_until_port_is_free(port_number=EsMetricsStore.HTTP_PORT, timeout=1)
+    except TimeoutError:
+        raise AssertionError(
+            f"Integration tests use Elasticsearch metrics store listening at 127.0.0.1:{EsMetricsStore.HTTP_PORT} which is not available."
+        )
+    try:
+        wait_until_port_is_free(port_number=BENCHMARK_IT_HTTP_PORT, timeout=1)
+    except TimeoutError:
+        raise AssertionError(
+            f"Integration tests benchmark Elasticsearch clusters listening at 127.0.0.1:{BENCHMARK_IT_HTTP_PORT} which is not available."
+        )
+    if es_pids := find_rally_es_pids():
+        raise AssertionError(
+            f"Rally started some Elasticsearch cluster(s) prior to integration tests, see PIDs {es_pids}. "
+            "Stop them before running the tests."
+        )
 
 
 def install_integration_test_config():
@@ -77,7 +94,7 @@ def build_docker_image():
 
 
 def remove_integration_test_config():
-    for config_name in [*IT_CONFIG_NAMES, METRICS_STORE_CONFIG_NAME]:
+    for config_name in IT_CONFIG_NAMES:
         os.remove(config.ConfigFile(config_name).location)
 
 
@@ -88,12 +105,10 @@ class EsMetricsStore:
     HTTP_PORT = 10200
 
     def __init__(self) -> None:
-        self.cluster = TestCluster(METRICS_STORE_CONFIG_NAME)
+        self.cluster = TestCluster(IT_CONFIG_NAMES[0])
 
     def start(self) -> None:
         """Installs metrics Elasticsearch cluster listening at ``HTTP_PORT``, and verifies if healthy."""
-        print(f"Verifying if Elasticsearch metrics store port {self.HTTP_PORT} is free...")
-        wait_until_port_is_free(port_number=self.HTTP_PORT)
         print(f"Starting Elasticsearch metrics store at port {self.HTTP_PORT}...")
         self.cluster.install(
             distribution_version=EsMetricsStore.VERSION,
@@ -161,10 +176,10 @@ class ConfigFile:
 @pytest.fixture
 def free_benchmark_http_port() -> Generator[int]:
     """
-    Before and after the test, clear Rally IT benchmark HTTP port (19200): stop orphaned
-    ``rally-benchmark`` / ``in-memory-it`` Elasticsearch (Docker or host JVM) and wait until the port is free.
-
-    See ``it.ensure_benchmark_http_port_free`` for rationale on the fixed port and teardown behavior.
+    Before and after the test:
+    1. Stop Rally-created Elasticsearch processes with the exception of metrics store cluster,
+    2. Stop Docker containers publishing at port 19200,
+    3. Wait until the 19200 port is free.
     """
     install_id = ES_METRICS_STORE.cluster.installation_id
     assert install_id is not None, "Elasticsearch metrics store should have been installed earlier"

--- a/it/conftest.py
+++ b/it/conftest.py
@@ -188,7 +188,7 @@ def free_benchmark_http_port() -> Generator[int]:
     See ``it.ensure_benchmark_http_port_free`` for rationale on the fixed port and teardown behavior.
     """
     port = ensure_benchmark_http_port_free()
-    # be paranoid, ES listens also on transport port
+    # ES also listens on transport port
     ensure_benchmark_transport_port_free()
     yield port
     ensure_benchmark_http_port_free(port)
@@ -203,7 +203,7 @@ def free_benchmark_http_port_module() -> Generator[int]:
     See ``it.ensure_benchmark_http_port_free`` for rationale on the fixed port and teardown behavior.
     """
     port = ensure_benchmark_http_port_free()
-    # be paranoid, ES listens also on transport port
+    # ES also listens on transport port
     ensure_benchmark_transport_port_free()
     yield port
     ensure_benchmark_http_port_free(port)

--- a/it/conftest.py
+++ b/it/conftest.py
@@ -25,7 +25,13 @@ import pytest
 
 from esrally import config, version
 from esrally.utils import process
-from it import CONFIG_NAMES, ROOT_DIR, TestCluster, ensure_benchmark_http_port_free
+from it import (
+    CONFIG_NAMES,
+    ROOT_DIR,
+    TestCluster,
+    ensure_benchmark_http_port_free,
+    ensure_benchmark_transport_port_free,
+)
 
 
 def check_prerequisites():
@@ -182,8 +188,11 @@ def free_benchmark_http_port() -> Generator[int]:
     See ``it.ensure_benchmark_http_port_free`` for rationale on the fixed port and teardown behavior.
     """
     port = ensure_benchmark_http_port_free()
+    # be paranoid, ES listens also on transport port
+    ensure_benchmark_transport_port_free()
     yield port
     ensure_benchmark_http_port_free(port)
+    ensure_benchmark_transport_port_free()
 
 
 @pytest.fixture(scope="module")
@@ -194,8 +203,11 @@ def free_benchmark_http_port_module() -> Generator[int]:
     See ``it.ensure_benchmark_http_port_free`` for rationale on the fixed port and teardown behavior.
     """
     port = ensure_benchmark_http_port_free()
+    # be paranoid, ES listens also on transport port
+    ensure_benchmark_transport_port_free()
     yield port
     ensure_benchmark_http_port_free(port)
+    ensure_benchmark_transport_port_free()
 
 
 # ensures that a fresh log file is available

--- a/it/distribution_test.py
+++ b/it/distribution_test.py
@@ -30,7 +30,7 @@ import it
 
 @pytest.mark.parametrize("dist", it.DISTRIBUTIONS)
 @pytest.mark.parametrize("track", it.TRACKS)
-@pytest.mark.parametrize("cfg", [random.choice(it.CONFIG_NAMES)])
+@pytest.mark.parametrize("cfg", [random.choice(it.IT_CONFIG_NAMES)])
 def test_tar_distributions(cfg, dist, track, free_benchmark_http_port: int):
 
     enable_assertions = track != "http_logs"  # http_logs assertions fail in test mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,8 @@ profile = 'black'
 [tool.pytest.ini_options]
 # set to true for more verbose output of tests
 log_cli = false
+log_date_format = "%Y-%m-%d %H:%M:%S"
+log_format = "%(asctime)s %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s"
 log_level = "INFO"
 addopts = "--verbose --color=yes"
 testpaths = "tests"


### PR DESCRIPTION
Attempts at improving https://github.com/elastic/rally/pull/2082 by switching to Elasticsearch process termination instead of port 19200 probing. Port probing was missing a case when ES triggered by previous test was not _yet_ running, so neither responding nor bound to the port. This was visible in `test_create_api_key_per_client` test failures. This test follows `test_interrupt` test, where Rally is interrupted with `SIGINT` but ES process continues to run. This perhaps should be ultimately addressed in Rally itself, but the focus here is integration test stabilization.

Metrics store listening at port 10200 must be installed as part of the IT run. Knowledge of metrics store installation ID is necessary to distinguish between Rally-created Elasticsearch processes started as part of tests, and the one started for the metrics store function.

In `wait_until_port_is_free()`, verification is made with `bind` instead of `connect` as this is more representative of what is required further by a _new_ ES process.

The change also adds more logs to Buildkite artifacts which might be useful in the future.