### PR TITLE
Add validate-track subcommand to check track parameters without running a benchmark

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -312,7 +312,7 @@ To check track parameters without running a benchmark, use the ``validate-track`
 
     esrally validate-track --track-path=/path/to/my-track --challenge=autoscaling --track-params='{"scheduling": [1]}' --build-flavor=serverless --no-quiet
 
-This loads the track (including Jinja rendering, schema checks, plugins, and any track ``dependencies``), resolves the challenge the same way ``race`` does (explicit ``--challenge`` or the default), runs validators registered for that challenge, and exits. Use ``--build-flavor`` / ``--serverless-operator`` when the track's templates depend on serverless conditionals (``validate-track`` cannot probe a cluster the way ``race`` does). On success the exit code is zero; confirmation text is silent by default unless you pass ``--no-quiet``. If no validators are registered for the resolved challenge, exit code 0 still means the track loaded, but no custom parameter checks ran. On failure it exits non-zero with the ``TrackConfigError`` message. See the :ref:`command line reference <clr_validate_track>` for scope limits (no corpora download; use ``--offline`` to skip track-repo updates).
+See the :ref:`command line reference <clr_validate_track>` for details, including serverless flags and scope limits.
 
 .. _adding_tracks_custom_runners:
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -308,6 +308,12 @@ Note the following:
 * Raise ``TrackConfigError`` to abort the benchmark. Rally runs the validators after loading the track and selecting the challenge, but before provisioning nodes or starting the benchmark, so a misconfigured parameter is reported without waiting for the engine to start.
 * You may register more than one validator for the same challenge; Rally invokes them in registration order.
 
+To check track parameters without running a benchmark, use the ``validate-track`` subcommand::
+
+    esrally validate-track --track-path=/path/to/my-track --challenge=autoscaling --track-params='{"scheduling": [1]}' --build-flavor=serverless --no-quiet
+
+This loads the track (including Jinja rendering, schema checks, plugins, and any track ``dependencies``), resolves the challenge the same way ``race`` does (explicit ``--challenge`` or the default), runs validators registered for that challenge, and exits. Use ``--build-flavor`` / ``--serverless-operator`` when the track's templates depend on serverless conditionals (``validate-track`` cannot probe a cluster the way ``race`` does). On success the exit code is zero; confirmation text is silent by default unless you pass ``--no-quiet``. If no validators are registered for the resolved challenge, exit code 0 still means the track loaded, but no custom parameter checks ran. On failure it exits non-zero with the ``TrackConfigError`` message. See the :ref:`command line reference <clr_validate_track>` for scope limits (no corpora download; use ``--offline`` to skip track-repo updates).
+
 .. _adding_tracks_custom_runners:
 
 Creating Your Own Operations With Custom Runners

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -90,6 +90,23 @@ You can also pass track parameters to see how they affect the rendered output::
 
 It is also possible to refer to a track via its path (``--track-path``) or use a different track repository (``--track-repository``).
 
+.. _clr_validate_track:
+
+``validate-track``
+~~~~~~~~~~~~~~~~~~
+
+The ``validate-track`` subcommand loads a track and runs any registered challenge validators without starting a benchmark or contacting a cluster. Use it to fail fast on invalid track parameters (for example from automation before provisioning load drivers).
+
+It resolves the challenge the same way ``race`` does: an explicit ``--challenge``, or the track's default challenge when ``--challenge`` is omitted. An unknown challenge name fails with a non-zero exit code. Loading includes Jinja rendering, schema checks, unused-parameter checks, track plugins, and installing any track ``dependencies``. It does **not** download corpora or provision nodes. Track repository git fetch/update may still occur unless you pass ``--offline``.
+
+Unlike ``race`` (which detects build flavor from the target cluster), ``validate-track`` defaults to the ``default`` build flavor. For tracks whose Jinja templates depend on serverless conditionals, pass ``--build-flavor=serverless`` and optionally ``--serverless-operator`` so rendering matches the intended race environment.
+
+Example with a local track that registers validators (see :ref:`adding_tracks_custom_validators`)::
+
+    esrally validate-track --track-path=/path/to/my-track --challenge=autoscaling --track-params='{"scheduling": [1]}' --build-flavor=serverless --no-quiet
+
+On success the process exits zero. Confirmation text is suppressed by default (``--quiet``); pass ``--no-quiet`` to see whether validators ran. Exit code 0 with no registered validators for the resolved challenge means the track loaded successfully, **not** that custom parameter checks passed — only that there was nothing to validate. On failure it exits non-zero and prints the error (for example a ``TrackConfigError`` from a validator).
+
 ``compare``
 ~~~~~~~~~~~
 

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -39,7 +39,6 @@ from esrally import (
     types,
     version,
 )
-from esrally.track import params
 from esrally.utils import console, opts, versions
 
 pipelines = collections.OrderedDict()
@@ -240,19 +239,13 @@ class BenchmarkCoordinator:
                         f"Cluster version must be at least [{min_es_version}] but was [{distribution_version}]"
                     )
 
-        self.current_track = track.load_track(self.cfg, install_dependencies=True)
+        loaded_track = track.load_track(self.cfg, install_dependencies=True)
+        self.current_track = loaded_track
         self.track_revision = self.cfg.opts("track", "repository.revision", mandatory=False)
-        challenge_name = self.cfg.opts("track", "challenge.name")
-        self.current_challenge = self.current_track.find_challenge_or_default(challenge_name)
-        if self.current_challenge is None:
-            raise exceptions.SystemSetupError(
-                "Track [{}] does not provide challenge [{}]. List the available tracks with {} list tracks.".format(
-                    self.current_track.name, challenge_name, PROGRAM_NAME
-                )
-            )
-        # Validate track parameters for the selected challenge before provisioning the engine so that invalid
-        # parameters fail fast. Track plugins were loaded (and any validators registered) during load_track above.
-        params.invoke_validators(self.current_challenge.name, self.cfg.opts("track", "params", mandatory=False, default_value={}))
+        # Resolve the challenge and validate track parameters before provisioning the engine so that
+        # invalid parameters fail fast. Track plugins were loaded (and any validators registered)
+        # during load_track above. Shared with ``esrally validate-track``.
+        self.current_challenge = track.resolve_challenge_and_invoke_validators(loaded_track, self.cfg)
         if self.current_challenge.user_info:
             console.info(self.current_challenge.user_info)
         for message in self.current_challenge.serverless_info:

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -283,6 +283,42 @@ def create_arg_parser():
         default=None,
     )
 
+    validate_track_parser = subparsers.add_parser(
+        "validate-track",
+        help="Load a track and run registered challenge validators without running a benchmark",
+    )
+    add_track_source(validate_track_parser)
+    validate_track_parser.add_argument(
+        "--track",
+        help=f"Define the track to use. List possible tracks with `{PROGRAM_NAME} list tracks`.",
+    )
+    validate_track_parser.add_argument(
+        "--track-params",
+        help="Define a comma-separated list of key:value pairs that are injected verbatim to the track as variables.",
+        default="",
+    )
+    validate_track_parser.add_argument(
+        "--ignore-unused-track-params",
+        help="Only warn (instead of failing) when track parameters are given that are not used by the track.",
+        action="store_true",
+        default=False,
+    )
+    validate_track_parser.add_argument(
+        "--challenge",
+        help=f"Define the challenge to validate. List possible challenges for tracks with `{PROGRAM_NAME} list tracks`.",
+    )
+    validate_track_parser.add_argument(
+        "--build-flavor",
+        help="Define the build flavor to load/validate the track for (affects Jinja rendering).",
+        choices=["default", "serverless"],
+    )
+    validate_track_parser.add_argument(
+        "--serverless-operator",
+        help="Whether to load/validate the track for a serverless operator (affects Jinja rendering).",
+        default=False,
+        action="store_true",
+    )
+
     create_track_parser = subparsers.add_parser("create-track", help="Create a Rally track from existing data")
     create_track_parser.add_argument(
         "--track",
@@ -927,6 +963,7 @@ def create_arg_parser():
         stop_parser,
         info_parser,
         render_track_parser,
+        validate_track_parser,
         create_track_parser,
     ]:
         # This option is needed to support a separate configuration for the integration tests on the same machine
@@ -937,8 +974,8 @@ def create_arg_parser():
         )
         p.add_argument(
             "--quiet",
-            help=f"Suppress as much output as possible (default: {str(p is render_track_parser).lower()}).",
-            default=p is render_track_parser,  # disable output for render-track
+            help=f"Suppress as much output as possible (default: {str(p is render_track_parser or p is validate_track_parser).lower()}).",
+            default=p is render_track_parser or p is validate_track_parser,  # disable output for render/validate-track
             action=argparse.BooleanOptionalAction,
         )
         p.add_argument(
@@ -1333,6 +1370,17 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             track.render_track(
                 cfg, build_flavor=args.build_flavor, serverless_operator=args.serverless_operator, output_path=args.output_path
             )
+        elif sub_command == "validate-track":
+            # Same track-source wiring as ``render-track`` (no task filters); challenge/params set explicitly.
+            configure_track_params(arg_parser, args, cfg, command_requires_track_details=False)
+            cfg.add(config.Scope.applicationOverride, "track", "params", opts.to_dict(args.track_params))
+            cfg.add(config.Scope.applicationOverride, "track", "params.ignore_unused", args.ignore_unused_track_params)
+            cfg.add(config.Scope.applicationOverride, "track", "challenge.name", args.challenge)
+            # TrackFileReader renders Jinja from these cfg keys (race sets them from the cluster probe).
+            if args.build_flavor:
+                cfg.add(config.Scope.applicationOverride, "mechanic", "distribution.flavor", args.build_flavor)
+            cfg.add(config.Scope.applicationOverride, "driver", "serverless.operator", args.serverless_operator)
+            track.validate_track(cfg)
         else:
             raise exceptions.SystemSetupError(f"Unknown subcommand [{sub_command}]")
         return ExitStatus.SUCCESSFUL

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -197,6 +197,62 @@ def render_track(cfg: types.Config, build_flavor=None, serverless_operator=False
         print(rendered_json)
 
 
+def resolve_challenge_and_invoke_validators(t: track.Track, cfg: types.Config):
+    """
+    Resolve the challenge the same way ``race`` does and run registered validators.
+
+    Uses ``find_challenge_or_default`` so an omitted challenge name selects the track's
+    default challenge, and an unknown challenge name raises ``InvalidName``.
+
+    :return: The resolved challenge.
+    """
+    challenge_name = cfg.opts("track", "challenge.name", mandatory=False)
+    challenge = t.find_challenge_or_default(challenge_name)
+    if challenge is None:
+        raise exceptions.SystemSetupError(
+            "Track [{}] does not provide challenge [{}]. List the available tracks with {} list tracks.".format(
+                t.name, challenge_name, PROGRAM_NAME
+            )
+        )
+    track_params = cfg.opts("track", "params", mandatory=False, default_value={})
+    params.invoke_validators(challenge.name, track_params)
+    return challenge
+
+
+def validate_track(cfg: types.Config):
+    """
+    Load a track and run registered challenge validators without starting a race.
+
+    Intended as a fast, machine-friendly check for automation (e.g. fail before provisioning
+    a benchmark environment). Loads the track (Jinja rendering, schema checks, unused-parameter
+    checks, track plugins, and track dependency installation) and invokes validators for the
+    resolved challenge (explicit ``--challenge`` or the track's default). Does not download
+    corpora, provision nodes, or contact a cluster. Track repository git fetch/update may
+    still occur unless ``--offline`` is set.
+
+    Jinja rendering uses ``mechanic.distribution.flavor`` (default ``default``) and
+    ``driver.serverless.operator`` from the config — set via ``--build-flavor`` /
+    ``--serverless-operator`` on the CLI so serverless-conditioned tracks match ``race``.
+
+    Exit code 0 means the track loaded and any registered validators for the resolved
+    challenge succeeded. If no validators are registered for that challenge, exit code 0
+    still means success, but no custom parameter checks ran.
+    """
+    t = load_track(cfg, install_dependencies=True)
+    challenge = resolve_challenge_and_invoke_validators(t, cfg)
+    validator_count = params.registered_validator_count(challenge.name)
+    # Quiet by default: confirmation is suppressed unless the user passes --no-quiet.
+    if validator_count:
+        console.println(
+            f"Track parameters for challenge [{challenge.name}] are valid "
+            f"({validator_count} validator{'s' if validator_count != 1 else ''} ran)."
+        )
+    else:
+        console.println(
+            f"Track [{t.name}] challenge [{challenge.name}] loaded successfully; " f"no validators are registered for this challenge."
+        )
+
+
 def track_info(cfg: types.Config):
     def format_task(t, indent="", num="", suffix=""):
         msg = f"{indent}{num}{str(t)}"

--- a/esrally/track/params.py
+++ b/esrally/track/params.py
@@ -91,6 +91,10 @@ def invoke_validators(challenge_name: str, track_params: dict) -> None:
             raise exceptions.TrackConfigError(f"Validator [{validator_name}] for challenge [{challenge_name}] failed: {e}") from e
 
 
+def registered_validator_count(challenge_name: str) -> int:
+    return len(__VALIDATORS_BY_CHALLENGE.get(challenge_name, []))
+
+
 # only intended for tests
 def _unregister_validators_for_challenge(challenge_name: str) -> None:
     __VALIDATORS_BY_CHALLENGE.pop(challenge_name, None)

--- a/it/resources/track_with_validator/track.json
+++ b/it/resources/track_with_validator/track.json
@@ -1,0 +1,27 @@
+{
+  "version": 2,
+  "description": "Minimal track for validate-track integration tests (ok={{ ok | default(0) }})",
+  "challenges": [
+    {
+      "name": "default",
+      "default": true,
+      "schedule": [
+        {
+          "operation": {
+            "operation-type": "cluster-health"
+          }
+        }
+      ]
+    },
+    {
+      "name": "validated",
+      "schedule": [
+        {
+          "operation": {
+            "operation-type": "cluster-health"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/it/resources/track_with_validator/track.py
+++ b/it/resources/track_with_validator/track.py
@@ -15,19 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from .loader import (
-    TrackProcessorRegistry,
-    list_tracks,
-    load_track,
-    load_track_plugins,
-    operation_parameters,
-    render_track,
-    resolve_challenge_and_invoke_validators,
-    set_absolute_data_path,
-    track_info,
-    track_repo,
-    validate_track,
-)
+from esrally.exceptions import TrackConfigError
 
-# expose the complete track API
-from .track import *
+
+def validate_ok(params):
+    if params.get("ok") != 1:
+        raise TrackConfigError("Track parameter 'ok' must be set to 1.")
+
+
+def register(registry):
+    registry.register_validator("default", validate_ok)
+    registry.register_validator("validated", validate_ok)

--- a/it/validate_track_test.py
+++ b/it/validate_track_test.py
@@ -35,8 +35,7 @@ def test_validate_track_succeeds_with_valid_params(cfg):
         f"validate-track --track-path={TRACK_PATH} --challenge=validated --track-params='ok:1' --no-quiet",
     )
     assert result.returncode == 0
-    assert "Track parameters for challenge [validated] are valid." in result.stdout
-    assert "validator" in result.stdout
+    assert "Track parameters for challenge [validated] are valid (1 validator ran)." in result.stdout
 
 
 @it.rally_in_mem

--- a/it/validate_track_test.py
+++ b/it/validate_track_test.py
@@ -1,0 +1,61 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import subprocess
+
+import it
+
+TRACK_PATH = os.path.join(os.path.dirname(__file__), "resources", "track_with_validator")
+
+
+def _run(cfg, command_line):
+    cmd = it.esrally_command_line_for(cfg, command_line)
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True)
+
+
+@it.rally_in_mem
+def test_validate_track_succeeds_with_valid_params(cfg):
+    result = _run(
+        cfg,
+        f"validate-track --track-path={TRACK_PATH} --challenge=validated --track-params='ok:1' --no-quiet",
+    )
+    assert result.returncode == 0
+        assert "Track parameters for challenge [validated] are valid." in result.stdout
+        assert "validator" in result.stdout
+
+
+@it.rally_in_mem
+def test_validate_track_uses_default_challenge_when_omitted(cfg):
+    result = _run(cfg, f"validate-track --track-path={TRACK_PATH} --track-params='ok:1'")
+    assert result.returncode == 0
+
+
+@it.rally_in_mem
+def test_validate_track_fails_on_invalid_params(cfg):
+    result = _run(cfg, f"validate-track --track-path={TRACK_PATH} --challenge=validated --track-params='ok:0'")
+    assert result.returncode != 0
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert "ok" in combined
+
+
+@it.rally_in_mem
+def test_validate_track_fails_on_unknown_challenge(cfg):
+    result = _run(cfg, f"validate-track --track-path={TRACK_PATH} --challenge=does-not-exist")
+    assert result.returncode != 0
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert "does-not-exist" in combined

--- a/it/validate_track_test.py
+++ b/it/validate_track_test.py
@@ -25,7 +25,7 @@ TRACK_PATH = os.path.join(os.path.dirname(__file__), "resources", "track_with_va
 
 def _run(cfg, command_line):
     cmd = it.esrally_command_line_for(cfg, command_line)
-    return subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return subprocess.run(cmd, shell=True, check=False, capture_output=True, text=True)
 
 
 @it.rally_in_mem
@@ -35,8 +35,8 @@ def test_validate_track_succeeds_with_valid_params(cfg):
         f"validate-track --track-path={TRACK_PATH} --challenge=validated --track-params='ok:1' --no-quiet",
     )
     assert result.returncode == 0
-        assert "Track parameters for challenge [validated] are valid." in result.stdout
-        assert "validator" in result.stdout
+    assert "Track parameters for challenge [validated] are valid." in result.stdout
+    assert "validator" in result.stdout
 
 
 @it.rally_in_mem

--- a/tests/track/loader_test.py
+++ b/tests/track/loader_test.py
@@ -222,6 +222,175 @@ class TestRenderTrack:
             loader.render_track(cfg)
 
 
+class TestValidateTrack:
+    def _track_with_challenges(self, *challenge_specs):
+        """
+        Build a track from (name, default) pairs. Challenges are not marked selected;
+        validation resolves via find_challenge_or_default like race.
+        """
+        challenges = [track.Challenge(name, default=default, schedule=[]) for name, default in challenge_specs]
+        return track.Track(name="unittest", challenges=challenges)
+
+    def _cfg(self, challenge_name=None, track_params=None):
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "track", "challenge.name", challenge_name)
+        cfg.add(config.Scope.application, "track", "params", track_params or {})
+        return cfg
+
+    def teardown_method(self, method):
+        params._clear_validators()  # pylint: disable=protected-access
+
+    @mock.patch("esrally.track.loader.load_track")
+    def test_validate_track_invokes_validators_for_explicit_challenge(self, load_track):
+        load_track.return_value = self._track_with_challenges(("validated", True), ("other", False))
+        cfg = self._cfg("validated", {"scheduling": [1, 2, 3]})
+
+        received = []
+
+        def validator(track_params):
+            received.append(track_params)
+            raise exceptions.TrackConfigError("'scheduling' must have 1 or 2 elements but had 3.")
+
+        params.register_validator("validated", validator)
+        with pytest.raises(exceptions.TrackConfigError, match="'scheduling' must have 1 or 2 elements but had 3."):
+            loader.validate_track(cfg)
+
+        assert received == [{"scheduling": [1, 2, 3]}]
+        load_track.assert_called_once_with(cfg, install_dependencies=True)
+
+    @mock.patch("esrally.track.loader.console.println")
+    @mock.patch("esrally.track.loader.load_track")
+    def test_validate_track_succeeds_when_validators_pass(self, load_track, println):
+        load_track.return_value = self._track_with_challenges(("validated", True))
+        cfg = self._cfg("validated", {"scheduling": [1]})
+
+        calls = []
+
+        def mark_ok(_):
+            calls.append("ok")
+
+        params.register_validator("validated", mark_ok)
+
+        loader.validate_track(cfg)
+
+        assert calls == ["ok"]
+        println.assert_called_once_with("Track parameters for challenge [validated] are valid (1 validator ran).")
+
+    @mock.patch("esrally.track.loader.console.println")
+    @mock.patch("esrally.track.loader.load_track")
+    def test_validate_track_uses_default_challenge_when_challenge_omitted(self, load_track, println):
+        load_track.return_value = self._track_with_challenges(("default-challenge", True), ("other", False))
+        cfg = self._cfg(None, {"scheduling": [1]})
+
+        calls = []
+
+        def mark_default(_):
+            calls.append("default")
+
+        def mark_other(_):
+            calls.append("other")
+
+        params.register_validator("default-challenge", mark_default)
+        params.register_validator("other", mark_other)
+
+        loader.validate_track(cfg)
+
+        assert calls == ["default"]
+        println.assert_called_once_with("Track parameters for challenge [default-challenge] are valid (1 validator ran).")
+
+    @mock.patch("esrally.track.loader.console.println")
+    @mock.patch("esrally.track.loader.load_track")
+    def test_validate_track_reports_when_no_validators_registered(self, load_track, println):
+        load_track.return_value = self._track_with_challenges(("validated", True))
+        cfg = self._cfg("validated", {})
+
+        loader.validate_track(cfg)
+
+        println.assert_called_once_with(
+            "Track [unittest] challenge [validated] loaded successfully; no validators are registered for this challenge."
+        )
+
+    @mock.patch("esrally.track.loader.load_track")
+    def test_validate_track_fails_on_unknown_challenge(self, load_track):
+        load_track.return_value = self._track_with_challenges(("default-challenge", True), ("other", False))
+        cfg = self._cfg("typo-challenge", {})
+
+        def noop(_):
+            return None
+
+        params.register_validator("default-challenge", noop)
+
+        with pytest.raises(exceptions.InvalidName, match="Unknown challenge \\[typo-challenge\\] for track \\[unittest\\]"):
+            loader.validate_track(cfg)
+
+    @mock.patch("esrally.track.loader.load_track")
+    def test_validate_track_fails_when_track_has_no_challenges(self, load_track):
+        load_track.return_value = track.Track(name="unittest", challenges=[])
+        cfg = self._cfg(None, {})
+
+        with pytest.raises(exceptions.SystemSetupError, match="Track \\[unittest\\] does not provide challenge"):
+            loader.validate_track(cfg)
+
+    @mock.patch("esrally.track.loader.load_track")
+    def test_validate_track_wraps_unexpected_validator_errors(self, load_track):
+        load_track.return_value = self._track_with_challenges(("validated", True))
+        cfg = self._cfg("validated", {})
+
+        def boom(_):
+            raise ValueError("boom")
+
+        params.register_validator("validated", boom)
+        with pytest.raises(exceptions.TrackConfigError, match="Validator \\[boom\\] for challenge \\[validated\\] failed: boom"):
+            loader.validate_track(cfg)
+
+    def test_resolve_challenge_and_invoke_validators_matches_race_semantics(self):
+        t = self._track_with_challenges(("default-challenge", True), ("other", False))
+        cfg = self._cfg(None, {"x": 1})
+
+        received = []
+        params.register_validator("default-challenge", received.append)
+
+        challenge = loader.resolve_challenge_and_invoke_validators(t, cfg)
+
+        assert challenge.name == "default-challenge"
+        assert received == [{"x": 1}]
+
+    @mock.patch("esrally.track.loader.console.println")
+    @mock.patch("esrally.track.loader.load_track")
+    def test_track_info_does_not_invoke_validators(self, load_track, println):
+        load_track.return_value = self._track_with_challenges(("validated", True))
+        # Mark selected so info prints a single challenge schedule without needing full corpora metadata.
+        load_track.return_value.challenges[0].selected = True
+        cfg = self._cfg("validated", {"scheduling": [1, 2, 3]})
+
+        called = []
+
+        def mark(_):
+            called.append(True)
+
+        params.register_validator("validated", mark)
+
+        loader.track_info(cfg)
+
+        assert called == []
+        load_track.assert_called_once_with(cfg)
+
+    def test_validate_track_loads_plugin_validators_from_track_path(self):
+        track_path = os.path.join(os.path.dirname(__file__), "..", "..", "it", "resources", "track_with_validator")
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "node", "rally.root", paths.rally_root())
+        cfg.add(config.Scope.application, "track", "track.path", os.path.abspath(track_path))
+        cfg.add(config.Scope.application, "track", "challenge.name", "validated")
+        cfg.add(config.Scope.application, "track", "params", {"ok": 1})
+        cfg.add(config.Scope.application, "track", "params.ignore_unused", False)
+
+        loader.validate_track(cfg)
+
+        cfg.add(config.Scope.application, "track", "params", {"ok": 0})
+        with pytest.raises(exceptions.TrackConfigError, match="Track parameter 'ok' must be set to 1."):
+            loader.validate_track(cfg)
+
+
 class TestTrackPreparation:
     @mock.patch("esrally.utils.io.prepare_file_offset_table")
     @mock.patch("os.path.getsize")


### PR DESCRIPTION
The track parameter validation hook (introduced in #2144) runs validators as part of `rally race`, inside the actor system, just before the benchmark starts. A bad parameter is only reported after Rally bootstraps the actor system, and the error is shown as a traceback rather than a clean message.

This PR adds a `validate-track` subcommand that loads a track, resolves the challenge the same way `race` does, runs registered validators via `params.invoke_validators`, and exits - without provisioning a cluster or running the benchmark. Validation runs in the main process for a fast, automation-friendly check (exit zero on success, quiet by default; non-zero with the `TrackConfigError` message on failure).

Closes #2145