### PR TITLE
Honour --format json for esrally list tracks

### DIFF
--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -1209,6 +1209,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "system", "admin.track", args.track)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.benchmark_name", args.benchmark_name)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.format", args.format)
+            cfg.add(config.Scope.applicationOverride, "system", "list.format", args.format)
             cfg.add(config.Scope.applicationOverride, "system", "list.races.user_tags", opts.to_dict(args.user_tags))
             cfg.add(config.Scope.applicationOverride, "system", "list.from_date", args.from_date)
             cfg.add(config.Scope.applicationOverride, "system", "list.to_date", args.to_date)

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -151,6 +151,26 @@ def list_tracks(cfg: types.Config):
     available_tracks = tracks(cfg)
     only_auto_generated_challenges = all(t.default_challenge.auto_generated for t in available_tracks)
 
+    output_format = cfg.opts("system", "list.format", mandatory=False, default_value="text")
+    if output_format == "json":
+        data = []
+        for t in sorted(available_tracks, key=lambda t: t.name):
+            entry = {
+                "name": t.name,
+                "description": t.description,
+                "documents": t.number_of_documents,
+                "compressed-size-in-bytes": t.compressed_size_in_bytes,
+                "uncompressed-size-in-bytes": t.uncompressed_size_in_bytes,
+            }
+            if not only_auto_generated_challenges:
+                entry["default-challenge"] = str(t.default_challenge)
+                entry["challenges"] = sorted(map(str, t.challenges))
+            data.append(entry)
+        console.println(json.dumps({"tracks": data}, indent=2))
+        return
+    if output_format != "text":
+        raise exceptions.RallyAssertionError(f"Unknown output format [{output_format}]")
+
     data = []
     for t in available_tracks:
         line = [

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -98,6 +98,7 @@ Key = Literal[
     "list.challenge",
     "list.config.option",
     "list.from_date",
+    "list.format",
     "list.max_results",
     "list.races.benchmark_name",
     "list.races.format",

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -17,6 +17,7 @@
 
 import copy
 import dataclasses
+import json
 import os
 import random
 import re
@@ -165,6 +166,31 @@ class TestGitRepository:
         assert repo.track_names == ["unittest", "unittest2", "unittest3", "unittest3/nested"]
         assert repo.track_dir("unittest") == "/tmp/tracks/default/unittest"
         assert repo.track_file("unittest") == "/tmp/tracks/default/unittest/track.json"
+
+
+class TestListTracks:
+    @mock.patch("esrally.track.loader.tracks")
+    def test_list_tracks_json_format(self, mock_tracks, capsys):
+        challenge = track.Challenge(name="default", default=True, auto_generated=True, schedule=[])
+        mock_tracks.return_value = [track.Track(name="unittest", description="unit test track", challenges=[challenge])]
+
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "system", "list.format", "json")
+
+        loader.list_tracks(cfg)
+
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == {
+            "tracks": [
+                {
+                    "name": "unittest",
+                    "description": "unit test track",
+                    "documents": 0,
+                    "compressed-size-in-bytes": 0,
+                    "uncompressed-size-in-bytes": 0,
+                }
+            ]
+        }
 
 
 class TestRenderTrack:


### PR DESCRIPTION
Closes #2055

`esrally list tracks --format json` printed the tabulate table, so the output could not be parsed as JSON. The `--format` flag was only stored under `list.races.format` and read by `metrics.list_races`; `loader.list_tracks` never saw it.

The flag is now also stored under a generic `list.format` key, and `list_tracks` emits a JSON document when it is set to `json`, mirroring the text/json branching `list_races` already uses.

New `TestListTracks::test_list_tracks_json_format` in `tests/track/loader_test.py` fails without the fix (JSONDecodeError) and passes with it; `tests/track/loader_test.py` is 112 passed, black and isort clean.
