### PR TITLE
Restore EsClients dictionary compatibility

### DIFF
--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -579,32 +579,19 @@ class ClientContext:
     api_key: Optional[ApiKey] = None
 
 
-class EsClients:
+class EsClients(dict):
     """
-    Wraps the cluster-name-to-client dict returned by create_es_clients().
+    A cluster-name-to-client dict returned by create_es_clients().
     Exposes a ``default`` property that returns the 'default' client, or the
     first available client when no 'default' key is present (multi-cluster mode
     with named clusters).
     """
 
-    def __init__(self, clients):
-        self._clients = clients
-
     @property
     def default(self):
-        return self._clients.get("default") or next(iter(self._clients.values()), None)
-
-    def __getitem__(self, key):
-        return self._clients[key]
-
-    def keys(self):
-        return self._clients.keys()
-
-    def values(self):
-        return self._clients.values()
-
-    def items(self):
-        return self._clients.items()
+        if "default" in self:
+            return self["default"]
+        return next(iter(self.values()), None)
 
 
 class Driver:

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import collections
+import copy
 import io
 import threading
 import time
@@ -57,6 +58,34 @@ class DriverTestParamSource:
             raise StopIteration()
         self._current += 1
         return self._params
+
+
+class TestEsClients:
+    def test_returns_default_client(self):
+        default_client = object()
+        clients = driver.EsClients({"other": object(), "default": default_client})
+
+        assert clients.default is default_client
+
+    def test_returns_first_client_when_default_is_missing(self):
+        first_client = object()
+        clients = driver.EsClients({"first": first_client, "second": object()})
+
+        assert clients.default is first_client
+
+    def test_returns_none_when_empty(self):
+        assert driver.EsClients().default is None
+
+    def test_shallow_copy_can_be_mutated_without_changing_original(self):
+        local_client = object()
+        remote_client = object()
+        clients = driver.EsClients({"local": local_client, "remote": remote_client})
+
+        remaining_clients = copy.copy(clients)
+
+        assert remaining_clients.pop("local") is local_client
+        assert remaining_clients == {"remote": remote_client}
+        assert clients == {"local": local_client, "remote": remote_client}
 
 
 class TestDriver:


### PR DESCRIPTION
Fix failure introduced by https://github.com/elastic/rally/pull/2087, specifically some CCS tests that [assume clients is a dict](https://github.com/elastic/rally-tracks/blob/e8c6da32e0f858bf161dc8208f6ad333ad1e40d4/elastic/shared/runners/remote_cluster.py#L73-L75):

```python
remaining_es_clients = copy.copy(multi_es)
remaining_es_clients.pop(params["source-cluster"])
```

Instead of adding every single dict method (there's a lot!), we subclass dict. This is explicitly supported by Python, and since we only add "default", all the gotchas like https://treyhunner.com/2019/04/why-you-shouldnt-inherit-from-list-and-dict-in-python/ don't apply to us.

Cursor wrote the code, I reviewed it and wrote the PR description.