### PR TITLE
Add query retry on 429 for serverless scale up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 #### Enhancements
 
+* Retry recoverable query errors (HTTP 429/5xx and ES|QL partial results) via ``--retry-recoverable-query-errors``. Each attempt is recorded as a sample with ``retry-count``, ``retry-attempts-remaining``, and ``retry-duration``.
 * [#2046](https://github.com/elastic/rally/pull/2046): Add detailed results support for ES|QL queries
 * [#2039](https://github.com/elastic/rally/pull/2039): Log warning on BadRequestError
 * [#1868](https://github.com/elastic/rally/pull/1868): Bulk http status & 429 retries

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -895,6 +895,45 @@ This option controls how Rally behaves when a response error occurs. The followi
   With ``continue-on-network``, Rally continues on network errors (e.g., "Connection Refused"/`ECONNREFUSED <http://man7.org/linux/man-pages/man2/connect.2.html>`_). For other errors, behavior is the same as ``continue``. 
   Use this option if you want Rally to be resilient to temporary network issues during a benchmark. Note that this will impact rally aborting in the case of a target Elasticsearch cluster being down.
 
+.. _command_line_reference_retry_recoverable_query_errors:
+
+``retry-recoverable-query-errors``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Retry recoverable errors on search, paginated search, scroll search, composite agg, SQL, ES|QL, and ES|QL profile operations.
+
+Recoverable errors are:
+
+* HTTP 429, except circuit breaker errors with ``durability: PERMANENT``
+* HTTP 502, 503, and 504
+* ES|QL responses with ``is_partial: true``
+
+This is intended for Elasticsearch Serverless, where 429s are expected while the deployment scales up. Rally records **each attempt as its own sample**:
+
+* ``service_time`` is the HTTP time of that attempt (so a 429 sample is how long the 429 took to return).
+* ``retry-count`` is present on every sample and starts at ``0`` for the original request. A successful sample's ``retry-count`` is how many times the request was retried before it succeeded.
+* ``retry-attempts-remaining`` is the unused attempt budget after this sample.
+* ``retry-duration`` is milliseconds elapsed from the first attempt's request start to this attempt's request end (including waits between retries).
+
+Failed retry samples have ``success: false`` and ``weight`` 0 so they do not inflate throughput; they **do** count toward error rate. Summary ``service_time`` percentiles mix failed and successful attempts; filter the metrics store by ``meta.success`` (and ``meta.retry-count``) when you want only successes or only 429s.
+
+After the attempt budget is exhausted, :ref:`on-error <command_line_reference_on_error>` applies as usual.
+
+elasticsearch-py's own 429 retries are disabled for these operations so the budget is not multiplied. Target-throughput scheduling treats the whole retry sequence as one operation.
+
+This option is off by default and does not change retry behavior of bulk indexing or administrative operations.
+
+``retry-recoverable-query-errors-attempts``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Maximum number of attempts per query when ``--retry-recoverable-query-errors`` is set, including the original request. Defaults to ``50``.
+
+**Example**
+
+ ::
+
+   esrally race --track=geonames --on-error=abort --retry-recoverable-query-errors --retry-recoverable-query-errors-attempts=50
+
 ``load-driver-hosts``
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/serverless.rst
+++ b/docs/serverless.rst
@@ -114,7 +114,8 @@ A similar approach can be used to express more nuanced benchmark variations. In 
 Hints
 -----
 
-- Elasticsearch Serverless should provide a clear message indicating unavailable API endpoint or index setting which can happen with custom tracks or some of the `public tracks <https://github.com/elastic/rally-tracks>`_. To surface this error fail fast by using ``--on-error="abort"`` command line option when running Rally. 
+- Elasticsearch Serverless should provide a clear message indicating unavailable API endpoint or index setting which can happen with custom tracks or some of the `public tracks <https://github.com/elastic/rally-tracks>`_. To surface this error fail fast by using ``--on-error="abort"`` command line option when running Rally.
+- When combining ``--on-error=abort`` with Serverless, also pass :ref:`--retry-recoverable-query-errors <command_line_reference_retry_recoverable_query_errors>` so transient 429s during scale-up are retried instead of aborting the race. Each attempt is recorded as a sample (``retry-count`` starts at 0; ``service_time`` on a failed sample is the 429 response time). Size ``--retry-recoverable-query-errors-attempts`` to the expected ramp (default 50).
 - Consider using ``--track-params="post_ingest_sleep:true"`` track parameter when benchmarking with `public tracks <https://github.com/elastic/rally-tracks>`_. Consult track README files to confirm availability of this parameter. The intention of the parameter is to introduce an extra delay between ingesting the data and running the search for better result stability. In traditional non-Serverless clusters this role is fulfilled by force merge operation, but explicit force merge action is not available in Serverless. When the post-ingest sleep is enabled, its duration is controlled by ``post_ingest_sleep_duration`` which defaults to 30s.
 
 

--- a/esrally/client/context.py
+++ b/esrally/client/context.py
@@ -87,6 +87,21 @@ class RequestContextHolder:
         meta["request_end"] = new_request_end
 
     @classmethod
+    def reset_request_timing(cls):
+        """
+        Drop start/end timestamps so the next HTTP attempt is measured on its own.
+
+        Used when Rally retries a request and should record service time of the
+        successful attempt rather than the full retry budget.
+        """
+        try:
+            meta = cls.request_context.get()
+        except LookupError:
+            return
+        meta.pop("request_start", None)
+        meta.pop("request_end", None)
+
+    @classmethod
     def on_request_start(cls):
         cls.update_request_start(time.perf_counter())
 

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -1907,6 +1907,7 @@ class AsyncIoAdapter:
                         self.complete,
                         task.error_behavior(self.on_error),
                         cluster_name=cluster_name,
+                        recoverable_query_retry_attempts=runner.recoverable_query_retry_attempts(self.cfg),
                     )
                     final_executor = AsyncProfiler(async_executor) if self.profiling_enabled else async_executor
                     awaitables.append(final_executor())
@@ -1935,6 +1936,7 @@ class AsyncIoAdapter:
                     self.complete,
                     task.error_behavior(self.on_error),
                     cluster_name=None,
+                    recoverable_query_retry_attempts=runner.recoverable_query_retry_attempts(self.cfg),
                 )
                 final_executor = AsyncProfiler(async_executor) if self.profiling_enabled else async_executor
                 awaitables.append(final_executor())
@@ -1992,6 +1994,26 @@ class AsyncProfiler:
             self.profile_logger.info(profile)
 
 
+def _clients_without_retries(es_clients: EsClients) -> EsClients:
+    """Return clients with elasticsearch-py retries disabled so Rally can sample each attempt."""
+    return EsClients(
+        {name: (es_client.options(max_retries=0) if hasattr(es_client, "options") else es_client) for name, es_client in es_clients.items()}
+    )
+
+
+def _request_error_message(request_meta_data):
+    msg = "Request returned an error. Error type: %s" % request_meta_data.get("error-type", "Unknown")
+    if description := request_meta_data.get("error-description"):
+        msg += f", Description: {description}"
+    if http_status := request_meta_data.get("http-status"):
+        msg += f", HTTP Status: {http_status}"
+    return msg
+
+
+def _api_error_durability(e):
+    return runner.api_error_durability(e)
+
+
 class AsyncExecutor:
     def __init__(
         self,
@@ -2004,6 +2026,7 @@ class AsyncExecutor:
         complete,
         on_error: OnErrorBehavior,
         cluster_name=None,
+        recoverable_query_retry_attempts=None,
     ):
         """
         Executes tasks according to the schedule for a given operation.
@@ -2016,6 +2039,7 @@ class AsyncExecutor:
         :param complete: A shared boolean that indicates we need to prematurely complete execution.
         :param on_error: An Enum of type `OnErrorBehaviour` specifying how the load generator should behave on errors.
         :param cluster_name: Optional name of the target cluster (for multi-cluster reporting).
+        :param recoverable_query_retry_attempts: Max attempts per query when retrying recoverable errors, else ``None``.
         """
         self.client_id = client_id
         self.task = task
@@ -2027,7 +2051,86 @@ class AsyncExecutor:
         self.complete = complete
         self.on_error = on_error
         self.cluster_name = cluster_name
+        self.recoverable_query_retry_attempts = recoverable_query_retry_attempts
+        self.retry_recoverable_queries = (
+            recoverable_query_retry_attempts is not None and self.op.type in runner.RECOVERABLE_QUERY_OPERATION_TYPES
+        )
+        self.es_ops = _clients_without_retries(es) if self.retry_recoverable_queries else es
         self.logger = logging.getLogger(__name__)
+
+    def _emit_sample(
+        self,
+        *,
+        op_runner,
+        sample_type,
+        request_meta_data,
+        absolute_processing_start,
+        request_start,
+        request_end,
+        processing_start,
+        processing_end,
+        total_start,
+        throughput_throttled,
+        absolute_expected_schedule_time,
+        total_ops,
+        total_ops_unit,
+        percent_completed,
+        task_completes_parent,
+    ):
+        service_time = request_end - request_start
+        processing_time = processing_end - processing_start
+        time_period = request_end - total_start
+        # Allow runners to override the throughput calculation in very specific circumstances. Usually, Rally
+        # assumes that throughput is the "amount of work" (determined by the "weight") per unit of time
+        # (determined by the elapsed time period). However, in certain cases (e.g. shard recovery or other
+        # long running operations where there is a dedicated stats API to determine progress), it is
+        # advantageous if the runner calculates throughput directly. The following restrictions apply:
+        #
+        # * Only one client must call that runner (when throughput is calculated, it is aggregated across
+        #   all clients but if the runner provides it, we take the value as is).
+        # * The runner should be rate-limited as each runner call will result in one throughput sample.
+        #
+        throughput = request_meta_data.pop("throughput", None)
+        # Do not calculate latency separately when we run unthrottled. This metric is just confusing then.
+        latency = request_end - absolute_expected_schedule_time if throughput_throttled else service_time
+        # If this task completes the parent task we should *not* check for completion by another client but
+        # instead continue until our own runner has completed. We need to do this because the current
+        # worker (process) could run multiple clients that execute the same task. We do not want all clients to
+        # finish this task as soon as the first of these clients has finished but rather continue until the last
+        # client has finished that task.
+        if task_completes_parent:
+            completed = op_runner.completed
+        else:
+            completed = self.complete.is_set() or op_runner.completed
+        # last sample should bump progress to 100% if externally completed.
+        if completed:
+            progress = 1.0
+        elif op_runner.percent_completed:
+            progress = op_runner.percent_completed
+        else:
+            progress = percent_completed
+
+        sample_meta = dict(request_meta_data) if request_meta_data else {}
+        if self.cluster_name is not None:
+            sample_meta["cluster"] = self.cluster_name
+        self.sampler.add(
+            self.task,
+            self.client_id,
+            sample_type,
+            sample_meta,
+            absolute_processing_start,
+            request_start,
+            latency,
+            service_time,
+            processing_time,
+            throughput,
+            total_ops,
+            total_ops_unit,
+            time_period,
+            progress,
+            request_meta_data.pop("dependent_timing", None),
+        )
+        return completed
 
     async def __call__(self, *args, **kwargs):
         any_task_completes_parent = self.task.any_completes_parent
@@ -2046,7 +2149,7 @@ class AsyncExecutor:
         self.logger.debug("Entering main loop for client id [%s].", self.client_id)
         # noinspection PyBroadException
         try:
-            async for expected_scheduled_time, sample_type, percent_completed, runner, params in schedule:
+            async for expected_scheduled_time, sample_type, percent_completed, op_runner, params in schedule:
                 if self.cancel.is_set():
                     self.logger.info("User cancelled execution.")
                     break
@@ -2057,70 +2160,88 @@ class AsyncExecutor:
                     if rest > 0:
                         await asyncio.sleep(rest)
 
-                absolute_processing_start = time.time()
                 processing_start = time.perf_counter()
                 self.schedule_handle.before_request(processing_start)
-                es_client = self.es.default
-                with es_client.new_request_context() as request_context:
-                    total_ops, total_ops_unit, request_meta_data = await execute_single(runner, self.es, params, self.on_error)
-                    request_start = request_context.request_start
-                    request_end = request_context.request_end
 
-                processing_end = time.perf_counter()
-                service_time = request_end - request_start
-                processing_time = processing_end - processing_start
-                time_period = request_end - total_start
-                self.schedule_handle.after_request(processing_end, total_ops, total_ops_unit, request_meta_data)
-                # Allow runners to override the throughput calculation in very specific circumstances. Usually, Rally
-                # assumes that throughput is the "amount of work" (determined by the "weight") per unit of time
-                # (determined by the elapsed time period). However, in certain cases (e.g. shard recovery or other
-                # long running operations where there is a dedicated stats API to determine progress), it is
-                # advantageous if the runner calculates throughput directly. The following restrictions apply:
-                #
-                # * Only one client must call that runner (when throughput is calculated, it is aggregated across
-                #   all clients but if the runner provides it, we take the value as is).
-                # * The runner should be rate-limited as each runner call will result in one throughput sample.
-                #
-                throughput = request_meta_data.pop("throughput", None)
-                # Do not calculate latency separately when we run unthrottled. This metric is just confusing then.
-                latency = request_end - absolute_expected_schedule_time if throughput_throttled else service_time
-                # If this task completes the parent task we should *not* check for completion by another client but
-                # instead continue until our own runner has completed. We need to do this because the current
-                # worker (process) could run multiple clients that execute the same task. We do not want all clients to
-                # finish this task as soon as the first of these clients has finished but rather continue until the last
-                # client has finished that task.
-                if task_completes_parent:
-                    completed = runner.completed
-                else:
-                    completed = self.complete.is_set() or runner.completed
-                # last sample should bump progress to 100% if externally completed.
-                if completed:
-                    progress = 1.0
-                elif runner.percent_completed:
-                    progress = runner.percent_completed
-                else:
-                    progress = percent_completed
-
-                sample_meta = dict(request_meta_data) if request_meta_data else {}
-                if self.cluster_name is not None:
-                    sample_meta["cluster"] = self.cluster_name
-                self.sampler.add(
-                    self.task,
-                    self.client_id,
-                    sample_type,
-                    sample_meta,
-                    absolute_processing_start,
-                    request_start,
-                    latency,
-                    service_time,
-                    processing_time,
-                    throughput,
-                    total_ops,
-                    total_ops_unit,
-                    time_period,
-                    progress,
-                    request_meta_data.pop("dependent_timing", None),
+                attempt = 0
+                first_request_start = None
+                total_ops = 0
+                total_ops_unit = "ops"
+                request_meta_data = {}
+                after_request_meta = {}
+                processing_end = processing_start
+                completed = False
+                # When retrying recoverable query errors, don't abort inside execute_single so each
+                # attempt can be sampled. Connection-error policy is unchanged (CONTINUE still aborts
+                # on connection refused; CONTINUE_ON_NETWORK is passed through).
+                attempt_on_error = (
+                    OnErrorBehavior.CONTINUE if self.retry_recoverable_queries and self.on_error == OnErrorBehavior.ABORT else self.on_error
                 )
+
+                while True:
+                    if self.cancel.is_set():
+                        self.logger.info("User cancelled execution.")
+                        break
+
+                    absolute_processing_start = time.time()
+                    processing_start = time.perf_counter()
+                    es_client = self.es.default
+                    with es_client.new_request_context() as request_context:
+                        total_ops, total_ops_unit, request_meta_data = await execute_single(
+                            op_runner, self.es_ops, params, attempt_on_error
+                        )
+                        request_start = request_context.request_start
+                        request_end = request_context.request_end
+
+                    processing_end = time.perf_counter()
+                    if first_request_start is None:
+                        first_request_start = request_start
+
+                    success = request_meta_data.get("success", True)
+                    if self.retry_recoverable_queries:
+                        if not success:
+                            # Failed retry attempts must not inflate throughput.
+                            total_ops = 0
+                        request_meta_data["retry-count"] = attempt
+                        request_meta_data["retry-attempts-remaining"] = self.recoverable_query_retry_attempts - attempt - 1
+                        request_meta_data["retry-duration"] = convert.seconds_to_ms(request_end - first_request_start)
+
+                    after_request_meta = dict(request_meta_data) if request_meta_data else {}
+                    completed = self._emit_sample(
+                        op_runner=op_runner,
+                        sample_type=sample_type,
+                        request_meta_data=request_meta_data,
+                        absolute_processing_start=absolute_processing_start,
+                        request_start=request_start,
+                        request_end=request_end,
+                        processing_start=processing_start,
+                        processing_end=processing_end,
+                        total_start=total_start,
+                        throughput_throttled=throughput_throttled,
+                        absolute_expected_schedule_time=absolute_expected_schedule_time,
+                        total_ops=total_ops,
+                        total_ops_unit=total_ops_unit,
+                        percent_completed=percent_completed,
+                        task_completes_parent=task_completes_parent,
+                    )
+
+                    recoverable = self.retry_recoverable_queries and runner.is_recoverable_request_meta(after_request_meta)
+                    attempts_left = self.retry_recoverable_queries and (attempt + 1) < self.recoverable_query_retry_attempts
+                    if success or not recoverable or not attempts_left:
+                        if not success and self.on_error == OnErrorBehavior.ABORT:
+                            raise exceptions.RallyAssertionError(_request_error_message(after_request_meta))
+                        break
+
+                    attempt += 1
+                    self.logger.info(
+                        "Recoverable error on [%s] (retry-count [%s]). Retrying in [%.2f] seconds.",
+                        self.task,
+                        attempt,
+                        runner.RECOVERABLE_QUERY_RETRY_WAIT_SECONDS,
+                    )
+                    await asyncio.sleep(runner.RECOVERABLE_QUERY_RETRY_WAIT_SECONDS)
+
+                self.schedule_handle.after_request(processing_end, total_ops, total_ops_unit, after_request_meta)
 
                 if completed:
                     self.logger.info("Task [%s] is considered completed due to external event.", self.task)
@@ -2265,6 +2386,8 @@ async def execute_single(runner, es, params, on_error: OnErrorBehavior):
         request_meta_data["error-description"] = error_description
         if e.status_code:
             request_meta_data["http-status"] = e.status_code
+        if durability := _api_error_durability(e):
+            request_meta_data["error-durability"] = durability
         request_meta_data.update(_parse_headers(e))
 
     except KeyError as e:
@@ -2274,15 +2397,7 @@ async def execute_single(runner, es, params, on_error: OnErrorBehavior):
 
     if not request_meta_data["success"]:
         if on_error == OnErrorBehavior.ABORT or (is_connection_error and on_error != OnErrorBehavior.CONTINUE_ON_NETWORK):
-            msg = "Request returned an error. Error type: %s" % request_meta_data.get("error-type", "Unknown")
-
-            if description := request_meta_data.get("error-description"):
-                msg += f", Description: {description}"
-
-            if http_status := request_meta_data.get("http-status"):
-                msg += f", HTTP Status: {http_status}"
-
-            raise exceptions.RallyAssertionError(msg)
+            raise exceptions.RallyAssertionError(_request_error_message(request_meta_data))
 
     return total_ops, total_ops_unit, request_meta_data
 

--- a/esrally/driver/runner.py
+++ b/esrally/driver/runner.py
@@ -36,6 +36,7 @@ from typing import Optional
 import ijson
 
 from esrally import exceptions, track, types
+from esrally.client.context import RequestContextHolder
 from esrally.utils import convert
 from esrally.utils.versions import Version
 
@@ -43,16 +44,64 @@ from esrally.utils.versions import Version
 
 __RUNNERS = {}
 
+DEFAULT_RECOVERABLE_QUERY_ERROR_ATTEMPTS = 50
+RECOVERABLE_QUERY_RETRY_WAIT_SECONDS = 0.5
+_RECOVERABLE_HTTP_STATUS = frozenset({429, 502, 503, 504})
+_PERMANENT_DURABILITY = "PERMANENT"
+RECOVERABLE_QUERY_OPERATION_TYPES = frozenset(
+    {
+        track.OperationType.Search.to_hyphenated_string(),
+        track.OperationType.PaginatedSearch.to_hyphenated_string(),
+        track.OperationType.ScrollSearch.to_hyphenated_string(),
+        track.OperationType.CompositeAgg.to_hyphenated_string(),
+        track.OperationType.Sql.to_hyphenated_string(),
+        track.OperationType.Esql.to_hyphenated_string(),
+        track.OperationType.EsqlProfile.to_hyphenated_string(),
+    }
+)
+
+
+def recoverable_query_retry_attempts(config: Optional[types.Config]) -> Optional[int]:
+    """Return the max attempts when the race-level recoverable-error switch is on, else ``None``."""
+    if not config:
+        return None
+    enabled = convert.to_bool(config.opts("driver", "retry.recoverable.query.errors", mandatory=False, default_value=False))
+    if not enabled:
+        return None
+    attempts = int(
+        config.opts(
+            "driver",
+            "retry.recoverable.query.errors.attempts",
+            mandatory=False,
+            default_value=DEFAULT_RECOVERABLE_QUERY_ERROR_ATTEMPTS,
+        )
+    )
+    if attempts < 1:
+        raise exceptions.SystemSetupError(f"--retry-recoverable-query-errors-attempts must be >= 1 but was [{attempts}].")
+    return attempts
+
 
 def register_default_runners(config: Optional[types.Config] = None):
+    attempts = recoverable_query_retry_attempts(config)
+    if attempts is not None:
+        logging.getLogger(__name__).info(
+            "Retrying recoverable errors for query operations (search, ES|QL, SQL) up to [%s] attempts; "
+            "each attempt is recorded as a sample.",
+            attempts,
+        )
+    query = Query(config=config)
+    sql = Sql()
+    esql = Esql()
+    esql_profile = EsqlProfile()
+
     register_runner(track.OperationType.Bulk, BulkIndex(), async_runner=True)
     register_runner(track.OperationType.ForceMerge, ForceMerge(), async_runner=True)
     register_runner(track.OperationType.IndexStats, Retry(IndicesStats()), async_runner=True)
     register_runner(track.OperationType.NodeStats, NodeStats(), async_runner=True)
-    register_runner(track.OperationType.Search, Query(config=config), async_runner=True)
-    register_runner(track.OperationType.PaginatedSearch, Query(config=config), async_runner=True)
-    register_runner(track.OperationType.CompositeAgg, Query(config=config), async_runner=True)
-    register_runner(track.OperationType.ScrollSearch, Query(config=config), async_runner=True)
+    register_runner(track.OperationType.Search, query, async_runner=True)
+    register_runner(track.OperationType.PaginatedSearch, query, async_runner=True)
+    register_runner(track.OperationType.CompositeAgg, query, async_runner=True)
+    register_runner(track.OperationType.ScrollSearch, query, async_runner=True)
     register_runner(track.OperationType.RawRequest, RawRequest(), async_runner=True)
     register_runner(track.OperationType.Composite, Composite(), async_runner=True)
     register_runner(track.OperationType.SubmitAsyncSearch, SubmitAsyncSearch(), async_runner=True)
@@ -60,10 +109,10 @@ def register_default_runners(config: Optional[types.Config] = None):
     register_runner(track.OperationType.DeleteAsyncSearch, DeleteAsyncSearch(), async_runner=True)
     register_runner(track.OperationType.OpenPointInTime, OpenPointInTime(), async_runner=True)
     register_runner(track.OperationType.ClosePointInTime, ClosePointInTime(), async_runner=True)
-    register_runner(track.OperationType.Sql, Sql(), async_runner=True)
+    register_runner(track.OperationType.Sql, sql, async_runner=True)
     register_runner(track.OperationType.FieldCaps, FieldCaps(), async_runner=True)
-    register_runner(track.OperationType.Esql, Esql(), async_runner=True)
-    register_runner(track.OperationType.EsqlProfile, EsqlProfile(), async_runner=True)
+    register_runner(track.OperationType.Esql, esql, async_runner=True)
+    register_runner(track.OperationType.EsqlProfile, esql_profile, async_runner=True)
 
     # This is an administrative operation but there is no need for a retry here as we don't issue a request
     register_runner(track.OperationType.Sleep, Sleep(), async_runner=True)
@@ -3319,6 +3368,83 @@ class RequestTiming(Runner, Delegator):
         return await self.delegate.__aexit__(exc_type, exc_val, exc_tb)
 
 
+def _error_object(body):
+    if isinstance(body, bytes):
+        try:
+            body = json.loads(body.decode("utf-8", errors="replace"))
+        except ValueError:
+            return None
+    elif isinstance(body, str):
+        try:
+            body = json.loads(body)
+        except ValueError:
+            return None
+    if not isinstance(body, dict):
+        return None
+    error = body.get("error")
+    return error if isinstance(error, dict) else None
+
+
+def api_error_durability(e):
+    error = _error_object(getattr(e, "body", None))
+    if not error:
+        return None
+    if durability := error.get("durability"):
+        return durability
+    for cause in error.get("root_cause") or []:
+        if isinstance(cause, dict) and (durability := cause.get("durability")):
+            return durability
+    return None
+
+
+def is_recoverable_api_error(e):
+    """
+    Return whether an Elasticsearch ``ApiError`` is worth retrying.
+
+    HTTP 502/503/504 are treated as recoverable. HTTP 429 is recoverable unless the
+    error body reports ``durability: PERMANENT`` (a circuit breaker that will not
+    clear without a different query or cluster configuration).
+    """
+    status = getattr(e, "status_code", None)
+    if status not in _RECOVERABLE_HTTP_STATUS:
+        return False
+    if status != 429:
+        return True
+    return api_error_durability(e) != _PERMANENT_DURABILITY
+
+
+def is_recoverable_request_meta(request_meta_data):
+    """
+    Return whether a recorded request failure is recoverable for query retries.
+
+    Used after ``execute_single`` has turned an exception or ``success: false``
+    result into request meta-data.
+    """
+    if not request_meta_data or request_meta_data.get("success", True):
+        return False
+    if request_meta_data.get("is_partial"):
+        return True
+    status = request_meta_data.get("http-status")
+    if status in (502, 503, 504):
+        return True
+    if status == 429:
+        return request_meta_data.get("error-durability") != _PERMANENT_DURABILITY
+    return False
+
+
+def _with_retry_meta(return_value, attempt, record_retries):
+    if not record_retries or attempt == 0 or not isinstance(return_value, dict):
+        return return_value
+    return_value["retries"] = attempt
+    return return_value
+
+
+async def _wait_before_retry(sleep_time, reset_timing):
+    if reset_timing:
+        RequestContextHolder.reset_request_timing()
+    await asyncio.sleep(sleep_time)
+
+
 # TODO: Allow to use this from (selected) regular runners and add user documentation.
 # TODO: It would maybe be interesting to add meta-data on how many retries there were.
 class Retry(Runner, Delegator):
@@ -3334,11 +3460,15 @@ class Retry(Runner, Delegator):
     * ``retry-on-timeout`` (optional, default True): Whether to retry on connection timeout.
     * ``retry-on-error`` (optional, default False): Whether to retry on failure (i.e. the delegate
                          returns ``success == False``)
+    * ``retry-on-recoverable`` (optional, default False): Retry HTTP 429 (except permanent circuit breakers),
+                              502, 503 and 504. Also retries ``success == False`` (e.g. ES|QL ``is_partial``).
     """
 
-    def __init__(self, delegate, retry_until_success=False):
+    def __init__(self, delegate, retry_until_success=False, retry_on_recoverable=False, retries=0):
         super().__init__(delegate=delegate)
         self.retry_until_success = retry_until_success
+        self.retry_on_recoverable = retry_on_recoverable
+        self.retries = retries
 
     async def __aenter__(self):
         await self.delegate.__aenter__()
@@ -3351,26 +3481,31 @@ class Retry(Runner, Delegator):
         import elasticsearch
 
         retry_until_success = params.get("retry-until-success", self.retry_until_success)
+        retry_on_recoverable = params.get("retry-on-recoverable", self.retry_on_recoverable)
         if retry_until_success:
             max_attempts = sys.maxsize
             retry_on_error = True
         else:
-            max_attempts = params.get("retries", 0) + 1
-            retry_on_error = params.get("retry-on-error", False)
+            max_attempts = params.get("retries", self.retries) + 1
+            retry_on_error = params.get("retry-on-error", False) or retry_on_recoverable
         sleep_time = params.get("retry-wait-period", 0.5)
         retry_on_timeout = params.get("retry-on-timeout", True)
+
+        if retry_on_recoverable and hasattr(es, "options"):
+            # Avoid nested elasticsearch-py 429 retries on top of Rally retries.
+            es = es.options(max_retries=0)
 
         for attempt in range(max_attempts):
             last_attempt = attempt + 1 == max_attempts
             try:
                 return_value = await self.delegate(es, params)
                 if last_attempt or not retry_on_error:
-                    return return_value
+                    return _with_retry_meta(return_value, attempt, retry_on_recoverable)
                 # we can determine success if and only if the runner returns a dict. Otherwise, we have to assume it was fine.
                 elif isinstance(return_value, dict):
                     if return_value.get("success", True):
                         self.logger.debug("%s has returned successfully", repr(self.delegate))
-                        return return_value
+                        return _with_retry_meta(return_value, attempt, retry_on_recoverable)
                     else:
                         self.logger.info(
                             "[%s] has returned with an error: %s. Retrying in [%.2f] seconds.",
@@ -3378,23 +3513,30 @@ class Retry(Runner, Delegator):
                             return_value,
                             sleep_time,
                         )
-                        await asyncio.sleep(sleep_time)
+                        await _wait_before_retry(sleep_time, retry_on_recoverable)
                 else:
                     return return_value
             except (socket.timeout, elasticsearch.exceptions.ConnectionError):
                 if last_attempt or not retry_on_timeout:
                     raise
-                await asyncio.sleep(sleep_time)
+                await _wait_before_retry(sleep_time, retry_on_recoverable)
             except elasticsearch.BadRequestError as e:
                 self.logger.warning("[%s] %s", str(self.delegate), str(e))
                 raise e
             except elasticsearch.ApiError as e:
-                if last_attempt or not retry_on_timeout:
+                if last_attempt:
                     raise e
-
-                if e.status_code == 408:
+                if e.status_code == 408 and retry_on_timeout:
                     self.logger.info("[%s] has timed out. Retrying in [%.2f] seconds.", repr(self.delegate), sleep_time)
-                    await asyncio.sleep(sleep_time)
+                    await _wait_before_retry(sleep_time, retry_on_recoverable)
+                elif retry_on_recoverable and is_recoverable_api_error(e):
+                    self.logger.info(
+                        "[%s] has returned a recoverable error (HTTP %s). Retrying in [%.2f] seconds.",
+                        repr(self.delegate),
+                        e.status_code,
+                        sleep_time,
+                    )
+                    await _wait_before_retry(sleep_time, retry_on_recoverable)
                 else:
                     raise e
 
@@ -3403,7 +3545,7 @@ class Retry(Runner, Delegator):
                     raise e
 
                 self.logger.info("[%s] has timed out. Retrying in [%.2f] seconds.", repr(self.delegate), sleep_time)
-                await asyncio.sleep(sleep_time)
+                await _wait_before_retry(sleep_time, retry_on_recoverable)
             except elasticsearch.exceptions.TransportError as e:
                 if last_attempt or not retry_on_timeout:
                     raise e

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -796,6 +796,21 @@ def create_arg_parser():
         default=OnErrorBehavior.CONTINUE,
     )
     race_parser.add_argument(
+        "--retry-recoverable-query-errors",
+        action="store_true",
+        default=False,
+        help="Retry HTTP 429 (except durability: PERMANENT), 502, 503, 504, and ES|QL partial results "
+        "(200 with is_partial: true) for search, ES|QL, and SQL. Intended for Elasticsearch Serverless scale-up. "
+        "Each attempt is recorded as a sample with retry-count, retry-attempts-remaining, and retry-duration.",
+    )
+    race_parser.add_argument(
+        "--retry-recoverable-query-errors-attempts",
+        type=int,
+        default=50,
+        metavar="N",
+        help="Maximum attempts per query when --retry-recoverable-query-errors is set, including the original request (default: 50).",
+    )
+    race_parser.add_argument(
         "--telemetry",
         help=f"Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry "
         f"devices with `{PROGRAM_NAME} list telemetry`.",
@@ -1326,6 +1341,17 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             cfg.add(config.Scope.applicationOverride, "driver", "profiling", args.enable_driver_profiling)
             cfg.add(config.Scope.applicationOverride, "driver", "assertions", args.enable_assertions)
             cfg.add(config.Scope.applicationOverride, "driver", "on.error", args.on_error)
+            if args.retry_recoverable_query_errors_attempts < 1:
+                raise exceptions.SystemSetupError(
+                    f"--retry-recoverable-query-errors-attempts must be >= 1 but was [{args.retry_recoverable_query_errors_attempts}]."
+                )
+            cfg.add(config.Scope.applicationOverride, "driver", "retry.recoverable.query.errors", args.retry_recoverable_query_errors)
+            cfg.add(
+                config.Scope.applicationOverride,
+                "driver",
+                "retry.recoverable.query.errors.attempts",
+                args.retry_recoverable_query_errors_attempts,
+            )
             cfg.add(config.Scope.applicationOverride, "driver", "load_driver_hosts", opts.csv_to_list(args.load_driver_hosts))
             cfg.add(config.Scope.applicationOverride, "track", "test.mode.enabled", args.test_mode)
             configure_track_params(arg_parser, args, cfg)

--- a/esrally/types.py
+++ b/esrally/types.py
@@ -144,6 +144,8 @@ Key = Literal[
     "remote.repo.url",
     "repository.name",
     "repository.revision",
+    "retry.recoverable.query.errors",
+    "retry.recoverable.query.errors.attempts",
     "root.dir",
     "runtime.jdk",
     "sample.key",

--- a/tests/client/factory_test.py
+++ b/tests/client/factory_test.py
@@ -513,6 +513,20 @@ class TestRequestContextManager:
         assert top_level_ctx.request_end > nested_ctx.request_end
         assert nested_ctx.request_end > nested_ctx.request_start + 0.01
 
+    def test_reset_request_timing_drops_start_and_end(self):
+        test_client = client.RequestContextHolder()
+        with test_client.new_request_context() as ctx:
+            test_client.on_request_start()
+            test_client.on_request_end()
+            assert ctx.request_start is not None
+            assert ctx.request_end is not None
+            test_client.reset_request_timing()
+            assert ctx.request_start is None
+            assert ctx.request_end is None
+
+    def test_reset_request_timing_without_context_is_noop(self):
+        client.RequestContextHolder.reset_request_timing()
+
 
 class TestRestLayer:
     @mock.patch("elasticsearch.Elasticsearch")

--- a/tests/driver/driver_test.py
+++ b/tests/driver/driver_test.py
@@ -60,6 +60,42 @@ class DriverTestParamSource:
         return self._params
 
 
+def _api_error(status, body=None, message="error"):
+    error_meta = elastic_transport.ApiResponseMeta(
+        status=status,
+        http_version="1.1",
+        headers=elastic_transport.HttpHeaders(),
+        duration=0.0,
+        node=elastic_transport.NodeConfig(scheme="http", host="localhost", port=9200),
+    )
+    return elasticsearch.ApiError(message=message, meta=error_meta, body=body)
+
+
+def _circuit_breaker_body(durability="TRANSIENT"):
+    return {
+        "error": {
+            "root_cause": [{"type": "circuit_breaking_exception", "reason": "Data too large", "durability": durability}],
+            "type": "circuit_breaking_exception",
+            "reason": "Data too large",
+            "durability": durability,
+        },
+        "status": 429,
+    }
+
+
+class ScriptedRunner:
+    def __init__(self, side_effects):
+        self.side_effects = list(side_effects)
+        self.calls = 0
+
+    async def __call__(self, es, params):
+        effect = self.side_effects[self.calls]
+        self.calls += 1
+        if isinstance(effect, BaseException):
+            raise effect
+        return effect
+
+
 class TestEsClients:
     def test_returns_default_client(self):
         default_client = object()
@@ -2018,6 +2054,172 @@ class TestAsyncExecutor:
 
         assert es.call_count == 0
 
+    async def _run_esql_schedule(self, es, side_effects, *, attempts, on_error):
+        task_start = time.perf_counter()
+        es.new_request_context.return_value = self.StaticRequestTiming(task_start=task_start)
+        es.options.return_value = es
+        scripted = ScriptedRunner(side_effects)
+        runner.register_runner(track.OperationType.Esql, scripted, async_runner=True)
+
+        params.register_param_source_for_name("driver-test-param-source", DriverTestParamSource)
+        test_track = track.Track(name="unittest", description="unittest track", indices=None, challenges=None)
+        task = track.Task(
+            "esql-query",
+            track.Operation(
+                "esql-query",
+                track.OperationType.Esql.to_hyphenated_string(),
+                params={"query": "FROM test"},
+                param_source="driver-test-param-source",
+            ),
+            iterations=1,
+            clients=1,
+        )
+        param_source = track.operation_parameters(test_track, task)
+        task_allocation = driver.TaskAllocation(task=task, client_index_in_task=0, global_client_index=0, total_clients=task.clients)
+        schedule = driver.schedule_for(task_allocation, param_source)
+        sampler = driver.Sampler(start_timestamp=task_start)
+        execute_schedule = driver.AsyncExecutor(
+            client_id=0,
+            task=task,
+            schedule=schedule,
+            es=driver.EsClients({"default": es}),
+            sampler=sampler,
+            cancel=threading.Event(),
+            complete=threading.Event(),
+            on_error=on_error,
+            recoverable_query_retry_attempts=attempts,
+        )
+        return execute_schedule, sampler, scripted
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_records_each_recoverable_failure_as_sample(self, es):
+        success = {"weight": 1, "unit": "ops", "success": True}
+        execute_schedule, sampler, scripted = await self._run_esql_schedule(
+            es,
+            [
+                _api_error(429, _circuit_breaker_body("TRANSIENT")),
+                _api_error(429, _circuit_breaker_body("TRANSIENT")),
+                success,
+            ],
+            attempts=50,
+            on_error=OnErrorBehavior.ABORT,
+        )
+
+        async def noop_sleep(_seconds):
+            return None
+
+        with mock.patch("esrally.driver.driver.asyncio.sleep", noop_sleep):
+            await execute_schedule()
+
+        samples = sampler.samples
+        assert len(samples) == 3
+        assert [s.request_meta_data["success"] for s in samples] == [False, False, True]
+        assert [s.request_meta_data["retry-count"] for s in samples] == [0, 1, 2]
+        assert [s.request_meta_data["retry-attempts-remaining"] for s in samples] == [49, 48, 47]
+        assert samples[0].total_ops == 0
+        assert samples[1].total_ops == 0
+        assert samples[2].total_ops == 1
+        assert samples[0].request_meta_data["http-status"] == 429
+        assert samples[0].request_meta_data["error-durability"] == "TRANSIENT"
+        assert samples[0].request_meta_data["retry-duration"] < samples[1].request_meta_data["retry-duration"]
+        assert samples[1].request_meta_data["retry-duration"] < samples[2].request_meta_data["retry-duration"]
+        es.options.assert_called_with(max_retries=0)
+        assert scripted.calls == 3
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_success_on_first_attempt_records_retry_count_zero(self, es):
+        execute_schedule, sampler, scripted = await self._run_esql_schedule(
+            es,
+            [{"weight": 1, "unit": "ops", "success": True}],
+            attempts=50,
+            on_error=OnErrorBehavior.ABORT,
+        )
+        await execute_schedule()
+
+        samples = sampler.samples
+        assert len(samples) == 1
+        assert samples[0].request_meta_data["success"] is True
+        assert samples[0].request_meta_data["retry-count"] == 0
+        assert samples[0].request_meta_data["retry-attempts-remaining"] == 49
+        assert scripted.calls == 1
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_retries_esql_partial_results_as_samples(self, es):
+        execute_schedule, sampler, scripted = await self._run_esql_schedule(
+            es,
+            [
+                {"weight": 1, "unit": "ops", "success": False, "is_partial": True},
+                {"weight": 1, "unit": "ops", "success": True, "is_partial": False},
+            ],
+            attempts=5,
+            on_error=OnErrorBehavior.ABORT,
+        )
+
+        async def noop_sleep(_seconds):
+            return None
+
+        with mock.patch("esrally.driver.driver.asyncio.sleep", noop_sleep):
+            await execute_schedule()
+
+        samples = sampler.samples
+        assert len(samples) == 2
+        assert samples[0].request_meta_data["success"] is False
+        assert samples[0].request_meta_data["is_partial"] is True
+        assert samples[0].request_meta_data["retry-count"] == 0
+        assert samples[0].total_ops == 0
+        assert samples[1].request_meta_data["success"] is True
+        assert samples[1].request_meta_data["retry-count"] == 1
+        assert scripted.calls == 2
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_does_not_retry_permanent_circuit_breaker(self, es):
+        execute_schedule, sampler, scripted = await self._run_esql_schedule(
+            es,
+            [_api_error(429, _circuit_breaker_body("PERMANENT"))],
+            attempts=50,
+            on_error=OnErrorBehavior.ABORT,
+        )
+
+        with pytest.raises(exceptions.RallyError, match="HTTP Status: 429"):
+            await execute_schedule()
+
+        samples = sampler.samples
+        assert len(samples) == 1
+        assert samples[0].request_meta_data["success"] is False
+        assert samples[0].request_meta_data["retry-count"] == 0
+        assert samples[0].request_meta_data["error-durability"] == "PERMANENT"
+        assert scripted.calls == 1
+
+    @mock.patch("elasticsearch.Elasticsearch")
+    @pytest.mark.asyncio
+    async def test_aborts_after_recoverable_attempts_exhausted(self, es):
+        execute_schedule, sampler, scripted = await self._run_esql_schedule(
+            es,
+            [
+                _api_error(429, _circuit_breaker_body("TRANSIENT")),
+                _api_error(429, _circuit_breaker_body("TRANSIENT")),
+            ],
+            attempts=2,
+            on_error=OnErrorBehavior.ABORT,
+        )
+
+        async def noop_sleep(_seconds):
+            return None
+
+        with mock.patch("esrally.driver.driver.asyncio.sleep", noop_sleep):
+            with pytest.raises(exceptions.RallyError, match="HTTP Status: 429"):
+                await execute_schedule()
+
+        samples = sampler.samples
+        assert len(samples) == 2
+        assert [s.request_meta_data["retry-count"] for s in samples] == [0, 1]
+        assert samples[1].request_meta_data["retry-attempts-remaining"] == 0
+        assert scripted.calls == 2
+
     @pytest.mark.asyncio
     async def test_execute_single_no_return_value(self):
         es = None
@@ -2214,6 +2416,22 @@ class TestAsyncExecutor:
             "error-description": "",
             "success": False,
         }
+
+    @pytest.mark.asyncio
+    async def test_execute_single_records_error_durability(self):
+        es = None
+        params = None
+        op_runner = mock.AsyncMock(side_effect=_api_error(429, _circuit_breaker_body("TRANSIENT")))
+
+        ops, unit, request_meta_data = await driver.execute_single(
+            self.context_managed(op_runner), es, params, on_error=OnErrorBehavior.CONTINUE
+        )
+
+        assert ops == 0
+        assert unit == "ops"
+        assert request_meta_data["success"] is False
+        assert request_meta_data["http-status"] == 429
+        assert request_meta_data["error-durability"] == "TRANSIENT"
 
     @pytest.mark.asyncio
     async def test_execute_single_with_key_error(self):

--- a/tests/driver/runner_test.py
+++ b/tests/driver/runner_test.py
@@ -8405,6 +8405,166 @@ class TestRetry:
         delegate.assert_has_calls([mock.call(es, params) for _ in range(failure_count + 1)])
 
 
+def _api_error(status, body=None, message="error"):
+    error_meta = elastic_transport.ApiResponseMeta(
+        status=status,
+        http_version="1.1",
+        headers=elastic_transport.HttpHeaders(),
+        duration=0.0,
+        node=elastic_transport.NodeConfig(scheme="http", host="localhost", port=9200),
+    )
+    return elasticsearch.ApiError(message=message, meta=error_meta, body=body)
+
+
+def _circuit_breaker_body(durability="TRANSIENT"):
+    return {
+        "error": {
+            "root_cause": [{"type": "circuit_breaking_exception", "reason": "Data too large", "durability": durability}],
+            "type": "circuit_breaking_exception",
+            "reason": "Data too large",
+            "durability": durability,
+        },
+        "status": 429,
+    }
+
+
+class TestRecoverableApiError:
+    def test_retries_transient_circuit_breaker(self):
+        assert runner.is_recoverable_api_error(_api_error(429, _circuit_breaker_body("TRANSIENT"))) is True
+
+    def test_does_not_retry_permanent_circuit_breaker(self):
+        assert runner.is_recoverable_api_error(_api_error(429, _circuit_breaker_body("PERMANENT"))) is False
+
+    def test_retries_429_without_durability(self):
+        assert runner.is_recoverable_api_error(_api_error(429, {"error": {"type": "es_rejected_execution_exception"}})) is True
+
+    def test_retries_503(self):
+        assert runner.is_recoverable_api_error(_api_error(503, {"error": {"type": "unavailable"}})) is True
+
+    def test_does_not_retry_404(self):
+        assert runner.is_recoverable_api_error(_api_error(404, {"error": {"type": "not_found"}})) is False
+
+    def test_request_meta_retries_transient_429(self):
+        assert runner.is_recoverable_request_meta({"success": False, "http-status": 429, "error-durability": "TRANSIENT"}) is True
+
+    def test_request_meta_retries_429_without_durability(self):
+        assert runner.is_recoverable_request_meta({"success": False, "http-status": 429}) is True
+
+    def test_request_meta_does_not_retry_permanent_429(self):
+        assert runner.is_recoverable_request_meta({"success": False, "http-status": 429, "error-durability": "PERMANENT"}) is False
+
+    def test_request_meta_retries_partial_results(self):
+        assert runner.is_recoverable_request_meta({"success": False, "is_partial": True}) is True
+
+    def test_request_meta_does_not_retry_success(self):
+        assert runner.is_recoverable_request_meta({"success": True, "http-status": 200}) is False
+
+
+class TestRecoverableQueryRetries:
+    def teardown_method(self, method):
+        runner.register_default_runners()
+
+    @pytest.mark.asyncio
+    async def test_retries_transient_429_then_succeeds(self):
+        success_return_value = {"weight": 1, "unit": "ops", "success": True}
+        delegate = mock.AsyncMock(
+            side_effect=[
+                _api_error(429, _circuit_breaker_body("TRANSIENT")),
+                _api_error(429, _circuit_breaker_body("TRANSIENT")),
+                success_return_value,
+            ]
+        )
+        es = mock.Mock()
+        es.options.return_value = es
+        params = {"retry-wait-period": 0.01}
+        retrier = runner.Retry(delegate, retry_on_recoverable=True, retries=4)
+
+        result = await retrier(es, params)
+
+        assert result == {"weight": 1, "unit": "ops", "success": True, "retries": 2}
+        es.options.assert_called_once_with(max_retries=0)
+        assert delegate.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_permanent_circuit_breaker(self):
+        err = _api_error(429, _circuit_breaker_body("PERMANENT"))
+        delegate = mock.AsyncMock(side_effect=err)
+        retrier = runner.Retry(delegate, retry_on_recoverable=True, retries=4)
+
+        with pytest.raises(elasticsearch.ApiError):
+            await retrier(None, {"retry-wait-period": 0.01})
+
+        delegate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_429_unless_recoverable_retries_enabled(self):
+        err = _api_error(429, _circuit_breaker_body("TRANSIENT"))
+        delegate = mock.AsyncMock(side_effect=err)
+        retrier = runner.Retry(delegate, retries=4)
+
+        with pytest.raises(elasticsearch.ApiError):
+            await retrier(None, {"retry-wait-period": 0.01, "retry-on-error": True})
+
+        delegate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_after_attempts_exhausted(self):
+        err = _api_error(429, _circuit_breaker_body("TRANSIENT"))
+        delegate = mock.AsyncMock(side_effect=err)
+        retrier = runner.Retry(delegate, retry_on_recoverable=True, retries=2)
+
+        with pytest.raises(elasticsearch.ApiError):
+            await retrier(None, {"retry-wait-period": 0.01})
+
+        assert delegate.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retries_esql_partial_results(self):
+        failed = {"weight": 1, "unit": "ops", "success": False, "is_partial": True}
+        success = {"weight": 1, "unit": "ops", "success": True, "is_partial": False}
+        delegate = mock.AsyncMock(side_effect=[failed, success])
+        retrier = runner.Retry(delegate, retry_on_recoverable=True, retries=3)
+
+        result = await retrier(None, {"retry-wait-period": 0.01})
+
+        assert result["success"] is True
+        assert result["retries"] == 1
+
+    @pytest.mark.asyncio
+    async def test_resets_request_timing_between_attempts(self):
+        success = {"weight": 1, "unit": "ops", "success": True}
+        delegate = mock.AsyncMock(side_effect=[_api_error(503), success])
+        retrier = runner.Retry(delegate, retry_on_recoverable=True, retries=2)
+
+        with mock.patch.object(runner.RequestContextHolder, "reset_request_timing") as reset_timing:
+            result = await retrier(None, {"retry-wait-period": 0.01})
+
+        assert result["retries"] == 1
+        reset_timing.assert_called_once()
+
+    def test_register_default_runners_does_not_wrap_query_ops_in_retry(self):
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "driver", "retry.recoverable.query.errors", True)
+        cfg.add(config.Scope.application, "driver", "retry.recoverable.query.errors.attempts", 4)
+        runner.register_default_runners(cfg)
+        for operation_type in ("search", "esql", "esql-profile", "sql", "paginated-search", "scroll-search", "composite-agg"):
+            assert "retryable" not in repr(runner.runner_for(operation_type)), operation_type
+        assert runner.recoverable_query_retry_attempts(cfg) == 4
+
+    def test_register_default_runners_does_not_wrap_query_ops_by_default(self):
+        runner.register_default_runners()
+        assert "retryable" not in repr(runner.runner_for("esql"))
+        assert "retryable" not in repr(runner.runner_for("search"))
+        assert runner.recoverable_query_retry_attempts(None) is None
+
+    def test_rejects_non_positive_attempts(self):
+        cfg = config.Config()
+        cfg.add(config.Scope.application, "driver", "retry.recoverable.query.errors", True)
+        cfg.add(config.Scope.application, "driver", "retry.recoverable.query.errors.attempts", 0)
+        with pytest.raises(exceptions.SystemSetupError, match="must be >= 1"):
+            runner.register_default_runners(cfg)
+
+
 class TestRemovePrefix:
     def test_remove_matching_prefix(self):
         suffix = "index-20201117".removeprefix("index")


### PR DESCRIPTION
Rally should be more lenient in Serverless scenarios where load-based search autoscaling is active (ES3) and the target is returning 429s for query requests. The 429 is the target's method of applying backpressure to the client. The client either needs to modify its request and resend, or wait for the search tier to scale up while retrying the same request. The goal of this PR is to measure the time to a successful result in the scale up scenario when the same request is retried.

* Adds global CLI option `--retry-recoverable-query-errors` for retrying query requests resulting in 429s during serverless scale up.
* Adds global CLI option `--retry-recoverable-query-errors-attempts` for setting the number of query retry attempts.
* Add documentation.

If this works, a follow up would add retry support to query runners not presently supporting it to allow more granular control over specific query operations.

### Workarounds

- Setting `max_retries` can work, however, it is possible for Elasticsearch to return a partial search result due to a circuit breaking exception with a 200 status code. Rally considers this a failure that causes the benchmark to exit if `--on-error=abort`.
- Using `--on-error=continue` to ignore 429s will work at the cost of not having any metric sample for the query operation since there was only a failed execution. This will mask failures behind an apparently successful benchmark run.