### PR TITLE
Add TCP keepalive to metrics store client connections

### DIFF
--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -23,6 +23,7 @@ import math
 import os
 import pickle
 import random
+import socket
 import statistics
 import sys
 import threading
@@ -31,6 +32,8 @@ import zlib
 from enum import Enum, IntEnum
 
 import tabulate
+import urllib3.connection
+from elastic_transport import Urllib3HttpNode
 
 from esrally import client, config, exceptions, paths, time, types, version
 from esrally.utils import console, convert, io, pretty, versions
@@ -253,6 +256,37 @@ DATASTORE_API_KEY: str = os.environ.get("RALLY_REPORTING_DATASTORE_API_KEY", "")
 DATASTORE_USER: str = os.environ.get("RALLY_REPORTING_DATASTORE_USER", "")
 DATASTORE_PASSWORD: str = os.environ.get("RALLY_REPORTING_DATASTORE_PASSWORD", "")
 
+# TCP keepalive detects dead connections (e.g. NAT state dropped) without waiting for request_timeout.
+_KEEPALIVE_SOCKET_OPTIONS = [
+    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+]
+if sys.platform == "linux" and hasattr(socket, "TCP_KEEPIDLE"):
+    # Probe after 60s idle, retry every 10s, give up after 6 missed probes (dead in ~120s).
+    _KEEPALIVE_SOCKET_OPTIONS += [
+        (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
+        (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10),
+        (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 6),
+    ]
+elif sys.platform == "darwin" and hasattr(socket, "TCP_KEEPALIVE"):
+    # macOS uses TCP_KEEPALIVE (not TCP_KEEPIDLE) for per-socket idle time; interval/count are system-wide only.
+    _KEEPALIVE_SOCKET_OPTIONS += [
+        (socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 60),
+    ]
+
+
+class KeepaliveUrllib3HttpNode(Urllib3HttpNode):
+    """Enables TCP keepalive on the metrics store connection pool."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        # Seed from urllib3's default (includes TCP_NODELAY) so we don't lose it by supplying
+        # socket_options explicitly; then extend with keepalive options.
+        self.pool.conn_kw.setdefault(
+            "socket_options",
+            list(urllib3.connection.HTTPConnection.default_socket_options),
+        )
+        self.pool.conn_kw["socket_options"] = self.pool.conn_kw["socket_options"] + _KEEPALIVE_SOCKET_OPTIONS
+
 
 class EsClientFactory:
     """
@@ -308,6 +342,9 @@ class EsClientFactory:
                 hosts=hosts, client_options=client_options
             )
             self._cluster_version = distribution_version
+
+        # Use keepalive nodes for the long-lived metrics connection only (not the probe above).
+        client_options["node_class"] = KeepaliveUrllib3HttpNode
 
         factory = client_factory(
             hosts=hosts,

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -22,7 +22,10 @@ import json
 import logging
 import os
 import random
+import socket
+import sys
 import tempfile
+import urllib3.connection
 import uuid
 from dataclasses import dataclass
 from unittest import mock
@@ -638,22 +641,16 @@ class TestKeepaliveUrllib3HttpNode:
         return metrics.KeepaliveUrllib3HttpNode(config=None)
 
     def test_enables_so_keepalive(self, monkeypatch):
-        import socket
-
         node = self._make_node(monkeypatch)
         assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in node.pool.conn_kw["socket_options"]
 
     def test_preserves_existing_socket_options(self, monkeypatch):
-        import socket
-
         sentinel = (socket.IPPROTO_TCP, 200, 42)
         node = self._make_node(monkeypatch, conn_kw={"socket_options": [sentinel]})
         assert sentinel in node.pool.conn_kw["socket_options"]
         assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in node.pool.conn_kw["socket_options"]
 
     def test_does_not_mutate_original_socket_options_list(self, monkeypatch):
-        import socket
-
         # Pass the original list object directly (no copy) so mutation is detectable.
         original = []
         node = self._make_node(monkeypatch, conn_kw={"socket_options": original})
@@ -661,10 +658,6 @@ class TestKeepaliveUrllib3HttpNode:
         assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in node.pool.conn_kw["socket_options"]
 
     def test_includes_tcp_nodelay_from_urllib3_default(self, monkeypatch):
-        import socket
-
-        import urllib3.connection
-
         # When conn_kw starts without socket_options the implementation must seed from
         # urllib3's default (which carries TCP_NODELAY) before appending keepalive opts.
         node = self._make_node(monkeypatch, conn_kw={})
@@ -673,9 +666,6 @@ class TestKeepaliveUrllib3HttpNode:
             assert default_opt in opts, f"Expected urllib3 default socket option {default_opt} to be preserved"
 
     def test_platform_specific_keepalive_options(self, monkeypatch):
-        import socket
-        import sys
-
         node = self._make_node(monkeypatch)
         opts = node.pool.conn_kw["socket_options"]
         if sys.platform == "linux" and hasattr(socket, "TCP_KEEPIDLE"):

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -25,7 +25,6 @@ import random
 import socket
 import sys
 import tempfile
-import urllib3.connection
 import uuid
 from dataclasses import dataclass
 from unittest import mock
@@ -33,6 +32,7 @@ from unittest import mock
 import elasticsearch.exceptions
 import elasticsearch.helpers
 import pytest
+import urllib3.connection
 
 from esrally import client, config, exceptions, metrics, paths, time, track
 from esrally.metrics import GlobalStatsCalculator

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -201,6 +201,7 @@ class TestEsClient:
             "basic_auth_user": _datastore_user,
             "basic_auth_password": _datastore_password,
             "verify_certs": _datastore_verify_certs,
+            "node_class": metrics.KeepaliveUrllib3HttpNode,
         }
 
         client_factory.assert_called_with(
@@ -251,6 +252,7 @@ class TestEsClient:
             "timeout": 120,
             "verify_certs": _datastore_verify_certs,
             "api_key": _datastore_apikey,
+            "node_class": metrics.KeepaliveUrllib3HttpNode,
         }
 
         client_factory.assert_called_with(
@@ -619,6 +621,69 @@ class TestEsClient:
             match=r"Unretryable error encountered when sending metrics to remote metrics store: \[version_conflict_engine_exception\]",
         ):
             client.guarded(raise_bulk_index_error)
+
+
+class TestKeepaliveUrllib3HttpNode:
+    """Tests for the TCP keepalive node subclass."""
+
+    def _make_node(self, monkeypatch, conn_kw=None):
+        """Return a KeepaliveUrllib3HttpNode with a mocked pool, bypassing real network setup."""
+        pool = mock.MagicMock()
+        pool.conn_kw = conn_kw if conn_kw is not None else {}
+
+        def fake_urllib3_init(self, config):
+            self.pool = pool
+
+        monkeypatch.setattr(metrics.Urllib3HttpNode, "__init__", fake_urllib3_init)
+        return metrics.KeepaliveUrllib3HttpNode(config=None)
+
+    def test_enables_so_keepalive(self, monkeypatch):
+        import socket
+
+        node = self._make_node(monkeypatch)
+        assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in node.pool.conn_kw["socket_options"]
+
+    def test_preserves_existing_socket_options(self, monkeypatch):
+        import socket
+
+        sentinel = (socket.IPPROTO_TCP, 200, 42)
+        node = self._make_node(monkeypatch, conn_kw={"socket_options": [sentinel]})
+        assert sentinel in node.pool.conn_kw["socket_options"]
+        assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in node.pool.conn_kw["socket_options"]
+
+    def test_does_not_mutate_original_socket_options_list(self, monkeypatch):
+        import socket
+
+        # Pass the original list object directly (no copy) so mutation is detectable.
+        original = []
+        node = self._make_node(monkeypatch, conn_kw={"socket_options": original})
+        assert original == []  # the production code must not mutate the original list in-place
+        assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in node.pool.conn_kw["socket_options"]
+
+    def test_includes_tcp_nodelay_from_urllib3_default(self, monkeypatch):
+        import socket
+
+        import urllib3.connection
+
+        # When conn_kw starts without socket_options the implementation must seed from
+        # urllib3's default (which carries TCP_NODELAY) before appending keepalive opts.
+        node = self._make_node(monkeypatch, conn_kw={})
+        opts = node.pool.conn_kw["socket_options"]
+        for default_opt in urllib3.connection.HTTPConnection.default_socket_options:
+            assert default_opt in opts, f"Expected urllib3 default socket option {default_opt} to be preserved"
+
+    def test_platform_specific_keepalive_options(self, monkeypatch):
+        import socket
+        import sys
+
+        node = self._make_node(monkeypatch)
+        opts = node.pool.conn_kw["socket_options"]
+        if sys.platform == "linux" and hasattr(socket, "TCP_KEEPIDLE"):
+            assert (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60) in opts
+            assert (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10) in opts
+            assert (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 6) in opts
+        elif sys.platform == "darwin" and hasattr(socket, "TCP_KEEPALIVE"):
+            assert (socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 60) in opts
 
 
 class TestIndexTemplateProvider:

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -33,6 +33,7 @@ import elasticsearch.exceptions
 import elasticsearch.helpers
 import pytest
 import urllib3.connection
+from elastic_transport import NodeConfig
 
 from esrally import client, config, exceptions, metrics, paths, time, track
 from esrally.metrics import GlobalStatsCalculator
@@ -674,6 +675,24 @@ class TestKeepaliveUrllib3HttpNode:
             assert (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 6) in opts
         elif sys.platform == "darwin" and hasattr(socket, "TCP_KEEPALIVE"):
             assert (socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 60) in opts
+
+    def test_socket_options_applied_to_real_connection(self):
+        # Verify urllib3 actually applies conn_kw["socket_options"] to a real socket.
+        listener = socket.socket()
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+        conn = None
+        try:
+            node = metrics.KeepaliveUrllib3HttpNode(NodeConfig(scheme="http", host="127.0.0.1", port=port))
+            conn = node.pool._new_conn()
+            conn.connect()
+            assert conn.sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) != 0
+        finally:
+            if conn is not None:
+                conn.close()
+            listener.close()
 
 
 class TestIndexTemplateProvider:


### PR DESCRIPTION
Adds TCP keepalive to the Elasticsearch client used by the metrics store (`EsMetricsStore`, `EsRaceStore`, `EsResultsStore`).

The root cause of the benchmark crash fixed in #2154 was a NAT gateway silently dropping its connection state while the socket remained `ESTABLISHED` on both ends. The client only discovered the connection was dead after waiting out the full `request_timeout` on every retry attempt. TCP keepalive detects this at the OS level without waiting for a request to time out. After 60 seconds of idle the OS sends a probe. If the server does not respond after 6 probes (one every 10 seconds) the socket is closed and the application receives an immediate connection error — worst case ~120 seconds instead of ~250 seconds. During active flushing (every 30 seconds) keepalive probes never fire since real traffic resets the idle timer.

Subclasses `elastic_transport.Urllib3HttpNode` to inject keepalive socket options into the urllib3 connection pool's `conn_kw` after pool initialization. The subclass is passed as `node_class` to the Elasticsearch client, which is the supported API for customising the transport layer. urllib3's default `TCP_NODELAY` option is preserved by seeding from `HTTPConnection.default_socket_options` before appending keepalive options. Linux sets `TCP_KEEPIDLE=60`, `TCP_KEEPINTVL=10`, `TCP_KEEPCNT=6`. macOS sets `TCP_KEEPALIVE=60` (the macOS equivalent of `TCP_KEEPIDLE`; interval and count are system-wide only). Both are guarded with `hasattr` to handle non-standard builds.

#2154 bounds the worst-case event-loop block to ~250 seconds via `request_timeout=60` and `max_retries=3`. This PR is the root-cause fix: keepalive surfaces dead connections before `request_timeout` fires, making the retry budget rarely needed in the NAT-drop scenario. The two mechanisms are complementary — keepalive catches dead network paths, `request_timeout` catches alive-but-unresponsive servers.