### PR TITLE
Add timeout and retries to git operations

### DIFF
--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -32,12 +32,12 @@ GIT_RETRY_BACKOFF_SECONDS = 2
 
 def _with_retries(operation, *, on_retry=None):
     """
-    Runs ``operation`` and retries it on :class:`exceptions.SupplyError` up to ``GIT_RETRIES`` times,
+    Runs ``operation`` and retries it on ``SupplyError`` up to ``GIT_RETRIES`` times,
     sleeping with exponential backoff between attempts. This is intended for network-bound git
     operations that may hang or fail transiently.
 
     :param operation: A zero-argument callable that performs the git operation and raises
-      :class:`exceptions.SupplyError` on failure.
+      ``exceptions.SupplyError`` on failure.
     :param on_retry: An optional zero-argument callable invoked between attempts (e.g. to clean up
       partial state) but not after the final, failing attempt.
     """

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -17,11 +17,42 @@
 
 import logging
 import os
+import shutil
+import time
 
 from esrally import exceptions
 from esrally.utils import io, process
 
 GIT_TIMEOUT = 600
+# Number of attempts for network-bound git operations (clone, fetch) before giving up.
+GIT_RETRIES = 3
+# Base delay for exponential backoff between retries, in seconds (waits ~2s, then ~4s).
+GIT_RETRY_BACKOFF_SECONDS = 2
+
+
+def _with_retries(operation, *, on_retry=None):
+    """
+    Runs ``operation`` and retries it on :class:`exceptions.SupplyError` up to ``GIT_RETRIES`` times,
+    sleeping with exponential backoff between attempts. This is intended for network-bound git
+    operations that may hang or fail transiently.
+
+    :param operation: A zero-argument callable that performs the git operation and raises
+      :class:`exceptions.SupplyError` on failure.
+    :param on_retry: An optional zero-argument callable invoked between attempts (e.g. to clean up
+      partial state) but not after the final, failing attempt.
+    """
+    logger = logging.getLogger(__name__)
+    for attempt in range(1, GIT_RETRIES + 1):
+        try:
+            return operation()
+        except exceptions.SupplyError:
+            if attempt == GIT_RETRIES:
+                raise
+            wait = GIT_RETRY_BACKOFF_SECONDS * 2 ** (attempt - 1)
+            logger.warning("git operation failed (attempt [%d/%d]); retrying in [%d]s.", attempt, GIT_RETRIES, wait)
+            if on_retry is not None:
+                on_retry()
+            time.sleep(wait)
 
 
 def probed(f):
@@ -71,16 +102,23 @@ def is_branch(src_dir, identifier):
 
 
 def clone(src, *, remote):
-    io.ensure_dir(src)
-    # Don't swallow subprocess output, user might need to enter credentials...
-    if process.run_subprocess_with_logging("git clone %s %s" % (remote, io.escape_path(src)), timeout=GIT_TIMEOUT):
-        raise exceptions.SupplyError("Could not clone from [%s] to [%s]" % (remote, src))
+    def _clone():
+        io.ensure_dir(src)
+        # Don't swallow subprocess output, user might need to enter credentials...
+        if process.run_subprocess_with_logging("git clone %s %s" % (remote, io.escape_path(src)), timeout=GIT_TIMEOUT):
+            raise exceptions.SupplyError("Could not clone from [%s] to [%s]" % (remote, src))
+
+    # A timed-out or failed clone could leave a partial directory behind, remove it so the retry starts clean.
+    _with_retries(_clone, on_retry=lambda: shutil.rmtree(src, ignore_errors=True))
 
 
 @probed
 def fetch(src, *, remote):
-    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src)} fetch --prune --tags {remote}", timeout=GIT_TIMEOUT):
-        raise exceptions.SupplyError("Could not fetch source tree from [%s]" % remote)
+    def _fetch():
+        if process.run_subprocess_with_logging(f"git -C {io.escape_path(src)} fetch --prune --tags {remote}", timeout=GIT_TIMEOUT):
+            raise exceptions.SupplyError("Could not fetch source tree from [%s]" % remote)
+
+    _with_retries(_fetch)
 
 
 @probed

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -21,12 +21,16 @@ import os
 from esrally import exceptions
 from esrally.utils import io, process
 
+GIT_TIMEOUT = 600
+
 
 def probed(f):
     def probe(src, *args, **kwargs):
         # Probe for -C
         if not process.exit_status_as_bool(
-            lambda: process.run_subprocess_with_logging(f"git -C {io.escape_path(src)} --version", level=logging.DEBUG),
+            lambda: process.run_subprocess_with_logging(
+                f"git -C {io.escape_path(src)} --version", level=logging.DEBUG, timeout=GIT_TIMEOUT
+            ),
             quiet=True,
         ):
             version = process.run_subprocess_with_output("git --version")
@@ -69,32 +73,32 @@ def is_branch(src_dir, identifier):
 def clone(src, *, remote):
     io.ensure_dir(src)
     # Don't swallow subprocess output, user might need to enter credentials...
-    if process.run_subprocess_with_logging("git clone %s %s" % (remote, io.escape_path(src))):
+    if process.run_subprocess_with_logging("git clone %s %s" % (remote, io.escape_path(src)), timeout=GIT_TIMEOUT):
         raise exceptions.SupplyError("Could not clone from [%s] to [%s]" % (remote, src))
 
 
 @probed
 def fetch(src, *, remote):
-    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src)} fetch --prune --tags {remote}"):
+    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src)} fetch --prune --tags {remote}", timeout=GIT_TIMEOUT):
         raise exceptions.SupplyError("Could not fetch source tree from [%s]" % remote)
 
 
 @probed
 def checkout(src_dir, *, branch):
-    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} checkout {branch}"):
+    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} checkout {branch}", timeout=GIT_TIMEOUT):
         raise exceptions.SupplyError("Could not checkout [%s]. Do you have uncommitted changes?" % branch)
 
 
 @probed
 def checkout_branch(src_dir, remote, branch):
-    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} checkout {remote}/{branch}"):
+    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} checkout {remote}/{branch}", timeout=GIT_TIMEOUT):
         raise exceptions.SupplyError("Could not checkout [%s]. Do you have uncommitted changes?" % branch)
 
 
 @probed
 def rebase(src_dir, *, remote, branch):
     checkout(src_dir, branch=branch)
-    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} rebase {remote}/{branch}"):
+    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} rebase {remote}/{branch}", timeout=GIT_TIMEOUT):
         raise exceptions.SupplyError("Could not rebase on branch [%s]" % branch)
 
 
@@ -114,13 +118,13 @@ def pull_ts(src_dir, ts, *, remote, branch, default_branch):
     else:
         rev_list_command = f'git -C {clean_src} rev-list -n 1 --before="{ts}" --date=iso8601 {remote}/{branch}'
     revision = process.run_subprocess_with_output(rev_list_command)[0].strip()
-    if process.run_subprocess_with_logging(f"git -C {clean_src} checkout {revision}"):
+    if process.run_subprocess_with_logging(f"git -C {clean_src} checkout {revision}", timeout=GIT_TIMEOUT):
         raise exceptions.SupplyError("Could not checkout source tree for timestamped revision [%s]" % ts)
 
 
 @probed
 def checkout_revision(src_dir, *, revision):
-    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} checkout {revision}"):
+    if process.run_subprocess_with_logging(f"git -C {io.escape_path(src_dir)} checkout {revision}", timeout=GIT_TIMEOUT):
         raise exceptions.SupplyError("Could not checkout source tree for revision [%s]" % revision)
 
 

--- a/esrally/utils/git.py
+++ b/esrally/utils/git.py
@@ -104,7 +104,6 @@ def is_branch(src_dir, identifier):
 def clone(src, *, remote):
     def _clone():
         io.ensure_dir(src)
-        # Don't swallow subprocess output, user might need to enter credentials...
         if process.run_subprocess_with_logging("git clone %s %s" % (remote, io.escape_path(src)), timeout=GIT_TIMEOUT):
             raise exceptions.SupplyError("Could not clone from [%s] to [%s]" % (remote, src))
 

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -18,6 +18,7 @@
 import logging
 import os
 import shlex
+import signal
 import subprocess
 import time
 from collections.abc import Iterable, Mapping
@@ -111,11 +112,12 @@ def run_subprocess_with_logging(
         env=env,
         stdin=stdin if stdin else None,
         preexec_fn=pre_exec,
+        start_new_session=True,
     ) as command_line_process:
         try:
             stdout, _ = command_line_process.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
-            command_line_process.kill()
+            os.killpg(command_line_process.pid, signal.SIGKILL)
             # finish handling pipes and populate the returncode attribute
             stdout, _ = command_line_process.communicate()
             output = f" Output: [{stdout}]" if stdout else ""

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -79,6 +79,7 @@ def run_subprocess_with_logging(
     stdin: Optional[Union[FileId, IO[bytes]]] = None,
     env: Optional[Mapping[str, str]] = None,
     detach: bool = False,
+    timeout: Optional[float] = None,
 ) -> int:
     """
     Runs the provided command line in a subprocess. All output will be captured by a logger.
@@ -90,6 +91,8 @@ def run_subprocess_with_logging(
       (default: None).
     :param env: Use specific environment variables (default: None).
     :param detach: Whether to detach this process from its parent process (default: False).
+    :param timeout: Optional time in seconds to wait for the subprocess to finish. If exceeded, the child is killed
+      and this function returns the exit code from the killed child. ``None`` (the default) waits indefinitely.
     :return: The process exit code as an int.
     """
     logger = logging.getLogger(__name__)
@@ -109,7 +112,22 @@ def run_subprocess_with_logging(
         stdin=stdin if stdin else None,
         preexec_fn=pre_exec,
     ) as command_line_process:
-        stdout, _ = command_line_process.communicate()
+        try:
+            stdout, _ = command_line_process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            command_line_process.kill()
+            # finish handling pipes and populate the returncode attribute
+            stdout, _ = command_line_process.communicate()
+            output = f" Output: [{stdout}]" if stdout else ""
+            logger.error(
+                "Subprocess [%s] exceeded timeout of [%s]s and was terminated with return code [%s].%s",
+                command_line,
+                timeout,
+                str(command_line_process.returncode),
+                output,
+            )
+            return command_line_process.returncode
+
         if stdout:
             logger.log(level=level, msg=stdout)
 

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -99,14 +99,9 @@ def run_subprocess_with_logging(
     logger = logging.getLogger(__name__)
     logger.debug("Running subprocess [%s] with logging.", command_line)
     command_line_args = shlex.split(command_line)
-    pre_exec = os.setpgrp if detach else None
     if header is not None:
         logger.info(header)
 
-    # only start a new session when a timeout is requested
-    new_session = timeout is not None
-
-    # pylint: disable=subprocess-popen-preexec-fn
     with subprocess.Popen(
         command_line_args,
         stdout=subprocess.PIPE,
@@ -114,8 +109,7 @@ def run_subprocess_with_logging(
         universal_newlines=True,
         env=env,
         stdin=stdin if stdin else None,
-        preexec_fn=pre_exec,
-        start_new_session=new_session,
+        start_new_session=detach or timeout is not None,
     ) as command_line_process:
         try:
             stdout, _ = command_line_process.communicate(timeout=timeout)
@@ -167,7 +161,6 @@ def run_subprocess_with_logging_and_output(
     logger = logging.getLogger(__name__)
     logger.debug("Running subprocess [%s] with logging.", command_line)
     command_line_args = shlex.split(command_line)
-    pre_exec = os.setpgrp if detach else None
     if header is not None:
         logger.info(header)
 
@@ -179,7 +172,7 @@ def run_subprocess_with_logging_and_output(
         env=env,
         check=False,
         stdin=stdin if stdin else None,
-        preexec_fn=pre_exec,
+        start_new_session=detach,
     )
 
     for stdout in completed.stdout.splitlines():

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -118,7 +118,7 @@ def run_subprocess_with_logging(
                 os.killpg(command_line_process.pid, signal.SIGKILL)
             except ProcessLookupError:
                 # the process group already exited between the timeout firing and the kill
-                logger.debug("Subprocess [%s] already exited before it could be killed.", command_line)
+                pass
             # finish handling pipes and populate the returncode attribute
             stdout, _ = command_line_process.communicate()
             output = f" Output: [{stdout}]" if stdout else ""

--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -103,6 +103,9 @@ def run_subprocess_with_logging(
     if header is not None:
         logger.info(header)
 
+    # only start a new session when a timeout is requested
+    new_session = timeout is not None
+
     # pylint: disable=subprocess-popen-preexec-fn
     with subprocess.Popen(
         command_line_args,
@@ -112,12 +115,16 @@ def run_subprocess_with_logging(
         env=env,
         stdin=stdin if stdin else None,
         preexec_fn=pre_exec,
-        start_new_session=True,
+        start_new_session=new_session,
     ) as command_line_process:
         try:
             stdout, _ = command_line_process.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
-            os.killpg(command_line_process.pid, signal.SIGKILL)
+            try:
+                os.killpg(command_line_process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                # the process group already exited between the timeout firing and the kill
+                logger.debug("Subprocess [%s] already exited before it could be killed.", command_line)
             # finish handling pipes and populate the returncode attribute
             stdout, _ = command_line_process.communicate()
             output = f" Output: [{stdout}]" if stdout else ""

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -154,28 +154,65 @@ class TestGit:
         git.clone(self.tmp_clone_dir, remote=self.remote_tmp_src_dir)
         assert git.is_working_copy(self.tmp_clone_dir)
 
-    def test_clone_with_error(self):
+    @mock.patch("time.sleep")
+    def test_clone_with_error(self, sleep):
         remote = "/this/remote/doesnt/exist"
         with pytest.raises(exceptions.SupplyError) as exc:
             git.clone(self.tmp_clone_dir, remote=remote)
         assert exc.value.args[0] == f"Could not clone from [{remote}] to [{self.tmp_clone_dir}]"
 
+    @mock.patch("time.sleep")
+    @mock.patch("shutil.rmtree")
     @mock.patch("esrally.utils.process.run_subprocess_with_logging")
-    def test_clone_raises_supply_error_on_timeout(self, run_subprocess_with_logging):
+    def test_clone_retries_until_exhausted(self, run_subprocess_with_logging, rmtree, sleep):
         run_subprocess_with_logging.return_value = -9
         remote = "https://github.com/elastic/rally-tracks"
         with pytest.raises(exceptions.SupplyError) as exc:
             git.clone(self.tmp_clone_dir, remote=remote)
         assert exc.value.args[0] == f"Could not clone from [{remote}] to [{self.tmp_clone_dir}]"
-        run_subprocess_with_logging.assert_called_once_with(f"git clone {remote} {self.tmp_clone_dir}", timeout=git.GIT_TIMEOUT)
+        run_subprocess_with_logging.assert_called_with(f"git clone {remote} {self.tmp_clone_dir}", timeout=git.GIT_TIMEOUT)
+        assert run_subprocess_with_logging.call_count == git.GIT_RETRIES
+        # the partial clone is cleaned up between attempts, but not after the final failure
+        assert rmtree.call_count == git.GIT_RETRIES - 1
+
+    @mock.patch("time.sleep")
+    @mock.patch("shutil.rmtree")
+    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
+    def test_clone_retries_then_succeeds(self, run_subprocess_with_logging, rmtree, sleep):
+        # fail once, then succeed
+        run_subprocess_with_logging.side_effect = [-9, 0]
+        remote = "https://github.com/elastic/rally-tracks"
+        git.clone(self.tmp_clone_dir, remote=remote)
+        assert run_subprocess_with_logging.call_count == 2
+        assert rmtree.call_count == 1
 
     def test_fetch_successful(self):
         git.fetch(self.local_tmp_src_dir, remote=self.local_remote_name)
 
-    def test_fetch_with_error(self):
+    @mock.patch("time.sleep")
+    def test_fetch_with_error(self, sleep):
         with pytest.raises(exceptions.SupplyError) as exc:
             git.fetch(self.local_tmp_src_dir, remote="this-remote-doesnt-actually-exist")
         assert exc.value.args[0] == "Could not fetch source tree from [this-remote-doesnt-actually-exist]"
+
+    @mock.patch("time.sleep")
+    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
+    def test_fetch_retries_until_exhausted(self, run_subprocess_with_logging, sleep):
+        # the @probed decorator first runs a `git --version` probe which must succeed
+        run_subprocess_with_logging.side_effect = lambda cmd, **kwargs: 0 if "--version" in cmd else -9
+        with pytest.raises(exceptions.SupplyError):
+            git.fetch(self.local_tmp_src_dir, remote="origin")
+        fetch_calls = [c for c in run_subprocess_with_logging.call_args_list if "fetch" in c.args[0]]
+        assert len(fetch_calls) == git.GIT_RETRIES
+
+    @mock.patch("time.sleep")
+    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
+    def test_fetch_retries_then_succeeds(self, run_subprocess_with_logging, sleep):
+        fetch_results = [-9, 0]
+        run_subprocess_with_logging.side_effect = lambda cmd, **kwargs: 0 if "--version" in cmd else fetch_results.pop(0)
+        git.fetch(self.local_tmp_src_dir, remote="origin")
+        fetch_calls = [c for c in run_subprocess_with_logging.call_args_list if "fetch" in c.args[0]]
+        assert len(fetch_calls) == 2
 
     def test_checkout_successful(self):
         git.checkout(self.local_tmp_src_dir, branch=self.local_branch)

--- a/tests/utils/git_test.py
+++ b/tests/utils/git_test.py
@@ -148,7 +148,7 @@ class TestGit:
         with pytest.raises(exceptions.SystemSetupError) as exc:
             git.head_revision("/src")
         assert exc.value.args[0] == "Your git version is [1.0.0] but Rally requires at least git 1.9. Please update git."
-        run_subprocess_with_logging.assert_called_with("git -C /src --version", level=logging.DEBUG)
+        run_subprocess_with_logging.assert_called_with("git -C /src --version", level=logging.DEBUG, timeout=git.GIT_TIMEOUT)
 
     def test_clone_successful(self):
         git.clone(self.tmp_clone_dir, remote=self.remote_tmp_src_dir)
@@ -159,6 +159,15 @@ class TestGit:
         with pytest.raises(exceptions.SupplyError) as exc:
             git.clone(self.tmp_clone_dir, remote=remote)
         assert exc.value.args[0] == f"Could not clone from [{remote}] to [{self.tmp_clone_dir}]"
+
+    @mock.patch("esrally.utils.process.run_subprocess_with_logging")
+    def test_clone_raises_supply_error_on_timeout(self, run_subprocess_with_logging):
+        run_subprocess_with_logging.return_value = -9
+        remote = "https://github.com/elastic/rally-tracks"
+        with pytest.raises(exceptions.SupplyError) as exc:
+            git.clone(self.tmp_clone_dir, remote=remote)
+        assert exc.value.args[0] == f"Could not clone from [{remote}] to [{self.tmp_clone_dir}]"
+        run_subprocess_with_logging.assert_called_once_with(f"git clone {remote} {self.tmp_clone_dir}", timeout=git.GIT_TIMEOUT)
 
     def test_fetch_successful(self):
         git.fetch(self.local_tmp_src_dir, remote=self.local_remote_name)

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -235,30 +235,6 @@ def test_run_subprocess_with_logging_timeout_kills_process_group(caplog, tmp_pat
     ), f"expected ERROR log starting with {expected!r}, got: {[r.getMessage() for r in caplog.records]}"
 
 
-@mock.patch("esrally.utils.process.subprocess.Popen")
-def test_run_subprocess_with_logging_without_timeout_does_not_start_new_session(popen):
-    proc = popen.return_value.__enter__.return_value
-    proc.returncode = 0
-    proc.communicate.return_value = ("", None)
-
-    process.run_subprocess_with_logging("true")
-
-    # a new session detaches the child from the controlling terminal, so only do it when we need
-    # os.killpg() to enforce a timeout
-    assert popen.call_args.kwargs["start_new_session"] is False
-
-
-@mock.patch("esrally.utils.process.subprocess.Popen")
-def test_run_subprocess_with_logging_with_timeout_starts_new_session(popen):
-    proc = popen.return_value.__enter__.return_value
-    proc.returncode = 0
-    proc.communicate.return_value = ("", None)
-
-    process.run_subprocess_with_logging("true", timeout=5)
-
-    assert popen.call_args.kwargs["start_new_session"] is True
-
-
 @mock.patch("esrally.utils.process.os.killpg", side_effect=ProcessLookupError)
 @mock.patch("esrally.utils.process.subprocess.Popen")
 def test_run_subprocess_with_logging_timeout_handles_already_exited_process(popen, killpg):

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -211,13 +211,18 @@ def test_run_subprocess():
     assert completed_process.stderr is None
 
 
-def test_run_subprocess_with_logging_timeout_kills_child(caplog):
-    cmd = "sleep 5"
-    timeout = 0
+def test_run_subprocess_with_logging_timeout_kills_process_group(caplog, tmp_path):
+    pid_file = tmp_path / "grandchild.pid"
+    # The shell backgrounds `sleep 600` in the same process group; both should die on timeout.
+    cmd = f"sh -c 'sleep 600 & echo $! > {pid_file}; wait'"
+    timeout = 1
+
     with caplog.at_level(logging.ERROR, logger="esrally.utils.process"):
         returncode = process.run_subprocess_with_logging(cmd, timeout=timeout)
+    grandchild_pid = int(pid_file.read_text().strip())
 
     assert returncode == -signal.SIGKILL
+    assert not psutil.pid_exists(grandchild_pid), f"grandchild PID {grandchild_pid} survived process-group kill"
     expected = f"Subprocess [{cmd}] exceeded timeout of [{timeout}]s and was terminated with return code [{-signal.SIGKILL}]."
     assert any(
         r.levelno == logging.ERROR and r.getMessage().startswith(expected) for r in caplog.records

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -18,6 +18,7 @@
 import logging
 import os
 import signal
+import time
 from unittest import mock
 
 import psutil
@@ -222,6 +223,10 @@ def test_run_subprocess_with_logging_timeout_kills_process_group(caplog, tmp_pat
     grandchild_pid = int(pid_file.read_text().strip())
 
     assert returncode == -signal.SIGKILL
+    # the grandchild PID is reaped asynchronously, so poll until its PID is gone
+    deadline = time.monotonic() + 10
+    while psutil.pid_exists(grandchild_pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
     assert not psutil.pid_exists(grandchild_pid), f"grandchild PID {grandchild_pid} survived process-group kill"
     expected = f"Subprocess [{cmd}] exceeded timeout of [{timeout}]s and was terminated with return code [{-signal.SIGKILL}]."
     assert any(

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -15,7 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
 import os
+import signal
 from unittest import mock
 
 import psutil
@@ -207,3 +209,16 @@ def test_run_subprocess():
     assert completed_process.returncode != 0
     assert completed_process.stdout != ""
     assert completed_process.stderr is None
+
+
+def test_run_subprocess_with_logging_timeout_kills_child(caplog):
+    cmd = "sleep 5"
+    timeout = 0
+    with caplog.at_level(logging.ERROR, logger="esrally.utils.process"):
+        returncode = process.run_subprocess_with_logging(cmd, timeout=timeout)
+
+    assert returncode == -signal.SIGKILL
+    expected = f"Subprocess [{cmd}] exceeded timeout of [{timeout}]s and was terminated with return code [{-signal.SIGKILL}]."
+    assert any(
+        r.levelno == logging.ERROR and r.getMessage().startswith(expected) for r in caplog.records
+    ), f"expected ERROR log starting with {expected!r}, got: {[r.getMessage() for r in caplog.records]}"

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -216,7 +216,7 @@ def test_run_subprocess():
 def test_run_subprocess_with_logging_timeout_kills_process_group(caplog, tmp_path):
     pid_file = tmp_path / "grandchild.pid"
     # The shell backgrounds `sleep 600` in the same process group; both should die on timeout.
-    cmd = f"sh -c 'sleep 600 & echo $! > {pid_file}; wait'"
+    cmd = f"sh -c 'sleep 600 & echo $! > \"{pid_file}\"; wait'"
     timeout = 1
 
     with caplog.at_level(logging.ERROR, logger="esrally.utils.process"):

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -18,6 +18,7 @@
 import logging
 import os
 import signal
+import subprocess
 import time
 from unittest import mock
 
@@ -232,3 +233,44 @@ def test_run_subprocess_with_logging_timeout_kills_process_group(caplog, tmp_pat
     assert any(
         r.levelno == logging.ERROR and r.getMessage().startswith(expected) for r in caplog.records
     ), f"expected ERROR log starting with {expected!r}, got: {[r.getMessage() for r in caplog.records]}"
+
+
+@mock.patch("esrally.utils.process.subprocess.Popen")
+def test_run_subprocess_with_logging_without_timeout_does_not_start_new_session(popen):
+    proc = popen.return_value.__enter__.return_value
+    proc.returncode = 0
+    proc.communicate.return_value = ("", None)
+
+    process.run_subprocess_with_logging("true")
+
+    # a new session detaches the child from the controlling terminal, so only do it when we need
+    # os.killpg() to enforce a timeout
+    assert popen.call_args.kwargs["start_new_session"] is False
+
+
+@mock.patch("esrally.utils.process.subprocess.Popen")
+def test_run_subprocess_with_logging_with_timeout_starts_new_session(popen):
+    proc = popen.return_value.__enter__.return_value
+    proc.returncode = 0
+    proc.communicate.return_value = ("", None)
+
+    process.run_subprocess_with_logging("true", timeout=5)
+
+    assert popen.call_args.kwargs["start_new_session"] is True
+
+
+@mock.patch("esrally.utils.process.os.killpg", side_effect=ProcessLookupError)
+@mock.patch("esrally.utils.process.subprocess.Popen")
+def test_run_subprocess_with_logging_timeout_handles_already_exited_process(popen, killpg):
+    proc = popen.return_value.__enter__.return_value
+    proc.pid = 4242
+    proc.returncode = -signal.SIGKILL
+    # first communicate() times out, second (after the kill) drains the pipes
+    proc.communicate.side_effect = [subprocess.TimeoutExpired(cmd="sleep 600", timeout=1), ("", None)]
+
+    # the process group exiting between the timeout and the kill must not propagate as an error
+    returncode = process.run_subprocess_with_logging("sleep 600", timeout=1)
+
+    assert returncode == -signal.SIGKILL
+    killpg.assert_called_once_with(4242, signal.SIGKILL)
+    assert proc.communicate.call_count == 2


### PR DESCRIPTION
A stalled subprocess (observed during a git clone of rally-tracks) can block indefinitely because `subprocess.communicate()` is invoked without a timeout. 

This commit adds an optional timeout kwarg to `run_subprocess_with_logging` that kills the child process on timeout expiry, drains output, and returns the (non-zero) child return code. Using this, we ensure all networked git operations now pass a 600s timeout to avoid blocking indefinitely, and are retried in the event of failure.

<details>

<summary> See example stack trace and ~2.5h git operation hang here </summary>

```python
$ sudo py-spy dump --pid 6272
[...]
Thread 6272 (idle): "MainThread"
    communicate (subprocess.py:1196)
    run_subprocess_with_logging (esrally/utils/process.py:112)
    clone (esrally/utils/git.py:72)
    __init__ (esrally/utils/repo.py:44)
    __init__ (esrally/track/loader.py:406)
    track_repo (esrally/track/loader.py:369)
    load_track (esrally/track/loader.py:252)
    setup (esrally/racecontrol.py:235)
    receiveMsg_Setup (esrally/racecontrol.py:114)
    guard (esrally/actor.py:96)
    receiveMessage (thespian/actors.py:840)
    _handleOneMessage (thespian/system/actorManager.py:164)
    handleMessages (thespian/system/actorManager.py:122)
    _runWithExpiry (thespian/system/transport/TCPTransport.py:1337)
    _run_subtransport (thespian/system/transport/wakeupTransportBase.py:80)
    run (thespian/system/transport/wakeupTransportBase.py:71)
    run (thespian/system/actorManager.py:88)
    startChild (thespian/system/multiprocCommon.py:696)
    run (multiprocessing/process.py:108)
    _bootstrap (multiprocessing/process.py:314)
    _launch (multiprocessing/popen_fork.py:71)
    __init__ (multiprocessing/popen_fork.py:19)
    _Popen (multiprocessing/context.py:281)
    start (multiprocessing/process.py:121)
    _startChildActor (thespian/system/multiprocCommon.py:358)
    h_PendingActor (thespian/system/admin/adminCore.py:318)
    h_PendingActor (thespian/system/admin/globalNames.py:19)
    handleIncoming (thespian/system/admin/adminCore.py:114)
    _runWithExpiry (thespian/system/transport/TCPTransport.py:1337)
    _run_subtransport (thespian/system/transport/wakeupTransportBase.py:80)
    run (thespian/system/transport/wakeupTransportBase.py:71)
    run (thespian/system/admin/convention.py:757)
    startAdmin (thespian/system/multiprocCommon.py:208)
    run (multiprocessing/process.py:108)
    _bootstrap (multiprocessing/process.py:314)
    _launch (multiprocessing/popen_fork.py:71)
    __init__ (multiprocessing/popen_fork.py:19)
    _Popen (multiprocessing/context.py:281)
    start (multiprocessing/process.py:121)
    _startAdmin (thespian/system/multiprocCommon.py:105)
    __init__ (thespian/system/systemBase.py:326)
    __init__ (thespian/system/multiprocCommon.py:83)
    __init__ (thespian/system/multiprocTCPBase.py:28)
    _startupActorSys (thespian/actors.py:678)
    __init__ (thespian/actors.py:637)
    bootstrap_actor_system (esrally/actor.py:311)
    start (esrally/rallyd.py:43)
    main (esrally/rallyd.py:120)
    <module> (esrallyd:6)

$ sudo ps -fp 6273,6274,6276 -o pid,ppid,etime,stat,cmd
    PID    PPID     ELAPSED STAT CMD
   6273    6272    02:32:07 Sl   git clone https://github.com/elastic/rally-tracks /home/esbench/.rally/benchmarks/tracks/default
   6274    6273    02:32:07 S     \_ /usr/bin/ssh -o SendEnv=GIT_PROTOCOL git@github.com git-upload-pack '/elastic/rally-tracks'
   6276    6273    02:32:05 S     \_ /usr/lib/git-core/git index-pack --stdin --fix-thin --keep=fetch-pack 6273 on rally-0 --check-self-contained-and-connected
```

</details>
