### PR TITLE
Default to abort for --on-error flag

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -886,8 +886,8 @@ Save the above responses as ``responses.json`` and execute a benchmark as follow
 
 This option controls how Rally behaves when a response error occurs. The following values are possible:
 
-* ``continue``: (default) only records that an error has happened and will continue with the benchmark unless there is a fatal error. At the end of a race, errors show up in the "error rate" metric.
-* ``abort``: aborts the benchmark on the first request error with a detailed error message. It is possible to permit *individual* tasks to ignore non-fatal errors using :ref:`ignore-response-error-level <track_schedule>`.
+* ``continue``: only records that an error has happened and will continue with the benchmark unless there is a fatal error. At the end of a race, errors show up in the "error rate" metric.
+* ``abort``: (default) aborts the benchmark on the first request error with a detailed error message. It is possible to permit *individual* tasks to ignore non-fatal errors using :ref:`ignore-response-error-level <track_schedule>`.
 * ``continue-on-network``: As with ``continue``, but also continues on network errors (such as connection refused).
 
 .. attention::

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -19,11 +19,6 @@ Migrate rally indices to data streams
 * Data streams are versioned ``rally-metrics-v1``, ``rally-races-v1`` and ``rally-results-v1``.
 * Old date-based patterned indices (e.g. ``rally-metrics-YYYY-MM``) are not removed and will continue to work as before, by setting ``datastore.use_data_streams`` value to ``false``.
 
-Default value of ``--on-error`` changed to ``abort``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Starting with Rally 2.14.0 the default value of ``--on-error`` has changed from ``continue`` to ``abort``. This means Rally will now abort the benchmark on the first request error by default. The previous behavior can be restored by explicitly passing ``--on-error=continue``. Individual tasks can still ignore non-fatal errors using the :ref:`ignore-response-error-level <track_schedule>` task parameter.
-
 Reindex of existing indices is recommended in order to benefit from the advantages of data streams.
 See the :ref:`data stream storage documentation <metrics_data_streams>` for more details about how to customize data streams.
 
@@ -105,6 +100,11 @@ Once you are satisfied the data has been migrated, you can delete the old date-b
 .. warning::
 
    Deleting old indices is irreversible. Ensure you have verified the reindex results and have backups before proceeding.
+
+Default value of ``--on-error`` changed to ``abort``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Starting with Rally 2.14.0 the default value of ``--on-error`` has changed from ``continue`` to ``abort``. This means Rally will now abort the benchmark on the first request error by default. The previous behavior can be restored by explicitly passing ``--on-error=continue``. Individual tasks can still ignore non-fatal errors using the :ref:`ignore-response-error-level <track_schedule>` task parameter.
 
 
 Migrating to Rally 2.13.0

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -19,6 +19,11 @@ Migrate rally indices to data streams
 * Data streams are versioned ``rally-metrics-v1``, ``rally-races-v1`` and ``rally-results-v1``.
 * Old date-based patterned indices (e.g. ``rally-metrics-YYYY-MM``) are not removed and will continue to work as before, by setting ``datastore.use_data_streams`` value to ``false``.
 
+Default value of ``--on-error`` changed to ``abort``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Starting with Rally 2.14.0 the default value of ``--on-error`` has changed from ``continue`` to ``abort``. This means Rally will now abort the benchmark on the first request error by default. The previous behavior can be restored by explicitly passing ``--on-error=continue``. Individual tasks can still ignore non-fatal errors using the :ref:`ignore-response-error-level <track_schedule>` task parameter.
+
 Reindex of existing indices is recommended in order to benefit from the advantages of data streams.
 See the :ref:`data stream storage documentation <metrics_data_streams>` for more details about how to customize data streams.
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -209,11 +209,11 @@ Consider a simple example Rally operation::
 
 This query requires the field ``source.geo.location`` to be mapped as a ``geo_point`` type. If incorrectly mapped, Elasticsearch will respond with an error. 
 
-Rally will not exit on errors (unless fatal e.g. `ECONNREFUSED <http://man7.org/linux/man-pages/man2/connect.2.html>`_) by default, instead reporting errors in the summary report via the :ref:`Error Rate <summary_report_error_rate>` statistic. This can potentially leading to misleading results. This behavior is by design and consistent with other load testing tools such as JMeter i.e. In most cases it is desirable that a large long running benchmark should not fail because of a single error response.
+Rally will abort on the first request error by default. It is possible to permit *individual* tasks to ignore non-fatal errors using :ref:`ignore-response-error-level <track_schedule>`. For a more lenient behavior, use ``--on-error=continue`` to only record errors in the summary report via the :ref:`Error Rate <summary_report_error_rate>` statistic instead of aborting.
 
-This behavior can also be changed, by invoking Rally with the :ref:`--on-error <command_line_reference_on_error>` switch e.g.::
+This behavior can be changed, by invoking Rally with the :ref:`--on-error <command_line_reference_on_error>` switch e.g.::
 
-	esrally race --track=geonames --on-error=abort
+	esrally race --track=geonames --on-error=continue
 	
 Checking Queries and Responses
 ------------------------------

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -211,7 +211,7 @@ This query requires the field ``source.geo.location`` to be mapped as a ``geo_po
 
 Rally will abort on the first request error by default. It is possible to permit *individual* tasks to ignore non-fatal errors using :ref:`ignore-response-error-level <track_schedule>`. For a more lenient behavior, use ``--on-error=continue`` to only record errors in the summary report via the :ref:`Error Rate <summary_report_error_rate>` statistic instead of aborting.
 
-This behavior can be changed, by invoking Rally with the :ref:`--on-error <command_line_reference_on_error>` switch e.g.::
+This behavior can be changed by invoking Rally with the :ref:`--on-error <command_line_reference_on_error>` switch e.g.::
 
 	esrally race --track=geonames --on-error=continue
 	

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -791,9 +791,9 @@ def create_arg_parser():
         "--on-error",
         type=OnErrorBehavior,
         choices=list(OnErrorBehavior),
-        help="Controls how Rally behaves on response errors (default: continue). 'continue-on-network' will retry on network errors"
+        help="Controls how Rally behaves on response errors (default: abort). 'continue-on-network' will retry on network errors"
         "(e.g., connection refused).",
-        default=OnErrorBehavior.CONTINUE,
+        default=OnErrorBehavior.ABORT,
     )
     race_parser.add_argument(
         "--telemetry",

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -791,8 +791,8 @@ def create_arg_parser():
         "--on-error",
         type=OnErrorBehavior,
         choices=list(OnErrorBehavior),
-        help="Controls how Rally behaves on response errors (default: abort). 'continue-on-network' will retry on network errors"
-        "(e.g., connection refused).",
+        help="Controls how Rally behaves on response errors (default: abort). 'continue-on-network' will continue on network errors"
+        " (e.g., connection refused).",
         default=OnErrorBehavior.ABORT,
     )
     race_parser.add_argument(


### PR DESCRIPTION
This PR changes the default value of the `--on-error` flag from `continue` to `abort`.

## Changes
- `esrally/rally.py`: Changed default from `OnErrorBehavior.CONTINUE` to `OnErrorBehavior.ABORT` and updated help text
- `docs/command_line_reference.rst`: Updated documentation to reflect new default
- `docs/migrate.rst`: Added migration note for 2.14.0
- `docs/recipes.rst`: Updated recipe documentation to reflect new default behavior

This is a breaking change for Rally 2.14.0. Users who want the old behavior can explicitly pass `--on-error=continue`.

Fixes: Reopens #2167 (original PR closed due to fork deletion)

Closes https://github.com/elastic/rally/issues/1581