### PR TITLE
Fix flaky test_union_document_corpora_is_symmetric test

### DIFF
--- a/esrally/track/track.py
+++ b/esrally/track/track.py
@@ -284,24 +284,8 @@ class Documents:
             r.append("%s = [%s]" % (prop, repr(value)))
         return ", ".join(r)
 
-    def __hash__(self):
+    def _identity(self, meta_data):
         return (
-            hash(self.source_format)
-            ^ hash(self.document_file)
-            ^ hash(self.document_archive)
-            ^ hash(self.base_url)
-            ^ hash(self.includes_action_and_meta_data)
-            ^ hash(self.number_of_documents)
-            ^ hash(self.compressed_size_in_bytes)
-            ^ hash(self.uncompressed_size_in_bytes)
-            ^ hash(self.target_index)
-            ^ hash(self.target_data_stream)
-            ^ hash(self.target_type)
-            ^ hash(frozenset(self.meta_data.items()))
-        )
-
-    def __eq__(self, othr):
-        return isinstance(othr, type(self)) and (
             self.source_format,
             self.document_file,
             self.document_archive,
@@ -310,24 +294,27 @@ class Documents:
             self.number_of_documents,
             self.compressed_size_in_bytes,
             self.uncompressed_size_in_bytes,
-            self.target_type,
+            self.target_index,
             self.target_data_stream,
             self.target_type,
-            self.meta_data,
-        ) == (
-            othr.source_format,
-            othr.document_file,
-            othr.document_archive,
-            othr.base_url,
-            othr.includes_action_and_meta_data,
-            othr.number_of_documents,
-            othr.compressed_size_in_bytes,
-            othr.uncompressed_size_in_bytes,
-            othr.target_type,
-            othr.target_data_stream,
-            othr.target_type,
-            othr.meta_data,
+            meta_data,
         )
+
+    def sort_key(self):
+        def optional(v):
+            return v is not None, v
+
+        # Sort keys need a deterministic, orderable representation of meta-data.
+        sorted_meta_data = tuple(sorted((repr(k), repr(v)) for k, v in self.meta_data.items()))
+        return tuple(optional(v) for v in self._identity(meta_data=sorted_meta_data))
+
+    def __hash__(self):
+        # Hashing needs meta-data to be immutable and hashable.
+        return hash(self._identity(meta_data=frozenset(self.meta_data.items())))
+
+    def __eq__(self, othr):
+        # Equality can compare the original dictionaries directly.
+        return isinstance(othr, type(self)) and self._identity(meta_data=self.meta_data) == othr._identity(meta_data=othr.meta_data)
 
 
 class DocumentCorpus:
@@ -399,7 +386,9 @@ class DocumentCorpus:
             return self
         else:
             return DocumentCorpus(
-                name=self.name, documents=list(set(self.documents).union(other.documents)), meta_data=dict(self.meta_data)
+                name=self.name,
+                documents=sorted(set(self.documents).union(other.documents), key=Documents.sort_key),
+                meta_data=dict(self.meta_data),
             )
 
     def __str__(self):

--- a/tests/track/track_test.py
+++ b/tests/track/track_test.py
@@ -230,6 +230,7 @@ class TestDocumentCorpus:
         )
         assert b.union(a) == a.union(b)
         assert len(a.union(b).documents) == 2
+        assert [d.target_index for d in a.union(b).documents] == ["logs-01", "logs-02"]
 
     def test_cannot_union_mixed_document_corpora_by_name(self):
         a = track.DocumentCorpus(


### PR DESCRIPTION
Example failure: https://github.com/elastic/rally/actions/runs/26035271579/job/76531523012?pr=2120

I can't reproduce locally, and this was only exposed by #2120, but the fix here makes sense without the rest of #2120. Using a set and expecting a given order can only result in flakiness.