### PR TITLE
Fix metrics store flush blocking the benchmark actor event loop

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -81,8 +81,9 @@ class EsClient:
     def delete_by_query(self, index, body):
         return self.guarded(self._client.delete_by_query, index=index, body=body)
 
-    def update_by_query(self, index, body):
-        return self.guarded(self._client.update_by_query, index=index, body=body)
+    def update_by_query(self, index, body, request_timeout=None):
+        client = self._client.options(request_timeout=request_timeout) if request_timeout is not None else self._client
+        return self.guarded(client.update_by_query, index=index, body=body)
 
     def delete(self, index, id):
         # ignore 404 status code (NotFoundError) when index does not exist
@@ -98,34 +99,38 @@ class EsClient:
     def exists(self, index):
         return self.guarded(self._client.indices.exists, index=index)
 
-    def refresh(self, index):
-        return self.guarded(self._client.indices.refresh, index=index)
+    def refresh(self, index, request_timeout=None):
+        client = self._client.options(request_timeout=request_timeout) if request_timeout is not None else self._client
+        return self.guarded(client.indices.refresh, index=index)
 
-    def bulk_index(self, *, index, items, use_data_streams):
+    def bulk_index(self, *, index, items, use_data_streams, request_timeout=None):
         # pylint: disable=import-outside-toplevel
         import elasticsearch.helpers
 
         if use_data_streams:
             for item in items:
                 item["_op_type"] = "create"
-        self.guarded(elasticsearch.helpers.bulk, self._client, items, index=index, chunk_size=5000)
+        client = self._client.options(request_timeout=request_timeout) if request_timeout is not None else self._client
+        self.guarded(elasticsearch.helpers.bulk, client, items, index=index, chunk_size=5000)
 
-    def index(self, *, index, item, id=None, use_data_streams):
+    def index(self, *, index, item, id=None, use_data_streams, request_timeout=None):
         doc = {"_source": item}
         if not use_data_streams and id:
             doc["_id"] = id
-        self.bulk_index(index=index, items=[doc], use_data_streams=use_data_streams)
+        self.bulk_index(index=index, items=[doc], use_data_streams=use_data_streams, request_timeout=request_timeout)
 
     def search(self, index, body):
         return self.guarded(self._client.search, index=index, body=body)
 
-    def guarded(self, target, *args, **kwargs):
+    def guarded(self, target, *args, _max_retries=3, **kwargs):
         # pylint: disable=import-outside-toplevel
         import elasticsearch
         import elasticsearch.helpers
         from elastic_transport import ApiError, TransportError
 
-        max_execution_count = 10
+        # 3 retries × 60s request_timeout + sleep keeps worst-case blocking under
+        # Thespian's 5-minute actor event-loop delivery timeout.
+        max_execution_count = _max_retries
         execution_count = 0
 
         while execution_count <= max_execution_count:
@@ -770,7 +775,7 @@ class MetricsStore:  # pylint: disable=too-many-public-methods
         """
         self._stop_watch.start()
 
-    def flush(self, refresh=True):
+    def flush(self, refresh=True, closing=False):
         """
         Explicitly flushes buffered metrics to the metric store. It is not required to flush before closing the metrics store.
         """
@@ -783,7 +788,7 @@ class MetricsStore:  # pylint: disable=too-many-public-methods
         """
         self.logger.info("Closing metrics store.")
         self.opened = False
-        self.flush()
+        self.flush(closing=True)
         self._clear_meta_info()
 
     def add_meta_info(self, scope, scope_key, key, value):
@@ -1226,6 +1231,7 @@ class EsMetricsStore(MetricsStore):
         self._client = client_factory_class(cfg).create()
         self._index_handler = IndexHandler(self._config, self._client, EsStoreType.metrics)
         self._docs = None
+        self._flush_consecutive_failures = 0
 
     def open(self, race_id=None, race_timestamp=None, track_name=None, challenge_name=None, car_name=None, ctx=None, create=False):
         self._docs = []
@@ -1248,33 +1254,78 @@ class EsMetricsStore(MetricsStore):
                     index_name = new_name
 
             # ensure we can search immediately after opening
-            self._client.refresh(index=index_name)
+            self._client.refresh(index=index_name, request_timeout=60)
 
-    def flush(self, refresh=True):
+    _MAX_FLUSH_FAILURES = 10
+
+    def flush(self, refresh=True, closing=False):
         with self._docs_lock:
             docs_to_flush = self._docs
             self._docs = []
+
+        indexed = False
+        if not docs_to_flush:
+            # A quiet cycle breaks the consecutive-failure chain.
+            self._flush_consecutive_failures = 0
         if docs_to_flush:
-            sw = time.StopWatch()
-            sw.start()
-            self._client.bulk_index(
-                index=self._index_handler.index_name(self._race_timestamp),
-                items=docs_to_flush,
-                use_data_streams=self._index_handler.use_data_streams,
-            )
-            sw.stop()
-            self.logger.info(
-                "Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",
-                len(docs_to_flush),
-                self._race_timestamp,
-                self._track,
-                self._challenge,
-                self._car,
-                sw.total_time(),
-            )
-        # ensure we can search immediately after flushing
-        if refresh:
-            self._client.refresh(index=self._index_handler.index_name(self._race_timestamp))
+            try:
+                sw = time.StopWatch()
+                sw.start()
+                self._client.bulk_index(
+                    index=self._index_handler.index_name(self._race_timestamp),
+                    items=docs_to_flush,
+                    use_data_streams=self._index_handler.use_data_streams,
+                    request_timeout=60,
+                )
+                sw.stop()
+                indexed = True
+                self._flush_consecutive_failures = 0
+                self.logger.info(
+                    "Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",
+                    len(docs_to_flush),
+                    self._race_timestamp,
+                    self._track,
+                    self._challenge,
+                    self._car,
+                    sw.total_time(),
+                )
+            except exceptions.SystemSetupError:
+                raise
+            except exceptions.RallyError as e:
+                self._flush_consecutive_failures += 1
+                if closing:
+                    self.logger.error(
+                        "Failed to flush final %d metrics docs on close — these docs are lost: %s",
+                        len(docs_to_flush),
+                        e,
+                    )
+                    return
+                if self._flush_consecutive_failures >= self._MAX_FLUSH_FAILURES:
+                    self.logger.error(
+                        "Metrics store unreachable after %d consecutive flush failures, failing benchmark.",
+                        self._MAX_FLUSH_FAILURES,
+                    )
+                    raise
+                with self._docs_lock:
+                    self._docs = docs_to_flush + self._docs
+                self.logger.warning(
+                    "Failed to flush %d metrics docs (attempt %d/%d), re-queuing for next cycle: %s",
+                    len(docs_to_flush),
+                    self._flush_consecutive_failures,
+                    self._MAX_FLUSH_FAILURES,
+                    e,
+                )
+                return
+
+        # Refresh only when docs were written — skipping when idle avoids a blocking call.
+        if refresh and indexed:
+            try:
+                self._client.refresh(
+                    index=self._index_handler.index_name(self._race_timestamp),
+                    request_timeout=60,
+                )
+            except exceptions.RallyError as e:
+                self.logger.warning("Metrics store refresh failed (docs were indexed successfully): %s", e)
 
     def _add(self, doc):
         with self._docs_lock:
@@ -1535,7 +1586,7 @@ class InMemoryMetricsStore(MetricsStore):
     def _add_unlocked(self, doc):
         self.docs.append(doc)
 
-    def flush(self, refresh=True):
+    def flush(self, refresh=True, closing=False):
         pass
 
     def to_externalizable(self, clear=False):
@@ -2205,7 +2256,7 @@ class EsRaceStore(RaceStore):
         index = self._index_handler.index_name(race.race_timestamp)
 
         if self._index_handler.use_data_streams and self._race_stored:
-            self.client.refresh(index)
+            self.client.refresh(index, request_timeout=60)
             self.client.update_by_query(
                 index=index,
                 body={
@@ -2216,12 +2267,14 @@ class EsRaceStore(RaceStore):
                         "params": race.as_dict(),
                     },
                 },
+                request_timeout=60,
             )
         elif self._index_handler.use_data_streams:
             self.client.index(
                 index=index,
                 item=race.as_dict(),
                 use_data_streams=True,
+                request_timeout=60,
             )
             self._race_stored = True
         else:
@@ -2230,6 +2283,7 @@ class EsRaceStore(RaceStore):
                 item=race.as_dict(),
                 id=race.race_id,
                 use_data_streams=False,
+                request_timeout=60,
             )
 
     def add_annotation(self):
@@ -2463,6 +2517,7 @@ class EsResultsStore:
             index=self._index_handler.index_name(race.race_timestamp),
             items=race.to_result_dicts(),
             use_data_streams=self._index_handler.use_data_streams,
+            request_timeout=60,
         )
 
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -47,8 +47,7 @@ class EsClient:
 
     def __init__(self, client, cluster_version=None):
         self._client = client
-        # Reused across the flush/close path so we don't rebuild a client (and its namespaced
-        # clients) on every call. The underlying transport/connection pool is shared.
+        # Reused across the flush/close path.
         self._flush_client = client.options(request_timeout=self.FLUSH_REQUEST_TIMEOUT)
         self.logger = logging.getLogger(__name__)
         self._cluster_version = cluster_version
@@ -1296,20 +1295,15 @@ class EsMetricsStore(MetricsStore):
             except exceptions.SystemSetupError:
                 raise
             except exceptions.RallyError as e:
-                self._flush_consecutive_failures += 1
                 if closing:
-                    self.logger.error(
-                        "Failed to flush final %d metrics docs on close, these documents have been dropped: %s",
-                        len(docs_to_flush),
-                        e,
-                    )
-                    return
+                    # The closing flush is the last chance to persist, so surface the failure.
+                    raise exceptions.RallyError(f"Failed to flush {len(docs_to_flush)} final metrics docs on close.", cause=e) from e
+                self._flush_consecutive_failures += 1
                 if self._flush_consecutive_failures >= self._MAX_FLUSH_FAILURES:
-                    self.logger.error(
-                        "Metrics store unreachable after %d consecutive flush failures, failing benchmark.",
-                        self._MAX_FLUSH_FAILURES,
-                    )
-                    raise
+                    raise exceptions.RallyError(
+                        f"Metrics store unreachable after {self._MAX_FLUSH_FAILURES} consecutive flush failures, failing benchmark.",
+                        cause=e,
+                    ) from e
                 with self._docs_lock:
                     self._docs = docs_to_flush + self._docs
                 self.logger.warning(

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1281,7 +1281,8 @@ class EsMetricsStore(MetricsStore):
                 indexed = True
                 self._flush_consecutive_failures = 0
                 self.logger.info(
-                    "Successfully added %d metrics documents for race timestamp=[%s], track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",
+                    "Successfully added %d metrics documents for race timestamp=[%s],"
+                    " track=[%s], challenge=[%s], car=[%s] in [%f] seconds.",
                     len(docs_to_flush),
                     self._race_timestamp,
                     self._track,

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -41,8 +41,15 @@ class EsClient:
     Provides a stripped-down client interface that is easier to exchange for testing
     """
 
+    # Per-request timeout for the flush/close path. Bounds worst-case blocking in the actor
+    # event loop (see guarded()) well under Thespian's 5-minute message delivery timeout.
+    FLUSH_REQUEST_TIMEOUT = 60
+
     def __init__(self, client, cluster_version=None):
         self._client = client
+        # Reused across the flush/close path so we don't rebuild a client (and its namespaced
+        # clients) on every call. The underlying transport/connection pool is shared.
+        self._flush_client = client.options(request_timeout=self.FLUSH_REQUEST_TIMEOUT)
         self.logger = logging.getLogger(__name__)
         self._cluster_version = cluster_version
         self.retryable_status_codes = [502, 503, 504, 429]
@@ -81,9 +88,8 @@ class EsClient:
     def delete_by_query(self, index, body):
         return self.guarded(self._client.delete_by_query, index=index, body=body)
 
-    def update_by_query(self, index, body, request_timeout=None):
-        client = self._client.options(request_timeout=request_timeout) if request_timeout is not None else self._client
-        return self.guarded(client.update_by_query, index=index, body=body)
+    def update_by_query(self, index, body):
+        return self.guarded(self._flush_client.update_by_query, index=index, body=body)
 
     def delete(self, index, id):
         # ignore 404 status code (NotFoundError) when index does not exist
@@ -99,25 +105,23 @@ class EsClient:
     def exists(self, index):
         return self.guarded(self._client.indices.exists, index=index)
 
-    def refresh(self, index, request_timeout=None):
-        client = self._client.options(request_timeout=request_timeout) if request_timeout is not None else self._client
-        return self.guarded(client.indices.refresh, index=index)
+    def refresh(self, index):
+        return self.guarded(self._flush_client.indices.refresh, index=index)
 
-    def bulk_index(self, *, index, items, use_data_streams, request_timeout=None):
+    def bulk_index(self, *, index, items, use_data_streams):
         # pylint: disable=import-outside-toplevel
         import elasticsearch.helpers
 
         if use_data_streams:
             for item in items:
                 item["_op_type"] = "create"
-        client = self._client.options(request_timeout=request_timeout) if request_timeout is not None else self._client
-        self.guarded(elasticsearch.helpers.bulk, client, items, index=index, chunk_size=5000)
+        self.guarded(elasticsearch.helpers.bulk, self._flush_client, items, index=index, chunk_size=5000)
 
-    def index(self, *, index, item, id=None, use_data_streams, request_timeout=None):
+    def index(self, *, index, item, id=None, use_data_streams):
         doc = {"_source": item}
         if not use_data_streams and id:
             doc["_id"] = id
-        self.bulk_index(index=index, items=[doc], use_data_streams=use_data_streams, request_timeout=request_timeout)
+        self.bulk_index(index=index, items=[doc], use_data_streams=use_data_streams)
 
     def search(self, index, body):
         return self.guarded(self._client.search, index=index, body=body)
@@ -1254,7 +1258,7 @@ class EsMetricsStore(MetricsStore):
                     index_name = new_name
 
             # ensure we can search immediately after opening
-            self._client.refresh(index=index_name, request_timeout=60)
+            self._client.refresh(index=index_name)
 
     _MAX_FLUSH_FAILURES = 10
 
@@ -1275,7 +1279,6 @@ class EsMetricsStore(MetricsStore):
                     index=self._index_handler.index_name(self._race_timestamp),
                     items=docs_to_flush,
                     use_data_streams=self._index_handler.use_data_streams,
-                    request_timeout=60,
                 )
                 sw.stop()
                 indexed = True
@@ -1323,7 +1326,6 @@ class EsMetricsStore(MetricsStore):
             try:
                 self._client.refresh(
                     index=self._index_handler.index_name(self._race_timestamp),
-                    request_timeout=60,
                 )
             except exceptions.RallyError as e:
                 self.logger.warning("Metrics store refresh failed (docs were indexed successfully): %s", e)
@@ -2257,7 +2259,7 @@ class EsRaceStore(RaceStore):
         index = self._index_handler.index_name(race.race_timestamp)
 
         if self._index_handler.use_data_streams and self._race_stored:
-            self.client.refresh(index, request_timeout=60)
+            self.client.refresh(index)
             self.client.update_by_query(
                 index=index,
                 body={
@@ -2268,14 +2270,12 @@ class EsRaceStore(RaceStore):
                         "params": race.as_dict(),
                     },
                 },
-                request_timeout=60,
             )
         elif self._index_handler.use_data_streams:
             self.client.index(
                 index=index,
                 item=race.as_dict(),
                 use_data_streams=True,
-                request_timeout=60,
             )
             self._race_stored = True
         else:
@@ -2284,7 +2284,6 @@ class EsRaceStore(RaceStore):
                 item=race.as_dict(),
                 id=race.race_id,
                 use_data_streams=False,
-                request_timeout=60,
             )
 
     def add_annotation(self):
@@ -2518,7 +2517,6 @@ class EsResultsStore:
             index=self._index_handler.index_name(race.race_timestamp),
             items=race.to_result_dicts(),
             use_data_streams=self._index_handler.use_data_streams,
-            request_timeout=60,
         )
 
 

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -1296,7 +1296,7 @@ class EsMetricsStore(MetricsStore):
                 self._flush_consecutive_failures += 1
                 if closing:
                     self.logger.error(
-                        "Failed to flush final %d metrics docs on close — these docs are lost: %s",
+                        "Failed to flush final %d metrics docs on close, these documents have been dropped: %s",
                         len(docs_to_flush),
                         e,
                     )

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -439,10 +439,10 @@ class TestEsClient:
             BulkIndexError(bulk_index_errors),
         ]
 
-        max_retry = 10
+        max_retry = 3
 
-        # The sec to sleep for 10 transport errors is
-        # [1, 2, 4, 8, 16, 32, 64, 128, 256, 512] ~> 17.05min in total
+        # Sleep slots for 3 retries: [1, 2, 4] ~> 7s total.
+        # Reduced from 10 to prevent blocking the Thespian actor event loop for ~39 minutes.
         sleep_slots = [float(2**i) for i in range(0, max_retry)]
 
         # we want deterministic timings to assess logging statements
@@ -1212,7 +1212,7 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         if case.prefer_new_index_suffix:
             expected_index = self.metrics_store._index_handler.migrated_index_name(expected_index)
         if case.want_refresh:
-            self.es_mock.refresh.assert_called_once_with(index=expected_index)
+            self.es_mock.refresh.assert_called_once_with(index=expected_index, request_timeout=60)
         else:
             self.es_mock.refresh.assert_not_called()
         self.es_mock.bulk_index.assert_not_called()
@@ -1227,7 +1227,7 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
 
         self.metrics_store._index_handler.ensure_index_template.assert_called_once_with(create=False)
         self.es_mock.exists.assert_called_once_with(index="rally-metrics-2016-01.new")
-        self.es_mock.refresh.assert_called_once_with(index="rally-metrics-2016-01.new")
+        self.es_mock.refresh.assert_called_once_with(index="rally-metrics-2016-01.new", request_timeout=60)
 
     def test_put_value_redacts_secret_prefixed_track_param_values(self):
         self.cfg.add(config.Scope.application, "track", "params", {"shard-count": 3, "secret_token": "nope"})
@@ -1253,7 +1253,7 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
             "meta": {},
         }
         self.metrics_store.close()
-        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc], use_data_streams=False)
+        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc], use_data_streams=False, request_timeout=60)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_value_without_meta_info(self, use_data_streams):
@@ -1280,8 +1280,8 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams)
-        es_mock.refresh.assert_called_with(index=expected_index)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_value_with_explicit_timestamps(self, use_data_streams):
@@ -1308,8 +1308,8 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams)
-        es_mock.refresh.assert_called_with(index=expected_index)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_value_with_meta_info(self, use_data_streams):
@@ -1352,8 +1352,8 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams)
-        es_mock.refresh.assert_called_with(index=expected_index)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_doc_no_meta_data(self, use_data_streams):
@@ -1385,8 +1385,8 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams)
-        es_mock.refresh.assert_called_with(index=expected_index)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_doc_with_metadata(self, use_data_streams):
@@ -1441,8 +1441,8 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams)
-        es_mock.refresh.assert_called_with(index=expected_index)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
 
     def test_get_one(self):
         duration = StaticClock.NOW * 1000
@@ -1855,7 +1855,7 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
 
         captured_items = []
 
-        def bulk_index_side_effect(*, index, items, use_data_streams):
+        def bulk_index_side_effect(*, index, items, use_data_streams, request_timeout=None):
             # Simulate a background thread appending during bulk_index.
             ms._add(doc_during)
             captured_items.extend(items)
@@ -1875,7 +1875,123 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
             index=ms._index_handler.index_name(self.RACE_TIMESTAMP),
             items=[doc_during],
             use_data_streams=True,
+            request_timeout=60,
         )
+
+
+    # ------------------------------------------------------------------ #
+    #  flush() error-path tests                                           #
+    # ------------------------------------------------------------------ #
+
+    def test_flush_requeues_docs_on_transient_error(self):
+        ms, es_mock = self._make_metrics_store(use_data_streams=False)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        doc = {"name": "metric"}
+        ms._add(doc)
+        es_mock.bulk_index.side_effect = exceptions.RallyError("connection failed")
+
+        ms.flush()  # must not raise
+
+        assert ms._flush_consecutive_failures == 1
+        assert ms._docs == [doc]
+        ms.logger.warning.assert_called_once()
+
+    def test_flush_increments_counter_across_cycles(self):
+        ms, es_mock = self._make_metrics_store(use_data_streams=False)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        es_mock.bulk_index.side_effect = exceptions.RallyError("timeout")
+        for i in range(1, 4):
+            ms._add({"name": f"doc{i}"})
+            ms.flush()
+            assert ms._flush_consecutive_failures == i
+
+    def test_flush_raises_after_max_consecutive_failures(self):
+        ms, es_mock = self._make_metrics_store(use_data_streams=False)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        es_mock.bulk_index.side_effect = exceptions.RallyError("unreachable")
+        ms._flush_consecutive_failures = metrics.EsMetricsStore._MAX_FLUSH_FAILURES - 1
+        ms._add({"name": "doc"})
+
+        with pytest.raises(exceptions.RallyError):
+            ms.flush()
+
+        assert ms._flush_consecutive_failures == metrics.EsMetricsStore._MAX_FLUSH_FAILURES
+
+    def test_flush_resets_counter_on_empty_cycle(self):
+        ms, es_mock = self._make_metrics_store(use_data_streams=False)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        ms._flush_consecutive_failures = 7
+        # No docs added — quiet cycle.
+        ms.flush()
+
+        assert ms._flush_consecutive_failures == 0
+        es_mock.bulk_index.assert_not_called()
+
+    def test_flush_resets_counter_on_success(self):
+        ms, es_mock = self._make_metrics_store(use_data_streams=False)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        ms._flush_consecutive_failures = 7
+        ms._add({"name": "doc"})
+        es_mock.bulk_index.side_effect = None
+
+        ms.flush()
+
+        assert ms._flush_consecutive_failures == 0
+
+    def test_flush_reraises_system_setup_error_immediately(self):
+        ms, es_mock = self._make_metrics_store(use_data_streams=False)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        ms._add({"name": "doc"})
+        es_mock.bulk_index.side_effect = exceptions.SystemSetupError("auth failed")
+
+        with pytest.raises(exceptions.SystemSetupError):
+            ms.flush()
+
+        # Docs must not be re-queued — a config error is not transient.
+        assert ms._docs == []
+
+    def test_flush_closing_drops_docs_without_raising(self):
+        ms, es_mock = self._make_metrics_store(use_data_streams=False)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        ms._add({"name": "doc"})
+        es_mock.bulk_index.side_effect = exceptions.RallyError("gone")
+
+        ms.flush(closing=True)  # must not raise
+
+        ms.logger.error.assert_called_once()
+        assert ms._docs == []
+
+    def test_flush_closing_does_not_raise_at_max_failures(self):
+        ms, es_mock = self._make_metrics_store(use_data_streams=False)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        ms._flush_consecutive_failures = metrics.EsMetricsStore._MAX_FLUSH_FAILURES
+        ms._add({"name": "doc"})
+        es_mock.bulk_index.side_effect = exceptions.RallyError("gone")
+
+        ms.flush(closing=True)  # closing=True must suppress the max-failure raise
+
+        ms.logger.error.assert_called_once()
+
+    def test_flush_refresh_failure_is_warned_not_raised(self):
+        ms, es_mock = self._make_metrics_store(use_data_streams=False)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
+        ms._add({"name": "doc"})
+        es_mock.bulk_index.side_effect = None
+        es_mock.refresh.side_effect = exceptions.RallyError("refresh timed out")
+
+        ms.flush()  # must not raise
+
+        ms.logger.warning.assert_called_once()
+        assert ms._flush_consecutive_failures == 0  # bulk succeeded, counter stays at 0
 
 
 class TestEsRaceStore:
@@ -2083,6 +2199,7 @@ class TestEsRaceStore:
                 index=expected_index,
                 item=expected_doc,
                 use_data_streams=True,
+                request_timeout=60,
             )
         else:
             es_mock.index.assert_called_with(
@@ -2090,6 +2207,7 @@ class TestEsRaceStore:
                 id=self.RACE_ID,
                 item=expected_doc,
                 use_data_streams=False,
+                request_timeout=60,
             )
         rs._index_handler.ensure_index_template.assert_called_once_with(create=True)
 
@@ -2148,7 +2266,7 @@ class TestEsRaceStore:
         rs.store_race(race)
 
         expected_index = rs._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.refresh.assert_called_once_with(expected_index)
+        es_mock.refresh.assert_called_once_with(expected_index, request_timeout=60)
         es_mock.update_by_query.assert_called_once_with(
             index=expected_index,
             body={
@@ -2159,6 +2277,7 @@ class TestEsRaceStore:
                     "params": race.as_dict(),
                 },
             },
+            request_timeout=60,
         )
         # index should still have been called only once (from the first store_race)
         es_mock.index.assert_called_once()
@@ -2494,7 +2613,7 @@ class TestEsResultsStore:
             },
         ]
         expected_index = rs._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=expected_docs, use_data_streams=use_data_streams)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=expected_docs, use_data_streams=use_data_streams, request_timeout=60)
         rs._index_handler.ensure_index_template.assert_called_once_with(create=True)
         es_mock.index.assert_not_called()
         es_mock.refresh.assert_not_called()
@@ -2637,7 +2756,7 @@ class TestEsResultsStore:
             },
         ]
         expected_index = rs._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=expected_docs, use_data_streams=use_data_streams)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=expected_docs, use_data_streams=use_data_streams, request_timeout=60)
         rs._index_handler.ensure_index_template.assert_called_once_with(create=True)
         es_mock.index.assert_not_called()
         es_mock.refresh.assert_not_called()

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -156,6 +156,9 @@ class TestEsClient:
         def __init__(self, hosts):
             self.transport = TestEsClient.TransportMock(hosts)
 
+        def options(self, **kwargs):
+            return self
+
     @pytest.mark.parametrize("password_configuration", [None, "config", "environment"])
     def test_config_opts_parsing_basic(self, password_configuration, monkeypatch):
         cfg = config.Config()
@@ -1212,7 +1215,7 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         if case.prefer_new_index_suffix:
             expected_index = self.metrics_store._index_handler.migrated_index_name(expected_index)
         if case.want_refresh:
-            self.es_mock.refresh.assert_called_once_with(index=expected_index, request_timeout=60)
+            self.es_mock.refresh.assert_called_once_with(index=expected_index)
         else:
             self.es_mock.refresh.assert_not_called()
         self.es_mock.bulk_index.assert_not_called()
@@ -1227,7 +1230,7 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
 
         self.metrics_store._index_handler.ensure_index_template.assert_called_once_with(create=False)
         self.es_mock.exists.assert_called_once_with(index="rally-metrics-2016-01.new")
-        self.es_mock.refresh.assert_called_once_with(index="rally-metrics-2016-01.new", request_timeout=60)
+        self.es_mock.refresh.assert_called_once_with(index="rally-metrics-2016-01.new")
 
     def test_put_value_redacts_secret_prefixed_track_param_values(self):
         self.cfg.add(config.Scope.application, "track", "params", {"shard-count": 3, "secret_token": "nope"})
@@ -1253,9 +1256,7 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
             "meta": {},
         }
         self.metrics_store.close()
-        self.es_mock.bulk_index.assert_called_with(
-            index="rally-metrics-2016-01", items=[expected_doc], use_data_streams=False, request_timeout=60
-        )
+        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc], use_data_streams=False)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_value_without_meta_info(self, use_data_streams):
@@ -1282,10 +1283,8 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(
-            index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60
-        )
-        es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams)
+        es_mock.refresh.assert_called_with(index=expected_index)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_value_with_explicit_timestamps(self, use_data_streams):
@@ -1312,10 +1311,8 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(
-            index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60
-        )
-        es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams)
+        es_mock.refresh.assert_called_with(index=expected_index)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_value_with_meta_info(self, use_data_streams):
@@ -1358,10 +1355,8 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(
-            index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60
-        )
-        es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams)
+        es_mock.refresh.assert_called_with(index=expected_index)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_doc_no_meta_data(self, use_data_streams):
@@ -1393,10 +1388,8 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(
-            index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60
-        )
-        es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams)
+        es_mock.refresh.assert_called_with(index=expected_index)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_doc_with_metadata(self, use_data_streams):
@@ -1451,10 +1444,8 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(
-            index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60
-        )
-        es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams)
+        es_mock.refresh.assert_called_with(index=expected_index)
 
     def test_get_one(self):
         duration = StaticClock.NOW * 1000
@@ -1867,7 +1858,7 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
 
         captured_items = []
 
-        def bulk_index_side_effect(*, index, items, use_data_streams, request_timeout=None):
+        def bulk_index_side_effect(*, index, items, use_data_streams):
             # Simulate a background thread appending during bulk_index.
             ms._add(doc_during)
             captured_items.extend(items)
@@ -1887,7 +1878,6 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
             index=ms._index_handler.index_name(self.RACE_TIMESTAMP),
             items=[doc_during],
             use_data_streams=True,
-            request_timeout=60,
         )
 
     # ------------------------------------------------------------------ #
@@ -2210,7 +2200,6 @@ class TestEsRaceStore:
                 index=expected_index,
                 item=expected_doc,
                 use_data_streams=True,
-                request_timeout=60,
             )
         else:
             es_mock.index.assert_called_with(
@@ -2218,7 +2207,6 @@ class TestEsRaceStore:
                 id=self.RACE_ID,
                 item=expected_doc,
                 use_data_streams=False,
-                request_timeout=60,
             )
         rs._index_handler.ensure_index_template.assert_called_once_with(create=True)
 
@@ -2277,7 +2265,7 @@ class TestEsRaceStore:
         rs.store_race(race)
 
         expected_index = rs._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.refresh.assert_called_once_with(expected_index, request_timeout=60)
+        es_mock.refresh.assert_called_once_with(expected_index)
         es_mock.update_by_query.assert_called_once_with(
             index=expected_index,
             body={
@@ -2288,7 +2276,6 @@ class TestEsRaceStore:
                     "params": race.as_dict(),
                 },
             },
-            request_timeout=60,
         )
         # index should still have been called only once (from the first store_race)
         es_mock.index.assert_called_once()
@@ -2624,9 +2611,7 @@ class TestEsResultsStore:
             },
         ]
         expected_index = rs._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(
-            index=expected_index, items=expected_docs, use_data_streams=use_data_streams, request_timeout=60
-        )
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=expected_docs, use_data_streams=use_data_streams)
         rs._index_handler.ensure_index_template.assert_called_once_with(create=True)
         es_mock.index.assert_not_called()
         es_mock.refresh.assert_not_called()
@@ -2769,9 +2754,7 @@ class TestEsResultsStore:
             },
         ]
         expected_index = rs._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(
-            index=expected_index, items=expected_docs, use_data_streams=use_data_streams, request_timeout=60
-        )
+        es_mock.bulk_index.assert_called_with(index=expected_index, items=expected_docs, use_data_streams=use_data_streams)
         rs._index_handler.ensure_index_template.assert_called_once_with(create=True)
         es_mock.index.assert_not_called()
         es_mock.refresh.assert_not_called()

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1891,12 +1891,14 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         doc = {"name": "metric"}
         ms._add(doc)
         es_mock.bulk_index.side_effect = exceptions.RallyError("connection failed")
+        es_mock.refresh.reset_mock()  # ignore the refresh issued by open()
 
         ms.flush()  # must not raise
 
         assert ms._flush_consecutive_failures == 1
         assert ms._docs == [doc]
         ms.logger.warning.assert_called_once()
+        es_mock.refresh.assert_not_called()  # nothing was indexed, so no refresh
 
     def test_flush_increments_counter_across_cycles(self):
         ms, es_mock = self._make_metrics_store(use_data_streams=False)
@@ -1912,13 +1914,19 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         ms, es_mock = self._make_metrics_store(use_data_streams=False)
         ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
-        es_mock.bulk_index.side_effect = exceptions.RallyError("unreachable")
+        original = exceptions.RallyError("unreachable")
+        es_mock.bulk_index.side_effect = original
         ms._flush_consecutive_failures = metrics.EsMetricsStore._MAX_FLUSH_FAILURES - 1
         ms._add({"name": "doc"})
 
-        with pytest.raises(exceptions.RallyError):
+        with pytest.raises(exceptions.RallyError) as exc_info:
             ms.flush()
 
+        # Context is in the exception; the cause is chained for both tracebacks and full_message.
+        assert "consecutive flush failures" in str(exc_info.value)
+        assert exc_info.value.__cause__ is original
+        assert exc_info.value.cause is original
+        assert "unreachable" in exc_info.value.full_message
         assert ms._flush_consecutive_failures == metrics.EsMetricsStore._MAX_FLUSH_FAILURES
 
     def test_flush_resets_counter_on_empty_cycle(self):
@@ -1939,10 +1947,12 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         ms._flush_consecutive_failures = 7
         ms._add({"name": "doc"})
         es_mock.bulk_index.side_effect = None
+        es_mock.refresh.reset_mock()  # ignore the refresh issued by open()
 
         ms.flush()
 
         assert ms._flush_consecutive_failures == 0
+        es_mock.refresh.assert_called_once()  # indexed docs are refreshed
 
     def test_flush_reraises_system_setup_error_immediately(self):
         ms, es_mock = self._make_metrics_store(use_data_streams=False)
@@ -1957,29 +1967,47 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         # Docs must not be re-queued — a config error is not transient.
         assert ms._docs == []
 
-    def test_flush_closing_drops_docs_without_raising(self):
+    def test_flush_closing_raises_and_chains_error(self):
         ms, es_mock = self._make_metrics_store(use_data_streams=False)
         ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
         ms._add({"name": "doc"})
-        es_mock.bulk_index.side_effect = exceptions.RallyError("gone")
+        original = exceptions.RallyError("gone")
+        es_mock.bulk_index.side_effect = original
 
-        ms.flush(closing=True)  # must not raise
+        # On close there is no next cycle, so the failure must surface rather than be dropped.
+        with pytest.raises(exceptions.RallyError) as exc_info:
+            ms.flush(closing=True)
 
-        ms.logger.error.assert_called_once()
-        assert ms._docs == []
+        assert "on close" in str(exc_info.value)
+        assert exc_info.value.__cause__ is original
+        assert exc_info.value.cause is original
+        assert "gone" in exc_info.value.full_message
+        # Closing raises before the counter increment, so it is left untouched.
+        assert ms._flush_consecutive_failures == 0
 
-    def test_flush_closing_does_not_raise_at_max_failures(self):
+    def test_flush_closing_without_docs_is_noop(self):
         ms, es_mock = self._make_metrics_store(use_data_streams=False)
         ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
 
-        ms._flush_consecutive_failures = metrics.EsMetricsStore._MAX_FLUSH_FAILURES
+        # A normal close with an already-drained buffer must not raise or hit the store.
+        ms.flush(closing=True)
+
+        es_mock.bulk_index.assert_not_called()
+
+    def test_flush_closing_reraises_system_setup_error_unwrapped(self):
+        ms, es_mock = self._make_metrics_store(use_data_streams=False)
+        ms.open(self.RACE_ID, self.RACE_TIMESTAMP, "test", "append", "defaults", create=True)
+
         ms._add({"name": "doc"})
-        es_mock.bulk_index.side_effect = exceptions.RallyError("gone")
+        original = exceptions.SystemSetupError("auth failed")
+        es_mock.bulk_index.side_effect = original
 
-        ms.flush(closing=True)  # closing=True must suppress the max-failure raise
+        # A config/auth error must propagate as-is, not be wrapped in the "on close" error.
+        with pytest.raises(exceptions.SystemSetupError) as exc_info:
+            ms.flush(closing=True)
 
-        ms.logger.error.assert_called_once()
+        assert exc_info.value is original
 
     def test_flush_refresh_failure_is_warned_not_raised(self):
         ms, es_mock = self._make_metrics_store(use_data_streams=False)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1253,7 +1253,9 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
             "meta": {},
         }
         self.metrics_store.close()
-        self.es_mock.bulk_index.assert_called_with(index="rally-metrics-2016-01", items=[expected_doc], use_data_streams=False, request_timeout=60)
+        self.es_mock.bulk_index.assert_called_with(
+            index="rally-metrics-2016-01", items=[expected_doc], use_data_streams=False, request_timeout=60
+        )
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
     def test_put_value_without_meta_info(self, use_data_streams):
@@ -1280,7 +1282,9 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(
+            index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60
+        )
         es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
@@ -1308,7 +1312,9 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(
+            index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60
+        )
         es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
@@ -1352,7 +1358,9 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(
+            index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60
+        )
         es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
@@ -1385,7 +1393,9 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(
+            index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60
+        )
         es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
 
     @pytest.mark.parametrize("use_data_streams", [True, False])
@@ -1441,7 +1451,9 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
         }
         ms.close()
         expected_index = ms._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(
+            index=expected_index, items=[expected_doc], use_data_streams=use_data_streams, request_timeout=60
+        )
         es_mock.refresh.assert_called_with(index=expected_index, request_timeout=60)
 
     def test_get_one(self):
@@ -1877,7 +1889,6 @@ class TestEsMetricsStore:  # pylint: disable=too-many-public-methods
             use_data_streams=True,
             request_timeout=60,
         )
-
 
     # ------------------------------------------------------------------ #
     #  flush() error-path tests                                           #
@@ -2613,7 +2624,9 @@ class TestEsResultsStore:
             },
         ]
         expected_index = rs._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=expected_docs, use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(
+            index=expected_index, items=expected_docs, use_data_streams=use_data_streams, request_timeout=60
+        )
         rs._index_handler.ensure_index_template.assert_called_once_with(create=True)
         es_mock.index.assert_not_called()
         es_mock.refresh.assert_not_called()
@@ -2756,7 +2769,9 @@ class TestEsResultsStore:
             },
         ]
         expected_index = rs._index_handler.index_name(self.RACE_TIMESTAMP)
-        es_mock.bulk_index.assert_called_with(index=expected_index, items=expected_docs, use_data_streams=use_data_streams, request_timeout=60)
+        es_mock.bulk_index.assert_called_with(
+            index=expected_index, items=expected_docs, use_data_streams=use_data_streams, request_timeout=60
+        )
         rs._index_handler.ensure_index_template.assert_called_once_with(create=True)
         es_mock.index.assert_not_called()
         es_mock.refresh.assert_not_called()


### PR DESCRIPTION
Rally's `DriverActor` runs in Thespian's single-threaded event loop, so any `time.sleep()` inside a message handler blocks all incoming messages. Every 30 seconds, `receiveMsg_WakeupMessage` calls `EsMetricsStore.flush()`, which calls `guarded()` — a retry wrapper that sleeps between attempts. With the original settings (10 retries, 120s socket timeout), a single stuck connection could block the event loop for ~39 minutes. Thespian's 5-minute message delivery timeout would then fire, returning `PoisonPacket` for every queued `UpdateSamples` and `JoinPointReached` message, silently killing the benchmark. This is what happened twice in my benchmarks: a dead TCP socket (blackhole state) between the EU load driver and the US metrics store caused exactly this. The metrics store itself was green throughout.

The fix bounds worst-case blocking to ~250 seconds by reducing retries in `guarded()` from 10 to 3 and applying a `request_timeout=60` on the flush path. `EsClient` builds a single `options(request_timeout=60)` client once and reuses it across the flush/close path. The same 60s timeout therefore also covers `EsRaceStore.store_race()` and `EsResultsStore.store_results()`, which run in the same actor context at benchmark completion, as well as annotation writes (previously the client default). `EsMetricsStore.flush()` is rewritten to catch transient errors and re-queue docs for the next 30-second cycle rather than crashing, with a consecutive-failure counter that fails the benchmark after 10 unrecoverable cycles. A quiet cycle (no docs to flush) resets the counter. `SystemSetupError` (auth/config failures) bypasses re-queuing and raises immediately. The closing path logs lost docs as an error rather than silently dropping or blocking. Nine new tests cover all the error paths introduced.