### PR TITLE
Handle ChunkedEncodingError as a retryable transfer failure

### DIFF
--- a/esrally/storage/http.py
+++ b/esrally/storage/http.py
@@ -105,7 +105,7 @@ class HTTPAdapter(Adapter):
             try:
                 with response:
                     yield from response.iter_content(chunk_size=self.chunk_size)
-            except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as ex:
+            except (requests.exceptions.Timeout, requests.exceptions.ChunkedEncodingError, requests.exceptions.ConnectionError) as ex:
                 raise TimeoutError(f"Timed out reading content from URL={url}: {ex}") from ex
 
         return GetResponse(head, iter_chunks())

--- a/tests/storage/http_test.py
+++ b/tests/storage/http_test.py
@@ -127,7 +127,9 @@ class GetCase:
     ),
     raise_timeout=GetCase(response(read_error=requests.exceptions.Timeout()), Head(URL), want_read_error=TimeoutError),
     raise_connection_error=GetCase(response(read_error=requests.exceptions.ConnectionError()), Head(URL), want_read_error=TimeoutError),
-    raise_chunked_encoding_error=GetCase(response(read_error=requests.exceptions.ChunkedEncodingError()), Head(URL), want_read_error=TimeoutError),
+    raise_chunked_encoding_error=GetCase(
+        response(read_error=requests.exceptions.ChunkedEncodingError()), Head(URL), want_read_error=TimeoutError
+    ),
 )
 def test_get(case: GetCase, session: Session) -> None:
     adapter = HTTPAdapter(

--- a/tests/storage/http_test.py
+++ b/tests/storage/http_test.py
@@ -127,6 +127,7 @@ class GetCase:
     ),
     raise_timeout=GetCase(response(read_error=requests.exceptions.Timeout()), Head(URL), want_read_error=TimeoutError),
     raise_connection_error=GetCase(response(read_error=requests.exceptions.ConnectionError()), Head(URL), want_read_error=TimeoutError),
+    raise_chunked_encoding_error=GetCase(response(read_error=requests.exceptions.ChunkedEncodingError()), Head(URL), want_read_error=TimeoutError),
 )
 def test_get(case: GetCase, session: Session) -> None:
     adapter = HTTPAdapter(

--- a/tests/storage/transfer_test.py
+++ b/tests/storage/transfer_test.py
@@ -266,7 +266,7 @@ def test_transfer(case: TransferCase, executor: dummy.DummyExecutor, local_dir: 
 
 
 
-def test_transfer_requeues_remaining_bytes_on_chunked_encoding_error(executor: dummy.DummyExecutor, tmpdir) -> None:
+def test_transfer_requeues_remaining_bytes_on_timeout_error(executor: dummy.DummyExecutor, tmpdir) -> None:
     """
     Requeues remaining bytes after a ChunkedEncodingError.
     """

--- a/tests/storage/transfer_test.py
+++ b/tests/storage/transfer_test.py
@@ -21,7 +21,6 @@ import json
 import os
 from collections.abc import Generator, Iterator
 from urllib.parse import urlparse
-from requests.exceptions import ChunkedEncodingError
 
 import pytest
 
@@ -61,6 +60,7 @@ class DummyClient(Client):
 
         return GetResponse(head, iter_chunks())
 
+
 class ErroringDummyClient(Client):
     def head(self, url: str, *, cache_ttl: float | None = None) -> Head:
         return Head(url, content_length=len(DATA), accept_ranges=True, crc32c=CRC32C)
@@ -75,7 +75,7 @@ class ErroringDummyClient(Client):
             cut = 128
             # chopping data at max of 128 bytes
             yield data[:cut]
-            raise ChunkedEncodingError("connection broken")
+            raise TimeoutError("connection broken")
 
         return GetResponse(head, iter_chunks())
 
@@ -265,17 +265,13 @@ def test_transfer(case: TransferCase, executor: dummy.DummyExecutor, local_dir: 
     assert transfer2.document_length == transfer.document_length
 
 
-
 def test_transfer_requeues_remaining_bytes_on_timeout_error(executor: dummy.DummyExecutor, tmpdir) -> None:
     """
-    Requeues remaining bytes after a ChunkedEncodingError.
+    Requeues remaining bytes after a TimeoutError.
     """
     cfg = StorageConfig()
     client = ErroringDummyClient.from_config(cfg)
-    path = os.path.join(
-        str(tmpdir),
-        os.path.basename(urlparse(URL).path)
-    )
+    path = os.path.join(str(tmpdir), os.path.basename(urlparse(URL).path))
 
     transfer = Transfer(
         client=client,
@@ -291,5 +287,6 @@ def test_transfer_requeues_remaining_bytes_on_timeout_error(executor: dummy.Dumm
 
     assert transfer.done == rangeset("0-127")
     assert transfer.todo == rangeset("128-1023")
-    assert transfer.errors
-    assert isinstance(transfer.errors[0], ChunkedEncodingError)
+    # The raised TimeoutError is treated as retryable. The remaining
+    # bytes are requeued with no terminal error recorded
+    assert transfer.errors == []

--- a/tests/storage/transfer_test.py
+++ b/tests/storage/transfer_test.py
@@ -21,6 +21,7 @@ import json
 import os
 from collections.abc import Generator, Iterator
 from urllib.parse import urlparse
+from requests.exceptions import ChunkedEncodingError
 
 import pytest
 
@@ -57,6 +58,24 @@ class DummyClient(Client):
 
         def iter_chunks() -> Generator[bytes]:
             yield from (data,)
+
+        return GetResponse(head, iter_chunks())
+
+class ErroringDummyClient(Client):
+    def head(self, url: str, *, cache_ttl: float | None = None) -> Head:
+        return Head(url, content_length=len(DATA), accept_ranges=True, crc32c=CRC32C)
+
+    def get(self, url: str, *, check_head: Head | None = None) -> GetResponse:
+        data = DATA
+        if check_head is not None and check_head.ranges:
+            data = data[check_head.ranges.start : check_head.ranges.end]
+        head = Head(url, ranges=check_head.ranges, content_length=len(data), document_length=len(DATA), crc32c=CRC32C)
+
+        def iter_chunks() -> Generator[bytes]:
+            cut = 128
+            # chopping data at max of 128 bytes
+            yield data[:cut]
+            raise ChunkedEncodingError("connection broken")
 
         return GetResponse(head, iter_chunks())
 
@@ -244,3 +263,33 @@ def test_transfer(case: TransferCase, executor: dummy.DummyExecutor, local_dir: 
     assert transfer2.done == transfer.done
     assert transfer2.todo == transfer.todo
     assert transfer2.document_length == transfer.document_length
+
+
+
+def test_transfer_requeues_remaining_bytes_on_chunked_encoding_error(executor: dummy.DummyExecutor, tmpdir) -> None:
+    """
+    Requeues remaining bytes after a ChunkedEncodingError.
+    """
+    cfg = StorageConfig()
+    client = ErroringDummyClient.from_config(cfg)
+    path = os.path.join(
+        str(tmpdir),
+        os.path.basename(urlparse(URL).path)
+    )
+
+    transfer = Transfer(
+        client=client,
+        url=URL,
+        document_length=len(DATA),
+        path=path,
+        executor=executor,
+        crc32c=CRC32C,
+        cfg=cfg,
+    )
+    transfer.start()
+    executor.execute_tasks()
+
+    assert transfer.done == rangeset("0-127")
+    assert transfer.todo == rangeset("128-1023")
+    assert transfer.errors
+    assert isinstance(transfer.errors[0], ChunkedEncodingError)


### PR DESCRIPTION
Fixes #2172.

  ## Summary

  `requests.exceptions.ChunkedEncodingError` raised while streaming
  HTTP response chunks was falling through to Rally's fatal generic
  exception path. That caused the whole transfer to abort even when partial progress
  had already been recorded.

  This change treats `ChunkedEncodingError` like Rally's other
  transient HTTP read failures in `HTTPAdapter.get()`, so interrupted
  range downloads stay on the retryable path and remaining bytes can be
  retried.

  ## Testing

  - Added coverage in `tests/storage/http_test.py` to verify
  `ChunkedEncodingError` is translated to `TimeoutError`
  - Added coverage in `tests/storage/transfer_test.py` to verify partial
  progress is preserved and remaining bytes stay in `todo`
  - Ran `make lint test`