### PR TITLE
Introduce named constants for config keys

### DIFF
--- a/esrally/config_keys.py
+++ b/esrally/config_keys.py
@@ -1,0 +1,75 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Named constants for configuration keys.
+
+Instead of scattering hard-coded strings for config keys all over the
+codebase (which is error-prone, as a typo does not raise an error), we
+define the keys as module-level constants so a typo becomes a real
+error (`AttributeError` / ``NameError``) instead of a silently missing
+config option.
+
+See https://github.com/elastic/rally/issues/1646.
+"""
+
+import typing
+
+# section: "system"
+SYSTEM_SECTION: typing.Final = "system"
+
+# `rally list` options
+LIST_CONFIG_OPTION: typing.Final = "list.config.option"
+LIST_MAX_RESULTS: typing.Final = "list.max_results"
+LIST_RACES_BENCHMARK_NAME: typing.Final = "list.races.benchmark_name"
+LIST_RACES_FORMAT: typing.Final = "list.races.format"
+LIST_RACES_USER_TAGS: typing.Final = "list.races.user_tags"
+LIST_FROM_DATE: typing.Final = "list.from_date"
+LIST_TO_DATE: typing.Final = "list.to_date"
+LIST_CHALLENGE: typing.Final = "list.challenge"
+
+# `rally delete` options
+DELETE_CONFIG_OPTION: typing.Final = "delete.config.option"
+DELETE_ID: typing.Final = "delete.id"
+
+# `rally install` options
+INSTALL_ID: typing.Final = "install.id"
+
+# `rally add` options (add results to an existing race)
+ADD_CONFIG_OPTION: typing.Final = "add.config.option"
+ADD_MESSAGE: typing.Final = "add.message"
+ADD_RACE_TIMESTAMP: typing.Final = "add.race_timestamp"
+ADD_CHART_TYPE: typing.Final = "add.chart_type"
+ADD_CHART_NAME: typing.Final = "add.chart_name"
+
+# administrative options
+ADMIN_TRACK: typing.Final = "admin.track"
+ADMIN_DRY_RUN: typing.Final = "admin.dry_run"
+
+# race-related options
+RACE_ID: typing.Final = "race.id"
+TIME_START: typing.Final = "time.start"
+ENV_NAME: typing.Final = "env.name"
+
+# runtime/behavior options
+OFFLINE_MODE: typing.Final = "offline.mode"
+QUIET_MODE: typing.Final = "quiet.mode"
+AVAILABLE_CORES: typing.Final = "available.cores"
+ASYNCHRONOUS_DEBUG: typing.Final = "async.debug"
+PASSENV: typing.Final = "passenv"
+
+# remote benchmarking support
+REMOTE_BENCHMARKING_SUPPORTED: typing.Final = "remote.benchmarking.supported"

--- a/esrally/driver/driver.py
+++ b/esrally/driver/driver.py
@@ -39,6 +39,7 @@ from esrally import (
     actor,
     client,
     config,
+    config_keys,
     exceptions,
     metrics,
     paths,
@@ -566,7 +567,9 @@ class TrackPreparationActor(actor.RallyActor):
 
 
 def num_cores(cfg: types.Config):
-    return int(cfg.opts("system", "available.cores", mandatory=False, default_value=multiprocessing.cpu_count()))
+    return int(
+        cfg.opts(config_keys.SYSTEM_SECTION, config_keys.AVAILABLE_CORES, mandatory=False, default_value=multiprocessing.cpu_count())
+    )
 
 
 ApiKey = collections.namedtuple("ApiKey", ["id", "secret"])
@@ -735,7 +738,7 @@ class Driver:
     def prepare_benchmark(self, t):
         self.track = t
         self.challenge = select_challenge(self.config, self.track)
-        self.quiet = self.config.opts("system", "quiet.mode", mandatory=False, default_value=False)
+        self.quiet = self.config.opts(config_keys.SYSTEM_SECTION, config_keys.QUIET_MODE, mandatory=False, default_value=False)
         downsample_factor = int(self.config.opts("reporting", "metrics.request.downsample.factor", mandatory=False, default_value=1))
         self.metrics_store = metrics.metrics_store(cfg=self.config, track=self.track.name, challenge=self.challenge.name, read_only=False)
 
@@ -1829,7 +1832,9 @@ class AsyncIoAdapter:
         self.parent_worker_id = worker_id
         self.profiling_enabled = self.cfg.opts("driver", "profiling")
         self.assertions_enabled = self.cfg.opts("driver", "assertions")
-        self.debug_event_loop = self.cfg.opts("system", "async.debug", mandatory=False, default_value=False)
+        self.debug_event_loop = self.cfg.opts(
+            config_keys.SYSTEM_SECTION, config_keys.ASYNCHRONOUS_DEBUG, mandatory=False, default_value=False
+        )
         self.logger = logging.getLogger(__name__)
 
     def __call__(self, *args, **kwargs):

--- a/esrally/mechanic/launcher.py
+++ b/esrally/mechanic/launcher.py
@@ -21,7 +21,7 @@ import subprocess
 
 import psutil
 
-from esrally import exceptions, telemetry, time, types
+from esrally import config_keys, exceptions, telemetry, time, types
 from esrally.mechanic import cluster, java_resolver
 from esrally.utils import io, opts, process
 
@@ -127,7 +127,9 @@ class ProcessLauncher:
         self.cfg = cfg
         self._clock = clock
         self.logger = logging.getLogger(__name__)
-        self.pass_env_vars = opts.csv_to_list(self.cfg.opts("system", "passenv", mandatory=False, default_value="PATH"))
+        self.pass_env_vars = opts.csv_to_list(
+            self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.PASSENV, mandatory=False, default_value="PATH")
+        )
 
     def start(self, node_configurations):
         node_count_on_host = len(node_configurations)

--- a/esrally/mechanic/mechanic.py
+++ b/esrally/mechanic/mechanic.py
@@ -27,7 +27,16 @@ from typing import Optional
 
 import thespian.actors
 
-from esrally import PROGRAM_NAME, actor, config, exceptions, metrics, paths, types
+from esrally import (
+    PROGRAM_NAME,
+    actor,
+    config,
+    config_keys,
+    exceptions,
+    metrics,
+    paths,
+    types,
+)
 from esrally.mechanic import launcher, provisioner, supplier, team
 from esrally.utils import console, net
 
@@ -90,16 +99,16 @@ def install(cfg: types.Config):
         raise exceptions.SystemSetupError(f"Unknown build type [{build_type}]")
 
     provisioner.save_node_configuration(root_path, node_config)
-    console.println(json.dumps({"installation-id": cfg.opts("system", "install.id")}, indent=2), force=True)
+    console.println(json.dumps({"installation-id": cfg.opts(config_keys.SYSTEM_SECTION, config_keys.INSTALL_ID)}, indent=2), force=True)
 
 
 def start(cfg: types.Config):
     root_path = paths.install_root(cfg)
-    race_id = cfg.opts("system", "race.id")
+    race_id = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.RACE_ID)
     # avoid double-launching - we expect that the node file is absent
     with contextlib.suppress(FileNotFoundError):
         _load_node_file(root_path)
-        install_id = cfg.opts("system", "install.id")
+        install_id = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.INSTALL_ID)
         raise exceptions.SystemSetupError(
             "A node with this installation id is already running. Please stop it first "
             "with {} stop --installation-id={}".format(PROGRAM_NAME, install_id)
@@ -751,7 +760,7 @@ class Mechanic:
         self.node_configs = []
 
     def _current_race(self):
-        race_id = self.cfg.opts("system", "race.id")
+        race_id = self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.RACE_ID)
         return metrics.race_store(self.cfg).find_by_race_id(race_id)
 
     def _add_results(self, current_race, node):

--- a/esrally/mechanic/team.py
+++ b/esrally/mechanic/team.py
@@ -25,7 +25,7 @@ from typing import Any, Callable, Optional, Union
 
 import tabulate
 
-from esrally import PROGRAM_NAME, config, exceptions, types
+from esrally import PROGRAM_NAME, config, config_keys, exceptions, types
 from esrally.utils import console, io, modules, repo
 
 TEAM_FORMAT_VERSION = 1
@@ -128,7 +128,7 @@ def team_path(cfg: types.Config) -> str:
         distribution_version = cfg.opts("mechanic", "distribution.version", mandatory=False)
         repo_name = cfg.opts("mechanic", "repository.name")
         repo_revision = cfg.opts("mechanic", "repository.revision")
-        offline = cfg.opts("system", "offline.mode")
+        offline = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.OFFLINE_MODE)
         # TODO remove the below ignore when introducing LiteralString on Python 3.11+
         remote_url = cfg.opts("teams", "%s.url" % repo_name, mandatory=False)  # type: ignore[arg-type]
         root = cfg.opts("node", "root.dir")

--- a/esrally/metrics.py
+++ b/esrally/metrics.py
@@ -35,7 +35,7 @@ import tabulate
 import urllib3.connection
 from elastic_transport import Urllib3HttpNode
 
-from esrally import client, config, exceptions, paths, time, types, version
+from esrally import client, config, config_keys, exceptions, paths, time, types, version
 from esrally.utils import console, convert, io, pretty, versions
 
 
@@ -691,8 +691,8 @@ def metrics_store(cfg: types.Config, read_only=True, track=None, challenge=None,
     store = cls(cfg=cfg, meta_info=meta_info)
     logging.getLogger(__name__).info("Creating %s", str(store))
 
-    race_id = cfg.opts("system", "race.id")
-    race_timestamp = cfg.opts("system", "time.start")
+    race_id = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.RACE_ID)
+    race_timestamp = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.TIME_START)
     selected_car = cfg.opts("mechanic", "car.names") if car is None else car
 
     store.open(race_id, race_timestamp, track, challenge, selected_car, create=not read_only)
@@ -746,7 +746,7 @@ class MetricsStore:  # pylint: disable=too-many-public-methods
         self._challenge = None
         self._car = None
         self._car_name = None
-        self._environment_name = cfg.opts("system", "env.name")
+        self._environment_name = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.ENV_NAME)
         self.opened = False
         if meta_info is None:
             self._meta_info = {}
@@ -1845,7 +1845,7 @@ def list_races(cfg: types.Config):
         else:
             return None
 
-    output_format: str = cfg.opts("system", "list.races.format")
+    output_format: str = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.LIST_RACES_FORMAT)
     if output_format == "text":
         races = []
         for race in race_store(cfg).list():
@@ -1899,9 +1899,9 @@ def list_races(cfg: types.Config):
 
 def create_race(cfg: types.Config, track, challenge, track_revision=None):
     car = cfg.opts("mechanic", "car.names")
-    environment = cfg.opts("system", "env.name")
-    race_id = cfg.opts("system", "race.id")
-    race_timestamp = cfg.opts("system", "time.start")
+    environment = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.ENV_NAME)
+    race_id = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.RACE_ID)
+    race_timestamp = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.TIME_START)
     user_tags = cfg.opts("race", "user.tags", default_value={}, mandatory=False)
     pipeline = cfg.opts("race", "pipeline")
     multi_cluster = cfg.opts("driver", "multi.cluster", mandatory=False, default_value=False)
@@ -2162,7 +2162,7 @@ class Race:
 class RaceStore:
     def __init__(self, cfg: types.Config):
         self.cfg = cfg
-        self.environment_name = cfg.opts("system", "env.name")
+        self.environment_name = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.ENV_NAME)
 
     def find_by_race_id(self, race_id):
         raise NotImplementedError("abstract method")
@@ -2186,43 +2186,43 @@ class RaceStore:
         raise NotImplementedError("abstract method")
 
     def _max_results(self):
-        return int(self.cfg.opts("system", "list.max_results"))
+        return int(self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.LIST_MAX_RESULTS))
 
     def _track(self):
-        return self.cfg.opts("system", "admin.track", mandatory=False)
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.ADMIN_TRACK, mandatory=False)
 
     def _benchmark_name(self):
-        return self.cfg.opts("system", "list.races.benchmark_name", mandatory=False)
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.LIST_RACES_BENCHMARK_NAME, mandatory=False)
 
     def _user_tags(self) -> dict:
-        return self.cfg.opts("system", "list.races.user_tags", default_value={}, mandatory=False)
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.LIST_RACES_USER_TAGS, default_value={}, mandatory=False)
 
     def _race_timestamp(self):
-        return self.cfg.opts("system", "add.race_timestamp")
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.ADD_RACE_TIMESTAMP)
 
     def _message(self):
-        return self.cfg.opts("system", "add.message")
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.ADD_MESSAGE)
 
     def _chart_type(self):
-        return self.cfg.opts("system", "add.chart_type", mandatory=False)
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.ADD_CHART_TYPE, mandatory=False)
 
     def _chart_name(self):
-        return self.cfg.opts("system", "add.chart_name", mandatory=False)
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.ADD_CHART_NAME, mandatory=False)
 
     def _from_date(self):
-        return self.cfg.opts("system", "list.from_date", mandatory=False)
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.LIST_FROM_DATE, mandatory=False)
 
     def _to_date(self):
-        return self.cfg.opts("system", "list.to_date", mandatory=False)
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.LIST_TO_DATE, mandatory=False)
 
     def _dry_run(self):
-        return self.cfg.opts("system", "admin.dry_run", mandatory=False)
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.ADMIN_DRY_RUN, mandatory=False)
 
     def _id(self):
-        return self.cfg.opts("system", "delete.id")
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.DELETE_ID)
 
     def _challenge(self):
-        return self.cfg.opts("system", "list.challenge", mandatory=False)
+        return self.cfg.opts(config_keys.SYSTEM_SECTION, config_keys.LIST_CHALLENGE, mandatory=False)
 
 
 # Does not inherit from RaceStore as it is only a delegator with the same API.

--- a/esrally/paths.py
+++ b/esrally/paths.py
@@ -16,7 +16,7 @@
 # under the License.
 import os
 
-from esrally import types
+from esrally import config_keys, types
 
 
 def rally_confdir():
@@ -34,12 +34,12 @@ def races_root(cfg: types.Config):
 
 def race_root(cfg: types.Config, race_id=None):
     if not race_id:
-        race_id = cfg.opts("system", "race.id")
+        race_id = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.RACE_ID)
     return os.path.join(races_root(cfg), race_id)
 
 
 def install_root(cfg: types.Config):
-    install_id = cfg.opts("system", "install.id")
+    install_id = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.INSTALL_ID)
     return os.path.join(races_root(cfg), install_id)
 
 

--- a/esrally/racecontrol.py
+++ b/esrally/racecontrol.py
@@ -29,6 +29,7 @@ from esrally import (
     actor,
     client,
     config,
+    config_keys,
     doc_link,
     driver,
     exceptions,
@@ -393,7 +394,7 @@ def list_pipelines():
 def run(cfg: types.Config):
     logger = logging.getLogger(__name__)
     name = cfg.opts("race", "pipeline")
-    race_id = cfg.opts("system", "race.id")
+    race_id = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.RACE_ID)
     console.info(f"Race id is [{race_id}]", logger=logger)
     if len(name) == 0:
         # assume from-distribution pipeline if distribution.version has been specified and --pipeline cli arg not set

--- a/esrally/rally.py
+++ b/esrally/rally.py
@@ -36,6 +36,7 @@ from esrally import (
     actor,
     check_python_version,
     config,
+    config_keys,
     doc_link,
     exceptions,
     log,
@@ -989,7 +990,7 @@ def create_arg_parser():
 
 
 def dispatch_list(cfg: types.Config):
-    what = cfg.opts("system", "list.config.option")
+    what = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.LIST_CONFIG_OPTION)
     if what == "telemetry":
         telemetry.list_telemetry()
     elif what == "tracks":
@@ -1009,7 +1010,7 @@ def dispatch_list(cfg: types.Config):
 
 
 def dispatch_add(cfg: types.Config):
-    what = cfg.opts("system", "add.config.option")
+    what = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.ADD_CONFIG_OPTION)
     if what == "annotation":
         metrics.add_annotation(cfg)
     else:
@@ -1017,7 +1018,7 @@ def dispatch_add(cfg: types.Config):
 
 
 def dispatch_delete(cfg: types.Config):
-    what = cfg.opts("system", "delete.config.option")
+    what = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.DELETE_CONFIG_OPTION)
     if what == "race":
         metrics.delete_race(cfg)
     elif what == "annotation":
@@ -1084,7 +1085,7 @@ def with_actor_system(runnable, cfg: types.Config):
     try:
         actors = actor.bootstrap_actor_system(try_join=bool(already_running), prefer_local_only=not already_running)
         # We can only support remote benchmarks if we have a dedicated daemon that is not only bound to 127.0.0.1
-        cfg.add(config.Scope.application, "system", "remote.benchmarking.supported", already_running)
+        cfg.add(config.Scope.application, config_keys.SYSTEM_SECTION, config_keys.REMOTE_BENCHMARKING_SUPPORTED, already_running)
     # This happens when the admin process could not be started, e.g. because it could not open a socket.
     except thespian.actors.InvalidActorAddress:
         LOG.info("Falling back to offline actor system.")
@@ -1232,8 +1233,8 @@ def configure_reporting_params(args, cfg: types.Config):
 def dispatch_sub_command(arg_parser, args, cfg: types.Config):
     sub_command = args.subcommand
 
-    cfg.add(config.Scope.application, "system", "quiet.mode", args.quiet)
-    cfg.add(config.Scope.application, "system", "offline.mode", args.offline)
+    cfg.add(config.Scope.application, config_keys.SYSTEM_SECTION, config_keys.QUIET_MODE, args.quiet)
+    cfg.add(config.Scope.application, config_keys.SYSTEM_SECTION, config_keys.OFFLINE_MODE, args.offline)
     logger = logging.getLogger(__name__)
 
     try:
@@ -1241,31 +1242,35 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             configure_reporting_params(args, cfg)
             reporter.compare(cfg, args.baseline, args.contender)
         elif sub_command == "list":
-            cfg.add(config.Scope.applicationOverride, "system", "list.config.option", args.configuration)
-            cfg.add(config.Scope.applicationOverride, "system", "list.max_results", args.limit)
-            cfg.add(config.Scope.applicationOverride, "system", "admin.track", args.track)
-            cfg.add(config.Scope.applicationOverride, "system", "list.races.benchmark_name", args.benchmark_name)
-            cfg.add(config.Scope.applicationOverride, "system", "list.races.format", args.format)
-            cfg.add(config.Scope.applicationOverride, "system", "list.races.user_tags", opts.to_dict(args.user_tags))
-            cfg.add(config.Scope.applicationOverride, "system", "list.from_date", args.from_date)
-            cfg.add(config.Scope.applicationOverride, "system", "list.to_date", args.to_date)
-            cfg.add(config.Scope.applicationOverride, "system", "list.challenge", args.challenge)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.LIST_CONFIG_OPTION, args.configuration)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.LIST_MAX_RESULTS, args.limit)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.ADMIN_TRACK, args.track)
+            cfg.add(
+                config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.LIST_RACES_BENCHMARK_NAME, args.benchmark_name
+            )
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.LIST_RACES_FORMAT, args.format)
+            cfg.add(
+                config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.LIST_RACES_USER_TAGS, opts.to_dict(args.user_tags)
+            )
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.LIST_FROM_DATE, args.from_date)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.LIST_TO_DATE, args.to_date)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.LIST_CHALLENGE, args.challenge)
             configure_mechanic_params(args, cfg, command_requires_car=False)
             configure_track_params(arg_parser, args, cfg, command_requires_track=False, command_requires_track_details=False)
             dispatch_list(cfg)
         elif sub_command == "delete":
-            cfg.add(config.Scope.applicationOverride, "system", "delete.config.option", args.configuration)
-            cfg.add(config.Scope.applicationOverride, "system", "delete.id", args.id)
-            cfg.add(config.Scope.applicationOverride, "system", "admin.dry_run", args.dry_run)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.DELETE_CONFIG_OPTION, args.configuration)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.DELETE_ID, args.id)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.ADMIN_DRY_RUN, args.dry_run)
             dispatch_delete(cfg)
         elif sub_command == "add":
-            cfg.add(config.Scope.applicationOverride, "system", "add.config.option", args.configuration)
-            cfg.add(config.Scope.applicationOverride, "system", "admin.track", args.track)
-            cfg.add(config.Scope.applicationOverride, "system", "add.message", args.message)
-            cfg.add(config.Scope.applicationOverride, "system", "add.race_timestamp", args.race_timestamp)
-            cfg.add(config.Scope.applicationOverride, "system", "add.chart_type", args.chart_type)
-            cfg.add(config.Scope.applicationOverride, "system", "add.chart_name", args.chart_name)
-            cfg.add(config.Scope.applicationOverride, "system", "admin.dry_run", args.dry_run)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.ADD_CONFIG_OPTION, args.configuration)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.ADMIN_TRACK, args.track)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.ADD_MESSAGE, args.message)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.ADD_RACE_TIMESTAMP, args.race_timestamp)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.ADD_CHART_TYPE, args.chart_type)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.ADD_CHART_NAME, args.chart_name)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.ADMIN_DRY_RUN, args.dry_run)
             dispatch_add(cfg)
         elif sub_command == "build":
             cfg.add(config.Scope.applicationOverride, "mechanic", "car.plugins", opts.csv_to_list(args.elasticsearch_plugins))
@@ -1283,7 +1288,7 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             configure_mechanic_params(args, cfg)
             mechanic.download(cfg)
         elif sub_command == "install":
-            cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.INSTALL_ID, args.installation_id)
             cfg.add(config.Scope.applicationOverride, "mechanic", "network.host", args.network_host)
             cfg.add(config.Scope.applicationOverride, "mechanic", "network.http.port", args.http_port)
             cfg.add(config.Scope.applicationOverride, "mechanic", "source.revision", args.revision)
@@ -1300,15 +1305,15 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             configure_mechanic_params(args, cfg)
             mechanic.install(cfg)
         elif sub_command == "start":
-            cfg.add(config.Scope.applicationOverride, "system", "race.id", args.race_id)
-            cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.RACE_ID, args.race_id)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.INSTALL_ID, args.installation_id)
             cfg.add(config.Scope.applicationOverride, "mechanic", "runtime.jdk", args.runtime_jdk)
             configure_telemetry_params(args, cfg)
             mechanic.start(cfg)
         elif sub_command == "stop":
             cfg.add(config.Scope.applicationOverride, "mechanic", "preserve.install", convert.to_bool(args.preserve_install))
             cfg.add(config.Scope.applicationOverride, "mechanic", "skip.telemetry", args.skip_telemetry)
-            cfg.add(config.Scope.applicationOverride, "system", "install.id", args.installation_id)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.INSTALL_ID, args.installation_id)
             mechanic.stop(cfg)
         elif sub_command == "race":
             # As the race command is doing more work than necessary at the moment, we duplicate several parameters
@@ -1316,10 +1321,10 @@ def dispatch_sub_command(arg_parser, args, cfg: types.Config):
             # these duplicated parameters will vanish as we move towards dedicated subcommands and use "race" only
             # to run the actual benchmark (i.e. generating load).
             if args.effective_start_date:
-                cfg.add(config.Scope.applicationOverride, "system", "time.start", args.effective_start_date)
-            cfg.add(config.Scope.applicationOverride, "system", "race.id", args.race_id)
+                cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.TIME_START, args.effective_start_date)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.RACE_ID, args.race_id)
             # use the race id implicitly also as the install id.
-            cfg.add(config.Scope.applicationOverride, "system", "install.id", args.race_id)
+            cfg.add(config.Scope.applicationOverride, config_keys.SYSTEM_SECTION, config_keys.INSTALL_ID, args.race_id)
             cfg.add(config.Scope.applicationOverride, "race", "pipeline", args.pipeline)
             cfg.add(config.Scope.applicationOverride, "race", "user.tags", opts.to_dict(args.user_tags))
             cfg.add(config.Scope.applicationOverride, "driver", "multi.cluster", args.multi_cluster)
@@ -1428,7 +1433,7 @@ def main():
     if not cfg.config_present():
         cfg.install_default_config()
     cfg.load_config(auto_upgrade=True)
-    cfg.add(config.Scope.application, "system", "time.start", datetime.datetime.now(tz=datetime.timezone.utc))
+    cfg.add(config.Scope.application, config_keys.SYSTEM_SECTION, config_keys.TIME_START, datetime.datetime.now(tz=datetime.timezone.utc))
     # Local config per node
     cfg.add(config.Scope.application, "node", "rally.root", paths.rally_root())
     cfg.add(config.Scope.application, "node", "rally.cwd", os.getcwd())

--- a/esrally/track/loader.py
+++ b/esrally/track/loader.py
@@ -35,6 +35,7 @@ from jinja2 import meta
 from esrally import (
     PROGRAM_NAME,
     config,
+    config_keys,
     exceptions,
     paths,
     storage,
@@ -459,7 +460,7 @@ class GitTrackRepository:
         distribution_version = cfg.opts("mechanic", "distribution.version", mandatory=False)
         repo_name = cfg.opts("track", "repository.name")
         repo_revision = cfg.opts("track", "repository.revision", mandatory=False)
-        offline = cfg.opts("system", "offline.mode")
+        offline = cfg.opts(config_keys.SYSTEM_SECTION, config_keys.OFFLINE_MODE)
         # TODO remove the below ignore when introducing LiteralString on Python 3.11+
         remote_url = cfg.opts("tracks", "%s.url" % repo_name, mandatory=False)  # type: ignore[arg-type]
         root = cfg.opts("node", "root.dir")
@@ -613,7 +614,9 @@ class Downloader:
 
     @classmethod
     def from_config(cls, cfg: types.Config):
-        offline: bool = convert.to_bool(cfg.opts("system", "offline.mode", mandatory=False, default_value=False))
+        offline: bool = convert.to_bool(
+            cfg.opts(config_keys.SYSTEM_SECTION, config_keys.OFFLINE_MODE, mandatory=False, default_value=False)
+        )
         test_mode: bool = convert.to_bool(cfg.opts("track", "test.mode.enabled", mandatory=False, default_value=False))
         use_transfer_manager: bool = convert.to_bool(
             cfg.opts("track", "track.downloader.multipart_enabled", mandatory=False, default_value=False)

--- a/tests/config_keys_test.py
+++ b/tests/config_keys_test.py
@@ -35,11 +35,7 @@ class TestConfigKeys:
                 assert value in valid_keys, f"{name} = {value!r} is not a valid types.Key"
 
     def test_constants_are_unique(self):
-        values = [
-            value
-            for name, value in vars(config_keys).items()
-            if not name.startswith("_") and isinstance(value, str)
-        ]
+        values = [value for name, value in vars(config_keys).items() if not name.startswith("_") and isinstance(value, str)]
         assert len(values) == len(set(values)), "config key constants are not unique"
 
     def test_system_section(self):

--- a/tests/config_keys_test.py
+++ b/tests/config_keys_test.py
@@ -1,0 +1,47 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import typing
+
+from esrally import config_keys, types
+
+
+class TestConfigKeys:
+    def test_constants_match_types_key_literal(self):
+        """Every config key constant must be a valid member of ``types.Key``.
+
+        This keeps the constants in sync with the static type contract and
+        ensures a typo in either place surfaces here as a test failure.
+        """
+        valid_keys = set(typing.get_args(types.Key))
+        for name, value in vars(config_keys).items():
+            if name.startswith("_") or name == "SYSTEM_SECTION":
+                continue
+            if isinstance(value, str) and "." in value:
+                assert value in valid_keys, f"{name} = {value!r} is not a valid types.Key"
+
+    def test_constants_are_unique(self):
+        values = [
+            value
+            for name, value in vars(config_keys).items()
+            if not name.startswith("_") and isinstance(value, str)
+        ]
+        assert len(values) == len(set(values)), "config key constants are not unique"
+
+    def test_system_section(self):
+        assert config_keys.SYSTEM_SECTION == "system"
+        assert "system" in typing.get_args(types.Section)


### PR DESCRIPTION
## Summary

Closes #1646

The `Config` object's keys were referenced as hard-coded strings all over the codebase: they get populated during argument parsing in `rally.py` (e.g. `cfg.add(config.Scope.applicationOverride, "system", "list.max_results", ...)`) and are read back, again as strings, in `metrics.py`, `paths.py`, `driver/driver.py`, the `mechanic` modules, and others. A typo in any of those strings silently resolves to a missing config option instead of raising an error — this is exactly the class of bug seen in #1645.

## Changes

- New module `esrally/config_keys.py` defining every `"system"` section config key as a module-level constant (e.g. `RACE_ID = "race.id"`, `LIST_MAX_RESULTS = "list.max_results"`), plus `SYSTEM_SECTION`. Constants are annotated with `typing.Final`, so mypy preserves their literal types and still accepts them wherever `types.Key` is expected — the static type contract stays fully intact.
- All ~100 call sites across `esrally/` now reference the constants instead of raw strings; a typo becomes a real error (`NameError`/`mypy` failure) instead of a silently missing option.
- New `tests/config_keys_test.py` guards that every constant is a valid member of the `types.Key` Literal and that the constants are unique, keeping the two in sync.

Behavior is unchanged: the constants carry the exact same string values, verified by the full unit test suite.

## Testing

- `make test` equivalent: full unit suite passes (1947 tests) — the only pre-existing failure is `tests/storage/mirror_test.py::test_from_config[mirror_files]`, which fails identically on unmodified `master` in this environment and is unrelated (it depends on a local `mirrors.json` fixture path).
- `make lint` equivalent: `pre-commit run --all-files` passes all hooks (black, isort, mypy, pylint, pyupgrade).
