### PR TITLE
Upgrade Buildkite agent images from Ubuntu 22.04 to 24.04

### DIFF
--- a/.buildkite/dev-docker/pipeline.yml
+++ b/.buildkite/dev-docker/pipeline.yml
@@ -2,7 +2,7 @@ agents:
   provider: "gcp"
   machineType: "n4-standard-4"
   diskType: hyperdisk-balanced
-  image: family/core-ubuntu-2204
+  image: family/core-ubuntu-2604
 
 steps:
   - input: "Build parameters"
@@ -50,7 +50,7 @@ steps:
     timeout_in_minutes: 20
     agents:
       machineType: "n4a-standard-4"
-      image: family/core-ubuntu-2204-aarch64
+      image: family/core-ubuntu-2604-aarch64
       # reduced list of zones
       zones: us-east1-b,us-east1-c,us-central1-a,us-central1-b,us-central1-c,us-west1-c
   - label: ":docker: build docker manifest"

--- a/.buildkite/dev-docker/pipeline.yml
+++ b/.buildkite/dev-docker/pipeline.yml
@@ -2,7 +2,7 @@ agents:
   provider: "gcp"
   machineType: "n4-standard-4"
   diskType: hyperdisk-balanced
-  image: family/core-ubuntu-2604
+  image: family/core-ubuntu-2404
 
 steps:
   - input: "Build parameters"
@@ -50,7 +50,7 @@ steps:
     timeout_in_minutes: 20
     agents:
       machineType: "n4a-standard-4"
-      image: family/core-ubuntu-2604-aarch64
+      image: family/core-ubuntu-2404-aarch64
       # reduced list of zones
       zones: us-east1-b,us-east1-c,us-central1-a,us-central1-b,us-central1-c,us-west1-c
   - label: ":docker: build docker manifest"

--- a/.buildkite/it/pipeline.yml
+++ b/.buildkite/it/pipeline.yml
@@ -2,6 +2,7 @@ agents:
   provider: "gcp"
   image: family/core-ubuntu-2604
   machineType: "n1-standard-8"
+  diskSizeGb: 50
 
 steps:
   - label: "Run 3.10 integration tests :test_tube:"

--- a/.buildkite/it/pipeline.yml
+++ b/.buildkite/it/pipeline.yml
@@ -1,6 +1,6 @@
 agents:
   provider: "gcp"
-  image: family/core-ubuntu-2204
+  image: family/core-ubuntu-2604
   machineType: "n1-standard-8"
 
 steps:

--- a/.buildkite/it/pipeline.yml
+++ b/.buildkite/it/pipeline.yml
@@ -1,8 +1,7 @@
 agents:
   provider: "gcp"
-  image: family/core-ubuntu-2604
+  image: family/core-ubuntu-2404
   machineType: "n1-standard-8"
-  diskSizeGb: 50
 
 steps:
   - label: "Run 3.10 integration tests :test_tube:"

--- a/.buildkite/it/run.sh
+++ b/.buildkite/it/run.sh
@@ -27,20 +27,25 @@ cat /proc/cpuinfo
 
 echo "--- System dependencies"
 
-export PY_VERSION="$1"
-retry 5 sudo add-apt-repository --yes ppa:deadsnakes/ppa
+PY_SHORT_VERSION="$1"
+
 retry 5 sudo apt-get update
 retry 5 sudo apt-get install -y \
-    "python${PY_VERSION}" "python${PY_VERSION}-dev" "python${PY_VERSION}-venv" \
-    git make jq docker \
+    git make jq \
     openjdk-21-jdk-headless openjdk-11-jdk-headless
 export JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 export JAVA21_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+
+export PY_VERSION=$(jq -r ".python_versions.PY$(echo "${PY_SHORT_VERSION}" | tr -d '.')" .ci/variables.json)
 
 echo "--- Install UV"
 
 curl -LsSf https://astral.sh/uv/0.11.19/install.sh | env UV_UNMANAGED_INSTALL="${HOME}/.local/bin" sh
 export PATH="${HOME}/.local/bin:${PATH}"
+
+echo "--- Install Python ${PY_VERSION}"
+
+uv python install "${PY_VERSION}"
 
 echo "--- Create virtual environment"
 

--- a/.buildkite/it/run_serverless.sh
+++ b/.buildkite/it/run_serverless.sh
@@ -17,22 +17,26 @@ export DEBIAN_FRONTEND=noninteractive
 sudo mkdir -p /etc/needrestart
 echo "\$nrconf{restart} = 'a';" | sudo tee -a /etc/needrestart/needrestart.conf > /dev/null
 
-export PY_VERSION="$1"
+PY_SHORT_VERSION="$1"
 TEST_NAME="$2"
 
 echo "--- System dependencies"
 
-retry 5 sudo add-apt-repository --yes ppa:deadsnakes/ppa
 retry 5 sudo apt-get update
 retry 5 sudo apt-get install -y \
-    "python${PY_VERSION}" "python${PY_VERSION}-dev" "python${PY_VERSION}-venv" \
-    make \
+    make jq \
     dnsutils # provides nslookup
+
+export PY_VERSION=$(jq -r ".python_versions.PY$(echo "${PY_SHORT_VERSION}" | tr -d '.')" .ci/variables.json)
 
 echo "--- Install UV"
 
 curl -LsSf https://astral.sh/uv/0.11.19/install.sh | env UV_UNMANAGED_INSTALL="${HOME}/.local/bin" sh
 export PATH="${HOME}/.local/bin:${PATH}"
+
+echo "--- Install Python ${PY_VERSION}"
+
+uv python install "${PY_VERSION}"
 
 echo "--- Create virtual environment"
 

--- a/.buildkite/it/serverless-pipeline.yml
+++ b/.buildkite/it/serverless-pipeline.yml
@@ -15,7 +15,7 @@ common:
 
 agents:
   provider: "gcp"
-  image: family/core-ubuntu-2204
+  image: family/core-ubuntu-2604
 
 steps:
   - label: "Run IT serverless tests with user privileges"

--- a/.buildkite/it/serverless-pipeline.yml
+++ b/.buildkite/it/serverless-pipeline.yml
@@ -15,7 +15,7 @@ common:
 
 agents:
   provider: "gcp"
-  image: family/core-ubuntu-2604
+  image: family/core-ubuntu-2404
 
 steps:
   - label: "Run IT serverless tests with user privileges"

--- a/.buildkite/release-docker/pipeline.yml
+++ b/.buildkite/release-docker/pipeline.yml
@@ -2,7 +2,7 @@ agents:
   provider: "gcp"
   machineType: "n4-standard-4"
   diskType: hyperdisk-balanced
-  image: family/core-ubuntu-2204
+  image: family/core-ubuntu-2604
 
 steps:
   - input: "Build parameters"
@@ -41,7 +41,7 @@ steps:
     timeout_in_minutes: 20
     agents:
       machineType: "n4a-standard-4"
-      image: family/core-ubuntu-2204-aarch64
+      image: family/core-ubuntu-2604-aarch64
       # reduced list of zones
       zones: us-east1-b,us-east1-c,us-central1-a,us-central1-b,us-central1-c,us-west1-c
   - label: ":docker: build docker manifest"

--- a/.buildkite/release-docker/pipeline.yml
+++ b/.buildkite/release-docker/pipeline.yml
@@ -2,7 +2,7 @@ agents:
   provider: "gcp"
   machineType: "n4-standard-4"
   diskType: hyperdisk-balanced
-  image: family/core-ubuntu-2604
+  image: family/core-ubuntu-2404
 
 steps:
   - input: "Build parameters"
@@ -41,7 +41,7 @@ steps:
     timeout_in_minutes: 20
     agents:
       machineType: "n4a-standard-4"
-      image: family/core-ubuntu-2604-aarch64
+      image: family/core-ubuntu-2404-aarch64
       # reduced list of zones
       zones: us-east1-b,us-east1-c,us-central1-a,us-central1-b,us-central1-c,us-west1-c
   - label: ":docker: build docker manifest"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VIRTUAL_ENV := $(or $(VIRTUAL_ENV),.venv$(if $(PY_VERSION),-$(PY_VERSION)))
 VENV_ACTIVATE_FILE := $(VIRTUAL_ENV)/bin/activate
 VENV_ACTIVATE := source $(VENV_ACTIVATE_FILE)
 
-PY_VERSION := $(shell jq -r '.python_versions.DEFAULT_PY_VER' .ci/variables.json)
+PY_VERSION ?= $(shell jq -r '.python_versions.DEFAULT_PY_VER' .ci/variables.json)
 export UV_PYTHON := $(PY_VERSION)
 export UV_PROJECT_ENVIRONMENT := $(VIRTUAL_ENV)
 

--- a/it/storage/manager_test.py
+++ b/it/storage/manager_test.py
@@ -67,9 +67,12 @@ class GetCase:
 )
 def test_get(case: GetCase, base_url: str, transfer_manager: storage.TransferManager):
     tr = transfer_manager.get(f"{base_url}/{case.path}")
-    tr.wait(timeout=300.0)
-    assert tr.done
-    assert os.path.isfile(tr.path)
-    assert os.path.getsize(tr.path) == case.want_size
-    assert tr.crc32c is not None
-    assert crc32c.Checksum.from_filename(tr.path) == crc32c.Checksum.from_base64(tr.crc32c)
+    try:
+        tr.wait(timeout=300.0)
+        assert tr.done
+        assert os.path.isfile(tr.path)
+        assert os.path.getsize(tr.path) == case.want_size
+        assert tr.crc32c is not None
+        assert crc32c.Checksum.from_filename(tr.path) == crc32c.Checksum.from_base64(tr.crc32c)
+    finally:
+        tr.prune()


### PR DESCRIPTION
The motivation is to fix the current Dev Docker Build alerts, which are caused by deadlocks/hangs in old Docker Compose versions. While this bug won't be fixed until https://github.com/elastic/ci-agent-images/pull/2913 is merged, Ubuntu 22.04 is near end-of-life anyway.

This upgrades agents to Ubuntu 24.04 for now (26.04 can follow later).

This also fixes the Rally IT tests to actually test Python 3.10 and 3.13, instead of testing Python 3.13 twice.