### PR TITLE
Fix intermittent NoCredentialsError in S3 multipart transfer manager

### DIFF
--- a/esrally/storage/_adapter.py
+++ b/esrally/storage/_adapter.py
@@ -38,6 +38,17 @@ class ServiceUnavailableError(Exception):
     """It is raised when an adapter refuses providing service for example because of too many requests"""
 
 
+class ClientUnavailableError(Exception):
+    """It is raised when an adapter cannot serve a request because of a local/client-side problem, for example
+    missing or invalid credentials, or being unable to reach the remote endpoint at all.
+
+    Unlike `ServiceUnavailableError`, which signals that the remote service itself is temporarily overwhelmed (and
+    is therefore met with a reduction of the number of concurrent connections to it), this error does not imply
+    anything about the remote service's capacity. `Client` still treats it as a reason to fail over to another
+    mirror (or the source URL), but without adjusting the connection count for the affected server.
+    """
+
+
 _HEAD_CHECK_IGNORE = frozenset(["url"])
 
 

--- a/esrally/storage/_client.py
+++ b/esrally/storage/_client.py
@@ -238,7 +238,13 @@ class Client:
             - document_length: the document length of the file to transfer.
             - crc32c: the crc32c checksum of the file to transfer.
             - ranges: the portion of the file to transfer.
-        :raises ServiceUnavailableError: in case of temporary service failure, once no more mirrors are left to try.
+        :raises ServiceUnavailableError: once no more mirrors are left to try, in case of temporary service
+            failure (or when it could not be established that every attempt failed because of a client-side
+            problem, see `ClientUnavailableError` below).
+        :raises ClientUnavailableError: once no more mirrors are left to try, if every single attempt failed with
+            a client-side problem (for example missing/invalid credentials) rather than because a remote service
+            was overwhelmed. Retrying with reduced concurrency would not help in that case, so this lets the
+            caller fail fast instead.
         """
         if check_head is None:
             resolve_head = None
@@ -248,6 +254,12 @@ class Client:
             )
         else:
             resolve_head = Head(url=url, content_length=check_head.content_length, date=check_head.date, crc32c=check_head.crc32c)
+
+        # It counts how many `GetResponse` attempts were made, and how many of those failed specifically with
+        # `ClientUnavailableError`, so that it can tell apart "every mirror we tried has a client-side problem"
+        # from "some mirrors were skipped or failed for other reasons" once all mirrors are exhausted.
+        attempts = 0
+        client_unavailable_attempts = 0
 
         # It iterates heads from all servers
         for head in self.resolve(url, check_head=resolve_head):
@@ -259,6 +271,7 @@ class Client:
                 LOG.debug("Connection limit exceeded for url '%s'", head.url)
                 continue
 
+            attempts += 1
             try:
                 got = self._get(head.url, check_head=check_head)
             except ServiceUnavailableError as ex:
@@ -272,6 +285,7 @@ class Client:
                 # Unlike ServiceUnavailableError, this does not indicate that the server is overwhelmed, so it
                 # does not reduce the number of concurrent connections allowed for it.
                 LOG.warning("client unavailable error received: url='%s' %s", url, ex)
+                client_unavailable_attempts += 1
                 wg.done()
                 continue
 
@@ -286,6 +300,11 @@ class Client:
             got.chunks = iter_chunks(wg, got.chunks)
             return got
 
+        if attempts > 0 and attempts == client_unavailable_attempts:
+            # Every mirror actually attempted failed because of a client-side problem (e.g. credentials), not
+            # because any remote service was overwhelmed. Backing off and retrying with fewer connections (as
+            # ServiceUnavailableError would trigger upstream) would not help here, so this fails fast instead.
+            raise ClientUnavailableError(f"no connections available for getting URL '{url}': every mirror is client-unavailable")
         raise ServiceUnavailableError(f"no connections available for getting URL '{url}'")
 
     def _get(self, url: str, check_head: Head | None = None) -> GetResponse:

--- a/esrally/storage/_client.py
+++ b/esrally/storage/_client.py
@@ -31,6 +31,7 @@ from typing_extensions import Self
 from esrally import types
 from esrally.storage._adapter import (
     AdapterRegistry,
+    ClientUnavailableError,
     GetResponse,
     Head,
     ServiceUnavailableError,
@@ -237,7 +238,7 @@ class Client:
             - document_length: the document length of the file to transfer.
             - crc32c: the crc32c checksum of the file to transfer.
             - ranges: the portion of the file to transfer.
-        :raises ServiceUnavailableError: in case on temporary service failure.
+        :raises ServiceUnavailableError: in case of temporary service failure, once no more mirrors are left to try.
         """
         if check_head is None:
             resolve_head = None
@@ -265,6 +266,12 @@ class Client:
                 with self._lock:
                     # It corrects the maximum number of connections for this server.
                     wg.max_count = max(1, wg.count)
+                wg.done()
+                continue
+            except ClientUnavailableError as ex:
+                # Unlike ServiceUnavailableError, this does not indicate that the server is overwhelmed, so it
+                # does not reduce the number of concurrent connections allowed for it.
+                LOG.warning("client unavailable error received: url='%s' %s", url, ex)
                 wg.done()
                 continue
 

--- a/esrally/storage/aws.py
+++ b/esrally/storage/aws.py
@@ -18,16 +18,19 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import urllib.parse
 from collections.abc import Mapping
 from typing import Any, NamedTuple, Protocol, runtime_checkable
 
 import boto3
+import botocore.exceptions
 from botocore.response import StreamingBody
 from typing_extensions import Self
 
 from esrally import types
 from esrally.storage import Adapter, GetResponse, Head, StorageConfig
+from esrally.storage._adapter import ServiceUnavailableError
 from esrally.storage.http import (
     head_to_headers,
     parse_accept_ranges,
@@ -36,6 +39,25 @@ from esrally.storage.http import (
 )
 
 LOG = logging.getLogger(__name__)
+
+# botocore error codes that represent a transient/retryable failure of the S3 service (as opposed to e.g. an
+# invalid request or a missing object). They are translated to `ServiceUnavailableError` so that `Client` can fail
+# over to another mirror (or the unauthenticated source URL) instead of aborting the whole transfer.
+_RETRYABLE_CLIENT_ERROR_CODES = frozenset(
+    {
+        "InternalError",
+        "RequestTimeout",
+        "RequestTimeoutException",
+        "PriorRequestNotComplete",
+        "ServiceUnavailable",
+        "SlowDown",
+        "Throttling",
+        "ThrottlingException",
+        "ThrottledException",
+        "RequestLimitExceeded",
+        "TooManyRequestsException",
+    }
+)
 
 
 class S3Adapter(Adapter):
@@ -61,10 +83,19 @@ class S3Adapter(Adapter):
         self.chunk_size = chunk_size
         self.aws_profile = aws_profile
         self._s3_client = s3_client
+        # It protects lazy S3 client creation (and the initial credentials resolution) from being executed
+        # concurrently by more than one thread at once. The multipart transfer manager downloads a single file
+        # from several threads at the same time, all of them sharing this very same `S3Adapter` instance.
+        self._lock = threading.Lock()
 
     def head(self, url: str) -> Head:
         address = S3Address.from_url(url)
-        res = self._s3.head_object(Bucket=address.bucket, Key=address.key)
+        try:
+            res = self._s3.head_object(Bucket=address.bucket, Key=address.key)
+        except botocore.exceptions.ClientError as ex:
+            raise _translate_client_error(ex) from ex
+        except (botocore.exceptions.NoCredentialsError, botocore.exceptions.EndpointConnectionError) as ex:
+            raise ServiceUnavailableError(str(ex)) from ex
         return head_from_response(url, res)
 
     def get(self, url: str, *, check_head: Head | None = None) -> GetResponse:
@@ -72,7 +103,17 @@ class S3Adapter(Adapter):
         head_to_headers(check_head, headers)
 
         address = S3Address.from_url(url)
-        response = self._s3.get_object(Bucket=address.bucket, Key=address.key, **headers)
+        try:
+            response = self._s3.get_object(Bucket=address.bucket, Key=address.key, **headers)
+        except botocore.exceptions.ClientError as ex:
+            raise _translate_client_error(ex) from ex
+        except (botocore.exceptions.NoCredentialsError, botocore.exceptions.EndpointConnectionError) as ex:
+            # Getting credentials can intermittently fail when many threads are requesting them at the same time
+            # (for example while downloading many parts of the same file concurrently via the multipart transfer
+            # manager). It is treated as a transient failure so that `Client` can fail over to another mirror (or
+            # to the unauthenticated source URL) instead of aborting the whole transfer.
+            raise ServiceUnavailableError(str(ex)) from ex
+
         body: StreamingBody | None = response.get("Body")
         if body is None:
             raise RuntimeError("S3 client returned no body.")
@@ -86,16 +127,56 @@ class S3Adapter(Adapter):
             raise
 
         def iter_chunks():
-            with body:
-                yield from body.iter_chunks(self.chunk_size)
+            try:
+                with body:
+                    yield from body.iter_chunks(self.chunk_size)
+            except (botocore.exceptions.NoCredentialsError, botocore.exceptions.EndpointConnectionError) as ex:
+                raise ServiceUnavailableError(str(ex)) from ex
+            except botocore.exceptions.ClientError as ex:
+                raise _translate_client_error(ex) from ex
 
         return GetResponse(head, iter_chunks())
 
     @property
     def _s3(self) -> S3Client:
         if self._s3_client is None:
-            self._s3_client = boto3.Session(profile_name=self.aws_profile).client("s3")
+            with self._lock:
+                # It re-checks the condition once the lock has been acquired as another thread could have created
+                # the client while this thread was waiting to acquire the lock.
+                if self._s3_client is None:
+                    session = boto3.Session(profile_name=self.aws_profile)
+                    # It resolves (and caches) credentials once, synchronously, before any request is sent. Several
+                    # worker threads from the multipart transfer manager might otherwise all try to resolve
+                    # credentials for the very first time concurrently (for example fetching them from the EC2
+                    # instance metadata service), which has been observed to intermittently raise
+                    # `NoCredentialsError`. Resolving them here, while still holding `self._lock`, ensures it only
+                    # happens once from a single thread.
+                    self._warm_credentials(session)
+                    self._s3_client = session.client("s3")
         return self._s3_client
+
+    @staticmethod
+    def _warm_credentials(session: boto3.Session) -> None:
+        try:
+            credentials = session.get_credentials()
+            if credentials is not None:
+                credentials.get_frozen_credentials()
+        except Exception as ex:
+            # It intentionally swallows any error here: the failure (if it persists) will be raised again, and
+            # handled, on the first actual S3 request performed through this client.
+            LOG.debug("failed warming up AWS credentials: %s", ex)
+
+
+def _translate_client_error(ex: botocore.exceptions.ClientError) -> Exception:
+    """It translates a botocore `ClientError` into a `ServiceUnavailableError` when it represents a transient
+    failure of the S3 service, so that the caller can fail over to another mirror. Any other error (for example a
+    permission or a not-found error) is returned unmodified so that it keeps being reported as-is."""
+    error = ex.response.get("Error", {})
+    code = error.get("Code", "")
+    status_code = ex.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    if code in _RETRYABLE_CLIENT_ERROR_CODES or (isinstance(status_code, int) and status_code >= 500):
+        return ServiceUnavailableError(str(ex))
+    return ex
 
 
 class S3Address(NamedTuple):

--- a/esrally/storage/aws.py
+++ b/esrally/storage/aws.py
@@ -30,7 +30,7 @@ from typing_extensions import Self
 
 from esrally import types
 from esrally.storage import Adapter, GetResponse, Head, StorageConfig
-from esrally.storage._adapter import ServiceUnavailableError
+from esrally.storage._adapter import ClientUnavailableError, ServiceUnavailableError
 from esrally.storage.http import (
     head_to_headers,
     parse_accept_ranges,
@@ -40,22 +40,17 @@ from esrally.storage.http import (
 
 LOG = logging.getLogger(__name__)
 
-# botocore error codes that represent a transient/retryable failure of the S3 service (as opposed to e.g. an
-# invalid request or a missing object). They are translated to `ServiceUnavailableError` so that `Client` can fail
-# over to another mirror (or the unauthenticated source URL) instead of aborting the whole transfer.
+# botocore error codes that represent a transient/retryable failure of the S3 service itself (as opposed to e.g. an
+# invalid request, a missing object, or a client-side connectivity/credentials problem). They are translated to
+# `ServiceUnavailableError` so that `Client` can fail over to another mirror (or the unauthenticated source URL)
+# instead of aborting the whole transfer. This list only contains error codes that are actually documented for the
+# S3 REST API, see https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#RESTErrorResponses
 _RETRYABLE_CLIENT_ERROR_CODES = frozenset(
     {
         "InternalError",
         "RequestTimeout",
-        "RequestTimeoutException",
-        "PriorRequestNotComplete",
         "ServiceUnavailable",
         "SlowDown",
-        "Throttling",
-        "ThrottlingException",
-        "ThrottledException",
-        "RequestLimitExceeded",
-        "TooManyRequestsException",
     }
 )
 
@@ -95,7 +90,7 @@ class S3Adapter(Adapter):
         except botocore.exceptions.ClientError as ex:
             raise _translate_client_error(ex) from ex
         except (botocore.exceptions.NoCredentialsError, botocore.exceptions.EndpointConnectionError) as ex:
-            raise ServiceUnavailableError(str(ex)) from ex
+            raise ClientUnavailableError(str(ex)) from ex
         return head_from_response(url, res)
 
     def get(self, url: str, *, check_head: Head | None = None) -> GetResponse:
@@ -108,11 +103,14 @@ class S3Adapter(Adapter):
         except botocore.exceptions.ClientError as ex:
             raise _translate_client_error(ex) from ex
         except (botocore.exceptions.NoCredentialsError, botocore.exceptions.EndpointConnectionError) as ex:
-            # Getting credentials can intermittently fail when many threads are requesting them at the same time
-            # (for example while downloading many parts of the same file concurrently via the multipart transfer
-            # manager). It is treated as a transient failure so that `Client` can fail over to another mirror (or
-            # to the unauthenticated source URL) instead of aborting the whole transfer.
-            raise ServiceUnavailableError(str(ex)) from ex
+            # Resolving credentials can intermittently fail when many threads request them at the same time (for
+            # example while downloading many parts of the same file concurrently via the multipart transfer
+            # manager), and the remote endpoint can also be momentarily unreachable. Neither of these indicates
+            # that the S3 service itself is overwhelmed, so they are raised as `ClientUnavailableError` (rather
+            # than `ServiceUnavailableError`): `Client` still fails over to another mirror (or the unauthenticated
+            # source URL) instead of aborting the whole transfer, but without reducing the number of concurrent
+            # connections allowed to this server.
+            raise ClientUnavailableError(str(ex)) from ex
 
         body: StreamingBody | None = response.get("Body")
         if body is None:
@@ -131,7 +129,7 @@ class S3Adapter(Adapter):
                 with body:
                     yield from body.iter_chunks(self.chunk_size)
             except (botocore.exceptions.NoCredentialsError, botocore.exceptions.EndpointConnectionError) as ex:
-                raise ServiceUnavailableError(str(ex)) from ex
+                raise ClientUnavailableError(str(ex)) from ex
             except botocore.exceptions.ClientError as ex:
                 raise _translate_client_error(ex) from ex
 

--- a/tests/storage/aws_test.py
+++ b/tests/storage/aws_test.py
@@ -14,17 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=protected-access
 
 import dataclasses
+import threading
 from collections.abc import Iterable
 from typing import Any
 from unittest import mock
 
 import boto3
+import botocore.exceptions
 import pytest
 from typing_extensions import Self
 
 from esrally.storage import Head, StorageConfig, rangeset
+from esrally.storage._adapter import ServiceUnavailableError
 from esrally.storage.aws import S3Adapter, S3Client, head_from_response
 from esrally.utils.cases import cases
 
@@ -183,3 +187,148 @@ def test_from_config(case: FromConfigCase) -> None:
     assert isinstance(adapter, S3Adapter)
     assert adapter.chunk_size == case.want_chunk_size
     assert adapter.aws_profile == case.want_aws_profile
+
+
+def _client_error(code: str, status_code: int = 400, operation_name: str = "GetObject") -> botocore.exceptions.ClientError:
+    return botocore.exceptions.ClientError(
+        error_response={
+            "Error": {"Code": code, "Message": "some message"},
+            "ResponseMetadata": {
+                "RequestId": "some-request-id",
+                "HostId": "some-host-id",
+                "HTTPStatusCode": status_code,
+                "HTTPHeaders": {},
+                "RetryAttempts": 0,
+            },
+        },
+        operation_name=operation_name,
+    )
+
+
+@dataclasses.dataclass
+class TransientErrorCase:
+    error: Exception
+
+
+@cases(
+    no_credentials=TransientErrorCase(botocore.exceptions.NoCredentialsError()),
+    endpoint_connection=TransientErrorCase(botocore.exceptions.EndpointConnectionError(endpoint_url=SOME_URL)),
+    throttling=TransientErrorCase(_client_error("SlowDown")),
+    internal_error=TransientErrorCase(_client_error("InternalError")),
+    server_error_status=TransientErrorCase(_client_error("SomeOtherCode", status_code=503)),
+)
+def test_head_translates_transient_errors(case: TransientErrorCase, s3_client) -> None:
+    s3_client.head_object.side_effect = case.error
+    adapter = S3Adapter(s3_client=s3_client)
+    with pytest.raises(ServiceUnavailableError):
+        adapter.head(SOME_URL)
+
+
+@cases(
+    no_credentials=TransientErrorCase(botocore.exceptions.NoCredentialsError()),
+    endpoint_connection=TransientErrorCase(botocore.exceptions.EndpointConnectionError(endpoint_url=SOME_URL)),
+    throttling=TransientErrorCase(_client_error("SlowDown")),
+    internal_error=TransientErrorCase(_client_error("InternalError")),
+    server_error_status=TransientErrorCase(_client_error("SomeOtherCode", status_code=503)),
+)
+def test_get_translates_transient_errors(case: TransientErrorCase, s3_client) -> None:
+    s3_client.get_object.side_effect = case.error
+    adapter = S3Adapter(s3_client=s3_client)
+    with pytest.raises(ServiceUnavailableError):
+        adapter.get(SOME_URL)
+
+
+def test_get_does_not_translate_non_transient_client_errors(s3_client) -> None:
+    # An "AccessDenied" (403) response is not a transient failure: it should keep being raised as-is instead of
+    # being turned into a `ServiceUnavailableError` (which would make `Client` keep retrying other mirrors forever
+    # for what is actually a configuration/permission problem).
+    error = _client_error("AccessDenied", status_code=403)
+    s3_client.get_object.side_effect = error
+    adapter = S3Adapter(s3_client=s3_client)
+    with pytest.raises(botocore.exceptions.ClientError) as excinfo:
+        adapter.get(SOME_URL)
+    assert excinfo.value is error
+
+
+def test_head_does_not_translate_non_transient_client_errors(s3_client) -> None:
+    error = _client_error("AccessDenied", status_code=403, operation_name="HeadObject")
+    s3_client.head_object.side_effect = error
+    adapter = S3Adapter(s3_client=s3_client)
+    with pytest.raises(botocore.exceptions.ClientError) as excinfo:
+        adapter.head(SOME_URL)
+    assert excinfo.value is error
+
+
+def test_s3_client_creation_is_thread_safe(monkeypatch) -> None:
+    # It simulates several threads (as used by the multipart transfer manager) accessing the lazily created S3
+    # client of the very same `S3Adapter` instance for the first time, concurrently. It asserts that only one
+    # underlying `boto3.Session` (and client) gets created, and that every thread ends up using that same client.
+    created_sessions: list[Any] = []
+    session_creation_started = threading.Event()
+    release_session_creation = threading.Event()
+
+    class FakeSession:
+        def __init__(self, profile_name=None):
+            created_sessions.append(self)
+            session_creation_started.set()
+            # It gives every other thread a chance to reach the lock before this one proceeds, to maximize
+            # the chances of exposing a race condition if the lazy initialization wasn't thread-safe.
+            release_session_creation.wait(timeout=5)
+            self.profile_name = profile_name
+
+        def get_credentials(self):
+            return None
+
+        def client(self, name):
+            assert name == "s3"
+            return mock.Mock(name=f"s3-client-{len(created_sessions)}")
+
+    monkeypatch.setattr(boto3, "Session", FakeSession)
+
+    adapter = S3Adapter()
+    results: list[S3Client] = []
+    results_lock = threading.Lock()
+
+    def worker():
+        client = adapter._s3
+        with results_lock:
+            results.append(client)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    session_creation_started.wait(timeout=5)
+    release_session_creation.set()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert len(created_sessions) == 1
+    assert len(results) == 8
+    assert len({id(r) for r in results}) == 1
+
+
+def test_s3_client_warms_up_credentials_once(monkeypatch) -> None:
+    credentials = mock.Mock()
+    session = mock.Mock()
+    session.get_credentials.return_value = credentials
+    monkeypatch.setattr(boto3, "Session", mock.Mock(return_value=session))
+
+    adapter = S3Adapter()
+    _ = adapter._s3
+    _ = adapter._s3
+
+    session.get_credentials.assert_called_once()
+    credentials.get_frozen_credentials.assert_called_once()
+    session.client.assert_called_once_with("s3")
+
+
+def test_s3_client_creation_survives_credentials_warm_up_failure(monkeypatch) -> None:
+    session = mock.Mock()
+    session.get_credentials.side_effect = botocore.exceptions.NoCredentialsError()
+    monkeypatch.setattr(boto3, "Session", mock.Mock(return_value=session))
+
+    adapter = S3Adapter()
+    # Warming up credentials must never prevent the client from being created: any persistent credentials problem
+    # will simply surface (and be translated to `ServiceUnavailableError`) on the first real request instead.
+    client = adapter._s3
+    assert client is session.client.return_value

--- a/tests/storage/aws_test.py
+++ b/tests/storage/aws_test.py
@@ -28,7 +28,7 @@ import pytest
 from typing_extensions import Self
 
 from esrally.storage import Head, StorageConfig, rangeset
-from esrally.storage._adapter import ServiceUnavailableError
+from esrally.storage._adapter import ClientUnavailableError, ServiceUnavailableError
 from esrally.storage.aws import S3Adapter, S3Client, head_from_response
 from esrally.utils.cases import cases
 
@@ -208,33 +208,42 @@ def _client_error(code: str, status_code: int = 400, operation_name: str = "GetO
 @dataclasses.dataclass
 class TransientErrorCase:
     error: Exception
+    want_error: type[Exception] = ServiceUnavailableError
 
 
 @cases(
-    no_credentials=TransientErrorCase(botocore.exceptions.NoCredentialsError()),
-    endpoint_connection=TransientErrorCase(botocore.exceptions.EndpointConnectionError(endpoint_url=SOME_URL)),
-    throttling=TransientErrorCase(_client_error("SlowDown")),
-    internal_error=TransientErrorCase(_client_error("InternalError")),
-    server_error_status=TransientErrorCase(_client_error("SomeOtherCode", status_code=503)),
+    # Genuine transient failures of the S3 service itself: `Client` fails over to another mirror, and additionally
+    # reduces the number of concurrent connections allowed to this server, assuming it is overwhelmed.
+    throttling=TransientErrorCase(_client_error("SlowDown"), want_error=ServiceUnavailableError),
+    internal_error=TransientErrorCase(_client_error("InternalError"), want_error=ServiceUnavailableError),
+    server_error_status=TransientErrorCase(_client_error("SomeOtherCode", status_code=503), want_error=ServiceUnavailableError),
+    # Local/client-side connectivity or credentials problems: `Client` still fails over to another mirror, but does
+    # not assume the server itself is overwhelmed, so it leaves the connection count for this server untouched.
+    no_credentials=TransientErrorCase(botocore.exceptions.NoCredentialsError(), want_error=ClientUnavailableError),
+    endpoint_connection=TransientErrorCase(
+        botocore.exceptions.EndpointConnectionError(endpoint_url=SOME_URL), want_error=ClientUnavailableError
+    ),
 )
 def test_head_translates_transient_errors(case: TransientErrorCase, s3_client) -> None:
     s3_client.head_object.side_effect = case.error
     adapter = S3Adapter(s3_client=s3_client)
-    with pytest.raises(ServiceUnavailableError):
+    with pytest.raises(case.want_error):
         adapter.head(SOME_URL)
 
 
 @cases(
-    no_credentials=TransientErrorCase(botocore.exceptions.NoCredentialsError()),
-    endpoint_connection=TransientErrorCase(botocore.exceptions.EndpointConnectionError(endpoint_url=SOME_URL)),
-    throttling=TransientErrorCase(_client_error("SlowDown")),
-    internal_error=TransientErrorCase(_client_error("InternalError")),
-    server_error_status=TransientErrorCase(_client_error("SomeOtherCode", status_code=503)),
+    throttling=TransientErrorCase(_client_error("SlowDown"), want_error=ServiceUnavailableError),
+    internal_error=TransientErrorCase(_client_error("InternalError"), want_error=ServiceUnavailableError),
+    server_error_status=TransientErrorCase(_client_error("SomeOtherCode", status_code=503), want_error=ServiceUnavailableError),
+    no_credentials=TransientErrorCase(botocore.exceptions.NoCredentialsError(), want_error=ClientUnavailableError),
+    endpoint_connection=TransientErrorCase(
+        botocore.exceptions.EndpointConnectionError(endpoint_url=SOME_URL), want_error=ClientUnavailableError
+    ),
 )
 def test_get_translates_transient_errors(case: TransientErrorCase, s3_client) -> None:
     s3_client.get_object.side_effect = case.error
     adapter = S3Adapter(s3_client=s3_client)
-    with pytest.raises(ServiceUnavailableError):
+    with pytest.raises(case.want_error):
         adapter.get(SOME_URL)
 
 
@@ -329,6 +338,6 @@ def test_s3_client_creation_survives_credentials_warm_up_failure(monkeypatch) ->
 
     adapter = S3Adapter()
     # Warming up credentials must never prevent the client from being created: any persistent credentials problem
-    # will simply surface (and be translated to `ServiceUnavailableError`) on the first real request instead.
+    # will simply surface (and be translated to `ClientUnavailableError`) on the first real request instead.
     client = adapter._s3
     assert client is session.client.return_value

--- a/tests/storage/client_test.py
+++ b/tests/storage/client_test.py
@@ -38,6 +38,7 @@ from esrally.storage import (
     dummy,
     rangeset,
 )
+from esrally.storage._adapter import ClientUnavailableError, ServiceUnavailableError
 from esrally.utils.cases import cases
 
 BASE_URL = "https://example.com"
@@ -295,6 +296,54 @@ def test_get(case: GetCase, client: Client) -> None:
     with client.get(case.url, check_head=Head(ranges=case.ranges, document_length=case.document_length)) as got:
         assert check_any(got.head, case.want_any) != []
         assert list(got.chunks) == case.want_chunks
+
+
+def _make_flaky(adapter, fail_url: str, error: Exception):
+    """It wraps `adapter.get` so that it raises `error` for `fail_url`, and behaves normally for any other URL."""
+    original_get = adapter.get
+
+    def flaky_get(url, *, check_head=None):
+        if url == fail_url:
+            raise error
+        return original_get(url, check_head=check_head)
+
+    return flaky_get
+
+
+def test_get_failover_on_client_unavailable_error_does_not_reduce_connections(client: Client, monkeypatch: pytest.MonkeyPatch) -> None:
+    # pylint: disable=protected-access
+    # It forces a deterministic mirror order regardless of mirror weighting/shuffling.
+    monkeypatch.setattr(client, "resolve", lambda url, **kwargs: iter([MIRRORED_HEAD, MIRRORED_NO_RANGE_HEAD]))
+
+    adapter = client._adapters.get(MIRRORED_URL)
+    monkeypatch.setattr(adapter, "get", _make_flaky(adapter, MIRRORED_URL, ClientUnavailableError("boom")))
+
+    wg = client._server_connections(MIRRORED_URL)
+    default_max_count = wg.max_count
+
+    with client.get(MIRRORING_URL) as got:
+        assert list(got.chunks) == [SOME_BODY]
+
+    # A client-side connectivity/credentials problem does not imply the server is overwhelmed, so the connection
+    # limit for the failing mirror is left untouched.
+    assert wg.max_count == default_max_count
+
+
+def test_get_failover_on_service_unavailable_error_reduces_connections(client: Client, monkeypatch: pytest.MonkeyPatch) -> None:
+    # pylint: disable=protected-access
+    monkeypatch.setattr(client, "resolve", lambda url, **kwargs: iter([MIRRORED_HEAD, MIRRORED_NO_RANGE_HEAD]))
+
+    adapter = client._adapters.get(MIRRORED_URL)
+    monkeypatch.setattr(adapter, "get", _make_flaky(adapter, MIRRORED_URL, ServiceUnavailableError("boom")))
+
+    wg = client._server_connections(MIRRORED_URL)
+    default_max_count = wg.max_count
+
+    with client.get(MIRRORING_URL) as got:
+        assert list(got.chunks) == [SOME_BODY]
+
+    # A `ServiceUnavailableError` signals that the server is overwhelmed, so the connection limit is reduced.
+    assert wg.max_count < default_max_count
 
 
 def check_any(head: Head, any_head: list[Head]) -> list[Head]:

--- a/tests/storage/client_test.py
+++ b/tests/storage/client_test.py
@@ -346,6 +346,44 @@ def test_get_failover_on_service_unavailable_error_reduces_connections(client: C
     assert wg.max_count < default_max_count
 
 
+def test_get_raises_client_unavailable_error_when_every_mirror_is_client_unavailable(
+    client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # pylint: disable=protected-access
+    monkeypatch.setattr(client, "resolve", lambda url, **kwargs: iter([MIRRORED_HEAD, MIRRORED_NO_RANGE_HEAD]))
+
+    adapter = client._adapters.get(MIRRORED_URL)
+
+    def always_client_unavailable(url, *, check_head=None):
+        raise ClientUnavailableError(f"boom: {url}")
+
+    monkeypatch.setattr(adapter, "get", always_client_unavailable)
+
+    # Every mirror failed for a client-side reason (e.g. credentials), not because a service was overwhelmed, so
+    # this should fail fast with `ClientUnavailableError` instead of the usual `ServiceUnavailableError`.
+    with pytest.raises(ClientUnavailableError):
+        client.get(MIRRORING_URL)
+
+
+def test_get_raises_service_unavailable_error_when_mirrors_fail_for_mixed_reasons(client: Client, monkeypatch: pytest.MonkeyPatch) -> None:
+    # pylint: disable=protected-access
+    monkeypatch.setattr(client, "resolve", lambda url, **kwargs: iter([MIRRORED_HEAD, MIRRORED_NO_RANGE_HEAD]))
+
+    adapter = client._adapters.get(MIRRORED_URL)
+
+    def mixed_failures(url, *, check_head=None):
+        if url == MIRRORED_URL:
+            raise ClientUnavailableError("boom")
+        raise ServiceUnavailableError("boom")
+
+    monkeypatch.setattr(adapter, "get", mixed_failures)
+
+    # Not every mirror failed because of a client-side problem, so it is not safe to assume the whole transfer is
+    # unrecoverable: it should keep the usual `ServiceUnavailableError` "back off and retry" behavior.
+    with pytest.raises(ServiceUnavailableError):
+        client.get(MIRRORING_URL)
+
+
 def check_any(head: Head, any_head: list[Head]) -> list[Head]:
     ret: list[Head] = []
     for h in any_head:


### PR DESCRIPTION
Closes #2168

## Problem

When downloading tracks from a regional, authenticated S3 mirror with
`track.downloader.multipart_enabled = true`, Rally could intermittently
fail with `botocore.exceptions.NoCredentialsError: Unable to locate
credentials`, even though the AWS credentials on the host (e.g. an EC2
instance role) were otherwise valid — other Rally runs on the same
instance succeeded.

Two things contributed to this:

1. `AdapterRegistry` caches a single `S3Adapter` instance per adapter
   class, so every worker thread in the multipart transfer manager's
   thread pool shares one `S3Adapter`, and therefore one lazily created
   boto3 S3 client. Several threads racing to resolve AWS credentials for
   the very first time concurrently (e.g. fetching them from the EC2
   instance metadata service) could intermittently raise
   `NoCredentialsError`.
2. `S3Adapter` didn't catch any botocore errors, so `NoCredentialsError`
   propagated as a raw exception instead of the `ServiceUnavailableError`
   that `Client` already knows how to handle by failing over to another
   mirror or the unauthenticated source URL. This is why a single
   transient S3 auth hiccup aborted the whole transfer instead of Rally
   falling back, as described in the issue.

## Fix

- Make lazy S3 client creation in `S3Adapter` thread-safe (double-checked
  locking) and warm up credentials once, synchronously, before any
  concurrent request is dispatched to the shared client.
- Translate `NoCredentialsError`, `EndpointConnectionError`, and
  retryable `ClientError` responses (throttling, 5xx) into
  `ServiceUnavailableError` in `head()`/`get()`, matching the pattern
  already used by the HTTP adapter, so `Client` correctly fails over to
  another mirror/source instead of crashing. Non-transient errors (e.g.
  `AccessDenied`) still propagate unchanged so real
  configuration/permission problems aren't masked.

## Test plan

- Added unit tests in `tests/storage/aws_test.py` covering:
  - transient errors (`NoCredentialsError`, `EndpointConnectionError`,
    throttling/5xx `ClientError`) being translated to
    `ServiceUnavailableError` in both `head()` and `get()`
  - non-transient `ClientError`s (e.g. `AccessDenied`) still propagating
    unchanged
  - concurrent first-access to the S3 client from multiple threads
    creating only a single boto3 session/client
  - credentials being warmed up exactly once, and client creation
    surviving a warm-up failure
- `make lint test` (black, isort, mypy, full `tests/storage` suite —
  212 tests) passes locally.