### PR TITLE
feat(telemetry): include field_type in disk-usage-stats meta

### DIFF
--- a/esrally/telemetry.py
+++ b/esrally/telemetry.py
@@ -2430,6 +2430,8 @@ class DiskUsageStats(TelemetryDevice):
 
             for field, field_info in idx_fields["fields"].items():
                 meta = {"index": index, "field": field}
+                if field_type := field_info.get("type"):
+                    meta["field_type"] = field_type
                 self.metrics_store.put_value_cluster_level("disk_usage_total", field_info["total_in_bytes"], meta_data=meta, unit="byte")
 
                 inverted_index = field_info.get("inverted_index", {"total_in_bytes": 0})["total_in_bytes"]

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -5332,6 +5332,7 @@ class TestDiskUsageStats:
             "foo": {
                 "fields": {
                     "prcp": {
+                        "type": "float",
                         "total_in_bytes": 1498,
                         "doc_values_in_bytes": 748,
                         "points_in_bytes": 750,
@@ -5344,9 +5345,9 @@ class TestDiskUsageStats:
         t.on_benchmark_start()
         t.on_benchmark_stop()
         assert metrics_store_cluster_level.mock_calls == [
-            self._mock_store("disk_usage_total", 1498, "prcp"),
-            self._mock_store("disk_usage_doc_values", 748, "prcp"),
-            self._mock_store("disk_usage_points", 750, "prcp"),
+            self._mock_store("disk_usage_total", 1498, "prcp", field_type="float"),
+            self._mock_store("disk_usage_doc_values", 748, "prcp", field_type="float"),
+            self._mock_store("disk_usage_points", 750, "prcp", field_type="float"),
         ]
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
@@ -5359,6 +5360,7 @@ class TestDiskUsageStats:
             "foo": {
                 "fields": {
                     "station.country_code": {
+                        "type": "keyword",
                         "total_in_bytes": 346,
                         "doc_values_in_bytes": 328,
                         "points_in_bytes": 18,
@@ -5371,9 +5373,9 @@ class TestDiskUsageStats:
         t.on_benchmark_start()
         t.on_benchmark_stop()
         assert metrics_store_cluster_level.mock_calls == [
-            self._mock_store("disk_usage_total", 346, "station.country_code"),
-            self._mock_store("disk_usage_doc_values", 328, "station.country_code"),
-            self._mock_store("disk_usage_points", 18, "station.country_code"),
+            self._mock_store("disk_usage_total", 346, "station.country_code", field_type="keyword"),
+            self._mock_store("disk_usage_doc_values", 328, "station.country_code", field_type="keyword"),
+            self._mock_store("disk_usage_points", 18, "station.country_code", field_type="keyword"),
         ]
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
@@ -5394,8 +5396,11 @@ class TestDiskUsageStats:
             self._mock_store("disk_usage_knn_vectors", 64179820, "title_vector"),
         ]
 
-    def _mock_store(self, name, size, field):
-        return mock.call(name, size, meta_data={"index": "foo", "field": field}, unit="byte")
+    def _mock_store(self, name, size, field, field_type=None):
+        meta = {"index": "foo", "field": field}
+        if field_type is not None:
+            meta["field_type"] = field_type
+        return mock.call(name, size, meta_data=meta, unit="byte")
 
     @mock.patch("esrally.metrics.EsMetricsStore.put_value_cluster_level")
     @mock.patch("elasticsearch.Elasticsearch")


### PR DESCRIPTION
## TL;DR

`DiskUsageStats` now stores `field_type` in the metrics meta for every field the `_disk_usage` API reports a type for. Downstream queries against the metrics store can filter or aggregate `disk-usage-*` metrics by field type directly, without reconstructing types from index mapping files.

## Summary

The Elasticsearch `_disk_usage` API returns a `type` key alongside storage byte counts for every mapped field: `keyword`, `float`, `date`, `long`, `dense_vector`, and so on. `DiskUsageStats.handle_telemetry_usage` was reading that response dict and discarding the `type` key; the meta dict stored with each metric contained only `index` and `field`.

Without the type in the store, any post-race analysis that breaks storage down by field type must reconstruct types from track mapping files. For tracks with templated mappings (for example `elastic/logs`, which spreads hundreds of ECS fields across Jinja2-conditional files), that reconstruction is complex and fragile.

The fix is a single conditional in `handle_telemetry_usage`: if the API response includes `type`, it is forwarded as `field_type` in the meta dict. Internal fields (`_id`, `_source`, `_seq_no`, and so on) carry no type in the API response and are unaffected, so existing tooling that reads those metrics is unchanged.

## Testing

```
pytest tests/telemetry_test.py::TestDiskUsageStats -v
```