### PR TITLE
Pin uv version in it CI

### DIFF
--- a/.buildkite/it/run.sh
+++ b/.buildkite/it/run.sh
@@ -39,8 +39,8 @@ export JAVA21_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 
 echo "--- Install UV"
 
-curl -LsSf https://astral.sh/uv/install.sh | sh
-source "${HOME}/.local/bin/env"
+curl -LsSf https://astral.sh/uv/0.11.19/install.sh | env UV_UNMANAGED_INSTALL="${HOME}/.local/bin" sh
+export PATH="${HOME}/.local/bin:${PATH}"
 
 echo "--- Create virtual environment"
 

--- a/.buildkite/it/run_serverless.sh
+++ b/.buildkite/it/run_serverless.sh
@@ -31,8 +31,8 @@ retry 5 sudo apt-get install -y \
 
 echo "--- Install UV"
 
-curl -LsSf https://astral.sh/uv/install.sh | sh
-source "${HOME}/.local/bin/env"
+curl -LsSf https://astral.sh/uv/0.11.19/install.sh | env UV_UNMANAGED_INSTALL="${HOME}/.local/bin" sh
+export PATH="${HOME}/.local/bin:${PATH}"
 
 echo "--- Create virtual environment"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install UV
         uses: astral-sh/setup-uv@v7
         with:
-          version: "0.8.22"
+          version: "0.11.19"
       - name: Run tests
         run: make lint
       - uses: elastic/es-perf-github-status@v2
@@ -60,7 +60,7 @@ jobs:
       - name: Install UV
         uses: astral-sh/setup-uv@v7
         with:
-          version: "0.8.22"
+          version: "0.11.19"
       - name: Run tests
         run: make test-${{matrix.python-version}}
       - uses: elastic/es-perf-github-status@v2
@@ -93,7 +93,7 @@ jobs:
       - name: Install UV
         uses: astral-sh/setup-uv@v7
         with:
-          version: "0.8.22"
+          version: "0.11.19"
       - name: Free Disk Space
         continue-on-error: true
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/docker/Dockerfiles/dev/Dockerfile
+++ b/docker/Dockerfiles/dev/Dockerfile
@@ -38,7 +38,7 @@ RUN chgrp 0 /entrypoint.sh && \
 RUN mkdir -p /rally/.rally && \
     chown -R 1000:0 /rally/
 
-COPY --from=ghcr.io/astral-sh/uv:0.8.22 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /uvx /bin/
 
 USER 1000
 

--- a/docker/Dockerfiles/release/Dockerfile
+++ b/docker/Dockerfiles/release/Dockerfile
@@ -40,7 +40,7 @@ RUN chgrp 0 /entrypoint.sh && \
 RUN mkdir -p /rally/.rally && \
     chown -R 1000:0 /rally/
 
-COPY --from=ghcr.io/astral-sh/uv:0.8.22 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /uvx /bin/
 
 USER 1000
 


### PR DESCRIPTION
Also switches to UV_UNMANAGED_INSTALL which is documented to be [useful on CI](https://docs.astral.sh/uv/reference/environment/#uv_unmanaged_install) as it disables self-updates and does not affect the $PATH.

As requested in https://github.com/elastic/rally-tracks/pull/1177#discussion_r3459010186.