### PR TITLE
Add AGENTS.md and basic skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md — Working with Rally
+
+Guidance for agents operating Rally (`esrally`), the macrobenchmarking framework for
+Elasticsearch. It sets up clusters, runs benchmarks (races), records results, and compares them.
+
+The `docs/*.rst` files and the [user guide](https://esrally.readthedocs.io/) are the source
+of truth — prefer reading them or running `esrally <subcommand> --help` over guessing flags.
+
+## Vocabulary
+
+- **race** — one benchmark execution, identified by a unique `race-id` (UUID).
+- **track** — a workload + dataset (e.g. `geonames`, `pmc`, `nyc_taxis`).
+- **challenge** — a named schedule of tasks within a track.
+- **task** — a scheduled step within a challenge that runs one operation; unique per invocation, so the same operation scheduled multiple times yields distinct tasks.
+- **operation** — the action a task runs (e.g. a bulk index or a search query), defined in the track.
+- **car** — an Elasticsearch node configuration. Only relevant when Rally provisions the cluster.
+- **pipeline** — what happens *around* the benchmark (provisioning/teardown), not the benchmark itself.
+- **telemetry device** — an optional probe that records extra metrics during a race.
+- **metrics store** — where Rally persists results: in-memory by default, or a dedicated Elasticsearch cluster.
+
+## Prerequisites & hard rules
+
+- Rally runs on Unix (Linux/macOS). Needs Python 3.10–3.13, git 1.9+.
+- **Never run Rally as root** — Elasticsearch refuses to start with root privileges.
+- **Never benchmark a production or production-like cluster.** Rally creates and mutates
+  indices, and any competing traffic invalidates results. Use a dedicated, quiet environment.
+- Config lives in `~/.rally/rally.ini`; cached data/artifacts under `~/.rally/benchmarks/`.
+- Do not invent flags. Verify against `docs/command_line_reference.rst` or `--help`.
+
+## Skills
+
+Task workflows live in `skills/`:
+
+- `skills/running-benchmarks/` — launch a race against a cluster (pipelines, target hosts,
+  TLS/API-key auth, tags, test mode) and interpret the summary report.
+- `skills/accessing-benchmark-results/` — list past races, get a race's overall results,
+  chart a metric across runs, compare races, and check convergence from an external metrics store.
+
+## Where to look next
+
+- Run benchmarks: `docs/race.rst`, `docs/pipelines.rst`
+- Recipes (existing cluster, Elastic Cloud, multi-cluster, distributed load): `docs/recipes.rst`
+- Serverless: `docs/serverless.rst`
+- Config & metrics store: `docs/configuration.rst`, `docs/metrics.rst`
+- Report interpretation: `docs/summary_report.rst`
+- Comparing races: `docs/tournament.rst`
+- Full CLI reference: `docs/command_line_reference.rst`
+- Authoring tracks: `docs/adding_tracks.rst`, `docs/track.rst`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ Task workflows live in `skills/`:
   TLS/API-key auth, tags, test mode) and interpret the summary report.
 - `skills/accessing-benchmark-results/` — list past races, get a race's overall results,
   chart a metric across runs, compare races, and check convergence from an external metrics store.
+- `skills/developing-rally/` — work *on* Rally's codebase: dev setup, make targets, source
+  layout, and the actor system.
 
 ## Where to look next
 
@@ -46,3 +48,4 @@ Task workflows live in `skills/`:
 - Comparing races: `docs/tournament.rst`
 - Full CLI reference: `docs/command_line_reference.rst`
 - Authoring tracks: `docs/adding_tracks.rst`, `docs/track.rst`
+- Developing Rally: `docs/developing.rst`, `CONTRIBUTING.md`, `docs/rally_daemon.rst`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/skills/accessing-benchmark-results/SKILL.md
+++ b/skills/accessing-benchmark-results/SKILL.md
@@ -35,9 +35,11 @@ across runs, comparisons, convergence, or ad-hoc aggregations.
 
 ## Where the data lives
 
-Default storage (`datastore.use_data_streams = true`) is three data streams. When it is
-`false`, Rally writes monthly indices (`rally-*-YYYY-MM`) instead. Query with a wildcard
-(`rally-races-*`, `rally-results-*`, `rally-metrics-*`) to cover both layouts.
+By default (`datastore.use_data_streams = true`) Rally writes to three data streams;
+`rally-races-v1`, `rally-results-v1`, and `rally-metrics-v1` (detailed below). If you set
+`datastore.use_data_streams = false`, Rally writes to monthly indices instead
+(`rally-races-YYYY-MM`, `rally-results-YYYY-MM`, `rally-metrics-YYYY-MM`). Querying with a
+wildcard (`rally-races-*`, `rally-results-*`, `rally-metrics-*`) covers both layouts.
 
 | Stream / index | One doc per | Contains |
 |---|---|---|
@@ -49,7 +51,7 @@ Default storage (`datastore.use_data_streams = true`) is three data streams. Whe
 
 `race-id` (UUID grouping a run), `race-timestamp`, `@timestamp` (epoch ms per sample),
 `relative-time` (ms since race start), `track`, `challenge`, `car`, `environment`,
-`sample-type` (`normal` = measured, `warmup` = discard), `name` (metric name, e.g.
+`sample-type` (`normal` = measured samples, `warmup` = warmup-phase samples), `name` (metric name, e.g.
 `service_time`), `value`, `unit`, `task`, `operation`, `operation-type`, and `meta.*`
 (host/CPU/OS info, `source_revision`, `distribution_version`, and user tags stored as
 `meta.tag_<key>`).
@@ -88,26 +90,28 @@ GET rally-races-*/_search
 
 ### Get one race's overall results (per task)
 
+Task and operation names are track-specific — discover them with `esrally info --track=<track>`.
+Omit the `task` filter to return every task.
+
 ```json
 GET rally-results-*/_search
 { "size": 200,
   "query": {"bool": {"filter": [
     {"term": {"race-id": "<uuid>"}},
-    {"term": {"task": "default"}}          // omit to get every task
+    {"term": {"task": "<task>"}}
   ]}} }
 ```
 
 ### Trend of a metric across runs
 
-One row per race; expand `size`/range as needed. Filter `sample-type: normal` to exclude
-warmup samples.
+One row per race; expand `size`/range as needed.
 
 ```json
 GET rally-metrics-*/_search
 { "size": 0,
   "query": {"bool": {"filter": [
     {"term": {"track": "geonames"}},
-    {"term": {"task": "default"}},
+    {"term": {"task": "<task>"}},
     {"term": {"name": "service_time"}},
     {"term": {"sample-type": "normal"}},
     {"range": {"@timestamp": {"gte": "now-30d"}}}
@@ -141,9 +145,11 @@ GET rally-metrics-*/_search
 
 ### Convergence / stability check
 
-Bucket one race's samples over time. If p50/p90/p99 flatten toward the end, the run
-converged; if they are still drifting, the results are unreliable and the workload may need a
-longer warmup or more iterations.
+Use this to check whether a race reached steady state before you trust its numbers. The
+query splits one task's `service_time` samples into up to ~60 time buckets and reports p50/p90/p99
+for each. If those percentiles level off toward the end of the run, the workload converged and
+the results are stable; if they keep drifting, the numbers are unreliable — rerun with a longer
+warmup or more iterations.
 
 ```json
 GET rally-metrics-*/_search
@@ -151,10 +157,10 @@ GET rally-metrics-*/_search
   "query": {"bool": {"filter": [
     {"term": {"race-id": "<uuid>"}},
     {"term": {"name": "service_time"}},
-    {"term": {"operation": "default"}}
+    {"term": {"task": "<task>"}}
   ]}},
   "aggs": {"over_time": {
-    "date_histogram": {"field": "@timestamp", "calendar_interval": "1m"},
+    "auto_date_histogram": {"field": "@timestamp", "buckets": 60},
     "aggs": {"pcts": {"percentiles": {"field": "value", "percents": [50, 90, 99]}}}
   }} }
 ```

--- a/skills/accessing-benchmark-results/SKILL.md
+++ b/skills/accessing-benchmark-results/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: accessing-benchmark-results
+description: >-
+  Retrieve Rally benchmark results from an external Elasticsearch metrics store.
+  Use to list past races, get a single race's overall (per-task) results, chart
+  a metric's trend across multiple runs, compare two races, or check whether a
+  run converged — e.g. "show me recent geonames races", "what's the service_time
+  trend for nyc_taxis over the last 30 days?", "compare these two race-ids".
+  Applies when datastore.type = elasticsearch is set in ~/.rally/rally.ini.
+---
+
+# Accessing Rally benchmark results
+
+Rally can persist every race to a dedicated Elasticsearch **metrics store** (set
+`datastore.type = elasticsearch` in the `[reporting]` section of `~/.rally/rally.ini`;
+see `docs/configuration.rst`). This skill covers reading that data back — overall results,
+trends across runs, comparisons, and convergence checks.
+
+The metrics store is a separate cluster from the one under test. Point queries at the
+metrics store host from `[reporting]`, never at the benchmark target.
+
+**Check for an existing report first.** If the race was launched via the
+`running-benchmarks` skill with `--report-file` (e.g. `~/benchmarks/result.md`), the
+summary report for that single race is already saved on disk — read that file instead of
+re-querying. Use this skill's queries for anything the saved report doesn't cover: trends
+across runs, comparisons, convergence, or ad-hoc aggregations.
+
+## When to use
+
+- Browsing past races for a track or time range.
+- Getting one race's overall per-task results (throughput, latency, service_time).
+- Charting how a metric moved across runs (regression / improvement detection).
+- Comparing two specific races to quantify a change.
+- Checking whether a run's metrics stabilized (converged) over its duration.
+
+## Where the data lives
+
+Default storage (`datastore.use_data_streams = true`) is three data streams. When it is
+`false`, Rally writes monthly indices (`rally-*-YYYY-MM`) instead. Query with a wildcard
+(`rally-races-*`, `rally-results-*`, `rally-metrics-*`) to cover both layouts.
+
+| Stream / index | One doc per | Contains |
+|---|---|---|
+| `rally-races-v1` | race | race metadata: track, challenge, car, timestamps, user tags |
+| `rally-results-v1` | task+metric | aggregated results — the summary-report numbers |
+| `rally-metrics-v1` | sample | raw time-series samples + node/GC/segment metrics |
+
+## Key fields (`docs/metrics.rst`)
+
+`race-id` (UUID grouping a run), `race-timestamp`, `@timestamp` (epoch ms per sample),
+`relative-time` (ms since race start), `track`, `challenge`, `car`, `environment`,
+`sample-type` (`normal` = measured, `warmup` = discard), `name` (metric name, e.g.
+`service_time`), `value`, `unit`, `task`, `operation`, `operation-type`, and `meta.*`
+(host/CPU/OS info, `source_revision`, `distribution_version`, and user tags stored as
+`meta.tag_<key>`).
+
+Metric direction: for `latency`, `service_time`, `processing_time`, and GC time, **lower
+is better**; for `throughput`, **higher is better**.
+
+## Prefer the built-in commands
+
+Two operations need no query — Rally reads the configured datastore directly:
+
+```bash
+# List past races (filter by track and/or user tags); note the race-ids.
+esrally list races --track=pmc --user-tags="intention:baseline-8.x"
+
+# Quantify the difference between two races.
+esrally compare --baseline=<race-id> --contender=<race-id>
+```
+
+See `docs/tournament.rst`. Reach for direct queries below when you need trends,
+aggregations, or fields these commands don't expose.
+
+## Direct queries
+
+Run these against the **metrics store** cluster with any Elasticsearch client, `curl`, or
+Kibana Dev Tools. Build complex request bodies programmatically (e.g. a Python dict +
+`json.dumps`) rather than hand-writing nested heredocs.
+
+### List recent races for a track
+
+```json
+GET rally-races-*/_search
+{ "size": 20, "sort": [{"race-timestamp": "desc"}],
+  "query": {"bool": {"filter": [{"term": {"track": "pmc"}}]}} }
+```
+
+### Get one race's overall results (per task)
+
+```json
+GET rally-results-*/_search
+{ "size": 200,
+  "query": {"bool": {"filter": [
+    {"term": {"race-id": "<uuid>"}},
+    {"term": {"task": "default"}}          // omit to get every task
+  ]}} }
+```
+
+### Trend of a metric across runs
+
+One row per race; expand `size`/range as needed. Filter `sample-type: normal` to exclude
+warmup samples.
+
+```json
+GET rally-metrics-*/_search
+{ "size": 0,
+  "query": {"bool": {"filter": [
+    {"term": {"track": "geonames"}},
+    {"term": {"task": "default"}},
+    {"term": {"name": "service_time"}},
+    {"term": {"sample-type": "normal"}},
+    {"range": {"@timestamp": {"gte": "now-30d"}}}
+  ]}},
+  "aggs": {"by_race": {
+    "terms": {"field": "race-id", "size": 100, "order": {"ts": "asc"}},
+    "aggs": {
+      "ts": {"min": {"field": "@timestamp"}},
+      "pcts": {"percentiles": {"field": "value", "percents": [50, 90, 99]}}
+    }}} }
+```
+
+### Compare two races by query
+
+When you want more than `esrally compare` shows, pull each race's per-task stats and diff
+them client-side. For latency/service_time a positive delta is a regression; for throughput
+a negative delta is a regression.
+
+```json
+GET rally-metrics-*/_search
+{ "size": 0,
+  "query": {"bool": {"filter": [
+    {"terms": {"race-id": ["<baseline-uuid>", "<contender-uuid>"]}},
+    {"term": {"name": "service_time"}},
+    {"term": {"sample-type": "normal"}}
+  ]}},
+  "aggs": {"by_race": {"terms": {"field": "race-id", "size": 2},
+    "aggs": {"by_task": {"terms": {"field": "task", "size": 100},
+      "aggs": {"pcts": {"percentiles": {"field": "value", "percents": [50, 90, 99]}}}}}}} }
+```
+
+### Convergence / stability check
+
+Bucket one race's samples over time. If p50/p90/p99 flatten toward the end, the run
+converged; if they are still drifting, the results are unreliable and the workload may need a
+longer warmup or more iterations.
+
+```json
+GET rally-metrics-*/_search
+{ "size": 0,
+  "query": {"bool": {"filter": [
+    {"term": {"race-id": "<uuid>"}},
+    {"term": {"name": "service_time"}},
+    {"term": {"operation": "default"}}
+  ]}},
+  "aggs": {"over_time": {
+    "date_histogram": {"field": "@timestamp", "calendar_interval": "1m"},
+    "aggs": {"pcts": {"percentiles": {"field": "value", "percents": [50, 90, 99]}}}
+  }} }
+```
+
+### Filter by a user tag
+
+Tags passed via `--user-tags` are stored under `meta.tag_<key>`. Add to any `filter`:
+
+```json
+{"term": {"meta.tag_intention": "baseline-8.x"}}
+```
+
+## Notes
+
+- Exclude warmup with `{"term": {"sample-type": "normal"}}` for reported metrics — unless
+  you specifically want to study cold-start behaviour, in which case keep the `warmup` samples.
+- `task` is unique per invocation of an operation; `operation` may repeat. `task`/`operation`
+  are only set on `latency`/`throughput`/`service_time` samples.
+- Node-level metrics (GC, segments, store size) are only present when Rally provisioned the
+  cluster or the `node-stats` telemetry device was enabled (`docs/telemetry.rst`).

--- a/skills/developing-rally/SKILL.md
+++ b/skills/developing-rally/SKILL.md
@@ -80,7 +80,8 @@ default, all run on the one machine where you invoke `esrally`:
 
 `--load-driver-hosts` and `--target-hosts` split the load driver and provisioner onto other
 machines; multi-machine runs use the `esrallyd` daemon. `esrally/actor.py` holds the shared
-`RallyActor` base and the bootstrap logic. If actor-system startup fails (common on a VPN),
+`RallyActor` base and the bootstrap logic; `docs/architecture/actor_system.md` walks through the actors
+and their message flow with sequence diagrams. If actor-system startup fails (common on a VPN),
 set `THESPIAN_BASE_IPADDR` to a routable address.
 
 ## Debugging
@@ -128,6 +129,7 @@ To debug any IT failure:
 - Developer setup & key components: `docs/developing.rst`
 - Contribution workflow (PRs, license headers, CLA): `CONTRIBUTING.md`
 - Distributed setup & the actor-system roles: `docs/rally_daemon.rst`
+- Actor message flow (sequence diagrams): `docs/architecture/actor_system.md`
 - Thespian actor framework: https://github.com/kquick/Thespian
 - All flags (do not invent flags; verify here or via `esrally <subcommand> --help`): `docs/command_line_reference.rst`
 - Running benchmarks against a cluster: the `running-benchmarks` skill

--- a/skills/developing-rally/SKILL.md
+++ b/skills/developing-rally/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: developing-rally
+description: >-
+  Work on Rally's own codebase, not running benchmarks with it. Use when
+  setting up the dev environment, running Rally's tests or linters, navigating
+  its source, debugging Rally's own code, or making changes to Rally itself.
+---
+
+# Developing Rally
+
+For working *on* Rally, not just running it. The docs under [References](#references) are the
+source of truth — prefer them over guessing.
+
+## Setup
+
+Development uses [`uv`](https://docs.astral.sh/uv/) and needs `jq`. Rally runs on Linux/macOS
+only (no Windows) and targets Python 3.10–3.13. From a clone:
+
+```
+make install            # create .venv and editable-install with dev extras
+source .venv/bin/activate
+esrally --help          # runs your working-tree code (editable install)
+```
+
+`make install` editable-installs the workspace, so `esrally` / `esrallyd` (or `uv run esrally …`)
+run your working-tree code directly. Avoid the `./rally` / `./rallyd` wrappers while developing:
+they auto-update from git (via `run.sh`) and only run on a clean `master`, otherwise erroring
+`There are uncommitted changes …` — pass `--skip-update` if you must use them.
+
+## Everyday make targets
+
+- `make lint` / `make format` — run/apply pre-commit linters (black, isort, …).
+- `make test` — unit tests. Scope with `make test ARGS=tests/foo_test.py`; `make test-all`
+  runs across Python 3.10–3.13.
+- `make it` — integration tests (slow, CI-oriented). `make benchmark` runs the micro-benchmarks.
+- `make docs` / `make serve-docs` — build/serve the `docs/` site.
+
+Before committing run `make lint test` (unit tests + lint; integration tests are too slow for
+the inner loop). Optionally `make install-pre-commit` to run lint automatically on each commit.
+
+## Testing & conventions
+
+- Unit tests live in `tests/` mirroring `esrally/`, named `*_test.py`; integration tests in
+  `it/`, micro-benchmarks in `benchmarks/`.
+- `asyncio_mode = strict`, so async tests need an explicit `@pytest.mark.asyncio`.
+- `xfail_strict = true`, so an `xfail` test that unexpectedly passes fails the suite.
+- Type hints are **not** used broadly — they're added opportunistically per module, with the
+  strictly-checked modules listed under `[tool.mypy].overrides` in `pyproject.toml`. Match the
+  surrounding code rather than typing everything.
+- **Keep the load-driver hot path tight.** Code in `driver/` runners, schedulers, and parameter
+  sources runs per operation during measurement, so extra overhead (logging, allocations,
+  blocking I/O, locks) perturbs the throughput/latency/service_time numbers Rally exists to
+  report. Do expensive work outside the measured loop.
+- For a **big or risky hot-path change**, consider quantifying its overhead with a
+  [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/) micro-benchmark under
+  `benchmarks/` — coverage there is sparse, so treat this as a tool to reach for, not a standing
+  requirement. Take the `benchmark` fixture, call `benchmark(fn)`, decorate with
+  `@pytest.mark.benchmark(group="...", warmup="on", disable_gc=True)`, and compare against a
+  baseline variant. See `benchmarks/driver/runner_test.py`.
+
+## Source organization (`esrally/`)
+
+- `rally.py` — CLI entry point: argument parsing and subcommand dispatch.
+- `racecontrol.py` — orchestrates a race end-to-end via the pipelines registry.
+- `mechanic/` — provisions, launches, and tears down Elasticsearch (only for `from-*` pipelines).
+- `driver/` — generates load: schedules tasks and runs `runner.py` operations against the cluster.
+- `track/` — loads and parses tracks/challenges; `tracker/` generates a track from an existing cluster.
+- `metrics.py` — the metrics store (in-memory or Elasticsearch); `reporter.py` — the summary report.
+- `client/` — Elasticsearch client factory; `telemetry.py` — telemetry devices; `config.py` / `types.py` — config.
+
+## Actor system
+
+Rally is a distributed system built on [Thespian](https://github.com/kquick/Thespian); even a
+single-machine race runs as actors. Three *logical* roles (`docs/rally_daemon.rst`) that, by
+default, all run on the one machine where you invoke `esrally`:
+
+- **benchmark coordinator** — drives the whole race and shows results.
+- **load driver** — interprets and runs the track.
+- **provisioner** — configures and starts Elasticsearch.
+
+`--load-driver-hosts` and `--target-hosts` split the load driver and provisioner onto other
+machines; multi-machine runs use the `esrallyd` daemon. `esrally/actor.py` holds the shared
+`RallyActor` base and the bootstrap logic. If actor-system startup fails (common on a VPN),
+set `THESPIAN_BASE_IPADDR` to a routable address.
+
+## Debugging
+
+- Rally logs to `~/.rally/logs/rally.log` (human-readable) and `rally.json` (structured);
+  profiling output goes to `profile.log`. Console output is only a summary — the full stack
+  trace of a failure is usually in the log file, not on stdout.
+- Each log line carries the emitting actor's address (`%(actorAddress)s`), so you can trace a
+  failure across the actor system. The actor framework's own internal log is separate:
+  `~/.rally/logs/actor-system-internal.log` (path via `THESPLOG_FILE`) — check it when actors
+  fail to start or communicate, and set `THESPLOG_THRESHOLD` (default `INFO`) to `DEBUG` for
+  more detail on the actor system itself.
+- Raise the log level to see more: edit `~/.rally/logging.json` (created on first run from
+  `esrally/resources/logging.json`) and set `"level": "DEBUG"` on the `root` logger for
+  everything, or add a per-module entry under `loggers` to scope it (matching the existing
+  entries, which just set a level and inherit the root handlers), e.g.:
+
+  ```json
+  "loggers": {
+    "esrally.driver": {"level": "DEBUG"}
+  }
+  ```
+
+  Then re-run. Revert to `INFO` when done — `DEBUG` is verbose.
+
+## Reproduce a failing integration test
+
+Integration tests in `it/` drive real races, so a failure usually reflects a real bug.
+To debug any IT failure:
+
+- Re-run the single failing test in isolation: `make it ARGS="it/<file>.py -k <pattern>"`.
+- Reproduce outside the test harness by running the equivalent race yourself — fast, against a
+  throwaway local cluster — then read the logs (see [Debugging](#debugging), raising the level
+  to `DEBUG` as needed):
+
+  ```bash
+  esrally race --distribution-version=9.4.0 --track=geonames --test-mode --on-error=abort
+  ```
+
+- If the failure is in the actor system, add `THESPLOG_THRESHOLD=DEBUG` and inspect a running
+  system with the Thespian shell: `python3 -m thespian.shell` (see `docs/rally_daemon.rst`).
+
+## References
+
+- Developer setup & key components: `docs/developing.rst`
+- Contribution workflow (PRs, license headers, CLA): `CONTRIBUTING.md`
+- Distributed setup & the actor-system roles: `docs/rally_daemon.rst`
+- Thespian actor framework: https://github.com/kquick/Thespian
+- All flags (do not invent flags; verify here or via `esrally <subcommand> --help`): `docs/command_line_reference.rst`
+- Running benchmarks against a cluster: the `running-benchmarks` skill

--- a/skills/running-benchmarks/SKILL.md
+++ b/skills/running-benchmarks/SKILL.md
@@ -3,9 +3,8 @@ name: running-benchmarks
 description: >-
   Run Rally benchmarks (races) against Elasticsearch — an existing/external
   cluster or a Rally-provisioned distribution — and read the summary report.
-  Use when launching a race, benchmarking a cluster, choosing a pipeline,
-  track, or challenge, setting target hosts or TLS/API-key auth, tagging runs,
-  saving reports, or interpreting throughput, latency, and service_time results.
+  Use when running a race (any pipeline, track, challenge, target-hosts, or
+  auth) or when interpreting throughput, latency, and service_time results.
 ---
 
 # Running Rally benchmarks
@@ -32,8 +31,8 @@ Rally infers the pipeline from your flags.
 | Pipeline | Use when | Selected by |
 |---|---|---|
 | `benchmark-only` | **Primary path.** Cluster is already running and you provisioned it. | `--pipeline=benchmark-only --target-hosts=...` |
-| `from-distribution` | Rally downloads and runs Elasticsearch locally. Smoke/demo only. | `--distribution-version=X` |
-| `from-sources` | Build Elasticsearch from a git revision (CI/dev). | `--revision=...` |
+| `from-distribution` | Rally downloads and runs Elasticsearch locally. Setup checks/demos; sharing a host skews results, so only large differences stand out. | `--distribution-version=X` |
+| `from-sources` | Rally builds Elasticsearch from a git revision and runs it locally (CI/dev). Setup checks/demos; sharing a host skews results, so only large differences stand out. | `--revision=...` |
 
 `benchmark-only` trade-off (`docs/pipelines.rst`): because Rally did not provision the
 cluster, results are not easily reproducible and Rally cannot gather host-level metrics

--- a/skills/running-benchmarks/SKILL.md
+++ b/skills/running-benchmarks/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: running-benchmarks
+description: >-
+  Run Rally benchmarks (races) against Elasticsearch — an existing/external
+  cluster or a Rally-provisioned distribution — and read the summary report.
+  Use when launching a race, benchmarking a cluster, choosing a pipeline,
+  track, or challenge, setting target hosts or TLS/API-key auth, tagging runs,
+  saving reports, or interpreting throughput, latency, and service_time results.
+---
+
+# Running Rally benchmarks
+
+Launch a race against Elasticsearch and interpret its summary report. Rally can run
+benchmarks several ways (see [Choose a pipeline](#choose-a-pipeline)).
+
+For **meaningful results**, prefer an existing/external cluster you control: running Rally
+locally co-locates the load driver and the system under test on one host, where they can
+perturb each other's measurements. Local deployment is a good fit when that's not a
+concern — smoke testing, fast iterative local development, or demos.
+
+## Safety
+
+- **Never run Rally as root** — Elasticsearch refuses to start with root privileges.
+- **Strongly avoid benchmarking production.** Rally mutates cluster state (creating,
+  writing to, and deleting indices), and competing traffic can perturb results. Prefer a
+  dedicated, quiet environment.
+
+## Choose a pipeline
+
+Rally infers the pipeline from your flags.
+
+| Pipeline | Use when | Selected by |
+|---|---|---|
+| `benchmark-only` | **Primary path.** Cluster is already running and you provisioned it. | `--pipeline=benchmark-only --target-hosts=...` |
+| `from-distribution` | Rally downloads and runs Elasticsearch locally. Smoke/demo only. | `--distribution-version=X` |
+| `from-sources` | Build Elasticsearch from a git revision (CI/dev). | `--revision=...` |
+
+`benchmark-only` trade-off (`docs/pipelines.rst`): because Rally did not provision the
+cluster, results are not easily reproducible and Rally cannot gather host-level metrics
+(CPU, GC, disk I/O, index size). Treat those numbers as directional.
+
+## Launch a race
+
+1. Discover tracks, then inspect one:
+
+   ```bash
+   esrally list tracks
+   esrally info --track=pmc
+   ```
+
+2. Run against the cluster:
+
+   ```bash
+   esrally race --track=pmc --pipeline=benchmark-only \
+     --target-hosts=10.5.5.10:9200,10.5.5.11:9200
+   ```
+
+3. Secured cluster — TLS + basic auth via `--client-options`:
+
+   ```bash
+   esrally race --track=pmc --pipeline=benchmark-only --target-hosts=host:9243 \
+     --client-options="use_ssl:true,verify_certs:true,basic_auth_user:'elastic',basic_auth_password:'changeme'"
+   ```
+
+   API-key auth (including Elastic Cloud / Serverless — see `docs/serverless.rst`):
+
+   ```bash
+   esrally race --track=geonames --pipeline=benchmark-only --target-hosts=${ES_HOST}:443 \
+     --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort
+   ```
+
+4. Record the `race-id` so you can find the results later. Rally assigns a random UUID by
+   default; pass your own with `--race-id` to know it up front:
+
+   ```bash
+   RACE_ID=$(uuidgen)
+   esrally race --track=pmc --pipeline=benchmark-only --target-hosts=host:9200 --race-id="$RACE_ID"
+   echo "$RACE_ID"   # note this for `esrally compare` / metrics-store queries
+   ```
+
+   If Rally generated the id, recover the most recent one afterwards with `esrally list races`.
+   (Optionally add `--user-tags="key:value"` for human-friendly filtering — not required.)
+5. Save the report: `--report-file=~/benchmarks/result.md` (add `--report-format=csv` for CSV).
+6. Fast setup/smoke check: add `--test-mode` to ingest a tiny slice instead of the full corpus.
+
+Multi-cluster A/B (benchmark-only only; telemetry disabled in this mode): add `--multi-cluster`
+with JSON-format `--target-hosts`/`--client-options`. See `docs/recipes.rst`.
+
+Races are long-running (often 20+ minutes) and download large corpora on the first run for a
+track. Treat a race as a long job, not a quick command.
+
+## Validate correctness before trusting numbers
+
+Rally does **not** abort on query errors by default — it folds them into the **error rate**
+in the summary, which silently skews results.
+
+- Confirm operations return the hits you expect. A mapping mismatch (e.g. `text` vs `keyword`)
+  yields 0 hits with no error.
+- While validating, use `--on-error=abort` and/or add track-level `assertions` and run with
+  `--enable-assertions`.
+- A non-zero error rate on a task means those results are suspect. See `docs/recipes.rst`.
+
+## Read the summary report
+
+- **throughput** — operations per second (higher is better).
+- **latency** — includes the time a request waits in the queue before Rally sends it.
+- **service_time** — request→response only, excludes wait (what most load-test tools
+  incorrectly call "latency").
+- **processing_time** — includes Rally's client-side overhead; a large gap vs `service_time`
+  points to a client-side bottleneck.
+- Metrics are reported **per task**; "Cumulative … of primary shards" is not wall-clock time.
+- Check **error rate** first as a validity gate.
+
+See `docs/summary_report.rst` and `docs/metrics.rst`.
+
+## References
+
+- Running & pipelines: `docs/race.rst`, `docs/pipelines.rst`
+- Recipes (existing cluster, Elastic Cloud, multi-cluster): `docs/recipes.rst`
+- Serverless: `docs/serverless.rst`
+- Report & metric definitions: `docs/summary_report.rst`, `docs/metrics.rst`
+- All flags (do not invent flags; verify here or via `esrally <subcommand> --help`): `docs/command_line_reference.rst`
+- Comparing and charting results across past races: the `accessing-benchmark-results` skill


### PR DESCRIPTION
Adds Rally agent skills (`AGENTS.md` + `running-benchmarks` and `accessing-benchmark-results` skills) so LLMs/agents can reliably launch races and query benchmark results without having to  guess CLI flags or the metrics-store schema. 