### PR TITLE
Ignore own parent process when detecting other Rally processes

### DIFF
--- a/esrally/utils/process.py
+++ b/esrally/utils/process.py
@@ -228,9 +228,12 @@ def kill_all(predicate: Callable[[psutil.Process], bool]) -> None:
 def for_all_other_processes(predicate: Callable[[psutil.Process], bool], action: Callable[[psutil.Process], None]) -> None:
     # no harakiri please
     my_pid = os.getpid()
+    # the process that launched us is not a competing Rally process either, even if its command line
+    # happens to mention Rally (e.g. a debugger or wrapper script that invokes esrally)
+    my_ppid = os.getppid()
     for p in psutil.process_iter():
         try:
-            if p.pid != my_pid and predicate(p):
+            if p.pid not in (my_pid, my_ppid) and predicate(p):
                 action(p)
         except (psutil.ZombieProcess, psutil.AccessDenied, psutil.NoSuchProcess):
             pass

--- a/tests/utils/process_test.py
+++ b/tests/utils/process_test.py
@@ -112,6 +112,16 @@ class TestProcess:
         assert process.find_all_other_rally_processes() == [rally_process_p, rally_process_r, rally_process_e, rally_process_mac]
 
     @mock.patch("psutil.process_iter")
+    def test_find_all_other_rally_processes_ignores_own_parent(self, process_iter):
+        # a launcher such as a debugger mentions esrally in its command line but is not a competing Rally process
+        parent_process = Process(os.getppid(), "python3", ["/usr/bin/python3", "/debugpy/launcher", "--", "~/.local/bin/esrally"])
+        rally_process_e = Process(107, "esrally", ["/usr/bin/python3", "~/.local/bin/esrally"])
+
+        process_iter.return_value = [parent_process, rally_process_e]
+
+        assert process.find_all_other_rally_processes() == [rally_process_e]
+
+    @mock.patch("psutil.process_iter")
     def test_find_no_other_rally_process_running(self, process_iter):
         metrics_store_process = Process(
             102,


### PR DESCRIPTION
Closes #2026

If the process that launches Rally is itself a Python process whose command line mentions `esrally` (a VS Code `debugpy` launcher, or a wrapper script), `is_rally_process()` matches it, so Rally reports its own parent as a conflicting instance and refuses to start.

`for_all_other_processes()` already skips the current PID; it now skips the parent PID too. Genuine concurrent Rally processes are still detected, and a regression test in `tests/utils/process_test.py` covers the launcher case.

Ran `tests/utils/process_test.py` (7 passed); the new test fails without the `process.py` change.
